### PR TITLE
Update link for Quick-start Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ We look forward to building an amazing open source toolkit with you!
 
 * [Repo Documentation](./docs/README.md)
 * [Conceptual Documentation](https://docs.microsoft.com/en-us/azure/communication-services/concepts/ui-framework/ui-sdk-overview)
-* [Quick-start Documentation](https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/ui-framework/getting-started-with-components)
+* [Quick-start Documentation](https://azure.github.io/communication-ui-sdk/?path=/story/quickstart-ui-components--page)


### PR DESCRIPTION
# What
Updated the link for Quick-start Documentation in the main README file

# Why
The previous link was giving a 404 message (missing page)

# How Tested
Opened the new link :D

# Process & policy checklist
N/A

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-sdk/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**
Not a breaking change ;)

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->