### PR TITLE
Update UseCases.stories to clarify iOS vs macOS screensharing support

### DIFF
--- a/packages/storybook/stories/UseCases.stories.mdx
+++ b/packages/storybook/stories/UseCases.stories.mdx
@@ -123,7 +123,7 @@ previous two releases.
 
 \*\*Note that Safari versions 13.1+ are supported. Outgoing video for Safari
 macOS is not yet supported, but it is supported on iOS. Outgoing screen sharing
-is only supported on desktop iOS.
+is only supported on desktop (macOS).
 
 ## Accessibility
 

--- a/packages/storybook/stories/UseCases.stories.mdx
+++ b/packages/storybook/stories/UseCases.stories.mdx
@@ -116,14 +116,17 @@ These client libraries also require the context for the call or chat they will j
 
 | SDK    | Windows            | macOS                | Ubuntu   | Linux    | Android  | iOS        |
 | ------ | ------------------ | -------------------- | -------- | -------- | -------- | ---------- |
-| UI SDK | Chrome\*, new Edge | Chrome\*, Safari\*\* | Chrome\* | Chrome\* | Chrome\* | Safari\*\* |
+| UI SDK - Calling | Chrome\*, new Edge | Chrome\*, Safari\*\* | Chrome\* | Chrome\* | Chrome\*\* | Safari\*\*\* |
+| UI SDK - Chat    | Firefox\*, Chrome\*, new Edge | Firefox\*, Chrome\*, Safari\* | Chrome\* | Chrome\* | Safari\*|
 
-\*Note that the latest version of Chrome is supported in addition to the
+\*Note that the latest version is supported in addition to the
 previous two releases.
 
-\*\*Note that Safari versions 13.1+ are supported. Outgoing video for Safari
-macOS is not yet supported, but it is supported on iOS. Outgoing screen sharing
-is only supported on desktop (macOS).
+\*\*Note that outgoing screen sharing is not supported for Chrome on Android.
+
+\*\*\*Note that Safari versions 13.1+ are supported. 1:1 calls are not supported on Safari. Outgoing video for Safari
+macOS supported only for Safari 14+/macOS 11+. Outgoing screen sharing
+is not supported on iOS, device enumeration (for example Bluetooth) is limited by OS, only one device available.
 
 ## Accessibility
 

--- a/packages/storybook/stories/UseCases.stories.mdx
+++ b/packages/storybook/stories/UseCases.stories.mdx
@@ -126,7 +126,7 @@ previous two releases.
 
 \*\*\*Note that Safari versions 13.1+ are supported. 1:1 calls are not supported on Safari. Outgoing video for Safari
 macOS supported only for Safari 14+/macOS 11+. Outgoing screen sharing
-is not supported on iOS, device enumeration (for example Bluetooth) is limited by OS, only one device available.
+is not supported on iOS, device selection(for example choosing Bluetooth headset) is limited by OS, only one device available.
 
 ## Accessibility
 


### PR DESCRIPTION
# What

> Outgoing screen sharing is only supported on desktop iOS.

Current storybook describes desktop iOS instead of desktop (macOS). Should here be a mention that screensharing on iOS is only supported via the native SDK? (if that is supported)

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
does not apply 

# Process & policy checklist

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->