### PR TITLE
Making Table of contents more usable.

### DIFF
--- a/packages/storybook/.storybook/TOC.tsx
+++ b/packages/storybook/.storybook/TOC.tsx
@@ -4,9 +4,14 @@ import { BackToTop, TableOfContents } from 'storybook-docs-toc';
 
 export const TOC = (props: {children: React.ReactNode}): JSX.Element => {
 
+  const [narrowDocs, setnarrowDocs] = useState(false);
   const [hideToc, setHideToc] = useState(false);
 
   window.matchMedia('(max-width: 1200px)').addEventListener('change', (e) => {
+    setnarrowDocs(e.matches);
+  })
+
+  window.matchMedia('(max-width: 900px)').addEventListener('change', (e) => {
     setHideToc(e.matches);
   })
 
@@ -39,7 +44,7 @@ export const TOC = (props: {children: React.ReactNode}): JSX.Element => {
         <div className={tocStyles}>
           <TableOfContents />
         </div>
-        <div>
+        <div style={narrowDocs ? { maxWidth: '768px' } : {}}>
           {props.children}
         </div>
         <div className={mergeStyles({'> button': { right: 16 }})}>

--- a/packages/storybook/.storybook/TOC.tsx
+++ b/packages/storybook/.storybook/TOC.tsx
@@ -1,0 +1,50 @@
+import { mergeStyles } from '@fluentui/react';
+import React, { useState } from 'react';
+import { BackToTop, TableOfContents } from 'storybook-docs-toc';
+
+export const TOC = (props: {children: React.ReactNode}): JSX.Element => {
+
+  const [hideToc, setHideToc] = useState(false);
+
+  window.matchMedia('(max-width: 1200px)').addEventListener('change', (e) => {
+    setHideToc(e.matches);
+  })
+
+  const tocStyles = mergeStyles({
+    display: hideToc ? 'none' : 'block',
+    fontFamily: 'Segoe UI Regular',
+    fontSize: '12px',
+    '& nav': { 
+      top: 0,
+      maxWidth: '10rem',
+      right: 0, 
+      'div > ol > li.toc-list-item': {
+        padding: '0 0.5rem',
+      },
+      'div > ol > li > a.toc-link': {
+        whiteSpace: 'break-spaces !important',
+        marginBottom: '4px',
+        marginTop: '4px',
+      },
+      'a.toc-link': {
+        whiteSpace: 'break-spaces !important',
+        marginBottom: '2px',
+        marginTop: '2px',
+      }
+    },
+  });
+
+  return (
+    <React.Fragment>
+        <div className={tocStyles}>
+          <TableOfContents />
+        </div>
+        <div>
+          {props.children}
+        </div>
+        <div className={mergeStyles({'> button': { right: 16 }})}>
+          <BackToTop />
+        </div>
+      </React.Fragment>
+  );
+} 

--- a/packages/storybook/.storybook/TOC.tsx
+++ b/packages/storybook/.storybook/TOC.tsx
@@ -10,11 +10,11 @@ import { BackToTop, TableOfContents } from 'storybook-docs-toc';
  */
 export const TOC = (props: {children: React.ReactNode}): JSX.Element => {
 
-  const [narrowDocs, setnarrowDocs] = useState(false);
+  const [narrowDocs, setNarrowDocs] = useState(false);
   const [hideToc, setHideToc] = useState(false);
 
   window.matchMedia('(max-width: 1200px)').addEventListener('change', (e) => {
-    setnarrowDocs(e.matches);
+    setNarrowDocs(e.matches);
   })
 
   window.matchMedia('(max-width: 900px)').addEventListener('change', (e) => {

--- a/packages/storybook/.storybook/TOC.tsx
+++ b/packages/storybook/.storybook/TOC.tsx
@@ -1,6 +1,9 @@
 import { mergeStyles } from '@fluentui/react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { BackToTop, TableOfContents } from 'storybook-docs-toc';
+
+const LAPTOP_WIDTH = '(max-width: 1200px)';
+const TABLET_WIDTH = '(max-width: 900px)';
 
 /**
  * Table Of Contents component used for displaying a floating table of content
@@ -10,16 +13,22 @@ import { BackToTop, TableOfContents } from 'storybook-docs-toc';
  */
 export const TOC = (props: {children: React.ReactNode}): JSX.Element => {
 
-  const [narrowDocs, setNarrowDocs] = useState(false);
-  const [hideToc, setHideToc] = useState(false);
+  const [narrowDocs, setNarrowDocs] = useState(window.matchMedia(LAPTOP_WIDTH).matches);
+  const [hideToc, setHideToc] = useState(window.matchMedia(TABLET_WIDTH).matches);
 
-  window.matchMedia('(max-width: 1200px)').addEventListener('change', (e) => {
-    setNarrowDocs(e.matches);
+  useEffect(() => {
+    const setNarrowDocsHandler = (e: MediaQueryListEvent) => setNarrowDocs(e.matches);
+    const setHideTocHandler = (e: MediaQueryListEvent) => setHideToc(e.matches);
+
+    window.matchMedia(LAPTOP_WIDTH).addEventListener('change', setNarrowDocsHandler);
+    window.matchMedia(TABLET_WIDTH).addEventListener('change', setHideTocHandler);
+
+    return () => {
+      window.matchMedia(LAPTOP_WIDTH).removeEventListener('change', setNarrowDocsHandler);
+      window.matchMedia(TABLET_WIDTH).removeEventListener('change', setHideTocHandler);
+    }
   })
 
-  window.matchMedia('(max-width: 900px)').addEventListener('change', (e) => {
-    setHideToc(e.matches);
-  })
 
   const tocStyles = mergeStyles({
     display: hideToc ? 'none' : 'block',

--- a/packages/storybook/.storybook/TOC.tsx
+++ b/packages/storybook/.storybook/TOC.tsx
@@ -2,6 +2,12 @@ import { mergeStyles } from '@fluentui/react';
 import React, { useState } from 'react';
 import { BackToTop, TableOfContents } from 'storybook-docs-toc';
 
+/**
+ * Table Of Contents component used for displaying a floating table of content
+ * inside Storybook Docs.
+ * @param props 
+ * @returns 
+ */
 export const TOC = (props: {children: React.ReactNode}): JSX.Element => {
 
   const [narrowDocs, setnarrowDocs] = useState(false);

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -4,9 +4,9 @@
 import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { FluentThemeProvider } from '@azure/communication-react';
-import { initializeIcons, loadTheme, mergeStyles } from '@fluentui/react';
+import { initializeIcons, loadTheme } from '@fluentui/react';
 import { DocsContainer } from '@storybook/addon-docs/blocks';
-import { BackToTop, TableOfContents } from 'storybook-docs-toc';
+import { TOC } from './TOC';
 import {
   COMPONENT_FOLDER_PREFIX,
   COMPOSITE_FOLDER_PREFIX,
@@ -24,15 +24,9 @@ export const parameters = {
   layout: 'fullscreen',
   docs: {
     container: props => (
-      <React.Fragment>
-        <div className={mergeStyles({'& nav': { right: 0 }})}>
-          <TableOfContents />
-        </div>
+      <TOC>
         <DocsContainer {...props} />
-        <div className={mergeStyles({'> button': { right: 0 }})}>
-          <BackToTop />
-        </div>
-      </React.Fragment>
+      </TOC>
     ),
   },
   options: {


### PR DESCRIPTION
# What
Table of contents is more stylized now. Looks sharper and has consistent fonts.
TOC has 
- reduced font sized 
- tighter margins
- Margins between list items.
- Margins between anchors.
- responsive. Will be hidden if the screen is not wide enough (1200px).

If viewport is wider than 1200px
![image](https://user-images.githubusercontent.com/9782747/120235476-f58e3380-c20e-11eb-864e-d7ccd3c664cc.png)

If viewport width is between 900px and 1200px
![image](https://user-images.githubusercontent.com/9782747/120236268-b6f97880-c210-11eb-81f2-0d5849d4be8e.png)

If viewport is smaller than 900px
![image](https://user-images.githubusercontent.com/9782747/120236676-d98b9180-c210-11eb-9ed2-d77a96264e1a.png)



# Why
For narrow screens, TOC would overlap content making it impossible to read.