### PR TITLE
Minor fix for collectCoverageFrom directory

### DIFF
--- a/common/config/jest/jest.config.js
+++ b/common/config/jest/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   clearMocks: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}', "!**/node_modules/**", '!src/mocks/**/*', '!coverage/**', '!index.ts'],
+  collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}', "!**/node_modules/**", '!src/mocks/**/*', '!**/coverage/**', '!**/index.ts'],
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
   maxWorkers: '50%',

--- a/common/config/jest/jest.config.js
+++ b/common/config/jest/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   clearMocks: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!/node_modules/', '!src/mocks/**/*'],
+  collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}', "!**/node_modules/**", '!src/mocks/**/*', '!coverage/**', '!index.ts'],
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
   maxWorkers: '50%',


### PR DESCRIPTION
# What
Minor update for the collectCoverageFrom directory as it wasn't picking up any files.

# Why
I think because we specify a rootDir, the collectCoverageFrom paths are build starting from the root dir. For example we had a rootDir of './src' and a collectCoverage path of 'src/...' the final path ended up being something like './src/src/...' which is not a folder we have and no files are there.

# How Tested
Run rushx test:coverage and view the coverage:

![image](https://user-images.githubusercontent.com/3343009/119914826-fb85cb00-bf15-11eb-8224-6c96422b1888.png)

# Process & policy checklist

- [X] I have updated the project documentation to reflect my changes if necessary.
- [X] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.