### PR TITLE
Add a permissions banner to warn user if the app has no camera/microphone permission

### DIFF
--- a/change/react-composites-bd5cbc6f-3561-4293-a395-b767ba02affd.json
+++ b/change/react-composites-bd5cbc6f-3561-4293-a395-b767ba02affd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add permissions banner",
+  "packageName": "react-composites",
+  "email": "allenhwang@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
@@ -28,6 +28,10 @@ import { ComplianceBanner } from './ComplianceBanner';
 import { lobbySelector } from './selectors/lobbySelector';
 import { Lobby } from './Lobby';
 import { AzureCommunicationCallAdapter, CallCompositePage } from './adapter';
+import { PermissionsBanner } from '../common/PermissionsBanner';
+import { permissionsBannerContainerStyle } from '../common/styles/PermissionsBanner.styles';
+import { devicePermissionSelector } from '@azure/acs-calling-selector';
+import { useAdaptedSelector } from './hooks/useAdaptedSelector';
 
 export const MINI_HEADER_WINDOW_WIDTH = 450;
 
@@ -60,6 +64,8 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
 
   const lobbyProps = useSelector(lobbySelector);
   const lobbyHandlers = useHandlers(Lobby);
+
+  const devicePermissions = useAdaptedSelector(devicePermissionSelector);
 
   const localVideoViewOption = {
     scalingMode: 'Crop',
@@ -118,6 +124,12 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
           </Stack.Item>
           <Stack.Item style={{ width: '100%' }}>
             <ComplianceBanner {...complianceBannerProps} />
+          </Stack.Item>
+          <Stack.Item style={permissionsBannerContainerStyle}>
+            <PermissionsBanner
+              microphonePermissionGranted={devicePermissions.audio}
+              cameraPermissionGranted={devicePermissions.video}
+            />
           </Stack.Item>
           <Stack.Item styles={subContainerStyles} grow>
             {!isScreenShareOn ? (

--- a/packages/react-composites/src/composites/common/PermissionsBanner.test.ts
+++ b/packages/react-composites/src/composites/common/PermissionsBanner.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  CAMERA_AND_MICROPHONE_PERMISSION_DENIED,
+  CAMERA_PERMISSION_DENIED,
+  getPermissionsBannerMessage,
+  MICROPHONE_PERMISSION_DENIED
+} from './PermissionsBanner';
+
+describe('permissions banner', () => {
+  test('warns about camera permission when no permission and banner is not dismissed', async () => {
+    const message = getPermissionsBannerMessage(false, undefined, false, false);
+    expect(message).toBe(CAMERA_PERMISSION_DENIED);
+  });
+
+  test('does not warn about camera permission when no permission but banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(false, undefined, true, false);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about camera permission when permission is yes and banner is not dismissed', async () => {
+    const message = getPermissionsBannerMessage(true, undefined, false, false);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about camera permission when permission is yes and banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(true, undefined, true, false);
+    expect(message).toBe('');
+  });
+
+  test('warns about microphone permission when no permission and banner is not dismissed', async () => {
+    const message = getPermissionsBannerMessage(undefined, false, false, false);
+    expect(message).toBe(MICROPHONE_PERMISSION_DENIED);
+  });
+
+  test('does not warn about microphone permission when no permission but banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(undefined, false, false, true);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about microphone permission when permission is yes and banner is not dismissed', async () => {
+    const message = getPermissionsBannerMessage(undefined, true, false, false);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about microphone permission when permission is yes and banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(undefined, true, false, true);
+    expect(message).toBe('');
+  });
+
+  test('warns about camera and microphone permission when no permission and banner is not dismissed', async () => {
+    const message = getPermissionsBannerMessage(false, false, false, false);
+    expect(message).toBe(CAMERA_AND_MICROPHONE_PERMISSION_DENIED);
+  });
+
+  test('does not warn about camera and microphone permission when no permission but banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(false, false, true, true);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about camera+microphone permission when permission is yes and banner not dismissed', async () => {
+    const message = getPermissionsBannerMessage(true, true, false, false);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about camera+microphone permission when permission is yes and banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(true, true, true, true);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about anything when permission ask is still pending', async () => {
+    const message = getPermissionsBannerMessage(undefined, undefined, false, false);
+    expect(message).toBe('');
+  });
+});

--- a/packages/react-composites/src/composites/common/PermissionsBanner.tsx
+++ b/packages/react-composites/src/composites/common/PermissionsBanner.tsx
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { MessageBar, MessageBarButton, MessageBarType } from '@fluentui/react';
+import { permissionsBannerMessageBarStyle } from '../common/styles/PermissionsBanner.styles';
+
+export const CAMERA_PERMISSION_DENIED = 'Camera use is blocked by your browser.';
+export const MICROPHONE_PERMISSION_DENIED = 'Microphone use is blocked by your browser.';
+export const CAMERA_AND_MICROPHONE_PERMISSION_DENIED = 'Camera and microphone use is blocked by your browser.';
+const ALLOW_PERMISSIONS_INSTRUCTIONS =
+  "Grant permission by clicking the lock in the address bar and selecting 'Allow'.";
+
+export interface PermissionsBannerProps {
+  /**
+   * If cameraPermission is true or undefined, no banner is shown for camera.
+   */
+  cameraPermissionGranted: boolean | undefined;
+  /**
+   * If microphonePermission is true or undefined, no banner is shown for microphone.
+   */
+  microphonePermissionGranted: boolean | undefined;
+}
+
+/**
+ * Returns the appropriate banner message for given states. Returns empty string if no banner message should be
+ * displayed.
+ *
+ * @param cameraPermissionGranted - If permission is granted for camera, undefined if no response to permission ask
+ * @param microphonePermissionGranted - If permission is granted for microphone, undefined if no response to permission
+ *   ask
+ * @param dismissedCameraBanner - If camera banner was already dismissed
+ * @param dismissedMicrophoneBanner - If microphone banner was already dismissed
+ * @returns
+ */
+export const getPermissionsBannerMessage = (
+  cameraPermissionGranted: boolean | undefined,
+  microphonePermissionGranted: boolean | undefined,
+  dismissedCameraBanner: boolean,
+  dismissedMicrophoneBanner: boolean
+): string => {
+  const showCameraMessage = cameraPermissionGranted !== undefined && !cameraPermissionGranted && !dismissedCameraBanner;
+  const showMicrophoneMessage =
+    microphonePermissionGranted !== undefined && !microphonePermissionGranted && !dismissedMicrophoneBanner;
+  if (showCameraMessage && showMicrophoneMessage) {
+    return CAMERA_AND_MICROPHONE_PERMISSION_DENIED;
+  } else if (showCameraMessage) {
+    return CAMERA_PERMISSION_DENIED;
+  } else if (showMicrophoneMessage) {
+    return MICROPHONE_PERMISSION_DENIED;
+  } else {
+    return '';
+  }
+};
+
+/**
+ * Shows a banner notifying user if camera or microphone permission is denied and also instructions on how to allow the
+ * necessary permissions. If either camera or microphone permission is true or undefined then no banner for those items
+ * are show. This banner will not show anything if the permission (undefined) has been requested but user has not
+ * responded to it. Sample app/composite will always request permission so the case of permission not requested is
+ * assumed to not happen by this component. If the banner was dismissed, it will be dismissed for the current state of
+ * the props and stay dismissed even if permission change after dismissal.
+ *
+ * @param props {@Link PermissionsBannerProps}
+ */
+export const PermissionsBanner = (props: PermissionsBannerProps): JSX.Element => {
+  const { cameraPermissionGranted, microphonePermissionGranted } = props;
+  const [dismissedCameraBanner, setDismissedCameraBanner] = useState<boolean>(false);
+  const [dismissedMicrophoneBanner, setDismissedMicrophoneBanner] = useState<boolean>(false);
+
+  const bannerMessage = useMemo(() => {
+    return getPermissionsBannerMessage(
+      cameraPermissionGranted,
+      microphonePermissionGranted,
+      dismissedCameraBanner,
+      dismissedMicrophoneBanner
+    );
+  }, [cameraPermissionGranted, microphonePermissionGranted, dismissedCameraBanner, dismissedMicrophoneBanner]);
+
+  const dismissBanner = useCallback(() => {
+    if (cameraPermissionGranted !== undefined && !cameraPermissionGranted) {
+      setDismissedCameraBanner(true);
+    }
+    if (microphonePermissionGranted !== undefined && !microphonePermissionGranted) {
+      setDismissedMicrophoneBanner(true);
+    }
+  }, [cameraPermissionGranted, microphonePermissionGranted]);
+
+  return bannerMessage === '' ? (
+    <></>
+  ) : (
+    <MessageBar
+      styles={permissionsBannerMessageBarStyle}
+      messageBarType={MessageBarType.warning}
+      isMultiline={false}
+      actions={<MessageBarButton onClick={dismissBanner}>Dismiss</MessageBarButton>}
+    >
+      <b>{bannerMessage}</b>&nbsp;{ALLOW_PERMISSIONS_INSTRUCTIONS}
+    </MessageBar>
+  );
+};

--- a/packages/react-composites/src/composites/common/styles/PermissionsBanner.styles.ts
+++ b/packages/react-composites/src/composites/common/styles/PermissionsBanner.styles.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { IMessageBarStyleProps, IMessageBarStyles, IStyleFunctionOrObject } from '@fluentui/react';
+
+export const permissionsBannerContainerStyle = {
+  width: '100%'
+};
+
+export const permissionsBannerMessageBarStyle: IStyleFunctionOrObject<IMessageBarStyleProps, IMessageBarStyles> = {
+  content: { alignItems: 'center', justifyContent: 'center', position: 'relative' },
+  text: { flexGrow: '0' },
+  actions: { position: 'absolute', right: '0px' }
+};

--- a/samples/Calling/src/app/CallScreen.tsx
+++ b/samples/Calling/src/app/CallScreen.tsx
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { useCallClient, useCall, useCallingSelector as useSelector } from '@azure/acs-calling-selector';
+import {
+  useCallClient,
+  useCall,
+  useCallingSelector as useSelector,
+  devicePermissionSelector
+} from '@azure/acs-calling-selector';
 import { CallState, GroupLocator, MeetingLocator } from '@azure/communication-calling';
 import { Label, Overlay, Spinner, Stack } from '@fluentui/react';
 import { VideoStreamOptions } from 'react-components';
@@ -27,6 +32,8 @@ import { Lobby } from './Lobby';
 import { ComplianceBanner } from './ComplianceBanner';
 import { mediaGallerySelector } from './selectors/mediaGallerySelector';
 import { complianceBannerSelector } from './selectors/complianceBannerSelector';
+import { PermissionsBanner } from './PermissionsBanner';
+import { permissionsBannerContainerStyle } from './styles/PermissionsBanner.styles';
 
 export interface CallScreenProps {
   screenWidth: number;
@@ -59,6 +66,8 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
   const lobbyProps = useSelector(lobbySelector);
 
   const complianceBannerProps = useSelector(complianceBannerSelector);
+
+  const devicePermissions = useSelector(devicePermissionSelector);
 
   useEffect(() => {
     const callEndReason = call?.callEndReason;
@@ -111,6 +120,12 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
           </Stack.Item>
           <Stack.Item>
             <ComplianceBanner {...complianceBannerProps} />
+          </Stack.Item>
+          <Stack.Item style={permissionsBannerContainerStyle}>
+            <PermissionsBanner
+              microphonePermissionGranted={devicePermissions.audio}
+              cameraPermissionGranted={devicePermissions.video}
+            />
           </Stack.Item>
           <Stack styles={subContainerStyles} grow horizontal>
             {!isScreenSharingOn ? (

--- a/samples/Calling/src/app/PermissionsBanner.test.ts
+++ b/samples/Calling/src/app/PermissionsBanner.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  CAMERA_AND_MICROPHONE_PERMISSION_DENIED,
+  CAMERA_PERMISSION_DENIED,
+  getPermissionsBannerMessage,
+  MICROPHONE_PERMISSION_DENIED
+} from './PermissionsBanner';
+
+describe('permissions banner', () => {
+  test('warns about camera permission when no permission and banner is not dismissed', async () => {
+    const message = getPermissionsBannerMessage(false, undefined, false, false);
+    expect(message).toBe(CAMERA_PERMISSION_DENIED);
+  });
+
+  test('does not warn about camera permission when no permission but banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(false, undefined, true, false);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about camera permission when permission is yes and banner is not dismissed', async () => {
+    const message = getPermissionsBannerMessage(true, undefined, false, false);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about camera permission when permission is yes and banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(true, undefined, true, false);
+    expect(message).toBe('');
+  });
+
+  test('warns about microphone permission when no permission and banner is not dismissed', async () => {
+    const message = getPermissionsBannerMessage(undefined, false, false, false);
+    expect(message).toBe(MICROPHONE_PERMISSION_DENIED);
+  });
+
+  test('does not warn about microphone permission when no permission but banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(undefined, false, false, true);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about microphone permission when permission is yes and banner is not dismissed', async () => {
+    const message = getPermissionsBannerMessage(undefined, true, false, false);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about microphone permission when permission is yes and banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(undefined, true, false, true);
+    expect(message).toBe('');
+  });
+
+  test('warns about camera and microphone permission when no permission and banner is not dismissed', async () => {
+    const message = getPermissionsBannerMessage(false, false, false, false);
+    expect(message).toBe(CAMERA_AND_MICROPHONE_PERMISSION_DENIED);
+  });
+
+  test('does not warn about camera and microphone permission when no permission but banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(false, false, true, true);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about camera+microphone permission when permission is yes and banner not dismissed', async () => {
+    const message = getPermissionsBannerMessage(true, true, false, false);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about camera+microphone permission when permission is yes and banner is dismissed', async () => {
+    const message = getPermissionsBannerMessage(true, true, true, true);
+    expect(message).toBe('');
+  });
+
+  test('does not warn about anything when permission ask is still pending', async () => {
+    const message = getPermissionsBannerMessage(undefined, undefined, false, false);
+    expect(message).toBe('');
+  });
+});

--- a/samples/Calling/src/app/PermissionsBanner.tsx
+++ b/samples/Calling/src/app/PermissionsBanner.tsx
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { MessageBar, MessageBarButton, MessageBarType } from '@fluentui/react';
+import { permissionsBannerMessageBarStyle } from './styles/PermissionsBanner.styles';
+
+export const CAMERA_PERMISSION_DENIED = 'Camera use is blocked by your browser.';
+export const MICROPHONE_PERMISSION_DENIED = 'Microphone use is blocked by your browser.';
+export const CAMERA_AND_MICROPHONE_PERMISSION_DENIED = 'Camera and microphone use is blocked by your browser.';
+const ALLOW_PERMISSIONS_INSTRUCTIONS =
+  "Grant permission by clicking the lock in the address bar and selecting 'Allow'.";
+
+export interface PermissionsBannerProps {
+  /**
+   * If cameraPermission is true or undefined, no banner is shown for camera.
+   */
+  cameraPermissionGranted: boolean | undefined;
+  /**
+   * If microphonePermission is true or undefined, no banner is shown for microphone.
+   */
+  microphonePermissionGranted: boolean | undefined;
+}
+
+/**
+ * Returns the appropriate banner message for given states. Returns empty string if no banner message should be
+ * displayed.
+ *
+ * @param cameraPermissionGranted - If permission is granted for camera, undefined if no response to permission ask
+ * @param microphonePermissionGranted - If permission is granted for microphone, undefined if no response to permission
+ *   ask
+ * @param dismissedCameraBanner - If camera banner was already dismissed
+ * @param dismissedMicrophoneBanner - If microphone banner was already dismissed
+ * @returns
+ */
+export const getPermissionsBannerMessage = (
+  cameraPermissionGranted: boolean | undefined,
+  microphonePermissionGranted: boolean | undefined,
+  dismissedCameraBanner: boolean,
+  dismissedMicrophoneBanner: boolean
+): string => {
+  const showCameraMessage = cameraPermissionGranted !== undefined && !cameraPermissionGranted && !dismissedCameraBanner;
+  const showMicrophoneMessage =
+    microphonePermissionGranted !== undefined && !microphonePermissionGranted && !dismissedMicrophoneBanner;
+  if (showCameraMessage && showMicrophoneMessage) {
+    return CAMERA_AND_MICROPHONE_PERMISSION_DENIED;
+  } else if (showCameraMessage) {
+    return CAMERA_PERMISSION_DENIED;
+  } else if (showMicrophoneMessage) {
+    return MICROPHONE_PERMISSION_DENIED;
+  } else {
+    return '';
+  }
+};
+
+/**
+ * Shows a banner notifying user if camera or microphone permission is denied and also instructions on how to allow the
+ * necessary permissions. If either camera or microphone permission is true or undefined then no banner for those items
+ * are show. This banner will not show anything if the permission (undefined) has been requested but user has not
+ * responded to it. Sample app/composite will always request permission so the case of permission not requested is
+ * assumed to not happen by this component. If the banner was dismissed, it will be dismissed for the current state of
+ * the props and stay dismissed even if permission change after dismissal.
+ *
+ * @param props {@Link PermissionsBannerProps}
+ */
+export const PermissionsBanner = (props: PermissionsBannerProps): JSX.Element => {
+  const { cameraPermissionGranted, microphonePermissionGranted } = props;
+  const [dismissedCameraBanner, setDismissedCameraBanner] = useState<boolean>(false);
+  const [dismissedMicrophoneBanner, setDismissedMicrophoneBanner] = useState<boolean>(false);
+
+  const bannerMessage = useMemo(() => {
+    return getPermissionsBannerMessage(
+      cameraPermissionGranted,
+      microphonePermissionGranted,
+      dismissedCameraBanner,
+      dismissedMicrophoneBanner
+    );
+  }, [cameraPermissionGranted, microphonePermissionGranted, dismissedCameraBanner, dismissedMicrophoneBanner]);
+
+  const dismissBanner = useCallback(() => {
+    if (cameraPermissionGranted !== undefined && !cameraPermissionGranted) {
+      setDismissedCameraBanner(true);
+    }
+    if (microphonePermissionGranted !== undefined && !microphonePermissionGranted) {
+      setDismissedMicrophoneBanner(true);
+    }
+  }, [cameraPermissionGranted, microphonePermissionGranted]);
+
+  return bannerMessage === '' ? (
+    <></>
+  ) : (
+    <MessageBar
+      styles={permissionsBannerMessageBarStyle}
+      messageBarType={MessageBarType.warning}
+      isMultiline={false}
+      actions={<MessageBarButton onClick={dismissBanner}>Dismiss</MessageBarButton>}
+    >
+      <b>{bannerMessage}</b>&nbsp;{ALLOW_PERMISSIONS_INSTRUCTIONS}
+    </MessageBar>
+  );
+};

--- a/samples/Calling/src/app/styles/PermissionsBanner.styles.ts
+++ b/samples/Calling/src/app/styles/PermissionsBanner.styles.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { IMessageBarStyleProps, IMessageBarStyles, IStyleFunctionOrObject } from '@fluentui/react';
+
+export const permissionsBannerContainerStyle = {
+  width: '100%'
+};
+
+export const permissionsBannerMessageBarStyle: IStyleFunctionOrObject<IMessageBarStyleProps, IMessageBarStyles> = {
+  content: { alignItems: 'center', justifyContent: 'center', position: 'relative' },
+  text: { flexGrow: '0' },
+  actions: { position: 'absolute', right: '0px' }
+};


### PR DESCRIPTION
# What
Add a permissions banner to warn user if the app has no camera/microphone permission.

# Why
Follow this reference design from Alex P:
![image](https://user-images.githubusercontent.com/3343009/119722552-4bcf3100-be21-11eb-90d5-4875c366b040.png)

Screenshots:
![image](https://user-images.githubusercontent.com/3343009/119722348-10ccfd80-be21-11eb-8571-6137dc97ab89.png)
![image](https://user-images.githubusercontent.com/3343009/119722365-13c7ee00-be21-11eb-89c2-3f76ffd2f60c.png)
![image](https://user-images.githubusercontent.com/3343009/119722369-175b7500-be21-11eb-98d9-452725504ec3.png)

# How Tested
Tested using unit test and also manual verification of Calling Sample, Calling Composite in Storybook, and OneToOne Call Sample.

# Process & policy checklist

- [X] I have updated the project documentation to reflect my changes if necessary.
- [X] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.