### PR TITLE
Remedy broken prod storybook by removing react telemetry plugin

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -18,6 +18,7 @@ dependencies:
   '@microsoft/api-documenter': 7.12.22
   '@microsoft/api-extractor': 7.13.5
   '@microsoft/applicationinsights-react-js': 3.0.5_react@16.14.0
+  '@microsoft/applicationinsights-shims': 2.0.0
   '@microsoft/applicationinsights-web': 2.6.2
   '@octokit/rest': 18.0.15
   '@rollup/plugin-commonjs': 17.1.0_rollup@2.42.4
@@ -20844,6 +20845,7 @@ packages:
       '@microsoft/api-documenter': 7.12.22
       '@microsoft/api-extractor': 7.13.5
       '@microsoft/applicationinsights-react-js': 3.0.5_react@16.14.0
+      '@microsoft/applicationinsights-shims': 2.0.0
       '@microsoft/applicationinsights-web': 2.6.2
       '@storybook/addon-actions': 6.1.21_30bc4764d4ba778218056aab0be8023f
       '@storybook/addon-docs': 6.1.21_5514be1c2f82a2c07dc23d6d89b846eb
@@ -20917,9 +20919,10 @@ packages:
     peerDependencies:
       webpack-cli: '*'
     resolution:
-      integrity: sha512-1SDidGsTxEYq4njaHKQip+G6ir97ZXfHt+e1RYi9XmfEc3L3BXC1bLbG/hm+K9gv72+8OoDkDkn+N6u3vxaIiA==
+      integrity: sha512-L7omrlDRrtKtIfu8I6naxSZbPwqciQkGP4tmlefZbLNf5kcig9gO/zukueFvjFetVaUKBS3gLfAjr14vstal7Q==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
+registry: ''
 specifiers:
   '@azure/communication-administration': 1.0.0-beta.3
   '@azure/communication-calling': 1.0.1-beta.1
@@ -20940,6 +20943,7 @@ specifiers:
   '@microsoft/api-documenter': ~7.12.11
   '@microsoft/api-extractor': ~7.13.2
   '@microsoft/applicationinsights-react-js': ~3.0.5
+  '@microsoft/applicationinsights-shims': ~2.0.0
   '@microsoft/applicationinsights-web': ~2.6.1
   '@octokit/rest': ~18.0.6
   '@rollup/plugin-commonjs': ~17.1.0

--- a/packages/storybook/.storybook/telemetry.ts
+++ b/packages/storybook/.storybook/telemetry.ts
@@ -1,6 +1,4 @@
 import { ApplicationInsights } from '@microsoft/applicationinsights-web'
-import { ReactPlugin } from '@microsoft/applicationinsights-react-js';
-import { createBrowserHistory } from "history";
 
 /**
  * Check if we have the necessary cookie consent to allow the app insights library to make use of cookies
@@ -45,21 +43,13 @@ const startTelemetry = (cookieConsent: boolean): ApplicationInsights | undefined
     return;
   }
 
-  // Initialize telemetry react plugin
-  const browserHistory = createBrowserHistory({ window });
-  var reactPlugin = new ReactPlugin();
-
 
   // Initialize and start collecting telemetry
   const appInsights = new ApplicationInsights({
     config: {
       disableCookiesUsage: !cookieConsent,
       instrumentationKey,
-      enableAutoRouteTracking: true,
-      extensions: [reactPlugin],
-      extensionConfig: {
-        [reactPlugin.identifier]: { history: browserHistory }
-      }
+      enableAutoRouteTracking: true
     }
   });
   appInsights.loadAppInsights();

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "description": "Azure Communication Services UI Toolkit Storybook",
   "scripts": {
-    "build": "build-storybook -s stories,./public --quiet --loglevel warn",
+    "build": "build-storybook -s stories,public,.storybook  --quiet --loglevel warn",
     "start": "concurrently \"rush build:watch -T storybook\" \"rushx start:storybook\"",
     "start:storybook": "start-storybook -p 6006 -s stories,./public --no-manager-cache --quiet --loglevel warn",
     "deploy-storybook": "storybook-to-ghpages --script build",
@@ -31,7 +31,7 @@
     "@fluentui/react-northstar": "^0.51.2",
     "@fluentui/react-theme-provider": "^0.18.0",
     "@microsoft/applicationinsights-react-js": "~3.0.5",
-    "@microsoft/applicationinsights-web": "~2.6.1",
+    "@microsoft/applicationinsights-web": "~2.6.2",
     "@uifabric/react-hooks": "~7.13.11",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "~3.3.1",

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -25,6 +25,6 @@
     "isolatedModules": true,
     "moduleResolution": "node"
   },
-  "include": ["stories/**/*", "./.storybook/**/*.test.ts"],
+  "include": ["stories/**/*", "./.storybook/**/*"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
# What
Remove the react plugin for the application insights to fix storybook runtime error.

Currently we are not making use of the react plugin's extra features so potentially we won't need this plugin. Let's see what the insights look like without it and then evaluate whether this should be re-added.

With `enableAutoRouteTracking: true` we should still get the different page view usage telemetry and user flows.

# Why
It causes this error:
`__extends is not defined`
![image](https://user-images.githubusercontent.com/2684369/115939493-19619b00-a453-11eb-8f3d-d601655ec53b.png)


There is a workaround fix here but unfortunately their solutions did not work for us: https://github.com/microsoft/ApplicationInsights-JS/issues/1527

# How Tested
Built storybook-static locally and was able to repro the issue - and then verify this fixed the issue.
