### PR TITLE
Fix: telemetry instrumentation key not picked up in storybook build task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       # Deploy Storybook - only perform this step on main branch CI
       - name: Deploy Storybook
-        if: github.ref == 'refs/heads/main' -- REMOVED FOR TESTING, DO NOT COMMIT
+        if: github.ref == 'refs/heads/main'
         # storybook requires the env vars to be in a .env file for access in the manager.ts
         run: |
           echo TELEMETRY_INSTRUMENTATION_KEY=${{ secrets.TELEMETRY_INSTRUMENTATION_KEY }} > .env


### PR DESCRIPTION
# What
Move the instrumentation key to a .env file in the build task so storybook picks up the key
(For some undocumented reason process.env.${{ var }} only works with preview and onwards files and not files like the manager.ts, docs: https://storybook.js.org/docs/react/configure/environment-variables)

# Why
Telemetry instrumentation key was not picked up in the build task

# How Tested
Ran build with a PR build that deployed storybook to verify