### PR TITLE
Wireframe localization API

### DIFF
--- a/packages/react-components/src/components/CameraButton.tsx
+++ b/packages/react-components/src/components/CameraButton.tsx
@@ -12,6 +12,22 @@ const defaultLocalVideoViewOption = {
   isMirrored: true
 } as VideoStreamOptions;
 
+interface CameraButtonStrings {
+  /**
+   * Label to indicate that pressing the button will turn off camera.
+   *
+   * Setting the underlying button `text` directly overrides this string.
+   */
+  turnOff?: string;
+
+  /**
+   * Label to indicate that pressing the button will turn on camera.
+   *
+   * Setting the underlying button `text` directly overrides this string.
+   */
+  turnOn?: string;
+}
+
 /**
  * Props for CameraButton component
  */
@@ -32,6 +48,8 @@ export interface CameraButtonProps extends IButtonProps {
    * Options for rendering local video view.
    */
   localVideoViewOption?: VideoStreamOptions;
+
+  strings?: CameraButtonStrings;
 }
 
 /**

--- a/packages/react-components/src/localization/localization.ts
+++ b/packages/react-components/src/localization/localization.ts
@@ -1,0 +1,33 @@
+import { CameraButtonStrings } from '../components/CameraButton';
+
+interface LocalizationProps {
+  /**
+   * Specific strings overides for components.
+   *
+   * Values here override those provided via the locale.
+   */
+  strings?: LocalizationStrings;
+
+  /**
+   * Locale for strings used by the components.
+   *
+   * Defaults to en-us (same as the default if no LocalizationProvider is used).
+   *
+   * For the list of supported locales, see ...
+   *
+   *   pprabhu comment: These work "out of the box", i.e., we provide the translations, but they can't be overridden.
+   *   The implementation should like just load a JSON value for `LocalizationStrings` instead of generating a flat list.
+   */
+  locale?: string;
+
+  children?: JSX.Element[];
+}
+
+interface LocalizationStrings {
+  cameraButton?: CameraButtonStrings;
+  /// .. and all other components.
+}
+
+const LocalizationProvider = (props: LocalicationProps): JSX.Element => {
+  /// ... implement me.
+};

--- a/packages/react-composites/src/composites/CallComposite/Call.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Call.tsx
@@ -11,7 +11,7 @@ import { CallAdapter, CallCompositePage } from './adapter/CallAdapter';
 import { PlaceholderProps } from 'react-components';
 import { useSelector } from './hooks/useSelector';
 import { getPage } from './selectors/baseSelectors';
-import { FluentThemeProvider } from 'react-components';
+import { FluentThemeProvider, LocalizationProps } from 'react-components';
 
 export type CallCompositeProps = {
   adapter: CallAdapter;
@@ -21,6 +21,14 @@ export type CallCompositeProps = {
    * Defaults to a light theme if undefined.
    */
   fluentTheme?: PartialTheme | Theme;
+  /**
+   * pprabhu comment: Works by using a LocalicationProvider internally, but key is that customers can override the
+   * strings for each component or just choose locale, and don't have to bother with the provider.
+   *
+   * Customers can also skip this entirely, and get en-us.
+   */
+  localization?: LocalizationProps;
+
   callInvitationURL?: string;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
 };


### PR DESCRIPTION
# What
Exploring localization API options.

## Components

Allows increasing levels of localization control:

* Do nothing, get en-US
* Use `LocalizationProvider` with `locale`, get canned translations that we ship and support. But can't modify strings inside.
* Use `LocalizationProvider` with `strings`, provide strings as you see fit in one place for all components.
* Use `strings` props on individual components, full control (and cost).

## Composite

Allows increasing levels of localization control:

* Do nothing, get en-US
* Pass in `localization.locale` prop, get canned translations that we ship and support. But can't modify strings inside.
* Pass in `Localization.strings` prop, provide strings as you see fit in one place for all components.
