### PR TITLE
Store and expose userId in call state as structured object

### DIFF
--- a/change/calling-component-bindings-44281a38-e134-4110-a5b0-9366d8f50544.json
+++ b/change/calling-component-bindings-44281a38-e134-4110-a5b0-9366d8f50544.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Serialize userId from state",
+  "packageName": "calling-component-bindings",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/calling-stateful-client-70134a8e-add0-473c-b5d7-c57db46f2829.json
+++ b/change/calling-stateful-client-70134a8e-add0-473c-b5d7-c57db46f2829.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Store userId as CommunicationUserKind",
+  "packageName": "calling-stateful-client",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-composites-94269ab5-208b-4951-a650-ceb061ae966e.json
+++ b/change/react-composites-94269ab5-208b-4951-a650-ceb061ae966e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "CallAdapter: store userId as CommunicationUserKind",
+  "packageName": "react-composites",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/src/baseSelectors.ts
+++ b/packages/calling-component-bindings/src/baseSelectors.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { toFlatCommunicationIdentifier } from 'acs-ui-common';
 import { CallState, CallClientState, DeviceManagerState, IncomingCallState } from 'calling-stateful-client';
 
 /**
@@ -25,4 +26,4 @@ export const getCall = (state: CallClientState, props: CallingBaseSelectorProps)
 
 export const getDisplayName = (state: CallClientState): string | undefined => state.callAgent?.displayName;
 
-export const getIdentifier = (state: CallClientState): string => state.userId;
+export const getIdentifier = (state: CallClientState): string => toFlatCommunicationIdentifier(state.userId);

--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -41,7 +41,7 @@ export interface CallClientState {
     deviceManager: DeviceManagerState;
     incomingCalls: Map<string, IncomingCallState>;
     incomingCallsEnded: IncomingCallState[];
-    userId: CommunicationUserIdentifier;
+    userId: CommunicationUserKind;
 }
 
 // @public

--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -41,7 +41,7 @@ export interface CallClientState {
     deviceManager: DeviceManagerState;
     incomingCalls: Map<string, IncomingCallState>;
     incomingCallsEnded: IncomingCallState[];
-    userId: string;
+    userId: CommunicationUserIdentifier;
 }
 
 // @public
@@ -65,7 +65,7 @@ export interface CallState {
 }
 
 // @public
-export const createStatefulCallClient: (args?: StatefulCallClientArgs | undefined, options?: StatefulCallClientOptions | undefined) => StatefulCallClient;
+export const createStatefulCallClient: (args: StatefulCallClientArgs, options?: StatefulCallClientOptions | undefined) => StatefulCallClient;
 
 // @public
 export type DeviceManagerState = {
@@ -131,7 +131,7 @@ export interface StatefulCallClient extends CallClient {
 
 // @public
 export type StatefulCallClientArgs = {
-    userId?: string;
+    userId: CommunicationUserKind;
 };
 
 // @public

--- a/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
@@ -153,7 +153,7 @@ class MockCallAgentWithMultipleCalls implements CallAgent {
 describe('declarative call agent', () => {
   test('should subscribe to callsUpdated and incomingCall events when created', () => {
     const mockCallAgent = new MockCallAgent();
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
     callAgentDeclaratify(mockCallAgent, context, internalContext);
     expect(mockCallAgent.emitter.eventNames().includes('incomingCall')).toBe(true);
@@ -162,7 +162,7 @@ describe('declarative call agent', () => {
 
   test('should subscribe to any existing calls and add to state when created', () => {
     const mockCallAgent = new MockCallAgent();
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const mockCall = createMockCall(mockCallId);
     mockCallAgent.calls = [mockCall];
     const internalContext = new InternalCallContext();
@@ -173,7 +173,7 @@ describe('declarative call agent', () => {
 
   test('should unsubscribe but not clear data when disposed is invoked', async () => {
     const mockCallAgent = new MockCallAgent();
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
     const mockCall = createMockCall(mockCallId);
     mockCallAgent.calls = [mockCall];
@@ -186,7 +186,7 @@ describe('declarative call agent', () => {
 
   test('should clear state if newly created agent and if there is old existing state', async () => {
     const mockCallAgent = new MockCallAgent();
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
     const mockCall = createMockCall(mockCallId);
     mockCallAgent.calls = [mockCall];
@@ -203,7 +203,7 @@ describe('declarative call agent', () => {
 
   test('should update state with new call when startCall is invoked', () => {
     const mockCallAgent = new MockCallAgent();
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
     expect(context.getState().calls.size).toBe(0);
     const declarativeCallAgent = callAgentDeclaratify(mockCallAgent, context, internalContext);
@@ -213,7 +213,7 @@ describe('declarative call agent', () => {
 
   test('should update state with new call when join is invoked', () => {
     const mockCallAgent = new MockCallAgent();
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
     expect(context.getState().calls.size).toBe(0);
     const declarativeCallAgent = callAgentDeclaratify(mockCallAgent, context, internalContext);
@@ -223,7 +223,7 @@ describe('declarative call agent', () => {
 
   test('should move call to callEnded when call is removed and add endTime', async () => {
     const mockCallAgent = new MockCallAgent();
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
     expect(context.getState().calls.size).toBe(0);
     callAgentDeclaratify(mockCallAgent, context, internalContext);
@@ -250,7 +250,7 @@ describe('declarative call agent', () => {
 
   test('should move incoming call to incomingCallEnded when incoming call is ended and add endTime', async () => {
     const mockCallAgent = new MockCallAgent();
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
     expect(context.getState().calls.size).toBe(0);
     callAgentDeclaratify(mockCallAgent, context, internalContext);
@@ -274,7 +274,7 @@ describe('declarative call agent', () => {
 
   test('should make sure that callsEnded not exceed max length', async () => {
     const mockCallAgent = new MockCallAgent();
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
     callAgentDeclaratify(mockCallAgent, context, internalContext);
 
@@ -298,7 +298,7 @@ describe('declarative call agent', () => {
 
   test('should make sure that incomingCallsEnded not exceed max length', async () => {
     const mockCallAgent = new MockCallAgent();
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
     callAgentDeclaratify(mockCallAgent, context, internalContext);
 
@@ -325,7 +325,7 @@ describe('declarative call agent', () => {
     const mockCallOne = createMockCall('mockCallIdOne');
     const mockCallTwo = createMockCall('mockCallIdTwo');
     const mockCallAgent = new MockCallAgentWithMultipleCalls([mockCallOne, mockCallTwo]);
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
     const declarativeCallAgent = callAgentDeclaratify(mockCallAgent, context, internalContext);
 

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -426,7 +426,7 @@ export interface CallClientState {
   /**
    * Stores a userId. This is not used by the {@Link StatefulCallClient} and is provided here as a convenience for the
    * developer for easier access to userId. Must be passed in at initialization of the {@Link StatefulCallClient}.
-   * Completely controled by the developer.
+   * Completely controlled by the developer.
    */
-  userId: string;
+  userId: CommunicationUserIdentifier;
 }

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -428,5 +428,5 @@ export interface CallClientState {
    * developer for easier access to userId. Must be passed in at initialization of the {@Link StatefulCallClient}.
    * Completely controlled by the developer.
    */
-  userId: CommunicationUserIdentifier;
+  userId: CommunicationUserKind;
 }

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CommunicationUserKind } from '@azure/communication-common';
 import {
   AudioDeviceInfo,
   DeviceAccess,
@@ -40,7 +41,7 @@ export class CallContext {
   private _emitter: EventEmitter;
   private _atomicId: number;
 
-  constructor(userId: string, maxListeners?: number) {
+  constructor(userId: CommunicationUserKind, maxListeners?: number) {
     this._state = {
       calls: new Map<string, CallState>(),
       callsEnded: [],

--- a/packages/calling-stateful-client/src/CallDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallDeclarative.test.ts
@@ -57,7 +57,7 @@ describe('declarative call', () => {
     mockCall.remoteParticipants = [];
     mockCall.api = createMockApiFeatures(new Map());
 
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     context.setCall(convertSdkCallToDeclarativeCall(mockCall));
 
     const declarativeCall = callDeclaratify(mockCall, context);
@@ -89,7 +89,7 @@ describe('declarative call', () => {
     mockCall.remoteParticipants = [];
     mockCall.api = createMockApiFeatures(new Map());
 
-    const context = new CallContext('');
+    const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     context.setCall(convertSdkCallToDeclarativeCall(mockCall));
 
     const declarativeCall = callDeclaratify(mockCall, context) as DeclarativeCall;

--- a/packages/calling-stateful-client/src/DeviceManagerDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/DeviceManagerDeclarative.test.ts
@@ -117,7 +117,7 @@ function createDeclarativeDeviceManager(): {
   callContext: CallContext;
 } {
   const mockDeviceManager = new MockDeviceManager();
-  const context = new CallContext('');
+  const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
   return {
     declarativeDeviceManager: deviceManagerDeclaratify(mockDeviceManager, context),
     mockDeviceManager: mockDeviceManager,

--- a/packages/calling-stateful-client/src/StatefulCallClient.test.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.test.ts
@@ -90,7 +90,9 @@ function createClientAndAgentMocks(testData: TestData): void {
   mockCallAgent = { calls: [] as ReadonlyArray<Call>, displayName: mockDisplayName } as MockCallAgent;
   addMockEmitter(mockCallAgent);
   testData.mockCallAgent = mockCallAgent;
-  testData.mockStatefulCallClient = createStatefulCallClient({ userId: mockUserId });
+  testData.mockStatefulCallClient = createStatefulCallClient({
+    userId: { kind: 'communicationUser', communicationUserId: mockUserId }
+  });
 }
 
 async function createMockCallAndEmitCallsUpdated(
@@ -185,8 +187,10 @@ async function waitWithBreakCondition(breakCondition: () => boolean): Promise<vo
 
 describe('Stateful call client', () => {
   test('should allow developer to specify userId and provide access to it in state', async () => {
-    const StatefulCallClient = createStatefulCallClient({ userId: mockUserId });
-    expect(StatefulCallClient.getState().userId).toBe(mockUserId);
+    const StatefulCallClient = createStatefulCallClient({
+      userId: { kind: 'communicationUser', communicationUserId: mockUserId }
+    });
+    expect(StatefulCallClient.getState().userId.communicationUserId).toBe(mockUserId);
   });
 
   test('should update callAgent state and have displayName when callAgent is created', async () => {

--- a/packages/calling-stateful-client/src/StatefulCallClient.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.ts
@@ -14,7 +14,7 @@ import { CallContext } from './CallContext';
 import { callAgentDeclaratify } from './CallAgentDeclarative';
 import { InternalCallContext } from './InternalCallContext';
 import { createView, disposeView } from './StreamUtils';
-import { CommunicationIdentifierKind } from '@azure/communication-common';
+import { CommunicationIdentifierKind, CommunicationUserKind } from '@azure/communication-common';
 
 /**
  * Defines the methods that allow CallClient {@Link @azure/communication-calling#CallClient} to be used statefully.
@@ -197,10 +197,9 @@ class ProxyCallClient implements ProxyHandler<CallClient> {
 export type StatefulCallClientArgs = {
   /**
    * UserId from SDK. This is provided for developer convenience to easily access the userId from the
-   * state. It is not used by StatefulCallClient so if you do not have this value or do not want to use this value,
-   * you could pass any dummy value like empty string.
+   * state. It is not used by StatefulCallClient.
    */
-  userId?: string;
+  userId: CommunicationUserKind;
 };
 
 /**
@@ -232,14 +231,11 @@ export type StatefulCallClientOptions = {
  * @returns
  */
 export const createStatefulCallClient = (
-  args?: StatefulCallClientArgs,
+  args: StatefulCallClientArgs,
   options?: StatefulCallClientOptions
 ): StatefulCallClient => {
   const callClient = new CallClient(options?.callClientOptions);
-  const context: CallContext = new CallContext(
-    args?.userId ?? 'contoso_user_id_not_set',
-    options?.maxStateChangeListeners
-  );
+  const context: CallContext = new CallContext(args.userId, options?.maxStateChangeListeners);
   const internalContext: InternalCallContext = new InternalCallContext();
 
   Object.defineProperty(callClient, 'getState', {

--- a/packages/calling-stateful-client/src/StreamUtils.test.ts
+++ b/packages/calling-stateful-client/src/StreamUtils.test.ts
@@ -114,7 +114,7 @@ function addMockRemoteStreamAndParticipant(
 }
 
 function createContexts(): TestData {
-  const context = new CallContext('');
+  const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
   const internalContext = new InternalCallContext();
 
   return {

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -243,9 +243,9 @@ export interface CallAdapter {
     unmute(): Promise<void>;
 }
 
-// @public (undocumented)
+// @public
 export type CallAdapterClientState = {
-    userId: string;
+    userId: CommunicationUserKind;
     displayName?: string;
     call?: CallState;
     devices: DeviceManagerState;
@@ -254,7 +254,7 @@ export type CallAdapterClientState = {
 // @public (undocumented)
 export type CallAdapterState = CallAdapterUiState & CallAdapterClientState;
 
-// @public (undocumented)
+// @public
 export type CallAdapterUiState = {
     error?: Error;
     isLocalPreviewMicrophoneEnabled: boolean;
@@ -314,7 +314,7 @@ export interface CallClientState {
     deviceManager: DeviceManagerState;
     incomingCalls: Map<string, IncomingCallState>;
     incomingCallsEnded: IncomingCallState[];
-    userId: string;
+    userId: CommunicationUserKind;
 }
 
 // @public (undocumented)
@@ -655,7 +655,7 @@ export const createDefaultChatHandlers: (chatClient: StatefulChatClient, chatThr
 export const createDefaultChatHandlersForComponent: <Props>(chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, _: (props: Props) => ReactElement | null) => Pick<DefaultChatHandlers, CommonProperties<DefaultChatHandlers, Props>>;
 
 // @public
-export const createStatefulCallClient: (args?: StatefulCallClientArgs | undefined, options?: StatefulCallClientOptions | undefined) => StatefulCallClient;
+export const createStatefulCallClient: (args: StatefulCallClientArgs, options?: StatefulCallClientOptions | undefined) => StatefulCallClient;
 
 // @public
 export const createStatefulChatClient: (args: StatefulChatClientArgs, options?: StatefulChatClientOptions | undefined) => StatefulChatClient;
@@ -1167,7 +1167,7 @@ export interface StatefulCallClient extends CallClient {
 
 // @public
 export type StatefulCallClientArgs = {
-    userId?: string;
+    userId: CommunicationUserKind;
 };
 
 // @public

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -208,9 +208,9 @@ export interface CallAdapter {
     unmute(): Promise<void>;
 }
 
-// @public (undocumented)
+// @public
 export type CallAdapterClientState = {
-    userId: string;
+    userId: CommunicationUserKind;
     displayName?: string;
     call?: CallState;
     devices: DeviceManagerState;
@@ -219,7 +219,7 @@ export type CallAdapterClientState = {
 // @public (undocumented)
 export type CallAdapterState = CallAdapterUiState & CallAdapterClientState;
 
-// @public (undocumented)
+// @public
 export type CallAdapterUiState = {
     error?: Error;
     isLocalPreviewMicrophoneEnabled: boolean;

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -20,17 +20,21 @@ import type {
 
 export type CallCompositePage = 'configuration' | 'call' | 'error' | 'errorJoiningTeamsMeeting' | 'removed';
 
+/**
+ * Purely UI related adapter state.
+ */
 export type CallAdapterUiState = {
-  // Self-contained state for composite
   error?: Error;
   isLocalPreviewMicrophoneEnabled: boolean;
   page: CallCompositePage;
   endedCall?: CallState | undefined;
 };
 
+/**
+ * State from the backend ACS services.
+ */
 export type CallAdapterClientState = {
-  // Properties from backend services
-  userId: string;
+  userId: CommunicationUserKind;
   displayName?: string;
   call?: CallState;
   devices: DeviceManagerState;

--- a/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
@@ -7,6 +7,7 @@ import memoizeOne from 'memoize-one';
 import { useAdapter } from '../adapter/CallAdapterProvider';
 import { CallAdapterState } from '../adapter/CallAdapter';
 import { CallState, CallClientState, DeviceManagerState } from 'calling-stateful-client';
+import { CommunicationUserKind } from '@azure/communication-common';
 
 // This function highly depends on chatClient.onChange event
 // It will be moved into selector folder when the ChatClientProvide when refactor finished
@@ -70,7 +71,7 @@ export const useSelectorWithAdaptation = <
 
 const memoizeState = memoizeOne(
   (
-    userId: string,
+    userId: CommunicationUserKind,
     deviceManager: DeviceManagerState,
     calls: Map<string, CallState>,
     displayName?: string

--- a/packages/react-composites/src/composites/CallComposite/selectors/baseSelectors.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/baseSelectors.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { CallState as SDKCallStatus } from '@azure/communication-calling';
+import { toFlatCommunicationIdentifier } from 'acs-ui-common';
 import { CallState, DeviceManagerState } from 'calling-stateful-client';
 import { CallAdapterState, CallCompositePage } from '../adapter/CallAdapter';
 
@@ -13,7 +14,7 @@ export const getIsPreviewCameraOn = (state: CallAdapterState): boolean => isPrev
 export const getPage = (state: CallAdapterState): CallCompositePage => state.page;
 export const getLocalMicrophoneEnabled = (state: CallAdapterState): boolean => state.isLocalPreviewMicrophoneEnabled;
 export const getDisplayName = (state: CallAdapterState): string | undefined => state.displayName;
-export const getIdentifier = (state: CallAdapterState): string => state.userId;
+export const getIdentifier = (state: CallAdapterState): string => toFlatCommunicationIdentifier(state.userId);
 
 const isPreviewOn = (deviceManager: DeviceManagerState): boolean => {
   // TODO: we should take in a LocalVideoStream that developer wants to use as their 'Preview' view. We should also

--- a/packages/react-composites/src/composites/OneToOneCall/providers/CallingProvider.tsx
+++ b/packages/react-composites/src/composites/OneToOneCall/providers/CallingProvider.tsx
@@ -53,7 +53,10 @@ const CallingProviderBase = (props: CallingProviderProps & ErrorHandlingProps): 
   // if there is no valid token then there is no valid userId
   const userIdFromToken = token ? getIdFromToken(token) : '';
   const [callClient, setCallClient] = useState<StatefulCallClient>(
-    createStatefulCallClient({ userId: userIdFromToken }, { callClientOptions })
+    createStatefulCallClient(
+      { userId: { kind: 'communicationUser', communicationUserId: userIdFromToken } },
+      { callClientOptions }
+    )
   );
   const [callAgent, setCallAgent] = useState<CallAgent | undefined>(undefined);
   const [deviceManager, setDeviceManager] = useState<StatefulDeviceManager | undefined>(undefined);

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -102,7 +102,9 @@ const App = (): JSX.Element => {
   useEffect(() => {
     // Create a new CallClient when at the home page or at the createCallClient page.
     if (page === 'createCallClient' || page === 'home') {
-      const newStatefulCallClient = createStatefulCallClient({ userId });
+      const newStatefulCallClient = createStatefulCallClient({
+        userId: { kind: 'communicationUser', communicationUserId: userId }
+      });
       setStatefulCallClient(newStatefulCallClient);
       page === 'createCallClient' && setPage('configuration');
 


### PR DESCRIPTION
# What
* Store userId as CommunicationUserKind in both StatefulCallClient and CallAdapter

# Why

* State uses backend DTOs. Using structured userId makes the type clear.
* Brings StatefulCallClient on par with StatefulChatClient, which already stores userId as CommunicationUserKind.

# How Tested
`rush build`
`rush test`

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [x] This change causes current functionality to break.
<!--- If yes, describe the impact. -->