### PR TITLE
CallComposite: Drop spurious use of composite supplied userId

### DIFF
--- a/change/react-composites-ab0efec4-3f3e-4f24-904a-931a619f4e2f.json
+++ b/change/react-composites-ab0efec4-3f3e-4f24-904a-931a619f4e2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Drop spurious references to userId in lobby",
+  "packageName": "react-composites",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/Lobby.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Lobby.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import React, { useEffect, useState } from 'react';
-import { StreamMedia, VideoGalleryLocalParticipant, VideoStreamOptions, VideoTile } from 'react-components';
+import { StreamMedia, VideoGalleryStream, VideoStreamOptions, VideoTile } from 'react-components';
 import { useTheme } from '@fluentui/react-theme-provider';
 import { LobbyCallControlBar } from './LobbyControlBar';
 import { useSelector } from './hooks/useSelector';
@@ -9,7 +9,7 @@ import { getIsPreviewCameraOn } from './selectors/baseSelectors';
 
 export interface LobbyProps {
   callState: string;
-  localParticipant: VideoGalleryLocalParticipant;
+  localParticipantVideoStream: VideoGalleryStream;
   localVideoViewOption?: VideoStreamOptions;
   isCameraChecked?: boolean;
   isMicrophoneChecked?: boolean;
@@ -27,9 +27,9 @@ export const Lobby = (props: LobbyProps): JSX.Element => {
   const [isButtonStatusSynced, setIsButtonStatusSynced] = useState(false);
   const isPreviewCameraOn = useSelector(getIsPreviewCameraOn);
 
-  const localVideoStream = props.localParticipant?.videoStream;
-  const isVideoReady = localVideoStream?.isAvailable;
-  const renderElement = props.localParticipant.videoStream?.renderElement;
+  const videoStream = props.localParticipantVideoStream;
+  const isVideoReady = videoStream.isAvailable;
+  const renderElement = videoStream.renderElement;
 
   const callStateText = props.callState === 'InLobby' ? 'Waiting to be admitted' : 'Connecting...';
 
@@ -52,13 +52,13 @@ export const Lobby = (props: LobbyProps): JSX.Element => {
   }, [isButtonStatusSynced, isPreviewCameraOn, isVideoReady, props, renderElement]);
 
   useEffect(() => {
-    if (localVideoStream && isVideoReady) {
+    if (videoStream && isVideoReady) {
       props.onCreateLocalStreamView &&
         props
           .onCreateLocalStreamView(props.localVideoViewOption)
           .catch((err) => console.log('Can not render video', err));
     }
-  }, [isVideoReady, localVideoStream, props, renderElement]);
+  }, [isVideoReady, videoStream, props, renderElement]);
 
   return (
     <VideoTile

--- a/packages/react-composites/src/composites/CallComposite/selectors/lobbySelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/lobbySelector.ts
@@ -3,24 +3,15 @@
 
 import * as reselect from 'reselect';
 import { CallState } from 'calling-stateful-client';
-import { getCall, getDisplayName, getIdentifier } from './baseSelectors';
+import { getCall } from './baseSelectors';
 
-export const lobbySelector = reselect.createSelector(
-  [getCall, getDisplayName, getIdentifier],
-  (call: CallState | undefined, displayName: string | undefined, identifier: string | undefined) => {
-    const localVideoStream = call?.localVideoStreams.find((i) => i.mediaStreamType === 'Video');
-    return {
-      localParticipant: {
-        userId: identifier ?? '',
-        displayName: displayName ?? '',
-        isMuted: call?.isMuted,
-        isScreenSharingOn: call?.isScreenSharingOn,
-        videoStream: {
-          isAvailable: !!localVideoStream,
-          isMirrored: localVideoStream?.view?.isMirrored,
-          renderElement: localVideoStream?.view?.target
-        }
-      }
-    };
-  }
-);
+export const lobbySelector = reselect.createSelector([getCall], (call: CallState | undefined) => {
+  const localVideoStream = call?.localVideoStreams.find((i) => i.mediaStreamType === 'Video');
+  return {
+    localParticipantVideoStream: {
+      isAvailable: !!localVideoStream,
+      isMirrored: localVideoStream?.view?.isMirrored,
+      renderElement: localVideoStream?.view?.target
+    }
+  };
+});


### PR DESCRIPTION
# What

* Drop a spurious reference to userId in CallComposite

# Why

* A step towards removing the use of `getIdFromToken` hack from `CallComposite`.

# How Tested

* Manually verified `CallComposite` stories.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->