### PR TITLE
Drop use of `getIdFromToken` in sample app

### DIFF
--- a/change/react-composites-681ee3e4-d90b-4c15-a798-18d86ef06e95.json
+++ b/change/react-composites-681ee3e4-d90b-4c15-a798-18d86ef06e95.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Drop internal export of getIdentifierFromToken",
+  "packageName": "react-composites",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/index.ts
+++ b/packages/react-composites/src/index.ts
@@ -4,7 +4,7 @@
 export * from './composites';
 export type { CommunicationUiErrorArgs, CommunicationUiErrorInfo, CommunicationUiErrorSeverity } from './types';
 
-export { propagateError, getIdFromToken, createAzureCommunicationUserCredential } from './utils';
+export { propagateError, createAzureCommunicationUserCredential } from './utils';
 export {
   CommunicationUiError,
   CommunicationUiErrorCode,

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -102,8 +102,7 @@ const App = (): JSX.Element => {
   useEffect(() => {
     // Create a new CallClient when at the home page or at the createCallClient page.
     if (page === 'createCallClient' || page === 'home') {
-      // This sample app does not use `userId`. The stateful client internally never uses it either.
-      const newStatefulCallClient = createStatefulCallClient({ userId: 'this_id_left_intentionally_blank' });
+      const newStatefulCallClient = createStatefulCallClient({ userId });
       setStatefulCallClient(newStatefulCallClient);
       page === 'createCallClient' && setPage('configuration');
 

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -22,7 +22,7 @@ import {
 } from './utils/AppUtils';
 import { localStorageAvailable } from './utils/constants';
 import { createStatefulCallClient, StatefulCallClient } from 'calling-stateful-client';
-import { getIdFromToken, createAzureCommunicationUserCredential } from 'react-composites';
+import { createAzureCommunicationUserCredential } from 'react-composites';
 import { AudioOptions, Call, CallAgent, GroupLocator } from '@azure/communication-calling';
 import { refreshTokenAsync } from './utils/refreshToken';
 
@@ -102,8 +102,8 @@ const App = (): JSX.Element => {
   useEffect(() => {
     // Create a new CallClient when at the home page or at the createCallClient page.
     if (page === 'createCallClient' || page === 'home') {
-      const userIdFromToken = token ? getIdFromToken(token) : '';
-      const newStatefulCallClient = createStatefulCallClient({ userId: userIdFromToken });
+      // This sample app does not use `userId`. The stateful client internally never uses it either.
+      const newStatefulCallClient = createStatefulCallClient({ userId: 'this_id_left_intentionally_blank' });
       setStatefulCallClient(newStatefulCallClient);
       page === 'createCallClient' && setPage('configuration');
 

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -115,7 +115,7 @@ const App = (): JSX.Element => {
       };
       askPermissionAndQueryDevices();
     }
-  }, [page, token]);
+  }, [page, token, userId]);
 
   /**
    * Routing flow of the sample app: (happy path)

--- a/samples/Calling/src/app/Lobby.tsx
+++ b/samples/Calling/src/app/Lobby.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import React, { useEffect, useState } from 'react';
-import { StreamMedia, VideoGalleryLocalParticipant, VideoStreamOptions, VideoTile } from 'react-components';
+import { StreamMedia, VideoStreamOptions, VideoTile, VideoGalleryStream } from 'react-components';
 import { useTheme } from '@fluentui/react-theme-provider';
 import { LobbyCallControlBar } from './LobbyControlBar';
 import { useCallingSelector as useSelector } from 'calling-component-bindings';
@@ -9,7 +9,7 @@ import { getIsPreviewCameraOn } from './selectors/baseSelectors';
 
 export interface LobbyProps {
   callState: string;
-  localParticipant: VideoGalleryLocalParticipant;
+  localParticipantVideoStream: VideoGalleryStream;
   localVideoViewOption?: VideoStreamOptions;
   isCameraChecked?: boolean;
   isMicrophoneChecked?: boolean;
@@ -27,9 +27,9 @@ export const Lobby = (props: LobbyProps): JSX.Element => {
   const [isButtonStatusSynced, setIsButtonStatusSynced] = useState(false);
   const isPreviewCameraOn = useSelector(getIsPreviewCameraOn);
 
-  const localVideoStream = props.localParticipant?.videoStream;
-  const isVideoReady = localVideoStream?.isAvailable;
-  const renderElement = props.localParticipant.videoStream?.renderElement;
+  const videoStream = props.localParticipantVideoStream;
+  const isVideoReady = videoStream.isAvailable;
+  const renderElement = videoStream.renderElement;
 
   const callStateText = props.callState === 'InLobby' ? 'Waiting to be admitted' : 'Connecting...';
 
@@ -52,13 +52,13 @@ export const Lobby = (props: LobbyProps): JSX.Element => {
   }, [isButtonStatusSynced, isPreviewCameraOn, isVideoReady, props, renderElement]);
 
   useEffect(() => {
-    if (localVideoStream && isVideoReady) {
+    if (videoStream && isVideoReady) {
       props.onCreateLocalStreamView &&
         props
           .onCreateLocalStreamView(props.localVideoViewOption)
           .catch((err) => console.log('Can not render video', err));
     }
-  }, [isVideoReady, localVideoStream, props, renderElement]);
+  }, [isVideoReady, videoStream, props, renderElement]);
 
   return (
     <VideoTile

--- a/samples/Calling/src/app/selectors/baseSelectors.ts
+++ b/samples/Calling/src/app/selectors/baseSelectors.ts
@@ -19,8 +19,6 @@ export const getCall = (state: CallClientState, props: CallingBaseSelectorProps)
 
 export const getDisplayName = (state: CallClientState): string | undefined => state.callAgent?.displayName;
 
-export const getIdentifier = (state: CallClientState): string => state.userId;
-
 export const getIsPreviewCameraOn = (state: CallClientState): boolean => isPreviewOn(state.deviceManager);
 
 // TODO: we should take in a LocalVideoStream that developer wants to use as their 'Preview' view. We should also handle

--- a/samples/Calling/src/app/selectors/lobbySelector.ts
+++ b/samples/Calling/src/app/selectors/lobbySelector.ts
@@ -5,24 +5,15 @@ import * as reselect from 'reselect';
 // @ts-ignore
 import { CallState, CallClientState, LocalVideoStream } from 'calling-stateful-client';
 // @ts-ignore
-import { getCall, CallingBaseSelectorProps, getDisplayName, getIdentifier } from 'calling-component-bindings';
+import { getCall, CallingBaseSelectorProps } from 'calling-component-bindings';
 
-export const lobbySelector = reselect.createSelector(
-  [getCall, getDisplayName, getIdentifier],
-  (call: CallState | undefined, displayName: string | undefined, identifier: string | undefined) => {
-    const localVideoStream = call?.localVideoStreams.find((i) => i.mediaStreamType === 'Video');
-    return {
-      localParticipant: {
-        userId: identifier ?? '',
-        displayName: displayName ?? '',
-        isMuted: call?.isMuted,
-        isScreenSharingOn: call?.isScreenSharingOn,
-        videoStream: {
-          isAvailable: !!localVideoStream,
-          isMirrored: localVideoStream?.view?.isMirrored,
-          renderElement: localVideoStream?.view?.target
-        }
-      }
-    };
-  }
-);
+export const lobbySelector = reselect.createSelector([getCall], (call: CallState | undefined) => {
+  const localVideoStream = call?.localVideoStreams.find((i) => i.mediaStreamType === 'Video');
+  return {
+    localParticipantVideoStream: {
+      isAvailable: !!localVideoStream,
+      isMirrored: localVideoStream?.view?.isMirrored,
+      renderElement: localVideoStream?.view?.target
+    }
+  };
+});

--- a/samples/Chat/src/app/App.tsx
+++ b/samples/Chat/src/app/App.tsx
@@ -34,7 +34,6 @@ export default (): JSX.Element => {
 
   useEffect(() => {
     if (token && userId && displayName && threadId && endpointUrl) {
-      // This hack can be removed when `getIdFromToken` is dropped in favour of actually passing in user credentials.
       const userIdKind = { kind: 'communicationUser', communicationUserId: userId } as CommunicationUserKind;
       const createClient = async (): Promise<void> => {
         const chatClient = createStatefulChatClient({


### PR DESCRIPTION
# What
Drop use of `getIdFromToken` and stop (non-release) exporting it from `react-composites`.

# Why
This is an unnecessasry hack going from token -> ID, when the ID is both already available in the sample, and not even required.

# How Tested
Joined a Teams meeting from Calling sample and ensured Lobby looks good with / without video turned on.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->