### PR TITLE
Drop userID from isMutedChanged event

### DIFF
--- a/change/react-composites-f2c9f955-12d8-4ba1-b7ee-b078587bc436.json
+++ b/change/react-composites-f2c9f955-12d8-4ba1-b7ee-b078587bc436.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Breaking: Drop Contoso-supplied fixed userId from isMutedChanged event.",
+  "packageName": "react-composites",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-composites-ffb020ed-60c7-48d0-a0af-533ea209fc1a.json
+++ b/change/react-composites-ffb020ed-60c7-48d0-a0af-533ea209fc1a.json
@@ -1,0 +1,6 @@
+{
+  "type": "prerelease",
+  "packageName": "react-composites",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -820,7 +820,6 @@ export interface IncomingCallState {
 
 // @public (undocumented)
 export type IsMuteChangedListener = (event: {
-    identifier: CallIdentifierKinds;
     isMuted: boolean;
 }) => void;
 

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -361,7 +361,6 @@ export type IncomingCallListener = (event: {
 
 // @public (undocumented)
 export type IsMuteChangedListener = (event: {
-    identifier: CallIdentifierKinds;
     isMuted: boolean;
 }) => void;
 

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -41,8 +41,7 @@ import {
 import { createAzureCommunicationUserCredential, getIdFromToken, isInCall } from '../../../utils';
 import { VideoStreamOptions } from 'react-components';
 import { fromFlatCommunicationIdentifier, toFlatCommunicationIdentifier } from 'acs-ui-common';
-import { CommunicationUserIdentifier } from '@azure/communication-signaling';
-import { CommunicationUserKind } from '@azure/communication-common';
+import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { ParticipantSubscriber } from './ParticipantSubcriber';
 
 // Context of Chat, which is a centralized context for all state updates
@@ -337,7 +336,7 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
 
   private subscribeCallEvents(): void {
     this.call?.on('remoteParticipantsUpdated', this.onRemoteParticipantsUpdated);
-    this.call?.on('isMutedChanged', this.isMyMutedChanged);
+    this.call?.on('isMutedChanged', this.isMutedChanged);
     this.call?.on('isScreenSharingOnChanged', this.isScreenSharingOnChanged);
     this.call?.on('idChanged', this.callIdChanged);
   }
@@ -348,17 +347,10 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
     }
     this.participantSubscribers.clear();
     this.call?.off('remoteParticipantsUpdated', this.onRemoteParticipantsUpdated);
-    this.call?.off('isMutedChanged', this.isMyMutedChanged);
+    this.call?.off('isMutedChanged', this.isMutedChanged);
     this.call?.off('isScreenSharingOnChanged', this.isScreenSharingOnChanged);
     this.call?.off('idChanged', this.callIdChanged);
   }
-
-  private isMyMutedChanged = (): void => {
-    this.emitter.emit('isMutedChanged', {
-      participantId: createCommunicationIdentifier(this.getState().userId),
-      isMuted: this.call?.isMuted
-    });
-  };
 
   public setPage = (page: CallCompositePage): void => {
     this.context.setPage(page);
@@ -392,6 +384,10 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
     });
   };
 
+  private isMutedChanged = (): void => {
+    this.emitter.emit('isMutedChanged', { isMuted: this.call?.isMuted });
+  };
+
   private isScreenSharingOnChanged = (): void => {
     this.emitter.emit('isLocalScreenSharingActiveChanged', { isScreenSharingOn: this.call?.isScreenSharingOn });
   };
@@ -422,10 +418,6 @@ const isPreviewOn = (deviceManager: DeviceManagerState): boolean => {
   // TODO: we should take in a LocalVideoStream that developer wants to use as their 'Preview' view. We should also
   // handle cases where 'Preview' view is in progress and not necessary completed.
   return deviceManager.unparentedViews.values().next().value?.view !== undefined;
-};
-
-const createCommunicationIdentifier = (rawId: string): CommunicationUserKind => {
-  return { kind: 'communicationUser', communicationUserId: rawId };
 };
 
 export const createAzureCommunicationCallAdapter = async (

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -62,7 +62,7 @@ export type ParticipantJoinedListener = (event: { joined: RemoteParticipant[] })
 
 export type ParticipantLeftListener = (event: { removed: RemoteParticipant[] }) => void;
 
-export type IsMuteChangedListener = (event: { identifier: CallIdentifierKinds; isMuted: boolean }) => void;
+export type IsMuteChangedListener = (event: { isMuted: boolean }) => void;
 
 export type CallIdChangedListener = (event: { callId: string }) => void;
 


### PR DESCRIPTION
# What

* Breaking change to CallAdapter API
* Drops the userId field from isMutedChanged event.

# Why

* Base Calling event doesn't include the user ID.
* The event *always* triggers for the local user (that's why base SDK doesn't include user ID).
* This was the *only place* where the user ID reported was the one stored in the stateful client context, the one provided by Contoso. In the case of CallComposite, this happens to be the same as the actual ACS ID because it's extracted from the token provided when creating the adapter. This is potentially very confusing because all other instances where a user ID is reported, the ID comes from the ACS services.
* Dropping this allows us to stop using the `getIdFromToken` hack and stop storing the user ID entirely in the adapter state (it's not needed anywhere else).

Profit!

# How Tested

`rush build`
`rush test`

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [x] This change causes current functionality to break.
<!--- If yes, describe the impact. -->