### PR TITLE
Add documentation (+small improvements) to alpha release and npm package publishing

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -45,10 +45,18 @@ jobs:
       - name: Test @azure/communication-react package
         run: rush test -t @azure/communication-react
 
+      # Retrieve new version to tag and publish release with
+      - name: Retrieve new version from package.json
+        id: version
+        run: |
+          ver=$(jq .version packages/communication-react/package.json)
+          echo version: $ver
+          echo "::set-output name=version::$ver"
+
       # Push git tags
       - name: Create and push git tags
         run: |
-          git tag 1.0.0-alpha-${{ steps.datetime.outputs.datetime }}
+          git tag ${{ steps.version.outputs.version }}
           git push --tags
 
       # Publish package
@@ -64,16 +72,16 @@ jobs:
           inlineScript: |
             az login --service-principal -u ${{ secrets.AZURESDKPARTNERDROPS_CLIENT_ID }} -p ${{ secrets.AZURESDKPARTNERDROPS_SERVICE_PRINCIPAL_KEY }} --tenant ${{ secrets.AZURESDKPARTNERDROPS_TENANT_ID }}
             az extension add --name storage-preview
-            az storage azcopy blob upload -s "packages/communication-react/release/*" -c "drops/azure-communication-services/react/npm/1.0.0-alpha-${{ steps.datetime.outputs.datetime }}" --account-name azuresdkpartnerdrops
+            az storage azcopy blob upload -s "packages/communication-react/release/*" -c "drops/azure-communication-services/react/npm/${{ steps.version.outputs.version }}" --account-name azuresdkpartnerdrops
 
       - name: Install github actions dependencies
         run: npm i
         working-directory: ./.github/workflows/azure-pipeline-action-fork
 
-      - name: Trigger alpha package release
+      - name: Trigger alpha package release pipeline
         uses: ./.github/workflows/azure-pipeline-action-fork
         with:
           azure-devops-project-url: 'https://dev.azure.com/azure-sdk/internal'
           azure-pipeline-name: 'azuresdkpartnerdrops to npm'
           azure-devops-token: '${{ secrets.AZURE_SDK_RELEASE_PIPELINE_DEVOPS_TOKEN }}'
-          azure-pipeline-variables: '{"accessLevel": "public", "BlobPath": "azure-communication-services/react/npm/1.0.0-alpha-${{ steps.datetime.outputs.datetime }}", "registry": "https://registry.npmjs.org/", "skipDiff": "False", "tag": "dev"}'
+          azure-pipeline-variables: '{"accessLevel": "public", "BlobPath": "azure-communication-services/react/npm/${{ steps.version.outputs.version }}", "registry": "https://registry.npmjs.org/", "skipDiff": "False", "tag": "dev"}'

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -75,7 +75,7 @@ jobs:
             az storage azcopy blob upload -s "packages/communication-react/release/*" -c "drops/azure-communication-services/react/npm/${{ steps.version.outputs.version }}" --account-name azuresdkpartnerdrops
 
       - name: Install github actions dependencies
-        run: npm i
+        run: npm ci
         working-directory: ./.github/workflows/azure-pipeline-action-fork
 
       - name: Trigger alpha package release pipeline

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -90,10 +90,18 @@ jobs:
       - name: Test @azure/communication-react package
         run: rush test -t @azure/communication-react
 
+      # Retrieve new version to tag and publish release with
+      - name: Retrieve new version from package.json
+        id: version
+        run: |
+          ver=$(jq .version packages/communication-react/package.json)
+          echo version: $ver
+          echo "::set-output name=version::$ver"
+
       # Push git tags
       - name: Create and push git tags
         run: |
-          git tag 1.0.0-alpha-${{ steps.datetime.outputs.datetime }}
+          git tag ${{ steps.version.outputs.version }}
           git push --tags
 
       # Publish package
@@ -109,16 +117,16 @@ jobs:
           inlineScript: |
             az login --service-principal -u ${{ secrets.AZURESDKPARTNERDROPS_CLIENT_ID }} -p ${{ secrets.AZURESDKPARTNERDROPS_SERVICE_PRINCIPAL_KEY }} --tenant ${{ secrets.AZURESDKPARTNERDROPS_TENANT_ID }}
             az extension add --name storage-preview
-            az storage azcopy blob upload -s "packages/communication-react/release/*" -c "drops/azure-communication-services/react/npm/1.0.0-alpha-${{ steps.datetime.outputs.datetime }}" --account-name azuresdkpartnerdrops
+            az storage azcopy blob upload -s "packages/communication-react/release/*" -c "drops/azure-communication-services/react/npm/${{ steps.version.outputs.version }}" --account-name azuresdkpartnerdrops
 
       - name: Install github actions dependencies
         run: npm i
         working-directory: ./.github/workflows/azure-pipeline-action-fork
 
-      - name: Trigger alpha package release
+      - name: Trigger alpha package release pipeline
         uses: ./.github/workflows/azure-pipeline-action-fork
         with:
           azure-devops-project-url: 'https://dev.azure.com/azure-sdk/internal'
           azure-pipeline-name: 'azuresdkpartnerdrops to npm'
           azure-devops-token: '${{ secrets.AZURE_SDK_RELEASE_PIPELINE_DEVOPS_TOKEN }}'
-          azure-pipeline-variables: '{"accessLevel": "public", "BlobPath": "azure-communication-services/react/npm/1.0.0-alpha-${{ steps.datetime.outputs.datetime }}", "registry": "https://registry.npmjs.org/", "skipDiff": "False", "tag": "dev"}'
+          azure-pipeline-variables: '{"accessLevel": "public", "BlobPath": "azure-communication-services/react/npm/${{ steps.version.outputs.version }}", "registry": "https://registry.npmjs.org/", "skipDiff": "False", "tag": "dev"}'

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -120,7 +120,7 @@ jobs:
             az storage azcopy blob upload -s "packages/communication-react/release/*" -c "drops/azure-communication-services/react/npm/${{ steps.version.outputs.version }}" --account-name azuresdkpartnerdrops
 
       - name: Install github actions dependencies
-        run: npm i
+        run: npm ci
         working-directory: ./.github/workflows/azure-pipeline-action-fork
 
       - name: Trigger alpha package release pipeline

--- a/docs/infrastructure/creating-a-release.md
+++ b/docs/infrastructure/creating-a-release.md
@@ -78,7 +78,7 @@ There is currently no GitHub action for creating a hotfix and must be done manua
 
 Alpha releases are created nightly using the [.github/workflows/nightly-ci.yml](https://github.com/Azure/communication-ui-library/blob/main/.github/workflows/nightly-ci.yml) GitHub action.
 
-They use beachball's `canary` CLI command to temporarily set all package versions to \<version\>-alpha+yyyymmdd-HHMM, create npm packages of each package and then upload the packages to the azure release pipeline.
+They use beachball's `canary` CLI command to temporarily set all package versions to \<version\>-alpha-yyyymmdd-HHMM, then package up the npm packages and upload the packages to the azure release pipeline.
 
 ### Creating beta releases
 
@@ -88,6 +88,8 @@ To create a beta release, ensure the above conditions then follow the instructio
 
 ## Publishing packages
 
-To ensure our packages are part of the `@Azure` organization our packages are published using Azure's publishing pipeline.
+To ensure our packages are part of the `@azure` organization our packages are published using [Azure's publishing pipeline](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/1/Partner-Release-Pipeline).
 
-This is currently being setup, _more documentation to follow_.
+This requires us to first upload the tarball of the package we wish to publish to their blob storage, then trigger their release pipeline. This can be done manually or by GitHub actions.
+
+Currently alpha package releases are entirely done through GitHub actions (see [.github/workflows/nightly-ci.yml](https://github.com/Azure/communication-ui-library/blob/main/.github/workflows/nightly-ci.yml)). This requires the use of internal keys and tokens. For more information on these, or how to update them, see: [Updating npm publishing credentials](../references/updating-npm-publishing-credentials.md).

--- a/docs/references/updating-npm-publishing-credentials.md
+++ b/docs/references/updating-npm-publishing-credentials.md
@@ -1,0 +1,18 @@
+# Updating npm publishing credentials
+
+Our GitHub actions that publish our npm package require keys and tokens for two places:
+
+1. The Azure Blob Store that we upload the npm tarball to.
+1. The ADO release pipeline that publishes tarball to npm.
+
+For more information on these visit the internal wiki page: <https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/1/Partner-Release-Pipeline>.
+
+## Required keys and tokens
+
+1. `AZURESDKPARTNERDROPS_SERVICE_PRINCIPAL_KEY`. **⚠ This could be rotated at any time and need updating. ⚠** This is stored in the Azure key vault and requires permissions from a security group to access. Details for this can be found on the [internal wiki page](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/1/Partner-Release-Pipeline).
+
+1. `AZURESDKPARTNERDROPS_CLIENT_ID`. This shouldn't change. This is the azure blob store client ID. This should be found on the [internal wiki page](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/1/Partner-Release-Pipeline).
+
+1. `AZURESDKPARTNERDROPS_TENANT_ID`. This shouldn't change. This is the azure blob store tenant ID. This should be found on the [internal wiki page](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/1/Partner-Release-Pipeline).
+
+1. `AZURE_SDK_RELEASE_PIPELINE_DEVOPS_TOKEN`. **⚠ This will expire periodically and need updating ⚠**. This is a personal access token. An account with access to the [ADO release pipeline](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/1/Partner-Release-Pipeline) should create a new access token when the old one expires. To gain access to this release page you must belong to the appropriate security group; follow the instructions on the [internal wiki page](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/1/Partner-Release-Pipeline). For more information on how to create a personal access token see: [Use personal access tokens - Create a PAT](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops#create-a-pat).


### PR DESCRIPTION
# What
Docs
* Update publishing documentation around alpha releases
* Add documentation regarding the keys and tokens used in creating npm releases from github

Improvements
* Get the package version from the npm package package.json instead of using a hardcoded value.
* Run `npm ci` for forked github action dependencies instead of `npm i`

# Why
Docs are needed.
Using version from package.json was a needed, fast follow up from #418.
`npm ci` will use the package-lock versions of packages so is more stable (`npm i` grabs new dependency versions if available).

# How Tested
Tested the `jq` command worked locally.
End-to-end test: https://github.com/Azure/communication-ui-library/actions/runs/903529260