### PR TITLE
Fix Storybook props not showing

### DIFF
--- a/packages/communication-react/src/index.ts
+++ b/packages/communication-react/src/index.ts
@@ -6,5 +6,5 @@
 // export * from '../../acs-calling-selector/src';
 export * from '../../chat-stateful-client/src';
 export * from '../../acs-chat-selector/src';
-export * from 'react-components';
-export * from 'react-composites';
+export * from '../../react-components/src';
+export * from '../../react-composites/src/index.release';


### PR DESCRIPTION
# What
Make meta package explicitly point to src code not just through aliases

# Why
Otherwise storybook doesn't pick up the tsconfig aliases and thus points to the dist folder of the react-components package when it builds - and the storybook props functionality only works with ts files and not transpiled js files.
Has no impact to regular tsc builds as it correctly picks up the tsconfig path aliases

# How Tested
Ran locally - verified props show