### PR TITLE
Add userId to ChatAdapter factory function

### DIFF
--- a/change/react-composites-56d1f128-3f50-4329-85fb-63c17b6c13bc.json
+++ b/change/react-composites-56d1f128-3f50-4329-85fb-63c17b6c13bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add userId to ChatAdapter factory function",
+  "packageName": "react-composites",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -625,7 +625,7 @@ export interface ControlBarProps {
 export const createAzureCommunicationCallAdapter: (token: string, locator: TeamsMeetingLinkLocator | GroupCallLocator, displayName: string, refreshTokenCallback?: (() => Promise<string>) | undefined, callClientOptions?: CallClientOptions | undefined) => Promise<CallAdapter>;
 
 // @public (undocumented)
-export const createAzureCommunicationChatAdapter: (token: string, endpointUrl: string, threadId: string, displayName: string, refreshTokenCallback?: (() => Promise<string>) | undefined) => Promise<ChatAdapter>;
+export const createAzureCommunicationChatAdapter: (userId: CommunicationUserIdentifier, token: string, endpointUrl: string, threadId: string, displayName: string, refreshTokenCallback?: (() => Promise<string>) | undefined) => Promise<ChatAdapter>;
 
 // @public (undocumented)
 export const createDefaultCallingHandlers: (callClient: StatefulCallClient, callAgent: CallAgent | undefined, deviceManager: StatefulDeviceManager | undefined, call: Call | undefined) => {

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -12,6 +12,7 @@ import { CallState } from 'calling-stateful-client';
 import type { ChatMessage } from '@azure/communication-chat';
 import type { ChatParticipant } from '@azure/communication-chat';
 import { ChatThreadClientState } from 'chat-stateful-client';
+import { CommunicationUserIdentifier } from '@azure/communication-common';
 import type { CommunicationUserKind } from '@azure/communication-common';
 import { DeviceManagerState } from 'calling-stateful-client';
 import { GroupCallLocator } from '@azure/communication-calling';
@@ -342,7 +343,7 @@ export type ChatUIState = {
 export const createAzureCommunicationCallAdapter: (token: string, locator: TeamsMeetingLinkLocator | GroupCallLocator, displayName: string, refreshTokenCallback?: (() => Promise<string>) | undefined, callClientOptions?: CallClientOptions | undefined) => Promise<CallAdapter>;
 
 // @public (undocumented)
-export const createAzureCommunicationChatAdapter: (token: string, endpointUrl: string, threadId: string, displayName: string, refreshTokenCallback?: (() => Promise<string>) | undefined) => Promise<ChatAdapter>;
+export const createAzureCommunicationChatAdapter: (userId: CommunicationUserIdentifier, token: string, endpointUrl: string, threadId: string, displayName: string, refreshTokenCallback?: (() => Promise<string>) | undefined) => Promise<ChatAdapter>;
 
 // @public (undocumented)
 export type DisplayNameChangedListener = (event: {

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -5,17 +5,17 @@ import { createStatefulChatClient, ChatClientState, StatefulChatClient } from 'c
 import { DefaultChatHandlers, createDefaultChatHandlers } from 'chat-component-bindings';
 import { ChatMessage, ChatThreadClient } from '@azure/communication-chat';
 
+import { CommunicationUserIdentifier, CommunicationUserKind, getIdentifierKind } from '@azure/communication-common';
 import type {
   ChatMessageReceivedEvent,
   ChatThreadPropertiesUpdatedEvent,
-  CommunicationUserKind,
   ParticipantsAddedEvent,
   ParticipantsRemovedEvent,
   ReadReceiptReceivedEvent
 } from '@azure/communication-signaling';
 import { toFlatCommunicationIdentifier } from 'acs-ui-common';
 import EventEmitter from 'events';
-import { createAzureCommunicationUserCredential, getIdFromToken } from '../../../utils';
+import { createAzureCommunicationUserCredential } from '../../../utils';
 import {
   ChatAdapter,
   ChatEvent,
@@ -244,18 +244,15 @@ const convertEventToChatMessage = (event: ChatMessageReceivedEvent): ChatMessage
 };
 
 export const createAzureCommunicationChatAdapter = async (
+  userId: CommunicationUserIdentifier,
   token: string,
   endpointUrl: string,
   threadId: string,
   displayName: string,
   refreshTokenCallback?: (() => Promise<string>) | undefined
 ): Promise<ChatAdapter> => {
-  const rawUserId = getIdFromToken(token);
-
-  // This hack can be removed when `getIdFromToken` is dropped in favour of actually passing in user credentials.
-  const userId = <CommunicationUserKind>{ kind: 'communicationUser', communicationUserId: rawUserId };
   const chatClient = createStatefulChatClient({
-    userId,
+    userId: getIdentifierKind(userId) as CommunicationUserKind,
     displayName,
     endpoint: endpointUrl,
     credential: createAzureCommunicationUserCredential(token, refreshTokenCallback)

--- a/packages/storybook/stories/ChatComposite/CustomBehaviorExampleContainer.tsx
+++ b/packages/storybook/stories/ChatComposite/CustomBehaviorExampleContainer.tsx
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { ChatAdapter, ChatComposite, createAzureCommunicationChatAdapter } from '@azure/communication-react';
 import React, { useState, useEffect } from 'react';
 
 export type ContainerProps = {
+  userId: CommunicationUserIdentifier;
   token: string;
   displayName: string;
   endpointUrl: string;
@@ -22,6 +24,7 @@ export const ContosoChatContainer = (props: ContainerProps): JSX.Element => {
 
     const createAdapter = async (): Promise<void> => {
       const newAdapter = await createAzureCommunicationChatAdapter(
+        props.userId,
         props.token,
         props.endpointUrl,
         props.threadId,

--- a/packages/storybook/stories/ChatComposite/snippets/Container.snippet.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/Container.snippet.tsx
@@ -1,8 +1,10 @@
+import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { ChatAdapter, ChatComposite, createAzureCommunicationChatAdapter } from '@azure/communication-react';
 import { Theme, PartialTheme } from '@fluentui/react-theme-provider';
 import React, { useState, useEffect } from 'react';
 
 export type ContainerProps = {
+  userId: CommunicationUserIdentifier;
   token: string;
   displayName: string;
   endpointUrl: string;
@@ -19,7 +21,13 @@ export const ContosoChatContainer = (props: ContainerProps): JSX.Element => {
     if (props) {
       const createAdapter = async (): Promise<void> => {
         setAdapter(
-          await createAzureCommunicationChatAdapter(props.token, props.endpointUrl, props.threadId, props.displayName)
+          await createAzureCommunicationChatAdapter(
+            props.userId,
+            props.token,
+            props.endpointUrl,
+            props.threadId,
+            props.displayName
+          )
         );
       };
       createAdapter();

--- a/packages/storybook/stories/ChatComposite/snippets/CustomDataModelExampleContainer.snippet.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/CustomDataModelExampleContainer.snippet.tsx
@@ -1,7 +1,9 @@
+import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { ChatAdapter, ChatComposite, createAzureCommunicationChatAdapter } from '@azure/communication-react';
 import React, { useState, useEffect, useCallback } from 'react';
 
 export interface CustomDataModelExampleContainerProps {
+  userId: CommunicationUserIdentifier;
   token: string;
   displayName: string;
   endpointUrl: string;
@@ -20,6 +22,7 @@ export const CustomDataModelExampleContainer = (props: CustomDataModelExampleCon
       const createAdapter = async (): Promise<void> => {
         setAdapter(
           await createAzureCommunicationChatAdapter(
+            props.userId,
             props.token,
             props.endpointUrl,
             props.threadId,

--- a/packages/storybook/stories/ChatComposite/snippets/CustomizeBehavior.snippet.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/CustomizeBehavior.snippet.tsx
@@ -1,7 +1,9 @@
+import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { ChatAdapter, ChatComposite, createAzureCommunicationChatAdapter } from '@azure/communication-react';
 import React, { useState, useEffect } from 'react';
 
 export type ContainerProps = {
+  userId: CommunicationUserIdentifier;
   token: string;
   displayName: string;
   endpointUrl: string;
@@ -16,6 +18,7 @@ export const ContosoChatContainer = (props: ContainerProps): JSX.Element => {
 
     const createAdapter = async (): Promise<void> => {
       const chatAdapter = await createAzureCommunicationChatAdapter(
+        props.userId,
         props.token,
         props.endpointUrl,
         props.threadId,

--- a/packages/storybook/stories/ChatComposite/snippets/JoinExistingChatThread.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/JoinExistingChatThread.tsx
@@ -11,12 +11,17 @@ export const JoinExistingChatThread: () => JSX.Element = () => {
   const knobs = useRef({
     endpointUrl: text('Azure Communication Services endpoint URL', '', 'External chat'),
     threadId: text('Existing thread', '', 'External chat'),
+    userId: text('User identifier for user', '', 'External chat'),
     token: text('Valid token for user', '', 'External chat'),
     displayName: text('Display name', '', 'External chat')
   });
 
   const areAllKnobsSet =
-    !!knobs.current.endpointUrl && !!knobs.current.threadId && !!knobs.current.token && !!knobs.current.displayName;
+    !!knobs.current.endpointUrl &&
+    !!knobs.current.threadId &&
+    !!knobs.current.userId &&
+    !!knobs.current.token &&
+    !!knobs.current.displayName;
 
   return (
     <div style={COMPOSITE_EXPERIENCE_CONTAINER_STYLE}>
@@ -24,6 +29,7 @@ export const JoinExistingChatThread: () => JSX.Element = () => {
         <ContosoChatContainer
           endpointUrl={knobs.current.endpointUrl}
           threadId={knobs.current.threadId}
+          userId={{ communicationUserId: knobs.current.userId }}
           token={knobs.current.token}
           displayName={knobs.current.displayName}
         />

--- a/packages/storybook/stories/ChatComposite/snippets/Server.snippet.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/Server.snippet.tsx
@@ -17,6 +17,7 @@ export const createUserAndThread = async (resourceConnectionString: string, disp
   await chatClient.getChatThreadClient(threadId).updateTopic('Chat with a friendly bot');
 
   return {
+    userId: user.user,
     token: user.token,
     endpointUrl,
     displayName,

--- a/packages/storybook/stories/QuickStarts/snippets/QuickstartCompositeAdapter.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/QuickstartCompositeAdapter.snippet.tsx
@@ -8,6 +8,7 @@ import React, { useState, useEffect } from 'react';
 
 function App(): JSX.Element {
   const endpointUrl = '<Azure Communication Services Resource Endpoint>';
+  const userId = '<Azure Communication Services Identifier>';
   const displayName = '<Display Name>';
   const token = '<Azure Communication Services Access Token>';
 
@@ -22,7 +23,15 @@ function App(): JSX.Element {
 
   useEffect(() => {
     const createAdapter = async (): Promise<void> => {
-      setChatAdapter(await createAzureCommunicationChatAdapter(token, endpointUrl, threadId, displayName));
+      setChatAdapter(
+        await createAzureCommunicationChatAdapter(
+          { communicationUserId: userId },
+          token,
+          endpointUrl,
+          threadId,
+          displayName
+        )
+      );
       setCallAdapter(await createAzureCommunicationCallAdapter(token, { groupId }, displayName));
     };
     createAdapter();

--- a/packages/storybook/stories/QuickStarts/snippets/QuickstartCompositeComplete.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/QuickstartCompositeComplete.snippet.tsx
@@ -10,6 +10,7 @@ import React, { useState, useEffect } from 'react';
 
 function App(): JSX.Element {
   const endpointUrl = '<Azure Communication Services Resource Endpoint>';
+  const userId = '<Azure Communication Services Identifier>';
   const displayName = '<Display Name>';
   const token = '<Azure Communication Services Access Token>';
 
@@ -24,7 +25,15 @@ function App(): JSX.Element {
 
   useEffect(() => {
     const createAdapter = async (): Promise<void> => {
-      setChatAdapter(await createAzureCommunicationChatAdapter(token, endpointUrl, threadId, displayName));
+      setChatAdapter(
+        await createAzureCommunicationChatAdapter(
+          { communicationUserId: userId },
+          token,
+          endpointUrl,
+          threadId,
+          displayName
+        )
+      );
       setCallAdapter(await createAzureCommunicationCallAdapter(token, { groupId }, displayName));
     };
     createAdapter();


### PR DESCRIPTION
# Why
A step towards deleting `getIdFromToken` hack.

# How Tested
Played with various `ChatComposite` canvases on local storybook.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [x] This change causes current functionality to break.
<!--- If yes, describe the impact. -->