### PR TITLE
Make arguments to CreateStatefulCallClient optional

### DIFF
--- a/change/calling-stateful-client-fd252e0a-f601-4c87-ae6a-06b7284e6614.json
+++ b/change/calling-stateful-client-fd252e0a-f601-4c87-ae6a-06b7284e6614.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Breaking: Make arguments to CreateStatefulCallClient optional",
+  "packageName": "calling-stateful-client",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -65,7 +65,7 @@ export interface CallState {
 }
 
 // @public
-export const createStatefulCallClient: (args: StatefulCallClientArgs, options?: StatefulCallClientOptions | undefined) => StatefulCallClient;
+export const createStatefulCallClient: (args?: StatefulCallClientArgs | undefined, options?: StatefulCallClientOptions | undefined) => StatefulCallClient;
 
 // @public
 export type DeviceManagerState = {
@@ -131,7 +131,7 @@ export interface StatefulCallClient extends CallClient {
 
 // @public
 export type StatefulCallClientArgs = {
-    userId: string;
+    userId?: string;
 };
 
 // @public

--- a/packages/calling-stateful-client/src/StatefulCallClient.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.ts
@@ -200,7 +200,7 @@ export type StatefulCallClientArgs = {
    * state. It is not used by StatefulCallClient so if you do not have this value or do not want to use this value,
    * you could pass any dummy value like empty string.
    */
-  userId: string;
+  userId?: string;
 };
 
 /**
@@ -232,11 +232,14 @@ export type StatefulCallClientOptions = {
  * @returns
  */
 export const createStatefulCallClient = (
-  args: StatefulCallClientArgs,
+  args?: StatefulCallClientArgs,
   options?: StatefulCallClientOptions
 ): StatefulCallClient => {
   const callClient = new CallClient(options?.callClientOptions);
-  const context: CallContext = new CallContext(args.userId, options?.maxStateChangeListeners);
+  const context: CallContext = new CallContext(
+    args?.userId ?? 'contoso_user_id_not_set',
+    options?.maxStateChangeListeners
+  );
   const internalContext: InternalCallContext = new InternalCallContext();
 
   Object.defineProperty(callClient, 'getState', {

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -655,7 +655,7 @@ export const createDefaultChatHandlers: (chatClient: StatefulChatClient, chatThr
 export const createDefaultChatHandlersForComponent: <Props>(chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, _: (props: Props) => ReactElement | null) => Pick<DefaultChatHandlers, CommonProperties<DefaultChatHandlers, Props>>;
 
 // @public
-export const createStatefulCallClient: (args: StatefulCallClientArgs, options?: StatefulCallClientOptions | undefined) => StatefulCallClient;
+export const createStatefulCallClient: (args?: StatefulCallClientArgs | undefined, options?: StatefulCallClientOptions | undefined) => StatefulCallClient;
 
 // @public
 export const createStatefulChatClient: (args: StatefulChatClientArgs, options?: StatefulChatClientOptions | undefined) => StatefulChatClient;
@@ -1167,7 +1167,7 @@ export interface StatefulCallClient extends CallClient {
 
 // @public
 export type StatefulCallClientArgs = {
-    userId: string;
+    userId?: string;
 };
 
 // @public


### PR DESCRIPTION
# What

The only argument this takes currently is a `userId`. This user ID is a Contoso supplied string that is merely persisted in the state. The documentation states that Contoso doesn't have to provide it. So make it so. The simplest way to create the object now is simply:

    createStatefulCallClient()

# Why

Make the types say what the documentation says.

# How Tested

`rush build`
`rush test`

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [x] This change causes current functionality to break.
<!--- If yes, describe the impact. -->