### PR TITLE
Fixing const being rendered as a new story

### DIFF
--- a/packages/storybook/stories/ControlBar/ControlBar.stories.tsx
+++ b/packages/storybook/stories/ControlBar/ControlBar.stories.tsx
@@ -23,7 +23,7 @@ import { getDocs } from './ControlBarDocs';
 import { DefaultButton } from '@fluentui/react';
 import { COMPONENT_FOLDER_PREFIX } from '../constants';
 
-export const CONTROL_BAR_LAYOUTS = [
+const CONTROL_BAR_LAYOUTS = [
   'horizontal',
   'vertical',
   'dockedTop',


### PR DESCRIPTION
# What
Fixing const being rendered as a new story if the const is exported from ControlBar.stories.tsx

![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/9782747/114229575-e1276c00-992c-11eb-8f14-17e8f06fa88f.png)


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-sdk/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->