### PR TITLE
Add device options to calling composite

### DIFF
--- a/change/react-composites-6c97b79f-e3c0-4a93-919b-47caccb0c918.json
+++ b/change/react-composites-6c97b79f-e3c0-4a93-919b-47caccb0c918.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add device options button to calling composite",
+  "packageName": "react-composites",
+  "email": "mail@jamesburnside.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallControls.tsx
@@ -7,6 +7,7 @@ import {
   ControlBar,
   EndCallButton,
   MicrophoneButton,
+  OptionsButton,
   ParticipantsButton,
   ScreenShareButton
 } from 'react-components';
@@ -27,6 +28,7 @@ export const CallControls = (props: GroupCallControlsProps): JSX.Element => {
   const cameraButtonProps = usePropsFor(CameraButton);
   const screenShareButtonProps = usePropsFor(ScreenShareButton);
   const participantsButtonProps = usePropsFor(ParticipantsButton);
+  const optionsButtonProps = usePropsFor(OptionsButton);
   const hangUpButtonProps = usePropsFor(EndCallButton);
   const onHangUp = useCallback(async () => {
     await hangUpButtonProps.onHangUp();
@@ -45,6 +47,7 @@ export const CallControls = (props: GroupCallControlsProps): JSX.Element => {
           callInvitationURL={callInvitationURL}
         />
       )}
+      <OptionsButton {...optionsButtonProps} showLabel={!compressedMode} />
       <EndCallButton
         {...hangUpButtonProps}
         onHangUp={onHangUp}


### PR DESCRIPTION
# What
Add device options button in the calling composite
![image](https://user-images.githubusercontent.com/2684369/122992582-1f90cc80-d35b-11eb-9682-3f9d63de20cd.png)

# Why
This was missing from the composite and removed from the calling sample when we switched the sample to using the calling composite in #486 

# How Tested
Ran locally