### PR TITLE
Fix alpha release - remove unintended quote marks

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Retrieve new version from package.json
         id: version
         run: |
-          ver=$(jq .version packages/communication-react/package.json)
+          ver=$(jq -r .version packages/communication-react/package.json)
           echo version: $ver
           echo "::set-output name=version::$ver"
 

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Retrieve new version from package.json
         id: version
         run: |
-          ver=$(jq .version packages/communication-react/package.json)
+          ver=$(jq -r .version packages/communication-react/package.json)
           echo version: $ver
           echo "::set-output name=version::$ver"
 


### PR DESCRIPTION
# What
Remove quote marks when getting the version number from the package.json by using `-r` in the jq query (i.e. `--raw-output`)

# Why
Alpha build failing because of this:
![image](https://user-images.githubusercontent.com/2684369/121065991-3d1c3e80-c77e-11eb-92d7-241b97549a92.png)
Example failing action: https://github.com/Azure/communication-ui-library/runs/2750588822?check_suite_focus=true

# How Tested
Just locally in wsl:
![image](https://user-images.githubusercontent.com/2684369/121066030-4efde180-c77e-11eb-9d00-4aaa478195e1.png)
