### PR TITLE
Block committing appsettings.json with pre commit hook

### DIFF
--- a/common/git-hooks/pre-commit
+++ b/common/git-hooks/pre-commit
@@ -9,6 +9,7 @@ if git diff --cached --name-only | grep -qE 'appsettings.json'; then
   echo 'appsettings.json has been staged for commit.' >&2
   echo 'This often contains the resource connection string which should not be checked in to source control.' >&2
   echo 'If you do want to check in changes to this file use `git commit --no-verify`.' >&2
+  echo 'Otherwise unstage this file.' >&2
   echo '============================' >&2
   exit 1;
 fi


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Block committing the appsettings.json with pre commit hook

## Motivation & context

This is because this file is often changed to house the resource connection string - however we never want to check this into github.
The best technique I've found so far is at the pre-commit hook level (this PR) which stops the file being accidently checked into git (and thus wont be pushed to github).
I have also posed the question on an internal message board and will update if a better solution appears - for now however this is a great way to give peace of mind that access keys won't be accidently checked in.


## Error Message
If you do try you will be presented with this error on trying to commit your changes:
![image](https://user-images.githubusercontent.com/2684369/108784943-4eba3d00-7525-11eb-8138-e7b05c6a7306.png)
