### PR TITLE
Make `getIdFromToken` internal to OneToOneCallComposite

### DIFF
--- a/change/react-composites-c5ab2478-d32f-4d95-8a87-968283d3029e.json
+++ b/change/react-composites-c5ab2478-d32f-4d95-8a87-968283d3029e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make `getIdFromToken` internal to OneToOneCallComposite",
+  "packageName": "react-composites",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/OneToOneCall/OneToOneCall.tsx
+++ b/packages/react-composites/src/composites/OneToOneCall/OneToOneCall.tsx
@@ -7,7 +7,7 @@ import { AbortSignalLike } from '@azure/core-http';
 import { MakeCallScreen } from './MakeCallScreen';
 import CallScreen from './CallScreen';
 import { CallEndScreen } from './CallEndScreen';
-import { getIdFromToken } from '../../utils';
+import { getIdFromToken } from './utils/SDKUtils';
 import { CallListener } from './CallListener';
 import { incomingCallHost } from './styles/App.styles';
 import { ErrorProvider } from './providers/ErrorProvider';

--- a/packages/react-composites/src/composites/OneToOneCall/providers/CallingProvider.tsx
+++ b/packages/react-composites/src/composites/OneToOneCall/providers/CallingProvider.tsx
@@ -7,8 +7,9 @@ import { AbortSignalLike } from '@azure/core-http';
 import React, { createContext, Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { CommunicationUiError, CommunicationUiErrorCode } from '../../../types/CommunicationUiError';
 import { DevicePermissionState } from '../../../types/DevicePermission';
-import { createAzureCommunicationUserCredential, getIdFromToken, propagateError } from '../../../utils';
+import { createAzureCommunicationUserCredential, propagateError } from '../../../utils';
 import { ErrorHandlingProps } from './ErrorProvider';
+import { getIdFromToken } from '../utils/SDKUtils';
 import { WithErrorHandling } from '../utils/WithErrorHandling';
 import { useValidContext } from '../utils/ValidContext';
 

--- a/packages/react-composites/src/composites/OneToOneCall/utils/SDKUtils.ts
+++ b/packages/react-composites/src/composites/OneToOneCall/utils/SDKUtils.ts
@@ -7,8 +7,8 @@ import {
   PhoneNumberKind,
   UnknownIdentifierKind
 } from '@azure/communication-common';
-
 import { AudioDeviceInfo, LocalVideoStream, VideoDeviceInfo } from '@azure/communication-calling';
+import { CommunicationUiErrorCode, CommunicationUiError } from '../../../types/CommunicationUiError';
 
 export const getACSId = (
   identifier: CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind
@@ -46,4 +46,40 @@ export const isLocalScreenShareSupportedInBrowser = (): boolean => {
     !isMobileSession() &&
     (/chrome/i.test(navigator.userAgent.toLowerCase()) || /safari/i.test(navigator.userAgent.toLowerCase()))
   );
+};
+
+// FIXME: This is hack to grab the userId from the token.
+//        Drop this in favor of explicitly passing in the userID to the composite.
+export const getIdFromToken = (jwtToken: string): string => {
+  const claimName = 'skypeid';
+
+  const jwtTokenParts = jwtToken.split('.');
+  if (jwtTokenParts.length !== 3) {
+    throw new CommunicationUiError({
+      message: 'Invalid jwt token',
+      code: CommunicationUiErrorCode.CONFIGURATION_ERROR
+    });
+  }
+
+  let base64DecodedClaims;
+  let base64DecodedClaimsAsJson;
+  try {
+    base64DecodedClaims = atob(jwtTokenParts[1]);
+    base64DecodedClaimsAsJson = JSON.parse(base64DecodedClaims);
+  } catch (error) {
+    throw new CommunicationUiError({
+      message: 'Invalid access token',
+      code: CommunicationUiErrorCode.CONFIGURATION_ERROR,
+      error: error
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(base64DecodedClaimsAsJson, claimName)) {
+    return `8:${base64DecodedClaimsAsJson[claimName]}`;
+  }
+
+  throw new CommunicationUiError({
+    message: 'Invalid access token',
+    code: CommunicationUiErrorCode.CONFIGURATION_ERROR
+  });
 };

--- a/packages/react-composites/src/utils/SDKUtils.test.ts
+++ b/packages/react-composites/src/utils/SDKUtils.test.ts
@@ -4,7 +4,7 @@
 import { isInCall } from './SDKUtils';
 
 describe('SDKUtils tests', () => {
-  describe('getACSId tests', () => {
+  describe('isInCall tests', () => {
     afterAll(() => {
       jest.resetAllMocks();
     });

--- a/packages/react-composites/src/utils/SDKUtils.ts
+++ b/packages/react-composites/src/utils/SDKUtils.ts
@@ -3,12 +3,7 @@
 
 import { AzureCommunicationTokenCredential, CommunicationTokenRefreshOptions } from '@azure/communication-common';
 import { CallState as CallStatus } from '@azure/communication-calling';
-import {
-  CommunicationUiErrorCode,
-  CommunicationUiError,
-  CommunicationUiErrorFromError,
-  CommunicationUiErrorInfo
-} from '../types/CommunicationUiError';
+import { CommunicationUiErrorFromError, CommunicationUiErrorInfo } from '../types/CommunicationUiError';
 
 export const isInCall = (callStatus: CallStatus): boolean => !!(callStatus !== 'None' && callStatus !== 'Disconnected');
 
@@ -28,42 +23,6 @@ export const createAzureCommunicationUserCredential = (
   } else {
     return new AzureCommunicationTokenCredential(token);
   }
-};
-
-// This is a temporary solution to grab the userId from the token.
-// In the future we want to use the AzureCommunicationUserCredential and CommunicationUser types into the Provider
-export const getIdFromToken = (jwtToken: string): string => {
-  const claimName = 'skypeid';
-
-  const jwtTokenParts = jwtToken.split('.');
-  if (jwtTokenParts.length !== 3) {
-    throw new CommunicationUiError({
-      message: 'Invalid jwt token',
-      code: CommunicationUiErrorCode.CONFIGURATION_ERROR
-    });
-  }
-
-  let base64DecodedClaims;
-  let base64DecodedClaimsAsJson;
-  try {
-    base64DecodedClaims = atob(jwtTokenParts[1]);
-    base64DecodedClaimsAsJson = JSON.parse(base64DecodedClaims);
-  } catch (error) {
-    throw new CommunicationUiError({
-      message: 'Invalid access token',
-      code: CommunicationUiErrorCode.CONFIGURATION_ERROR,
-      error: error
-    });
-  }
-
-  if (Object.prototype.hasOwnProperty.call(base64DecodedClaimsAsJson, claimName)) {
-    return `8:${base64DecodedClaimsAsJson[claimName]}`;
-  }
-
-  throw new CommunicationUiError({
-    message: 'Invalid access token',
-    code: CommunicationUiErrorCode.CONFIGURATION_ERROR
-  });
 };
 
 export const propagateError = (error: Error, onErrorCallback?: (error: CommunicationUiErrorInfo) => void): void => {


### PR DESCRIPTION

# Why
* `getIdFromToken` has been excised from the rest of the codebase.
* Cleanup of this composite is pending decision about its future.

# How Tested
`rush build`
`rush test`

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->