### PR TITLE
CallClientState: Replace maps with arrays

### DIFF
--- a/change/calling-component-bindings-ec1e4fd2-7a5b-496e-8d64-9e0906c0f0e9.json
+++ b/change/calling-component-bindings-ec1e4fd2-7a5b-496e-8d64-9e0906c0f0e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Expose calls as array instead of map",
+  "packageName": "calling-component-bindings",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/calling-stateful-client-0f52e5ca-676c-471a-bd42-f54e6f1d5169.json
+++ b/change/calling-stateful-client-0f52e5ca-676c-471a-bd42-f54e6f1d5169.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Expose calls as array instead of map",
+  "packageName": "calling-stateful-client",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-composites-283721bc-47ea-4c4b-8ad8-9d6753812e42.json
+++ b/change/react-composites-283721bc-47ea-4c4b-8ad8-9d6753812e42.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Expose calls as array instead of map",
+  "packageName": "react-composites",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/review/calling-component-bindings.api.md
+++ b/packages/calling-component-bindings/review/calling-component-bindings.api.md
@@ -177,7 +177,7 @@ export const getDisplayName: (state: CallClientState) => string | undefined;
 export const getIdentifier: (state: CallClientState) => string;
 
 // @public (undocumented)
-export const getIncomingCalls: (state: CallClientState) => Map<string, IncomingCallState>;
+export const getIncomingCalls: (state: CallClientState) => IncomingCallState[];
 
 // @public (undocumented)
 export const getIncomingCallsEnded: (state: CallClientState) => IncomingCallState[];

--- a/packages/calling-component-bindings/review/calling-component-bindings.api.md
+++ b/packages/calling-component-bindings/review/calling-component-bindings.api.md
@@ -162,7 +162,7 @@ export type GetCallingSelector<Component> = AreEqual<Component, typeof VideoGall
 export const getCallingSelector: <Component extends (props: any) => JSX.Element | undefined>(component: Component) => GetCallingSelector<Component>;
 
 // @public (undocumented)
-export const getCalls: (state: CallClientState) => Map<string, CallState>;
+export const getCalls: (state: CallClientState) => CallState[];
 
 // @public (undocumented)
 export const getCallsEnded: (state: CallClientState) => CallState[];

--- a/packages/calling-component-bindings/src/baseSelectors.ts
+++ b/packages/calling-component-bindings/src/baseSelectors.ts
@@ -15,7 +15,7 @@ export const getCalls = (state: CallClientState): CallState[] => state.calls;
 
 export const getCallsEnded = (state: CallClientState): CallState[] => state.callsEnded;
 
-export const getIncomingCalls = (state: CallClientState): Map<string, IncomingCallState> => state.incomingCalls;
+export const getIncomingCalls = (state: CallClientState): IncomingCallState[] => state.incomingCalls;
 
 export const getIncomingCallsEnded = (state: CallClientState): IncomingCallState[] => state.incomingCallsEnded;
 

--- a/packages/calling-component-bindings/src/baseSelectors.ts
+++ b/packages/calling-component-bindings/src/baseSelectors.ts
@@ -11,7 +11,7 @@ export type CallingBaseSelectorProps = {
   callId: string;
 };
 
-export const getCalls = (state: CallClientState): Map<string, CallState> => state.calls;
+export const getCalls = (state: CallClientState): CallState[] => state.calls;
 
 export const getCallsEnded = (state: CallClientState): CallState[] => state.callsEnded;
 
@@ -22,7 +22,7 @@ export const getIncomingCallsEnded = (state: CallClientState): IncomingCallState
 export const getDeviceManager = (state: CallClientState): DeviceManagerState => state.deviceManager;
 
 export const getCall = (state: CallClientState, props: CallingBaseSelectorProps): CallState | undefined =>
-  state.calls.get(props.callId);
+  state.calls.find((candidate) => candidate.id === props.callId);
 
 export const getDisplayName = (state: CallClientState): string | undefined => state.callAgent?.displayName;
 

--- a/packages/calling-component-bindings/src/baseSelectors.ts
+++ b/packages/calling-component-bindings/src/baseSelectors.ts
@@ -22,7 +22,7 @@ export const getIncomingCallsEnded = (state: CallClientState): IncomingCallState
 export const getDeviceManager = (state: CallClientState): DeviceManagerState => state.deviceManager;
 
 export const getCall = (state: CallClientState, props: CallingBaseSelectorProps): CallState | undefined =>
-  state.calls.find((candidate) => candidate.id === props.callId);
+  state.calls.find((c) => c.id === props.callId);
 
 export const getDisplayName = (state: CallClientState): string | undefined => state.callAgent?.displayName;
 

--- a/packages/calling-component-bindings/src/handlers/createHandlers.ts
+++ b/packages/calling-component-bindings/src/handlers/createHandlers.ts
@@ -188,7 +188,7 @@ export const createDefaultCallingHandlers = memoizeOne(
         return;
       }
 
-      const callState = callClient.getState().calls.find((candidate) => candidate.id === call.id);
+      const callState = callClient.getState().calls.find((c) => c.id === call.id);
       if (!callState) {
         return;
       }
@@ -203,7 +203,7 @@ export const createDefaultCallingHandlers = memoizeOne(
 
     const onCreateRemoteStreamView = async (userId: string, options?: VideoStreamOptions): Promise<void> => {
       if (!call) return;
-      const callState = callClient.getState().calls.find((candidate) => candidate.id === call.id);
+      const callState = callClient.getState().calls.find((c) => c.id === call.id);
       if (!callState) throw new Error(`Call Not Found: ${call.id}`);
 
       const participant = Array.from(callState.remoteParticipants.values()).find(
@@ -232,7 +232,7 @@ export const createDefaultCallingHandlers = memoizeOne(
 
     const onDisposeRemoteStreamView = async (userId: string): Promise<void> => {
       if (!call) return;
-      const callState = callClient.getState().calls.find((candidate) => candidate.id === call.id);
+      const callState = callClient.getState().calls.find((c) => c.id === call.id);
       if (!callState) throw new Error(`Call Not Found: ${call.id}`);
 
       const participant = Array.from(callState.remoteParticipants.values()).find(

--- a/packages/calling-component-bindings/src/handlers/createHandlers.ts
+++ b/packages/calling-component-bindings/src/handlers/createHandlers.ts
@@ -188,7 +188,7 @@ export const createDefaultCallingHandlers = memoizeOne(
         return;
       }
 
-      const callState = callClient.getState().calls.get(call.id);
+      const callState = callClient.getState().calls.find((candidate) => candidate.id === call.id);
       if (!callState) {
         return;
       }
@@ -203,7 +203,7 @@ export const createDefaultCallingHandlers = memoizeOne(
 
     const onCreateRemoteStreamView = async (userId: string, options?: VideoStreamOptions): Promise<void> => {
       if (!call) return;
-      const callState = callClient.getState().calls.get(call.id);
+      const callState = callClient.getState().calls.find((candidate) => candidate.id === call.id);
       if (!callState) throw new Error(`Call Not Found: ${call.id}`);
 
       const participant = Array.from(callState.remoteParticipants.values()).find(
@@ -232,7 +232,7 @@ export const createDefaultCallingHandlers = memoizeOne(
 
     const onDisposeRemoteStreamView = async (userId: string): Promise<void> => {
       if (!call) return;
-      const callState = callClient.getState().calls.get(call.id);
+      const callState = callClient.getState().calls.find((candidate) => candidate.id === call.id);
       if (!callState) throw new Error(`Call Not Found: ${call.id}`);
 
       const participant = Array.from(callState.remoteParticipants.values()).find(

--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -39,7 +39,7 @@ export interface CallClientState {
     calls: CallState[];
     callsEnded: CallState[];
     deviceManager: DeviceManagerState;
-    incomingCalls: Map<string, IncomingCallState>;
+    incomingCalls: IncomingCallState[];
     incomingCallsEnded: IncomingCallState[];
     userId: CommunicationUserKind;
 }

--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -36,7 +36,7 @@ export interface CallAgentState {
 // @public
 export interface CallClientState {
     callAgent: CallAgentState | undefined;
-    calls: Map<string, CallState>;
+    calls: CallState[];
     callsEnded: CallState[];
     deviceManager: DeviceManagerState;
     incomingCalls: Map<string, IncomingCallState>;

--- a/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
@@ -167,7 +167,7 @@ describe('declarative call agent', () => {
     mockCallAgent.calls = [mockCall];
     const internalContext = new InternalCallContext();
     callAgentDeclaratify(mockCallAgent, context, internalContext);
-    expect(context.getState().calls.size).toBe(1);
+    expect(context.getState().calls.length).toBe(1);
     expect(mockCall.emitter.eventNames().length).not.toBe(0);
   });
 
@@ -181,7 +181,7 @@ describe('declarative call agent', () => {
     await declarativeCallAgent.dispose();
     expect(mockCall.emitter.eventNames().length).toBe(0);
     expect(mockCallAgent.emitter.eventNames().length).toBe(0);
-    expect(context.getState().calls.size).toBe(1);
+    expect(context.getState().calls.length).toBe(1);
   });
 
   test('should clear state if newly created agent and if there is old existing state', async () => {
@@ -194,10 +194,10 @@ describe('declarative call agent', () => {
     await declarativeCallAgent.dispose();
     expect(mockCall.emitter.eventNames().length).toBe(0);
     expect(mockCallAgent.emitter.eventNames().length).toBe(0);
-    expect(context.getState().calls.size).toBe(1);
+    expect(context.getState().calls.length).toBe(1);
     mockCallAgent.calls = [];
     callAgentDeclaratify(mockCallAgent, context, internalContext);
-    expect(context.getState().calls.size).toBe(0);
+    expect(context.getState().calls.length).toBe(0);
     expect(internalContext.getRemoteRenderInfos().size).toBe(0);
   });
 
@@ -205,36 +205,36 @@ describe('declarative call agent', () => {
     const mockCallAgent = new MockCallAgent();
     const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
-    expect(context.getState().calls.size).toBe(0);
+    expect(context.getState().calls.length).toBe(0);
     const declarativeCallAgent = callAgentDeclaratify(mockCallAgent, context, internalContext);
     declarativeCallAgent.startCall([]);
-    expect(context.getState().calls.size).toBe(1);
+    expect(context.getState().calls.length).toBe(1);
   });
 
   test('should update state with new call when join is invoked', () => {
     const mockCallAgent = new MockCallAgent();
     const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
-    expect(context.getState().calls.size).toBe(0);
+    expect(context.getState().calls.length).toBe(0);
     const declarativeCallAgent = callAgentDeclaratify(mockCallAgent, context, internalContext);
     declarativeCallAgent.join({ meetingLink: '' });
-    expect(context.getState().calls.size).toBe(1);
+    expect(context.getState().calls.length).toBe(1);
   });
 
   test('should move call to callEnded when call is removed and add endTime', async () => {
     const mockCallAgent = new MockCallAgent();
     const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
-    expect(context.getState().calls.size).toBe(0);
+    expect(context.getState().calls.length).toBe(0);
     callAgentDeclaratify(mockCallAgent, context, internalContext);
 
     const mockCall = createMockCall(mockCallId);
     mockCallAgent.calls = [mockCall];
     mockCallAgent.emit('callsUpdated', { added: [mockCall], removed: [] });
 
-    await waitWithBreakCondition(() => context.getState().calls.size !== 0);
+    await waitWithBreakCondition(() => context.getState().calls.length !== 0);
 
-    expect(context.getState().calls.size).toBe(1);
+    expect(context.getState().calls.length).toBe(1);
 
     mockCall.callEndReason = { code: 1 };
     mockCallAgent.calls = [];
@@ -242,7 +242,7 @@ describe('declarative call agent', () => {
 
     await waitWithBreakCondition(() => context.getState().callsEnded.length !== 0);
 
-    expect(context.getState().calls.size).toBe(0);
+    expect(context.getState().calls.length).toBe(0);
     expect(context.getState().callsEnded.length).toBe(1);
     expect(context.getState().callsEnded[0].callEndReason?.code).toBe(1);
     expect(context.getState().callsEnded[0].endTime).toBeTruthy();
@@ -252,7 +252,7 @@ describe('declarative call agent', () => {
     const mockCallAgent = new MockCallAgent();
     const context = new CallContext({ kind: 'communicationUser', communicationUserId: '' });
     const internalContext = new InternalCallContext();
-    expect(context.getState().calls.size).toBe(0);
+    expect(context.getState().calls.length).toBe(0);
     callAgentDeclaratify(mockCallAgent, context, internalContext);
 
     const mockIncomingCall = createMockIncomingCall(mockCallId);
@@ -287,11 +287,11 @@ describe('declarative call agent', () => {
     mockCallAgent.calls = mockCalls;
     mockCallAgent.emit('callsUpdated', { added: mockCalls, removed: [] });
 
-    await waitWithBreakCondition(() => context.getState().calls.size === numberOfCalls);
+    await waitWithBreakCondition(() => context.getState().calls.length === numberOfCalls);
 
     mockCallAgent.emit('callsUpdated', { added: [], removed: mockCalls });
 
-    await waitWithBreakCondition(() => context.getState().calls.size === 0);
+    await waitWithBreakCondition(() => context.getState().calls.length === 0);
 
     expect(context.getState().callsEnded.length).toBe(MAX_CALL_HISTORY_LENGTH);
   });

--- a/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
@@ -258,15 +258,15 @@ describe('declarative call agent', () => {
     const mockIncomingCall = createMockIncomingCall(mockCallId);
     mockCallAgent.emit('incomingCall', { incomingCall: mockIncomingCall });
 
-    await waitWithBreakCondition(() => context.getState().incomingCalls.size !== 0);
+    await waitWithBreakCondition(() => context.getState().incomingCalls.length !== 0);
 
-    expect(context.getState().incomingCalls.size).toBe(1);
+    expect(context.getState().incomingCalls.length).toBe(1);
 
     mockIncomingCall.emit('callEnded', { callEndReason: { code: 1 } });
 
     await waitWithBreakCondition(() => context.getState().incomingCallsEnded.length !== 0);
 
-    expect(context.getState().incomingCalls.size).toBe(0);
+    expect(context.getState().incomingCalls.length).toBe(0);
     expect(context.getState().incomingCallsEnded.length).toBe(1);
     expect(context.getState().incomingCallsEnded[0].callEndReason?.code).toBe(1);
     expect(context.getState().incomingCallsEnded[0].endTime).toBeTruthy();
@@ -310,13 +310,13 @@ describe('declarative call agent', () => {
       mockCallAgent.emit('incomingCall', { incomingCall: mockIncomingCall });
     }
 
-    await waitWithBreakCondition(() => context.getState().incomingCalls.size === numberOfCalls);
+    await waitWithBreakCondition(() => context.getState().incomingCalls.length === numberOfCalls);
 
     for (const mockIncomingCall of mockIncomingCalls) {
       mockIncomingCall.emit('callEnded', { callEndReason: { code: 1 } });
     }
 
-    await waitWithBreakCondition(() => context.getState().incomingCalls.size === 0);
+    await waitWithBreakCondition(() => context.getState().incomingCalls.length === 0);
 
     expect(context.getState().incomingCallsEnded.length).toBe(MAX_CALL_HISTORY_LENGTH);
   });

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -393,7 +393,7 @@ export interface CallClientState {
    * could change. You should not cache the id itself but the entire {@Link @azure/communication-calling#Call} and then
    * use the id contained to look up data in this map.
    */
-  calls: Map<string, CallState>;
+  calls: CallState[];
   /**
    * Calls that have ended are stored here so the callEndReason could be checked. It is an array of CallState
    * {@Link CallState}. Calls are pushed on to the array as they end, meaning this is sorted by endTime ascending. Only

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -388,10 +388,7 @@ export type DeviceManagerState = {
  */
 export interface CallClientState {
   /**
-   * Proxy of {@Link @azure/communication-calling#CallAgent.calls} as a map of CallState {@Link CallState}. It is keyed
-   * by {@Link @azure/communication-calling#Call.id}. Please note that {@Link @azure/communication-calling#Call.id}
-   * could change. You should not cache the id itself but the entire {@Link @azure/communication-calling#Call} and then
-   * use the id contained to look up data in this map.
+   * Proxy of {@Link @azure/communication-calling#CallAgent.calls} as an array of CallState {@Link CallState}.
    */
   calls: CallState[];
   /**
@@ -402,11 +399,10 @@ export interface CallClientState {
    */
   callsEnded: CallState[];
   /**
-   * Proxy of {@Link @azure/communication-calling#IncomingCall} as a map of IncomingCall {@Link IncomingCall} received
-   * in the event 'incomingCall' emitted by {@Link @azure/communication-calling#CallAgent}. It is keyed by
-   * {@Link @azure/communication-calling#IncomingCall.id}.
+   * Proxy of {@Link @azure/communication-calling#IncomingCall} as an array of IncomingCall {@Link IncomingCall} received
+   * in the event 'incomingCall' emitted by {@Link @azure/communication-calling#CallAgent}.
    */
-  incomingCalls: Map<string, IncomingCallState>;
+  incomingCalls: IncomingCallState[];
   /**
    * Incoming Calls that have ended are stored here so the callEndReason could be checked. It is a array of IncomingCall
    * {@Link IncomingCall} received in the event 'incomingCall' emitted by

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -105,7 +105,7 @@ export class CallContext {
   public setCall(call: CallState): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const existingCall = draft.calls.find((candidate) => candidate.id === call.id);
+        const existingCall = draft.calls.find((c) => c.id === call.id);
         if (existingCall) {
           existingCall.callerInfo = call.callerInfo;
           existingCall.state = call.state;
@@ -128,7 +128,7 @@ export class CallContext {
   public removeCall(callId: string): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const callIndex = draft.calls.findIndex((candidate) => candidate.id === callId);
+        const callIndex = draft.calls.findIndex((c) => c.id === callId);
         if (callIndex !== -1) {
           draft.calls.splice(callIndex, 1);
         }
@@ -139,7 +139,7 @@ export class CallContext {
   public setCallEnded(callId: string, callEndReason: CallEndReason | undefined): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const callIndex = draft.calls.findIndex((candidate) => candidate.id === callId);
+        const callIndex = draft.calls.findIndex((c) => c.id === callId);
         if (callIndex !== -1) {
           const [call] = draft.calls.splice(callIndex, 1);
           call.endTime = new Date();
@@ -156,7 +156,7 @@ export class CallContext {
   public setCallState(callId: string, state: CallStatus): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           call.state = state;
         }
@@ -167,7 +167,7 @@ export class CallContext {
   public setCallId(newCallId: string, oldCallId: string): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === oldCallId);
+        const call = draft.calls.find((c) => c.id === oldCallId);
         if (call) {
           call.id = newCallId;
         }
@@ -178,7 +178,7 @@ export class CallContext {
   public setCallIsScreenSharingOn(callId: string, isScreenSharingOn: boolean): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           call.isScreenSharingOn = isScreenSharingOn;
         }
@@ -193,7 +193,7 @@ export class CallContext {
   ): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           removeRemoteParticipant.forEach((id: string) => {
             call.remoteParticipants.delete(id);
@@ -213,7 +213,7 @@ export class CallContext {
   ): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           removeRemoteParticipant.forEach((id: string) => {
             call.remoteParticipantsEnded.delete(id);
@@ -229,7 +229,7 @@ export class CallContext {
   public setCallLocalVideoStream(callId: string, streams: LocalVideoStreamState[]): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           call.localVideoStreams = streams;
         }
@@ -240,7 +240,7 @@ export class CallContext {
   public setCallIsMicrophoneMuted(callId: string, isMicrophoneMuted: boolean): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           call.isMuted = isMicrophoneMuted;
         }
@@ -251,7 +251,7 @@ export class CallContext {
   public setCallRecordingActive(callId: string, isRecordingActive: boolean): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           call.recording.isRecordingActive = isRecordingActive;
         }
@@ -262,7 +262,7 @@ export class CallContext {
   public setCallTranscriptionActive(callId: string, isTranscriptionActive: boolean): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           call.transcription.isTranscriptionActive = isTranscriptionActive;
         }
@@ -273,7 +273,7 @@ export class CallContext {
   public setCallReceivedTransferRequest(callId: string, transfer: TransferRequest): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           if (call.transfer.receivedTransferRequests.length >= MAX_TRANSFER_REQUEST_LENGTH) {
             call.transfer.receivedTransferRequests.shift();
@@ -287,7 +287,7 @@ export class CallContext {
   public setCallRequestedTransfer(callId: string, transfer: Transfer): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           if (call.transfer.requestedTransfers.length >= MAX_TRANSFER_REQUEST_LENGTH) {
             call.transfer.requestedTransfers.shift();
@@ -306,7 +306,7 @@ export class CallContext {
   ): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           for (const requestedTransfer of call.transfer.requestedTransfers) {
             if (requestedTransfer.id === transferId) {
@@ -323,7 +323,7 @@ export class CallContext {
   public setCallScreenShareParticipant(callId: string, participantKey: string | undefined): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           call.screenShareRemoteParticipant = participantKey;
         }
@@ -334,7 +334,7 @@ export class CallContext {
   public setLocalVideoStreamRendererView(callId: string, view: VideoStreamRendererViewState | undefined): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           if (call.localVideoStreams.length > 0) {
             call.localVideoStreams[0].view = view;
@@ -347,7 +347,7 @@ export class CallContext {
   public setParticipantState(callId: string, participantKey: string, state: RemoteParticipantStatus): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           const participant = call.remoteParticipants.get(participantKey);
           if (participant) {
@@ -361,7 +361,7 @@ export class CallContext {
   public setParticipantIsMuted(callId: string, participantKey: string, muted: boolean): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           const participant = call.remoteParticipants.get(participantKey);
           if (participant) {
@@ -375,7 +375,7 @@ export class CallContext {
   public setParticipantDisplayName(callId: string, participantKey: string, displayName: string): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           const participant = call.remoteParticipants.get(participantKey);
           if (participant) {
@@ -389,7 +389,7 @@ export class CallContext {
   public setParticipantIsSpeaking(callId: string, participantKey: string, isSpeaking: boolean): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           const participant = call.remoteParticipants.get(participantKey);
           if (participant) {
@@ -403,7 +403,7 @@ export class CallContext {
   public setParticipantVideoStream(callId: string, participantKey: string, stream: RemoteVideoStreamState): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           const participant = call.remoteParticipants.get(participantKey);
           if (participant) {
@@ -430,7 +430,7 @@ export class CallContext {
   ): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           const participant = call.remoteParticipants.get(participantKey);
           if (participant) {
@@ -452,7 +452,7 @@ export class CallContext {
   ): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           const participant = call.remoteParticipants.get(participantKey);
           if (participant) {
@@ -485,7 +485,7 @@ export class CallContext {
   ): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        const call = draft.calls.find((candidate) => candidate.id === callId);
+        const call = draft.calls.find((c) => c.id === callId);
         if (call) {
           const participant = call.remoteParticipants.get(participantKey);
           if (participant) {

--- a/packages/calling-stateful-client/src/CallDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallDeclarative.test.ts
@@ -66,17 +66,25 @@ describe('declarative call', () => {
 
     const transfer = declarativeTransfer.transfer({ targetParticipant: { communicationUserId: 'a' } }) as any;
 
-    expect(context.getState().calls.get(mockCallId)?.transfer.requestedTransfers.length).toBe(1);
-    expect(context.getState().calls.get(mockCallId)?.transfer.requestedTransfers[0].state).toBe('None');
+    expect(
+      context.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer.requestedTransfers.length
+    ).toBe(1);
+    expect(
+      context.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer.requestedTransfers[0].state
+    ).toBe('None');
 
     transfer.state = 'Transferred';
     transfer.emit('stateChanged');
 
     await waitWithBreakCondition(
-      () => context.getState().calls.get(mockCallId)?.transfer.requestedTransfers[0].state !== 'None'
+      () =>
+        context.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer.requestedTransfers[0]
+          .state !== 'None'
     );
 
-    expect(context.getState().calls.get(mockCallId)?.transfer.requestedTransfers[0].state).toBe('Transferred');
+    expect(
+      context.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer.requestedTransfers[0].state
+    ).toBe('Transferred');
   });
 
   test('when unsubscribe called unsubscribes from DeclarativeTransferCallFeature', async () => {

--- a/packages/calling-stateful-client/src/CallDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallDeclarative.test.ts
@@ -66,25 +66,21 @@ describe('declarative call', () => {
 
     const transfer = declarativeTransfer.transfer({ targetParticipant: { communicationUserId: 'a' } }) as any;
 
-    expect(
-      context.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer.requestedTransfers.length
-    ).toBe(1);
-    expect(
-      context.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer.requestedTransfers[0].state
-    ).toBe('None');
+    expect(context.getState().calls.find((c) => c.id === mockCallId)?.transfer.requestedTransfers.length).toBe(1);
+    expect(context.getState().calls.find((c) => c.id === mockCallId)?.transfer.requestedTransfers[0].state).toBe(
+      'None'
+    );
 
     transfer.state = 'Transferred';
     transfer.emit('stateChanged');
 
     await waitWithBreakCondition(
-      () =>
-        context.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer.requestedTransfers[0]
-          .state !== 'None'
+      () => context.getState().calls.find((c) => c.id === mockCallId)?.transfer.requestedTransfers[0].state !== 'None'
     );
 
-    expect(
-      context.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer.requestedTransfers[0].state
-    ).toBe('Transferred');
+    expect(context.getState().calls.find((c) => c.id === mockCallId)?.transfer.requestedTransfers[0].state).toBe(
+      'Transferred'
+    );
   });
 
   test('when unsubscribe called unsubscribes from DeclarativeTransferCallFeature', async () => {

--- a/packages/calling-stateful-client/src/RemoteVideoStreamSubscriber.ts
+++ b/packages/calling-stateful-client/src/RemoteVideoStreamSubscriber.ts
@@ -58,9 +58,8 @@ export class RemoteVideoStreamSubscriber {
       return;
     }
 
-    const existingScreenShare = this._context
-      .getState()
-      .calls.find((candidate) => candidate.id === this._callIdRef.callId)?.screenShareRemoteParticipant;
+    const existingScreenShare = this._context.getState().calls.find((c) => c.id === this._callIdRef.callId)
+      ?.screenShareRemoteParticipant;
 
     // If somehow we end up with an event where a RemoteParticipant's ScreenShare stream is set to
     // unavailable but there exists already another different participant actively sharing, and they are still
@@ -72,7 +71,7 @@ export class RemoteVideoStreamSubscriber {
 
     const streams = this._context
       .getState()
-      .calls.find((candidate) => candidate.id === this._callIdRef.callId)
+      .calls.find((c) => c.id === this._callIdRef.callId)
       ?.remoteParticipants.get(existingScreenShare)?.videoStreams;
 
     if (!streams) {

--- a/packages/calling-stateful-client/src/RemoteVideoStreamSubscriber.ts
+++ b/packages/calling-stateful-client/src/RemoteVideoStreamSubscriber.ts
@@ -58,8 +58,9 @@ export class RemoteVideoStreamSubscriber {
       return;
     }
 
-    const existingScreenShare = this._context.getState().calls.get(this._callIdRef.callId)
-      ?.screenShareRemoteParticipant;
+    const existingScreenShare = this._context
+      .getState()
+      .calls.find((candidate) => candidate.id === this._callIdRef.callId)?.screenShareRemoteParticipant;
 
     // If somehow we end up with an event where a RemoteParticipant's ScreenShare stream is set to
     // unavailable but there exists already another different participant actively sharing, and they are still
@@ -71,7 +72,7 @@ export class RemoteVideoStreamSubscriber {
 
     const streams = this._context
       .getState()
-      .calls.get(this._callIdRef.callId)
+      .calls.find((candidate) => candidate.id === this._callIdRef.callId)
       ?.remoteParticipants.get(existingScreenShare)?.videoStreams;
 
     if (!streams) {

--- a/packages/calling-stateful-client/src/StatefulCallClient.test.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.test.ts
@@ -131,8 +131,8 @@ async function createMockParticipantAndEmitParticipantUpdated(
     waitCondition
       ? waitCondition
       : () =>
-          testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-            ?.remoteParticipants.size !== 0
+          testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipants.size !==
+          0
   );
 }
 
@@ -157,7 +157,7 @@ async function createMockRemoteVideoStreamAndEmitVideoStreamsUpdated(
     () =>
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))?.videoStreams
         .size !== 0
   );
@@ -237,14 +237,11 @@ describe('Stateful call client', () => {
     testData.mockCall.emit('stateChanged');
 
     await waitWithBreakCondition(
-      () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.state ===
-        'InLobby'
+      () => testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.state === 'InLobby'
     );
-    expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.state ===
-        'InLobby'
-    ).toBe(true);
+    expect(testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.state === 'InLobby').toBe(
+      true
+    );
   });
 
   test('should update state when call `idChanged` event and update participantListeners', async () => {
@@ -257,16 +254,10 @@ describe('Stateful call client', () => {
     testData.mockCall.emit('idChanged');
 
     await waitWithBreakCondition(() => {
-      return (
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId2) !== undefined
-      );
+      return testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId2) !== undefined;
     });
-    expect(testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)).toBe(
-      undefined
-    );
-    expect(testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId2)).not.toBe(
-      undefined
-    );
+    expect(testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)).toBe(undefined);
+    expect(testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId2)).not.toBe(undefined);
 
     testData.mockRemoteParticipant.displayName = 'a';
     testData.mockRemoteParticipant.emit('displayNameChanged');
@@ -275,14 +266,14 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId2)
+          .calls.find((c) => c.id === mockCallId2)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.displayName !== undefined
     );
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId2)
+        .calls.find((c) => c.id === mockCallId2)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))?.displayName
     ).toBe('a');
   });
@@ -298,13 +289,12 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.isScreenSharingOn === !oldIsScreenSharingOn
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.isScreenSharingOn ===
+        !oldIsScreenSharingOn
     );
-    expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.isScreenSharingOn
-    ).toBe(!oldIsScreenSharingOn);
+    expect(testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.isScreenSharingOn).toBe(
+      !oldIsScreenSharingOn
+    );
   });
 
   test('should update state when call added local video `localVideoStreamsUpdated` event', async () => {
@@ -320,12 +310,11 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.localVideoStreams.length !== 0
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams.length !==
+        0
     );
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.localVideoStreams.length
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams.length
     ).toBe(1);
   });
 
@@ -344,8 +333,8 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.localVideoStreams.length !== 0
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams.length !==
+        0
     );
 
     testData.mockCall.localVideoStreams = [];
@@ -354,8 +343,7 @@ describe('Stateful call client', () => {
       removed: [{ source: {} as VideoDeviceInfo, mediaStreamType: 'Video' } as LocalVideoStream]
     });
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.localVideoStreams.length
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams.length
     ).toBe(0);
   });
 
@@ -365,8 +353,7 @@ describe('Stateful call client', () => {
     await createMockCallAndEmitCallsUpdated(testData);
     await createMockParticipantAndEmitParticipantUpdated(testData);
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.remoteParticipants.size
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipants.size
     ).toBe(1);
     expect(testData.mockRemoteParticipant.emitter.eventNames().length).not.toBe(0);
   });
@@ -385,12 +372,10 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.remoteParticipants.size === 0
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipants.size === 0
     );
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.remoteParticipants.size
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipants.size
     ).toBe(0);
     expect(testData.mockRemoteParticipant.emitter.eventNames().length).toBe(0);
   });
@@ -409,13 +394,13 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(participantKey)?.state === 'Idle'
     );
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(participantKey)?.state
     ).toBe('Idle');
   });
@@ -435,13 +420,13 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(participantKey)?.isMuted === !oldIsMuted
     );
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(participantKey)?.isMuted
     ).toBe(!oldIsMuted);
   });
@@ -460,13 +445,13 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(participantKey)?.displayName === 'z'
     );
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(participantKey)?.displayName
     ).toBe('z');
   });
@@ -486,13 +471,13 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(participantKey)?.isSpeaking === !oldIsSpeaking
     );
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(participantKey)?.isSpeaking
     ).toBe(!oldIsSpeaking);
   });
@@ -509,13 +494,13 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(participantKey)?.videoStreams.size !== 0
     );
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(participantKey)?.videoStreams.size
     ).toBe(1);
   });
@@ -532,7 +517,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(participantKey)?.videoStreams.size !== 0
     );
 
@@ -546,13 +531,13 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(participantKey)?.videoStreams.size === 0
     );
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(participantKey)?.videoStreams.size
     ).toBe(0);
   });
@@ -569,7 +554,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(participantKey)?.videoStreams.size !== 0
     );
 
@@ -580,14 +565,14 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(participantKey)
           ?.videoStreams.get(1)?.isAvailable === true
     );
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(participantKey)
         ?.videoStreams.get(1)?.isAvailable
     ).toBe(true);
@@ -601,13 +586,11 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.remoteParticipants.size !== 0
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipants.size !== 0
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.remoteParticipants.size
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipants.size
     ).toBe(1);
 
     testData.mockCall.remoteParticipants = [];
@@ -616,23 +599,20 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.remoteParticipants.size === 0
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipants.size === 0
     );
 
     const participantKey = toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier);
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.remoteParticipants.size
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipants.size
     ).toBe(0);
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.remoteParticipantsEnded.size
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipantsEnded.size
     ).toBe(1);
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipantsEnded.get(participantKey)?.callEndReason?.code
     ).toBe(1);
   });
@@ -654,20 +634,20 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.localVideoStreams.length !== 0
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams.length !==
+        0
     );
 
     const remoteVideoStream = testData.mockStatefulCallClient
       .getState()
-      .calls.find((candidate) => candidate.id === mockCallId)
+      .calls.find((c) => c.id === mockCallId)
       ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
       ?.videoStreams.get(1);
     if (!remoteVideoStream) {
@@ -680,9 +660,8 @@ describe('Stateful call client', () => {
       );
     }
 
-    const localVideoStream = testData.mockStatefulCallClient
-      .getState()
-      .calls.find((candidate) => candidate.id === mockCallId)?.localVideoStreams[0];
+    const localVideoStream = testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)
+      ?.localVideoStreams[0];
     if (!localVideoStream) {
       expect(localVideoStream).toBeDefined();
     } else {
@@ -693,7 +672,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view !== undefined
     );
@@ -702,7 +681,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view !== undefined
     );
@@ -710,14 +689,13 @@ describe('Stateful call client', () => {
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)?.view
     ).toBeDefined();
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.localVideoStreams[0].view
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams[0].view
     ).toBeDefined();
   });
 
@@ -738,20 +716,20 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.localVideoStreams.length !== 0
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams.length !==
+        0
     );
 
     const remoteVideoStream = testData.mockStatefulCallClient
       .getState()
-      .calls.find((candidate) => candidate.id === mockCallId)
+      .calls.find((c) => c.id === mockCallId)
       ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
       ?.videoStreams.get(1);
     if (!remoteVideoStream) {
@@ -765,9 +743,8 @@ describe('Stateful call client', () => {
       );
     }
 
-    const localVideoStream = testData.mockStatefulCallClient
-      .getState()
-      .calls.find((candidate) => candidate.id === mockCallId)?.localVideoStreams[0];
+    const localVideoStream = testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)
+      ?.localVideoStreams[0];
     if (!localVideoStream) {
       expect(localVideoStream).toBeDefined();
       return;
@@ -779,7 +756,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view !== undefined
     );
@@ -788,7 +765,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view !== undefined
     );
@@ -796,14 +773,13 @@ describe('Stateful call client', () => {
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)?.view
     ).toBeDefined();
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.localVideoStreams[0]?.view
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams[0]?.view
     ).toBeDefined();
 
     testData.mockStatefulCallClient.disposeView(
@@ -817,28 +793,27 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view === undefined
     );
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.localVideoStreams[0]?.view === undefined
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams[0]
+          ?.view === undefined
     );
 
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)?.view
     ).not.toBeDefined();
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.localVideoStreams[0].view
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams[0].view
     ).not.toBeDefined();
   });
 
@@ -859,20 +834,20 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.localVideoStreams.length !== 0
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams.length !==
+        0
     );
 
     const remoteVideoStream = testData.mockStatefulCallClient
       .getState()
-      .calls.find((candidate) => candidate.id === mockCallId)
+      .calls.find((c) => c.id === mockCallId)
       ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
       ?.videoStreams.get(1);
     if (!remoteVideoStream) {
@@ -886,9 +861,8 @@ describe('Stateful call client', () => {
       );
     }
 
-    const localVideoStream = testData.mockStatefulCallClient
-      .getState()
-      .calls.find((candidate) => candidate.id === mockCallId)?.localVideoStreams[0];
+    const localVideoStream = testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)
+      ?.localVideoStreams[0];
     if (!localVideoStream) {
       expect(localVideoStream).toBeDefined();
       return;
@@ -900,26 +874,25 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view !== undefined
     );
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.localVideoStreams[0]?.view !== undefined
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams[0]
+          ?.view !== undefined
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.localVideoStreams[0]?.view
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams[0]?.view
     ).toBeDefined();
 
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)?.view
     ).toBeDefined();
@@ -940,8 +913,7 @@ describe('Stateful call client', () => {
     ).not.toBeDefined();
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.localVideoStreams[0]?.view
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams[0]?.view
     ).not.toBeDefined();
   });
 
@@ -956,13 +928,12 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.recording
           .isRecordingActive === true
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
-        .isRecordingActive
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.recording.isRecordingActive
     ).toBe(true);
   });
 
@@ -977,12 +948,12 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.transcription
           .isTranscriptionActive === true
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.transcription
         .isTranscriptionActive
     ).toBe(true);
   });
@@ -998,13 +969,12 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.recording
           .isRecordingActive === true
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
-        .isRecordingActive
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.recording.isRecordingActive
     ).toBe(true);
 
     const recording = featureCache.get(Features.Recording);
@@ -1013,13 +983,12 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.recording
           .isRecordingActive === false
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
-        .isRecordingActive
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.recording.isRecordingActive
     ).toBe(false);
   });
 
@@ -1034,12 +1003,12 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.transcription
           .isTranscriptionActive === true
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.transcription
         .isTranscriptionActive
     ).toBe(true);
 
@@ -1049,12 +1018,12 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.transcription
           .isTranscriptionActive === false
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.transcription
         .isTranscriptionActive
     ).toBe(false);
   });
@@ -1070,19 +1039,18 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.recording
           .isRecordingActive === true
     );
 
     expect(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.recording
           .isRecordingActive === true
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
-        .isRecordingActive
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.recording.isRecordingActive
     ).toBe(true);
 
     testData.mockCallAgent.calls = [];
@@ -1108,12 +1076,12 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.transcription
           .isTranscriptionActive === true
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.transcription
         .isTranscriptionActive
     ).toBe(true);
 
@@ -1140,19 +1108,18 @@ describe('Stateful call client', () => {
     await createMockCallAndEmitCallsUpdated(testData, undefined, mockCall);
 
     await waitWithBreakCondition(
-      () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId) !== undefined
+      () => testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId) !== undefined
     );
 
     transfer.emit('transferRequested', { targetParticipant: { communicationUserId: 'a', kind: 'communicationUser' } });
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.transfer
           .receivedTransferRequests.length !== 0
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.transfer
         .receivedTransferRequests.length
     ).toBe(1);
   });
@@ -1167,8 +1134,7 @@ describe('Stateful call client', () => {
     await createMockCallAndEmitCallsUpdated(testData, undefined, mockCall);
 
     await waitWithBreakCondition(
-      () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId) !== undefined
+      () => testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId) !== undefined
     );
 
     testData.mockCallAgent.calls = [];
@@ -1194,14 +1160,13 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.screenShareRemoteParticipant
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.screenShareRemoteParticipant
     ).toBeDefined();
   });
 
@@ -1216,7 +1181,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
@@ -1228,8 +1193,7 @@ describe('Stateful call client', () => {
     });
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.screenShareRemoteParticipant
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.screenShareRemoteParticipant
     ).not.toBeDefined();
   });
 
@@ -1249,8 +1213,7 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.remoteParticipants.size === 2
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipants.size === 2
     );
 
     // Add a second inactive screenshare and ensure it doesn't overwrite the first one
@@ -1268,18 +1231,16 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier({ communicationUserId: secondMockParticipantId }))
           ?.videoStreams.size !== 0
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.screenShareRemoteParticipant
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.screenShareRemoteParticipant
     ).toBeDefined();
     expect(
-      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-        ?.screenShareRemoteParticipant
+      testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.screenShareRemoteParticipant
     ).toBe(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier));
   });
 
@@ -1302,7 +1263,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
@@ -1317,8 +1278,7 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
-          ?.remoteParticipants.size !== 0
+        testData.mockStatefulCallClient.getState().calls.find((c) => c.id === mockCallId)?.remoteParticipants.size !== 0
     );
 
     const mockRemoteVideoStream2 = createMockRemoteVideoStream(false);
@@ -1333,7 +1293,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockRemoteParticipant2.identifier))?.videoStreams
           .size !== 0
     );
@@ -1349,7 +1309,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.find((candidate) => candidate.id === mockCallId)
+          .calls.find((c) => c.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockRemoteParticipant2.identifier))?.videoStreams
           .size === 0
     );
@@ -1364,14 +1324,14 @@ describe('Stateful call client', () => {
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)
     ).toBeDefined();
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)?.view
     ).toBeDefined();

--- a/packages/calling-stateful-client/src/StatefulCallClient.test.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.test.ts
@@ -112,7 +112,7 @@ async function createMockCallAndEmitCallsUpdated(
     removed: []
   });
   await waitWithBreakCondition(
-    waitCondition ? waitCondition : () => testData.mockStatefulCallClient.getState().calls.size !== 0
+    waitCondition ? waitCondition : () => testData.mockStatefulCallClient.getState().calls.length !== 0
   );
 }
 
@@ -130,7 +130,9 @@ async function createMockParticipantAndEmitParticipantUpdated(
   await waitWithBreakCondition(
     waitCondition
       ? waitCondition
-      : () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.size !== 0
+      : () =>
+          testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+            ?.remoteParticipants.size !== 0
   );
 }
 
@@ -155,7 +157,7 @@ async function createMockRemoteVideoStreamAndEmitVideoStreamsUpdated(
     () =>
       testData.mockStatefulCallClient
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))?.videoStreams
         .size !== 0
   );
@@ -205,9 +207,9 @@ describe('Stateful call client', () => {
   test('should update state when call added in `callUpdated` event and subscribe to call', async () => {
     const testData = {} as TestData;
     createClientAndAgentMocks(testData);
-    expect(testData.mockStatefulCallClient.getState().calls.size).toBe(0);
+    expect(testData.mockStatefulCallClient.getState().calls.length).toBe(0);
     await createMockCallAndEmitCallsUpdated(testData);
-    expect(testData.mockStatefulCallClient.getState().calls.size).toBe(1);
+    expect(testData.mockStatefulCallClient.getState().calls.length).toBe(1);
     expect(testData.mockCall.emitter.eventNames().length).not.toBe(0);
   });
 
@@ -222,7 +224,7 @@ describe('Stateful call client', () => {
       removed: [testData.mockCall]
     });
 
-    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.size === 0);
+    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.length === 0);
     expect(testData.mockCall.emitter.eventNames().length).toBe(0);
   });
 
@@ -235,9 +237,14 @@ describe('Stateful call client', () => {
     testData.mockCall.emit('stateChanged');
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.state === 'InLobby'
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.state ===
+        'InLobby'
     );
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.state === 'InLobby').toBe(true);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.state ===
+        'InLobby'
+    ).toBe(true);
   });
 
   test('should update state when call `idChanged` event and update participantListeners', async () => {
@@ -250,10 +257,16 @@ describe('Stateful call client', () => {
     testData.mockCall.emit('idChanged');
 
     await waitWithBreakCondition(() => {
-      return testData.mockStatefulCallClient.getState().calls.get(mockCallId2) !== undefined;
+      return (
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId2) !== undefined
+      );
     });
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)).toBe(undefined);
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId2)).not.toBe(undefined);
+    expect(testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)).toBe(
+      undefined
+    );
+    expect(testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId2)).not.toBe(
+      undefined
+    );
 
     testData.mockRemoteParticipant.displayName = 'a';
     testData.mockRemoteParticipant.emit('displayNameChanged');
@@ -262,14 +275,14 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId2)
+          .calls.find((candidate) => candidate.id === mockCallId2)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.displayName !== undefined
     );
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.get(mockCallId2)
+        .calls.find((candidate) => candidate.id === mockCallId2)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))?.displayName
     ).toBe('a');
   });
@@ -285,11 +298,13 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.isScreenSharingOn === !oldIsScreenSharingOn
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.isScreenSharingOn === !oldIsScreenSharingOn
     );
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.isScreenSharingOn).toBe(
-      !oldIsScreenSharingOn
-    );
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.isScreenSharingOn
+    ).toBe(!oldIsScreenSharingOn);
   });
 
   test('should update state when call added local video `localVideoStreamsUpdated` event', async () => {
@@ -304,9 +319,14 @@ describe('Stateful call client', () => {
     });
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams.length !== 0
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.localVideoStreams.length !== 0
     );
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams.length).toBe(1);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.localVideoStreams.length
+    ).toBe(1);
   });
 
   test('should update state when call remove local video `localVideoStreamsUpdated` event', async () => {
@@ -323,7 +343,9 @@ describe('Stateful call client', () => {
     });
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams.length !== 0
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.localVideoStreams.length !== 0
     );
 
     testData.mockCall.localVideoStreams = [];
@@ -331,7 +353,10 @@ describe('Stateful call client', () => {
       added: [],
       removed: [{ source: {} as VideoDeviceInfo, mediaStreamType: 'Video' } as LocalVideoStream]
     });
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams.length).toBe(0);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.localVideoStreams.length
+    ).toBe(0);
   });
 
   test('should update state when participant added in `remoteParticipantsUpdated` and subscribe to it', async () => {
@@ -339,7 +364,10 @@ describe('Stateful call client', () => {
     createClientAndAgentMocks(testData);
     await createMockCallAndEmitCallsUpdated(testData);
     await createMockParticipantAndEmitParticipantUpdated(testData);
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.size).toBe(1);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipants.size
+    ).toBe(1);
     expect(testData.mockRemoteParticipant.emitter.eventNames().length).not.toBe(0);
   });
 
@@ -356,9 +384,14 @@ describe('Stateful call client', () => {
     });
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.size === 0
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.size === 0
     );
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.size).toBe(0);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipants.size
+    ).toBe(0);
     expect(testData.mockRemoteParticipant.emitter.eventNames().length).toBe(0);
   });
 
@@ -374,11 +407,16 @@ describe('Stateful call client', () => {
     const participantKey = toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier);
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-          ?.state === 'Idle'
+        testData.mockStatefulCallClient
+          .getState()
+          .calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.get(participantKey)?.state === 'Idle'
     );
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)?.state
+      testData.mockStatefulCallClient
+        .getState()
+        .calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipants.get(participantKey)?.state
     ).toBe('Idle');
   });
 
@@ -395,11 +433,16 @@ describe('Stateful call client', () => {
     const participantKey = toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier);
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-          ?.isMuted === !oldIsMuted
+        testData.mockStatefulCallClient
+          .getState()
+          .calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.get(participantKey)?.isMuted === !oldIsMuted
     );
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)?.isMuted
+      testData.mockStatefulCallClient
+        .getState()
+        .calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipants.get(participantKey)?.isMuted
     ).toBe(!oldIsMuted);
   });
 
@@ -415,12 +458,16 @@ describe('Stateful call client', () => {
     const participantKey = toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier);
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-          ?.displayName === 'z'
+        testData.mockStatefulCallClient
+          .getState()
+          .calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.get(participantKey)?.displayName === 'z'
     );
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-        ?.displayName
+      testData.mockStatefulCallClient
+        .getState()
+        .calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipants.get(participantKey)?.displayName
     ).toBe('z');
   });
 
@@ -437,12 +484,16 @@ describe('Stateful call client', () => {
     const participantKey = toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier);
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-          ?.isSpeaking === !oldIsSpeaking
+        testData.mockStatefulCallClient
+          .getState()
+          .calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.get(participantKey)?.isSpeaking === !oldIsSpeaking
     );
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-        ?.isSpeaking
+      testData.mockStatefulCallClient
+        .getState()
+        .calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipants.get(participantKey)?.isSpeaking
     ).toBe(!oldIsSpeaking);
   });
 
@@ -456,12 +507,16 @@ describe('Stateful call client', () => {
     const participantKey = toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier);
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-          ?.videoStreams.size !== 0
+        testData.mockStatefulCallClient
+          .getState()
+          .calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.get(participantKey)?.videoStreams.size !== 0
     );
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-        ?.videoStreams.size
+      testData.mockStatefulCallClient
+        .getState()
+        .calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipants.get(participantKey)?.videoStreams.size
     ).toBe(1);
   });
 
@@ -475,8 +530,10 @@ describe('Stateful call client', () => {
     const participantKey = toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier);
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-          ?.videoStreams.size !== 0
+        testData.mockStatefulCallClient
+          .getState()
+          .calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.get(participantKey)?.videoStreams.size !== 0
     );
 
     testData.mockRemoteParticipant.videoStreams = [];
@@ -487,12 +544,16 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-          ?.videoStreams.size === 0
+        testData.mockStatefulCallClient
+          .getState()
+          .calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.get(participantKey)?.videoStreams.size === 0
     );
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-        ?.videoStreams.size
+      testData.mockStatefulCallClient
+        .getState()
+        .calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipants.get(participantKey)?.videoStreams.size
     ).toBe(0);
   });
 
@@ -506,8 +567,10 @@ describe('Stateful call client', () => {
     const participantKey = toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier);
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.get(participantKey)
-          ?.videoStreams.size !== 0
+        testData.mockStatefulCallClient
+          .getState()
+          .calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.get(participantKey)?.videoStreams.size !== 0
     );
 
     testData.mockRemoteVideoStream.isAvailable = true;
@@ -517,14 +580,14 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(participantKey)
           ?.videoStreams.get(1)?.isAvailable === true
     );
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(participantKey)
         ?.videoStreams.get(1)?.isAvailable
     ).toBe(true);
@@ -537,25 +600,40 @@ describe('Stateful call client', () => {
     await createMockParticipantAndEmitParticipantUpdated(testData);
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.size !== 0
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.size !== 0
     );
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.size).toBe(1);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipants.size
+    ).toBe(1);
 
     testData.mockCall.remoteParticipants = [];
     testData.mockRemoteParticipant.callEndReason = { code: 1 };
     testData.mockCall.emit('remoteParticipantsUpdated', { added: [], removed: [testData.mockRemoteParticipant] });
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.size === 0
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.size === 0
     );
 
     const participantKey = toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier);
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.size).toBe(0);
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipantsEnded.size).toBe(1);
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipantsEnded.get(participantKey)
-        ?.callEndReason?.code
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipants.size
+    ).toBe(0);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipantsEnded.size
+    ).toBe(1);
+    expect(
+      testData.mockStatefulCallClient
+        .getState()
+        .calls.find((candidate) => candidate.id === mockCallId)
+        ?.remoteParticipantsEnded.get(participantKey)?.callEndReason?.code
     ).toBe(1);
   });
 
@@ -576,18 +654,20 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams.length !== 0
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.localVideoStreams.length !== 0
     );
 
     const remoteVideoStream = testData.mockStatefulCallClient
       .getState()
-      .calls.get(mockCallId)
+      .calls.find((candidate) => candidate.id === mockCallId)
       ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
       ?.videoStreams.get(1);
     if (!remoteVideoStream) {
@@ -600,7 +680,9 @@ describe('Stateful call client', () => {
       );
     }
 
-    const localVideoStream = testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams[0];
+    const localVideoStream = testData.mockStatefulCallClient
+      .getState()
+      .calls.find((candidate) => candidate.id === mockCallId)?.localVideoStreams[0];
     if (!localVideoStream) {
       expect(localVideoStream).toBeDefined();
     } else {
@@ -611,7 +693,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view !== undefined
     );
@@ -620,7 +702,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view !== undefined
     );
@@ -628,12 +710,15 @@ describe('Stateful call client', () => {
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)?.view
     ).toBeDefined();
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams[0].view).toBeDefined();
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.localVideoStreams[0].view
+    ).toBeDefined();
   });
 
   test('should stop rendering the stream and remove from state when disposeView is called', async () => {
@@ -653,18 +738,20 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams.length !== 0
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.localVideoStreams.length !== 0
     );
 
     const remoteVideoStream = testData.mockStatefulCallClient
       .getState()
-      .calls.get(mockCallId)
+      .calls.find((candidate) => candidate.id === mockCallId)
       ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
       ?.videoStreams.get(1);
     if (!remoteVideoStream) {
@@ -678,7 +765,9 @@ describe('Stateful call client', () => {
       );
     }
 
-    const localVideoStream = testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams[0];
+    const localVideoStream = testData.mockStatefulCallClient
+      .getState()
+      .calls.find((candidate) => candidate.id === mockCallId)?.localVideoStreams[0];
     if (!localVideoStream) {
       expect(localVideoStream).toBeDefined();
       return;
@@ -690,7 +779,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view !== undefined
     );
@@ -699,7 +788,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view !== undefined
     );
@@ -707,12 +796,15 @@ describe('Stateful call client', () => {
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)?.view
     ).toBeDefined();
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams[0]?.view).toBeDefined();
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.localVideoStreams[0]?.view
+    ).toBeDefined();
 
     testData.mockStatefulCallClient.disposeView(
       mockCallId,
@@ -725,25 +817,28 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view === undefined
     );
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams[0]?.view === undefined
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.localVideoStreams[0]?.view === undefined
     );
 
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)?.view
     ).not.toBeDefined();
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams[0].view
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.localVideoStreams[0].view
     ).not.toBeDefined();
   });
 
@@ -764,18 +859,20 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams.length !== 0
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.localVideoStreams.length !== 0
     );
 
     const remoteVideoStream = testData.mockStatefulCallClient
       .getState()
-      .calls.get(mockCallId)
+      .calls.find((candidate) => candidate.id === mockCallId)
       ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
       ?.videoStreams.get(1);
     if (!remoteVideoStream) {
@@ -789,7 +886,9 @@ describe('Stateful call client', () => {
       );
     }
 
-    const localVideoStream = testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams[0];
+    const localVideoStream = testData.mockStatefulCallClient
+      .getState()
+      .calls.find((candidate) => candidate.id === mockCallId)?.localVideoStreams[0];
     if (!localVideoStream) {
       expect(localVideoStream).toBeDefined();
       return;
@@ -801,21 +900,26 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.get(1)?.view !== undefined
     );
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams[0]?.view !== undefined
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.localVideoStreams[0]?.view !== undefined
     );
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams[0]?.view).toBeDefined();
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.localVideoStreams[0]?.view
+    ).toBeDefined();
 
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)?.view
     ).toBeDefined();
@@ -826,7 +930,7 @@ describe('Stateful call client', () => {
       removed: [testData.mockCall]
     });
 
-    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.size === 0);
+    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.length === 0);
 
     expect(
       testData.mockStatefulCallClient
@@ -836,7 +940,8 @@ describe('Stateful call client', () => {
     ).not.toBeDefined();
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.localVideoStreams[0]?.view
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.localVideoStreams[0]?.view
     ).not.toBeDefined();
   });
 
@@ -850,10 +955,15 @@ describe('Stateful call client', () => {
     await createMockCallAndEmitCallsUpdated(testData, undefined, mockCall);
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.recording.isRecordingActive === true
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+          .isRecordingActive === true
     );
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.recording.isRecordingActive).toBe(true);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+        .isRecordingActive
+    ).toBe(true);
   });
 
   test('should detect if call already has transcription active', async () => {
@@ -867,12 +977,14 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.transcription.isTranscriptionActive === true
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+          .isTranscriptionActive === true
     );
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.transcription.isTranscriptionActive).toBe(
-      true
-    );
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+        .isTranscriptionActive
+    ).toBe(true);
   });
 
   test('should detect recording changes in call', async () => {
@@ -885,20 +997,30 @@ describe('Stateful call client', () => {
     await createMockCallAndEmitCallsUpdated(testData, undefined, mockCall);
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.recording.isRecordingActive === true
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+          .isRecordingActive === true
     );
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.recording.isRecordingActive).toBe(true);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+        .isRecordingActive
+    ).toBe(true);
 
     const recording = featureCache.get(Features.Recording);
     recording.isRecordingActive = false;
     recording.emitter.emit('isRecordingActiveChanged');
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.recording.isRecordingActive === false
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+          .isRecordingActive === false
     );
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.recording.isRecordingActive).toBe(false);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+        .isRecordingActive
+    ).toBe(false);
   });
 
   test('should detect transcription changes in call', async () => {
@@ -912,12 +1034,14 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.transcription.isTranscriptionActive === true
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+          .isTranscriptionActive === true
     );
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.transcription.isTranscriptionActive).toBe(
-      true
-    );
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+        .isTranscriptionActive
+    ).toBe(true);
 
     const transcription = featureCache.get(Features.Transcription);
     transcription.isTranscriptionActive = false;
@@ -925,12 +1049,14 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.transcription.isTranscriptionActive === false
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+          .isTranscriptionActive === false
     );
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.transcription.isTranscriptionActive).toBe(
-      false
-    );
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+        .isTranscriptionActive
+    ).toBe(false);
   });
 
   test('should unsubscribe to recording changes when call ended', async () => {
@@ -943,14 +1069,21 @@ describe('Stateful call client', () => {
     await createMockCallAndEmitCallsUpdated(testData, undefined, mockCall);
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.recording.isRecordingActive === true
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+          .isRecordingActive === true
     );
 
     expect(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.recording.isRecordingActive === true
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+          .isRecordingActive === true
     );
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.recording.isRecordingActive).toBe(true);
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.recording
+        .isRecordingActive
+    ).toBe(true);
 
     testData.mockCallAgent.calls = [];
     testData.mockCallAgent.emit('callsUpdated', {
@@ -958,7 +1091,7 @@ describe('Stateful call client', () => {
       removed: [testData.mockCall]
     });
 
-    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.size === 0);
+    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.length === 0);
 
     const recording = featureCache.get(Features.Recording);
     expect(recording.emitter.eventNames().length).toBe(0);
@@ -975,12 +1108,14 @@ describe('Stateful call client', () => {
 
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.transcription.isTranscriptionActive === true
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+          .isTranscriptionActive === true
     );
 
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.transcription.isTranscriptionActive).toBe(
-      true
-    );
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transcription
+        .isTranscriptionActive
+    ).toBe(true);
 
     testData.mockCallAgent.calls = [];
     testData.mockCallAgent.emit('callsUpdated', {
@@ -988,7 +1123,7 @@ describe('Stateful call client', () => {
       removed: [testData.mockCall]
     });
 
-    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.size === 0);
+    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.length === 0);
 
     const transcription = featureCache.get(Features.Transcription);
     expect(transcription.emitter.eventNames().length).toBe(0);
@@ -1004,16 +1139,21 @@ describe('Stateful call client', () => {
     mockCall.api = createMockApiFeatures(featureCache);
     await createMockCallAndEmitCallsUpdated(testData, undefined, mockCall);
 
-    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.get(mockCallId) !== undefined);
+    await waitWithBreakCondition(
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId) !== undefined
+    );
 
     transfer.emit('transferRequested', { targetParticipant: { communicationUserId: 'a', kind: 'communicationUser' } });
     await waitWithBreakCondition(
       () =>
-        testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.transfer.receivedTransferRequests.length !== 0
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer
+          .receivedTransferRequests.length !== 0
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.transfer.receivedTransferRequests.length
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)?.transfer
+        .receivedTransferRequests.length
     ).toBe(1);
   });
 
@@ -1026,7 +1166,10 @@ describe('Stateful call client', () => {
     mockCall.api = createMockApiFeatures(featureCache);
     await createMockCallAndEmitCallsUpdated(testData, undefined, mockCall);
 
-    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.get(mockCallId) !== undefined);
+    await waitWithBreakCondition(
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId) !== undefined
+    );
 
     testData.mockCallAgent.calls = [];
     testData.mockCallAgent.emit('callsUpdated', {
@@ -1034,7 +1177,7 @@ describe('Stateful call client', () => {
       removed: [testData.mockCall]
     });
 
-    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.size === 0);
+    await waitWithBreakCondition(() => testData.mockStatefulCallClient.getState().calls.length === 0);
 
     const transfer = featureCache.get(Features.Transfer);
     expect(transfer.emitter.eventNames().length).toBe(0);
@@ -1051,13 +1194,14 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.screenShareRemoteParticipant
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.screenShareRemoteParticipant
     ).toBeDefined();
   });
 
@@ -1072,7 +1216,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
@@ -1084,7 +1228,8 @@ describe('Stateful call client', () => {
     });
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.screenShareRemoteParticipant
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.screenShareRemoteParticipant
     ).not.toBeDefined();
   });
 
@@ -1103,7 +1248,9 @@ describe('Stateful call client', () => {
     });
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.size === 2
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.size === 2
     );
 
     // Add a second inactive screenshare and ensure it doesn't overwrite the first one
@@ -1121,17 +1268,19 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier({ communicationUserId: secondMockParticipantId }))
           ?.videoStreams.size !== 0
     );
 
     expect(
-      testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.screenShareRemoteParticipant
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.screenShareRemoteParticipant
     ).toBeDefined();
-    expect(testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.screenShareRemoteParticipant).toBe(
-      toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier)
-    );
+    expect(
+      testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+        ?.screenShareRemoteParticipant
+    ).toBe(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier));
   });
 
   test('should not overwrite another stream of another participant if the stream ids are the same', async () => {
@@ -1153,7 +1302,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
           ?.videoStreams.size !== 0
     );
@@ -1167,7 +1316,9 @@ describe('Stateful call client', () => {
     });
 
     await waitWithBreakCondition(
-      () => testData.mockStatefulCallClient.getState().calls.get(mockCallId)?.remoteParticipants.size !== 0
+      () =>
+        testData.mockStatefulCallClient.getState().calls.find((candidate) => candidate.id === mockCallId)
+          ?.remoteParticipants.size !== 0
     );
 
     const mockRemoteVideoStream2 = createMockRemoteVideoStream(false);
@@ -1182,7 +1333,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockRemoteParticipant2.identifier))?.videoStreams
           .size !== 0
     );
@@ -1198,7 +1349,7 @@ describe('Stateful call client', () => {
       () =>
         testData.mockStatefulCallClient
           .getState()
-          .calls.get(mockCallId)
+          .calls.find((candidate) => candidate.id === mockCallId)
           ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockRemoteParticipant2.identifier))?.videoStreams
           .size === 0
     );
@@ -1213,14 +1364,14 @@ describe('Stateful call client', () => {
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)
     ).toBeDefined();
     expect(
       testData.mockStatefulCallClient
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(testData.mockRemoteParticipant.identifier))
         ?.videoStreams.get(1)?.view
     ).toBeDefined();

--- a/packages/calling-stateful-client/src/StreamUtils.test.ts
+++ b/packages/calling-stateful-client/src/StreamUtils.test.ts
@@ -176,7 +176,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).toBeDefined();
@@ -195,7 +195,9 @@ describe('stream utils', () => {
     expect(internalContext.getLocalRenderInfo(mockCallId)?.stream).toBeDefined();
     expect(internalContext.getLocalRenderInfo(mockCallId)?.renderer).toBeDefined();
     expect(internalContext.getLocalRenderInfo(mockCallId)?.status).toBe('Rendered');
-    expect(context.getState().calls.get(mockCallId)?.localVideoStreams[0].view).toBeDefined();
+    expect(
+      context.getState().calls.find((candidate) => candidate.id === mockCallId)?.localVideoStreams[0].view
+    ).toBeDefined();
   });
 
   test('cleans up state and stop rendering when disposeView is called on remote stream', async () => {
@@ -226,7 +228,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).not.toBeDefined();
@@ -268,7 +270,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).toBeDefined();
@@ -282,7 +284,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier2))
         ?.videoStreams.get(mockStreamId2)?.view
     ).toBeDefined();
@@ -313,7 +315,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).not.toBeDefined();
@@ -327,7 +329,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier2))
         ?.videoStreams.get(mockStreamId2)?.view
     ).not.toBeDefined();
@@ -371,7 +373,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).toBeDefined();
@@ -385,7 +387,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.get(mockCallId2)
+        .calls.find((candidate) => candidate.id === mockCallId2)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier2))
         ?.videoStreams.get(mockStreamId2)?.view
     ).toBeDefined();
@@ -416,7 +418,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.get(mockCallId)
+        .calls.find((candidate) => candidate.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).not.toBeDefined();
@@ -430,7 +432,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.get(mockCallId2)
+        .calls.find((candidate) => candidate.id === mockCallId2)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier2))
         ?.videoStreams.get(mockStreamId2)?.view
     ).not.toBeDefined();

--- a/packages/calling-stateful-client/src/StreamUtils.test.ts
+++ b/packages/calling-stateful-client/src/StreamUtils.test.ts
@@ -176,7 +176,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).toBeDefined();
@@ -195,9 +195,7 @@ describe('stream utils', () => {
     expect(internalContext.getLocalRenderInfo(mockCallId)?.stream).toBeDefined();
     expect(internalContext.getLocalRenderInfo(mockCallId)?.renderer).toBeDefined();
     expect(internalContext.getLocalRenderInfo(mockCallId)?.status).toBe('Rendered');
-    expect(
-      context.getState().calls.find((candidate) => candidate.id === mockCallId)?.localVideoStreams[0].view
-    ).toBeDefined();
+    expect(context.getState().calls.find((c) => c.id === mockCallId)?.localVideoStreams[0].view).toBeDefined();
   });
 
   test('cleans up state and stop rendering when disposeView is called on remote stream', async () => {
@@ -228,7 +226,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).not.toBeDefined();
@@ -270,7 +268,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).toBeDefined();
@@ -284,7 +282,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier2))
         ?.videoStreams.get(mockStreamId2)?.view
     ).toBeDefined();
@@ -315,7 +313,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).not.toBeDefined();
@@ -329,7 +327,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier2))
         ?.videoStreams.get(mockStreamId2)?.view
     ).not.toBeDefined();
@@ -373,7 +371,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).toBeDefined();
@@ -387,7 +385,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId2)
+        .calls.find((c) => c.id === mockCallId2)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier2))
         ?.videoStreams.get(mockStreamId2)?.view
     ).toBeDefined();
@@ -418,7 +416,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId)
+        .calls.find((c) => c.id === mockCallId)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier))
         ?.videoStreams.get(mockStreamId)?.view
     ).not.toBeDefined();
@@ -432,7 +430,7 @@ describe('stream utils', () => {
     expect(
       context
         .getState()
-        .calls.find((candidate) => candidate.id === mockCallId2)
+        .calls.find((c) => c.id === mockCallId2)
         ?.remoteParticipants.get(toFlatCommunicationIdentifier(mockParticipantIdentifier2))
         ?.videoStreams.get(mockStreamId2)?.view
     ).not.toBeDefined();

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -320,7 +320,7 @@ export interface CallClientState {
     calls: CallState[];
     callsEnded: CallState[];
     deviceManager: DeviceManagerState;
-    incomingCalls: Map<string, IncomingCallState>;
+    incomingCalls: IncomingCallState[];
     incomingCallsEnded: IncomingCallState[];
     userId: CommunicationUserKind;
 }
@@ -790,7 +790,7 @@ export const getDisplayName: (state: CallClientState) => string | undefined;
 export const getIdentifier: (state: CallClientState) => string;
 
 // @public (undocumented)
-export const getIncomingCalls: (state: CallClientState) => Map<string, IncomingCallState>;
+export const getIncomingCalls: (state: CallClientState) => IncomingCallState[];
 
 // @public (undocumented)
 export const getIncomingCallsEnded: (state: CallClientState) => IncomingCallState[];

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -317,7 +317,7 @@ export interface CallClientProviderProps {
 // @public
 export interface CallClientState {
     callAgent: CallAgentState | undefined;
-    calls: Map<string, CallState>;
+    calls: CallState[];
     callsEnded: CallState[];
     deviceManager: DeviceManagerState;
     incomingCalls: Map<string, IncomingCallState>;
@@ -769,7 +769,7 @@ export type GetCallingSelector<Component> = AreEqual<Component, typeof VideoGall
 export const getCallingSelector: <Component extends (props: any) => JSX.Element | undefined>(component: Component) => GetCallingSelector<Component>;
 
 // @public (undocumented)
-export const getCalls: (state: CallClientState) => Map<string, CallState>;
+export const getCalls: (state: CallClientState) => CallState[];
 
 // @public (undocumented)
 export const getCallsEnded: (state: CallClientState) => CallState[];

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -96,7 +96,7 @@ class CallContext {
 
   public updateClientState(clientState: CallClientState): void {
     const callId = this.callId ?? '';
-    const call = clientState.calls.find((candidate) => candidate.id === callId);
+    const call = clientState.calls.find((c) => c.id === callId);
     const endedCall =
       clientState.callsEnded.length > 0 ? clientState.callsEnded[clientState.callsEnded.length - 1] : undefined;
     this.setState({

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -95,7 +95,8 @@ class CallContext {
   }
 
   public updateClientState(clientState: CallClientState): void {
-    const call = clientState.calls.get(this.callId ?? '');
+    const callId = this.callId ?? '';
+    const call = clientState.calls.find((candidate) => candidate.id === callId);
     const endedCall =
       clientState.callsEnded.length > 0 ? clientState.callsEnded[clientState.callsEnded.length - 1] : undefined;
     this.setState({

--- a/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
@@ -77,7 +77,7 @@ const memoizeState = memoizeOne(
     displayName?: string
   ): CallClientState => ({
     userId,
-    incomingCalls: new Map([]),
+    incomingCalls: [],
     incomingCallsEnded: [],
     callsEnded: [],
     deviceManager,

--- a/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
@@ -73,7 +73,7 @@ const memoizeState = memoizeOne(
   (
     userId: CommunicationUserKind,
     deviceManager: DeviceManagerState,
-    calls: Map<string, CallState>,
+    call: CallState | undefined,
     displayName?: string
   ): CallClientState => ({
     userId,
@@ -82,16 +82,11 @@ const memoizeState = memoizeOne(
     callsEnded: [],
     deviceManager,
     callAgent: { displayName },
-    calls
+    calls: call ? [call] : []
   })
-);
-
-const memoizeCallMap = memoizeOne(
-  (call?: CallState): Map<string, CallState> => (call ? new Map([[call.id, call]]) : new Map([]))
 );
 
 const adaptCompositeState = (compositeState: CallAdapterState): CallClientState => {
   const call = compositeState.call;
-  const callMap = memoizeCallMap(call);
-  return memoizeState(compositeState.userId, compositeState.devices, callMap, compositeState.displayName);
+  return memoizeState(compositeState.userId, compositeState.devices, call, compositeState.displayName);
 };

--- a/samples/Calling/src/app/CallScreen.tsx
+++ b/samples/Calling/src/app/CallScreen.tsx
@@ -79,8 +79,12 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
   // It seems unnecessary in this case, so we get the updated states using this approach.
   useEffect(() => {
     const onStateChange = (state: CallClientState): void => {
-      call?.id && setCallState(state.calls.get(call.id)?.state);
-      call?.id && setIsScreenSharingOn(state.calls.get(call.id)?.isScreenSharingOn);
+      const statefulCall = call?.id ? state.calls.find((candidate) => candidate.id === call.id) : undefined;
+      if (!statefulCall) {
+        return;
+      }
+      setCallState(statefulCall.state);
+      setIsScreenSharingOn(statefulCall.isScreenSharingOn);
     };
     callClient.onStateChange(onStateChange);
     return () => {

--- a/samples/Calling/src/app/CallScreen.tsx
+++ b/samples/Calling/src/app/CallScreen.tsx
@@ -79,7 +79,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
   // It seems unnecessary in this case, so we get the updated states using this approach.
   useEffect(() => {
     const onStateChange = (state: CallClientState): void => {
-      const statefulCall = call?.id ? state.calls.find((candidate) => candidate.id === call.id) : undefined;
+      const statefulCall = call?.id ? state.calls.find((c) => c.id === call.id) : undefined;
       if (!statefulCall) {
         return;
       }

--- a/samples/Calling/src/app/selectors/baseSelectors.ts
+++ b/samples/Calling/src/app/selectors/baseSelectors.ts
@@ -4,8 +4,6 @@
 import { CallState, CallClientState, DeviceManagerState, IncomingCallState } from 'calling-stateful-client';
 import { CallingBaseSelectorProps } from 'calling-component-bindings';
 
-export const getCalls = (state: CallClientState): Map<string, CallState> => state.calls;
-
 export const getCallsEnded = (state: CallClientState): CallState[] => state.callsEnded;
 
 export const getIncomingCalls = (state: CallClientState): Map<string, IncomingCallState> => state.incomingCalls;
@@ -15,7 +13,7 @@ export const getIncomingCallsEnded = (state: CallClientState): IncomingCallState
 export const getDeviceManager = (state: CallClientState): DeviceManagerState => state.deviceManager;
 
 export const getCall = (state: CallClientState, props: CallingBaseSelectorProps): CallState | undefined =>
-  state.calls.get(props.callId);
+  state.calls.find((candidate) => candidate.id === props.callId);
 
 export const getDisplayName = (state: CallClientState): string | undefined => state.callAgent?.displayName;
 

--- a/samples/Calling/src/app/selectors/baseSelectors.ts
+++ b/samples/Calling/src/app/selectors/baseSelectors.ts
@@ -6,7 +6,7 @@ import { CallingBaseSelectorProps } from 'calling-component-bindings';
 
 export const getCallsEnded = (state: CallClientState): CallState[] => state.callsEnded;
 
-export const getIncomingCalls = (state: CallClientState): Map<string, IncomingCallState> => state.incomingCalls;
+export const getIncomingCalls = (state: CallClientState): IncomingCallState[] => state.incomingCalls;
 
 export const getIncomingCallsEnded = (state: CallClientState): IncomingCallState[] => state.incomingCallsEnded;
 

--- a/samples/Calling/src/app/selectors/baseSelectors.ts
+++ b/samples/Calling/src/app/selectors/baseSelectors.ts
@@ -13,7 +13,7 @@ export const getIncomingCallsEnded = (state: CallClientState): IncomingCallState
 export const getDeviceManager = (state: CallClientState): DeviceManagerState => state.deviceManager;
 
 export const getCall = (state: CallClientState, props: CallingBaseSelectorProps): CallState | undefined =>
-  state.calls.find((candidate) => candidate.id === props.callId);
+  state.calls.find((c) => c.id === props.callId);
 
 export const getDisplayName = (state: CallClientState): string | undefined => state.callAgent?.displayName;
 


### PR DESCRIPTION
# What
Use array for `calls` and `incomingCalls` in CallClientState.
This is part of the effort to excise maps from the stateful API.

# Why
Maps break time-travel debugging in Redux.

# How Tested

* `rush build`
* `rush test`
* Play around with `CallComposite` on storybook.
* Join a Teams meeting via Calling sample.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [x] This change causes current functionality to break.
<!--- If yes, describe the impact. -->