### PR TITLE
Reapply: Create GitHub issue from failing main CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,14 @@ jobs:
         working-directory: ./packages/communication-ui
         env:
           GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+
+      # Create a GitHub issue if the CI failed when running on the `main` branch
+      - name: Create issue if main branch CI failed
+        id: create-issue
+        if: failure() && github.ref == 'refs/heads/main'
+        uses: JasonEtco/create-an-issue@v2.4.0
+        with:
+          filename: .github/failed_ci_build_template.md
+          update_existing: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Original PR: #18 (Create GitHub issue from failing main CI pipeline)

This looks to have been accidently reverted in a merge conflict here: https://github.com/Azure/communication-ui-sdk/pull/23/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f