### PR TITLE
Revert ignoring CI build if only markdown files are changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      # Don't run if only basic markdown files have changed.
-      - '**.md'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This blocks PRs and we'll need a different solution to not require CI builds when only markdown files change