### PR TITLE
Replace memoizeFn with react.memo

### DIFF
--- a/change/calling-stateful-client-82655838-6d98-474f-af21-dfcb0b74fea1.json
+++ b/change/calling-stateful-client-82655838-6d98-474f-af21-dfcb0b74fea1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix maxListener warnings",
+  "packageName": "calling-stateful-client",
+  "email": "jinan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-components-f5b8a61a-362e-422c-874d-672850b696dc.json
+++ b/change/react-components-f5b8a61a-362e-422c-874d-672850b696dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Replace memoizeFn with react.memo Fix maxListener warning by default",
+  "packageName": "react-components",
+  "email": "jinan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -40,7 +40,7 @@ export class CallContext {
   private _emitter: EventEmitter;
   private _atomicId: number;
 
-  constructor(userId: string, maxListeners?: number) {
+  constructor(userId: string, maxListeners = 50) {
     this._state = {
       calls: new Map<string, CallState>(),
       callsEnded: [],
@@ -57,9 +57,8 @@ export class CallContext {
       userId: userId
     };
     this._emitter = new EventEmitter();
-    if (maxListeners) {
-      this._emitter.setMaxListeners(maxListeners);
-    }
+    this._emitter.setMaxListeners(maxListeners);
+
     this._atomicId = 0;
   }
 

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -177,9 +177,9 @@ const RemoteVideoTile = React.memo(
       if (isAvailable && !renderElement) {
         onCreateRemoteStreamView && onCreateRemoteStreamView(userId, remoteVideoViewOption);
       }
-      return () => {
+      if (!isAvailable) {
         onDisposeRemoteStreamView && onDisposeRemoteStreamView(userId);
-      };
+      }
     }, [
       isAvailable,
       onCreateRemoteStreamView,
@@ -188,6 +188,12 @@ const RemoteVideoTile = React.memo(
       renderElement,
       userId
     ]);
+
+    useEffect(() => {
+      return () => {
+        onDisposeRemoteStreamView && onDisposeRemoteStreamView(userId);
+      };
+    }, [onDisposeRemoteStreamView, userId]);
 
     return (
       <Stack className={gridStyle} key={userId} grow>

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -189,8 +189,6 @@ const RemoteVideoTile = React.memo(
       userId
     ]);
 
-    console.log('Rerender');
-
     useEffect(() => {
       return () => {
         onDisposeRemoteStreamView && onDisposeRemoteStreamView(userId);

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -177,9 +177,9 @@ const RemoteVideoTile = React.memo(
       if (isAvailable && !renderElement) {
         onCreateRemoteStreamView && onCreateRemoteStreamView(userId, remoteVideoViewOption);
       }
-      if (!isAvailable) {
+      return () => {
         onDisposeRemoteStreamView && onDisposeRemoteStreamView(userId);
-      }
+      };
     }, [
       isAvailable,
       onCreateRemoteStreamView,
@@ -188,12 +188,6 @@ const RemoteVideoTile = React.memo(
       renderElement,
       userId
     ]);
-
-    useEffect(() => {
-      return () => {
-        onDisposeRemoteStreamView && onDisposeRemoteStreamView(userId);
-      };
-    }, [onDisposeRemoteStreamView, userId]);
 
     return (
       <Stack className={gridStyle} key={userId} grow>

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Stack } from '@fluentui/react';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
   BaseCustomStylesProps,
   VideoGalleryLocalParticipant,
@@ -12,7 +12,6 @@ import {
 import { GridLayout } from './GridLayout';
 import { StreamMedia } from './StreamMedia';
 import { gridStyle, videoTileStyle } from './styles/VideoGallery.styles';
-import { memoizeFnAll } from 'acs-ui-common';
 import { VideoTile, PlaceholderProps } from './VideoTile';
 
 /**
@@ -51,39 +50,6 @@ export interface VideoGalleryProps {
   /** Callback to render a particpant avatar */
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
 }
-
-// @todo: replace with React.memo method
-const memoizeAllRemoteParticipants = memoizeFnAll(
-  (
-    userId: string,
-    onCreateRemoteStreamView: any,
-    onDisposeRemoteStreamView?: (userId: string) => Promise<void>,
-    isAvailable?: boolean,
-    renderElement?: HTMLElement,
-    displayName?: string,
-    remoteVideoViewOption?: VideoStreamOptions,
-    onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element
-  ): JSX.Element => {
-    if (isAvailable && !renderElement) {
-      onCreateRemoteStreamView && onCreateRemoteStreamView(userId, remoteVideoViewOption);
-    }
-    if (!isAvailable) {
-      onDisposeRemoteStreamView && onDisposeRemoteStreamView(userId);
-    }
-    return (
-      <Stack className={gridStyle} key={userId} grow>
-        <VideoTile
-          userId={userId}
-          isVideoReady={isAvailable}
-          renderElement={<StreamMedia videoStreamElement={renderElement ?? null} />}
-          displayName={displayName}
-          styles={videoTileStyle}
-          onRenderPlaceholder={onRenderAvatar}
-        />
-      </Stack>
-    );
-  }
-);
 
 /**
  * VideoGallery represents a `GridLayout` of video tiles for a specific call.
@@ -144,23 +110,33 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
       return remoteParticipants.map((participant) => onRenderRemoteVideoTile(participant));
     }
 
-    return memoizeAllRemoteParticipants((memoizedRemoteParticipantFn) => {
-      // Else return Remote Stream Video Tiles
-      return remoteParticipants.map((participant) => {
+    // Else return Remote Stream Video Tiles
+    return remoteParticipants.map(
+      (participant): JSX.Element => {
         const remoteVideoStream = participant.videoStream;
-        return memoizedRemoteParticipantFn(
-          participant.userId,
-          onCreateRemoteStreamView,
-          onDisposeRemoteStreamView,
-          remoteVideoStream?.isAvailable,
-          remoteVideoStream?.renderElement,
-          participant.displayName,
-          remoteVideoViewOption,
-          onRenderAvatar
+        return (
+          <RemoteVideoTile
+            key={participant.userId}
+            userId={participant.userId}
+            onCreateRemoteStreamView={onCreateRemoteStreamView}
+            onDisposeRemoteStreamView={onDisposeRemoteStreamView}
+            isAvailable={remoteVideoStream?.isAvailable}
+            renderElement={remoteVideoStream?.renderElement}
+            displayName={participant.displayName}
+            remoteVideoViewOption={remoteVideoViewOption}
+            onRenderAvatar={onRenderAvatar}
+          />
         );
-      });
-    });
-  }, [remoteParticipants, onRenderRemoteVideoTile, onCreateRemoteStreamView, remoteVideoViewOption]);
+      }
+    );
+  }, [
+    remoteParticipants,
+    onRenderRemoteVideoTile,
+    onCreateRemoteStreamView,
+    onDisposeRemoteStreamView,
+    remoteVideoViewOption,
+    onRenderAvatar
+  ]);
 
   return (
     <GridLayout styles={styles}>
@@ -171,3 +147,67 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
     </GridLayout>
   );
 };
+
+// Use React.memo to create memoize cache for each RemoteVideoTile
+const RemoteVideoTile = React.memo(
+  (props: {
+    userId: string;
+    onCreateRemoteStreamView?: (userId: string, options?: VideoStreamOptions | undefined) => Promise<void>;
+    onDisposeRemoteStreamView?: (userId: string) => Promise<void>;
+    isAvailable?: boolean;
+    renderElement?: HTMLElement;
+    displayName?: string;
+    remoteVideoViewOption?: VideoStreamOptions;
+    onRenderAvatar?: (
+      props: PlaceholderProps,
+      defaultOnRender: (props: PlaceholderProps) => JSX.Element
+    ) => JSX.Element;
+  }) => {
+    const {
+      isAvailable,
+      onCreateRemoteStreamView,
+      onDisposeRemoteStreamView,
+      remoteVideoViewOption,
+      renderElement,
+      userId,
+      displayName,
+      onRenderAvatar
+    } = props;
+    useEffect(() => {
+      if (isAvailable && !renderElement) {
+        onCreateRemoteStreamView && onCreateRemoteStreamView(userId, remoteVideoViewOption);
+      }
+      if (!isAvailable) {
+        onDisposeRemoteStreamView && onDisposeRemoteStreamView(userId);
+      }
+    }, [
+      isAvailable,
+      onCreateRemoteStreamView,
+      onDisposeRemoteStreamView,
+      remoteVideoViewOption,
+      renderElement,
+      userId
+    ]);
+
+    console.log('Rerender');
+
+    useEffect(() => {
+      return () => {
+        onDisposeRemoteStreamView && onDisposeRemoteStreamView(userId);
+      };
+    }, [onDisposeRemoteStreamView, userId]);
+
+    return (
+      <Stack className={gridStyle} key={userId} grow>
+        <VideoTile
+          userId={userId}
+          isVideoReady={isAvailable}
+          renderElement={<StreamMedia videoStreamElement={renderElement ?? null} />}
+          displayName={displayName}
+          styles={videoTileStyle}
+          onRenderPlaceholder={onRenderAvatar}
+        />
+      </Stack>
+    );
+  }
+);

--- a/packages/storybook/stories/UseCases.stories.mdx
+++ b/packages/storybook/stories/UseCases.stories.mdx
@@ -116,14 +116,17 @@ These client libraries also require the context for the call or chat they will j
 
 | SDK    | Windows            | macOS                | Ubuntu   | Linux    | Android  | iOS        |
 | ------ | ------------------ | -------------------- | -------- | -------- | -------- | ---------- |
-| UI SDK | Chrome\*, new Edge | Chrome\*, Safari\*\* | Chrome\* | Chrome\* | Chrome\* | Safari\*\* |
+| UI SDK - Calling | Chrome\*, new Edge | Chrome\*, Safari\*\* | Chrome\* | Chrome\* | Chrome\*\* | Safari\*\*\* |
+| UI SDK - Chat    | Firefox\*, Chrome\*, new Edge | Firefox\*, Chrome\*, Safari\* | Chrome\* | Chrome\* | Safari\*|
 
-\*Note that the latest version of Chrome is supported in addition to the
+\*Note that the latest version is supported in addition to the
 previous two releases.
 
-\*\*Note that Safari versions 13.1+ are supported. Outgoing video for Safari
-macOS is not yet supported, but it is supported on iOS. Outgoing screen sharing
-is only supported on desktop iOS.
+\*\*Note that outgoing screen sharing is not supported for Chrome on Android.
+
+\*\*\*Note that Safari versions 13.1+ are supported. 1:1 calls are not supported on Safari. Outgoing video for Safari
+macOS supported only for Safari 14+/macOS 11+. Outgoing screen sharing
+is not supported on iOS, device selection(for example choosing Bluetooth headset) is limited by OS, only one device available.
 
 ## Accessibility
 


### PR DESCRIPTION
Replace memoizeFn with react.memo

- There is one memoizeFn could be replaced by react built in memoization function React.memo
- This will unlock the ability for us to call useEffect for unmounting
- Add unmounting function to VideoTile so no memory leak anymore

Also this PR fixes maxListener warning by setting a practical default number of maxListener(yea, it comes back)
![image](https://user-images.githubusercontent.com/11863655/120568506-daffba00-c3c8-11eb-9b0b-bd24250b10d1.png)


# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->