### PR TITLE
Auto Smooth Scroll to the top on storybook page change

### DIFF
--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { FluentThemeProvider } from '@azure/communication-react';
 import { initializeIcons, loadTheme } from '@fluentui/react';
-import { DocsContainer } from '@storybook/addon-docs/blocks';
+import { Anchor, DocsContainer } from '@storybook/addon-docs/blocks';
 import { TOC } from './TOC';
 import {
   COMPONENT_FOLDER_PREFIX,
@@ -25,7 +25,10 @@ export const parameters = {
   docs: {
     container: props => (
       <TOC>
-        <DocsContainer {...props} />
+        <DocsContainer context={props.context}>
+          <Anchor storyId={props.context.id} />
+          {props.children}
+        </DocsContainer>
       </TOC>
     ),
   },


### PR DESCRIPTION
# What
Storybook will now automatically scroll to the top if a user changes a page.
It is a smooth scroll.


https://user-images.githubusercontent.com/9782747/120379587-d35ee900-c2d4-11eb-9242-49831d2a050b.mp4

# Why
If a user was halfway in a storybook doc and switched to another page, the scrollbar remained at the same position requiring the user to manually scroll to the top.

