### PR TITLE
Selected camera bug fix

### DIFF
--- a/change/calling-stateful-client-a070dce9-f5e7-4d54-b7d0-0fe17fcb2edc.json
+++ b/change/calling-stateful-client-a070dce9-f5e7-4d54-b7d0-0fe17fcb2edc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed initial value selectedCamera when permissions have been granted.",
+  "packageName": "calling-stateful-client",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -570,7 +570,7 @@ export class CallContext {
   public setDeviceManagerCameras(cameras: VideoDeviceInfo[]): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        if ((!draft.deviceManager.cameras || draft.deviceManager.cameras.length === 0) && cameras.length > 0) {
+        if (cameras.length > 0 && !cameras.some((camera) => camera.id === draft.deviceManager.selectedCamera?.id)) {
           draft.deviceManager.selectedCamera = cameras[0];
         }
         draft.deviceManager.cameras = cameras;

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -570,7 +570,13 @@ export class CallContext {
   public setDeviceManagerCameras(cameras: VideoDeviceInfo[]): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        if (cameras.length > 0 && !cameras.some((camera) => camera.id === draft.deviceManager.selectedCamera?.id)) {
+        if (
+          /** SDK initializes cameras with one dummy camera with value { id: 'camera:id', name: '', deviceType: 'USBCamera' } before camera permissions are granted.
+          So selectedCamera will have this value before new cameras are updated. We should reset selectedCamera to the first camera when there are cameras AND 
+          when current selectedCamera does not exist in the new array of cameras **/
+          cameras.length > 0 &&
+          !cameras.some((camera) => camera.id === draft.deviceManager.selectedCamera?.id)
+        ) {
           draft.deviceManager.selectedCamera = cameras[0];
         }
         draft.deviceManager.cameras = cameras;

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -570,14 +570,11 @@ export class CallContext {
   public setDeviceManagerCameras(cameras: VideoDeviceInfo[]): void {
     this.setState(
       produce(this._state, (draft: CallClientState) => {
-        if (
-          /** SDK initializes cameras with one dummy camera with value { id: 'camera:id', name: '', deviceType: 'USBCamera' } before camera permissions are granted.
-          So selectedCamera will have this value before new cameras are updated. We should reset selectedCamera to the first camera when there are cameras AND 
-          when current selectedCamera does not exist in the new array of cameras **/
-          cameras.length > 0 &&
-          !cameras.some((camera) => camera.id === draft.deviceManager.selectedCamera?.id)
-        ) {
-          draft.deviceManager.selectedCamera = cameras[0];
+        /** SDK initializes cameras with one dummy camera with value { id: 'camera:id', name: '', deviceType: 'USBCamera' } immediately after
+         * camera permissions are granted. So selectedCamera will have this value before the actual cameras are obtained. Therefore we should reset
+         * selectedCamera to the first camera when there are cameras AND when current selectedCamera does not exist in the new array of cameras **/
+        if (cameras.length > 0 && !cameras.some((camera) => camera.id === draft.deviceManager.selectedCamera?.id)) {
+          this.setDeviceManagerSelectedCamera(cameras[0]);
         }
         draft.deviceManager.cameras = cameras;
       })


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
SDK initializes cameras with one dummy camera:
`{ id: 'camera:id', name: '', deviceType: 'USBCamera' }`
So selectedCamera will have this value { id: 'camera:id', name: '', deviceType: 'USBCamera' } before new cameras are updated. So it makes sense that we only reset selectedCamera to the first camera if we don't see it in the new list of cameras.

Video where I also test adding a new camera and showing that selectedCamera is NOT set again because it is still on the list.
https://user-images.githubusercontent.com/79475487/122629625-49a07100-d073-11eb-928d-4b4778f20584.mp4

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2475044

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->