### PR TITLE
tiny cleanup - remove office-ui-fabric usage

### DIFF
--- a/samples/Chat/package.json
+++ b/samples/Chat/package.json
@@ -59,7 +59,6 @@
     "@types/react-linkify": "^1.0.0",
     "acs-ui-common": "~1.0.0-beta.1",
     "json-stringify-safe": "^5.0.1",
-    "office-ui-fabric-react": "^7.160.2",
     "preval.macro": "^5.0.0",
     "react": "^16.13.1",
     "react-aria-live": "^2.0.5",

--- a/samples/Chat/src/app/ConfigurationScreen.tsx
+++ b/samples/Chat/src/app/ConfigurationScreen.tsx
@@ -2,8 +2,7 @@
 // Licensed under the MIT license.
 
 import { CAT, FOX, KOALA, MONKEY, MOUSE, OCTOPUS } from './utils/utils';
-import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
-import { PrimaryButton, Spinner, Stack } from '@fluentui/react';
+import { FocusZone, FocusZoneDirection, PrimaryButton, Spinner, Stack } from '@fluentui/react';
 import React, { useCallback, useEffect, useState } from 'react';
 import { buttonStyle, chatIconStyle, mainContainerStyle } from './styles/ConfigurationScreen.styles';
 import {


### PR DESCRIPTION
# What
Remove dependency on `office-ui-fabric-react` in chat sample

# Why
This is no longer needed as focus zones are exported from fluentui/react package

# How Tested
