### PR TITLE
Use CommunicationIdentifierKind instead of the list of types

### DIFF
--- a/change/calling-stateful-client-ce9d64b8-7b9a-448d-af42-b05b364abdfc.json
+++ b/change/calling-stateful-client-ce9d64b8-7b9a-448d-af42-b05b364abdfc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use CommunicationIdentifierKind in stream utils",
+  "packageName": "calling-stateful-client",
+  "email": "allenhwang@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -11,6 +11,7 @@ import { CallDirection } from '@azure/communication-calling';
 import { CallEndReason } from '@azure/communication-calling';
 import { CallerInfo } from '@azure/communication-calling';
 import { CallState as CallState_2 } from '@azure/communication-calling';
+import { CommunicationIdentifierKind } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { CommunicationUserKind } from '@azure/communication-common';
 import { CreateViewOptions } from '@azure/communication-calling';
@@ -121,8 +122,8 @@ export interface RemoteVideoStreamState {
 
 // @public
 export interface StatefulCallClient extends CallClient {
-    createView(callId: string | undefined, participantId: CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind | undefined, stream: LocalVideoStreamState | RemoteVideoStreamState, options?: CreateViewOptions): Promise<void>;
-    disposeView(callId: string | undefined, participantId: CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind | undefined, stream: LocalVideoStreamState | RemoteVideoStreamState): void;
+    createView(callId: string | undefined, participantId: CommunicationIdentifierKind | undefined, stream: LocalVideoStreamState | RemoteVideoStreamState, options?: CreateViewOptions): Promise<void>;
+    disposeView(callId: string | undefined, participantId: CommunicationIdentifierKind | undefined, stream: LocalVideoStreamState | RemoteVideoStreamState): void;
     getState(): CallClientState;
     offStateChange(handler: (state: CallClientState) => void): void;
     onStateChange(handler: (state: CallClientState) => void): void;

--- a/packages/calling-stateful-client/src/StatefulCallClient.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.ts
@@ -14,12 +14,7 @@ import { CallContext } from './CallContext';
 import { callAgentDeclaratify } from './CallAgentDeclarative';
 import { InternalCallContext } from './InternalCallContext';
 import { createView, disposeView } from './StreamUtils';
-import {
-  CommunicationUserKind,
-  MicrosoftTeamsUserKind,
-  PhoneNumberKind,
-  UnknownIdentifierKind
-} from '@azure/communication-common';
+import { CommunicationIdentifierKind } from '@azure/communication-common';
 
 /**
  * Defines the methods that allow CallClient {@Link @azure/communication-calling#CallClient} to be used statefully.
@@ -103,7 +98,7 @@ export interface StatefulCallClient extends CallClient {
    */
   createView(
     callId: string | undefined,
-    participantId: CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind | undefined,
+    participantId: CommunicationIdentifierKind | undefined,
     stream: LocalVideoStreamState | RemoteVideoStreamState,
     options?: CreateViewOptions
   ): Promise<void>;
@@ -133,7 +128,7 @@ export interface StatefulCallClient extends CallClient {
    */
   disposeView(
     callId: string | undefined,
-    participantId: CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind | undefined,
+    participantId: CommunicationIdentifierKind | undefined,
     stream: LocalVideoStreamState | RemoteVideoStreamState
   ): void;
 }
@@ -250,13 +245,7 @@ export const createStatefulCallClient = (
     configurable: false,
     value: (
       callId: string | undefined,
-      participantId:
-        | CommunicationUserKind
-        | PhoneNumberKind
-        | MicrosoftTeamsUserKind
-        | UnknownIdentifierKind
-        | string
-        | undefined,
+      participantId: CommunicationIdentifierKind | string | undefined,
       stream: LocalVideoStreamState | RemoteVideoStreamState,
       options?: CreateViewOptions
     ): Promise<void> => {
@@ -267,13 +256,7 @@ export const createStatefulCallClient = (
     configurable: false,
     value: (
       callId: string | undefined,
-      participantId:
-        | CommunicationUserKind
-        | PhoneNumberKind
-        | MicrosoftTeamsUserKind
-        | UnknownIdentifierKind
-        | string
-        | undefined,
+      participantId: CommunicationIdentifierKind | string | undefined,
       stream: LocalVideoStreamState | RemoteVideoStreamState
     ): void => {
       disposeView(context, internalContext, callId, participantId, stream);

--- a/packages/calling-stateful-client/src/StreamUtils.ts
+++ b/packages/calling-stateful-client/src/StreamUtils.ts
@@ -2,12 +2,7 @@
 // Licensed under the MIT license.
 
 import { CreateViewOptions, LocalVideoStream, VideoStreamRenderer } from '@azure/communication-calling';
-import {
-  CommunicationUserKind,
-  MicrosoftTeamsUserKind,
-  PhoneNumberKind,
-  UnknownIdentifierKind
-} from '@azure/communication-common';
+import { CommunicationIdentifierKind } from '@azure/communication-common';
 import { LocalVideoStreamState, RemoteVideoStreamState } from './CallClientState';
 import { CallContext } from './CallContext';
 import {
@@ -22,7 +17,7 @@ async function createViewRemoteVideo(
   context: CallContext,
   internalContext: InternalCallContext,
   callId: string,
-  participantId: CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind | string,
+  participantId: CommunicationIdentifierKind | string,
   stream: RemoteVideoStreamState,
   options?: CreateViewOptions
 ): Promise<void> {
@@ -248,7 +243,7 @@ function disposeViewRemoteVideo(
   context: CallContext,
   internalContext: InternalCallContext,
   callId: string,
-  participantId: CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind | string,
+  participantId: CommunicationIdentifierKind | string,
   stream: RemoteVideoStreamState
 ): void {
   const streamId = stream.id;
@@ -330,13 +325,7 @@ export function createView(
   context: CallContext,
   internalContext: InternalCallContext,
   callId: string | undefined,
-  participantId:
-    | CommunicationUserKind
-    | PhoneNumberKind
-    | MicrosoftTeamsUserKind
-    | UnknownIdentifierKind
-    | string
-    | undefined,
+  participantId: CommunicationIdentifierKind | string | undefined,
   stream: LocalVideoStreamState | RemoteVideoStreamState,
   options?: CreateViewOptions
 ): Promise<void> {
@@ -359,13 +348,7 @@ export function disposeView(
   context: CallContext,
   internalContext: InternalCallContext,
   callId: string | undefined,
-  participantId:
-    | CommunicationUserKind
-    | PhoneNumberKind
-    | MicrosoftTeamsUserKind
-    | UnknownIdentifierKind
-    | string
-    | undefined,
+  participantId: CommunicationIdentifierKind | string | undefined,
   stream: LocalVideoStreamState | RemoteVideoStreamState
 ): void {
   if ('id' in stream && callId && participantId) {

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -1156,8 +1156,8 @@ export interface SendBoxStylesProps extends BaseCustomStylesProps {
 
 // @public
 export interface StatefulCallClient extends CallClient {
-    createView(callId: string | undefined, participantId: CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind | undefined, stream: LocalVideoStreamState | RemoteVideoStreamState, options?: CreateViewOptions): Promise<void>;
-    disposeView(callId: string | undefined, participantId: CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind | undefined, stream: LocalVideoStreamState | RemoteVideoStreamState): void;
+    createView(callId: string | undefined, participantId: CommunicationIdentifierKind | undefined, stream: LocalVideoStreamState | RemoteVideoStreamState, options?: CreateViewOptions): Promise<void>;
+    disposeView(callId: string | undefined, participantId: CommunicationIdentifierKind | undefined, stream: LocalVideoStreamState | RemoteVideoStreamState): void;
     getState(): CallClientState;
     offStateChange(handler: (state: CallClientState) => void): void;
     onStateChange(handler: (state: CallClientState) => void): void;


### PR DESCRIPTION
# What
Instead of `CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind` use `CommunicationIdentifierKind` as it is a type designed to contain all the kinds of identifiers.

# Why
Follow up for code review feedback: https://github.com/Azure/communication-ui-library/pull/293#discussion_r635586193.

# How Tested
Manually tested using Calling Sample and verify existing functionality works.

# Process & policy checklist

- [X] I have updated the project documentation to reflect my changes if necessary.
- [X] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.