### PR TITLE
[POC] Chat button in call control (restricted function signature)

### DIFF
--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -325,7 +325,14 @@ export type CallCompositeProps = {
     fluentTheme?: PartialTheme | Theme;
     callInvitationURL?: string;
     onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
+    overrideCallControlButtons?: (defaultButtons: CallControlButtonCollection) => CallControlButtonCollection;
 };
+
+// @public (undocumented)
+export type CallControlButton = DefaultCallControlButton | CustomCallControlButton;
+
+// @public (undocumented)
+export type CallControlButtonCollection = CallControlButton[];
 
 // @public (undocumented)
 export type CallEndedListener = (event: {
@@ -627,6 +634,18 @@ export type CommunicationParticipant = {
 // @public
 export const ControlBar: (props: ControlBarProps) => JSX.Element;
 
+// @public
+export const ControlBarButton: (props: ControlBarButtonProps) => JSX.Element;
+
+// @public
+export interface ControlBarButtonProps extends IButtonProps {
+    icon?: JSX.Element;
+    labelText?: string;
+    showLabel?: boolean;
+    toggledIcon?: JSX.Element;
+    toggledLabelText?: string;
+}
+
 // @public (undocumented)
 export type ControlBarLayoutType = 'horizontal' | 'vertical' | 'dockedTop' | 'dockedBottom' | 'dockedLeft' | 'dockedRight' | 'floatingTop' | 'floatingBottom' | 'floatingLeft' | 'floatingRight';
 
@@ -673,6 +692,12 @@ export const createStatefulCallClient: (args: StatefulCallClientArgs, options?: 
 export const createStatefulChatClient: (args: StatefulChatClientArgs, options?: StatefulChatClientOptions | undefined) => StatefulChatClient;
 
 // @public (undocumented)
+export interface CustomCallControlButton extends ControlBarButtonProps {
+    // (undocumented)
+    newProp: string;
+}
+
+// @public (undocumented)
 export type CustomMessage = Message<'custom'>;
 
 // @public (undocumented)
@@ -683,6 +708,9 @@ export type CustomMessagePayload = {
 
 // @public
 export const darkTheme: PartialTheme & CallingTheme;
+
+// @public (undocumented)
+export type DefaultCallControlButton = 'microphone' | 'camera' | 'screenShare' | 'participants' | 'leave';
 
 // @public (undocumented)
 export type DefaultCallingHandlers = {
@@ -715,6 +743,9 @@ export type DefaultChatHandlers = {
 };
 
 // @public (undocumented)
+export const defaultControlButtonStyle: IButtonStyles;
+
+// @public (undocumented)
 export type DefaultMessageRendererType = (props: MessageProps) => JSX.Element;
 
 // @public
@@ -743,7 +774,7 @@ export const emptySelector: () => Record<string, never>;
 export const EndCallButton: (props: EndCallButtonProps) => JSX.Element;
 
 // @public
-export interface EndCallButtonProps extends IButtonProps {
+export interface EndCallButtonProps extends ControlBarButtonProps {
     onHangUp?: () => Promise<void>;
     showLabel?: boolean;
 }

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -694,7 +694,7 @@ export const createStatefulChatClient: (args: StatefulChatClientArgs, options?: 
 // @public (undocumented)
 export interface CustomCallControlButton extends ControlBarButtonProps {
     // (undocumented)
-    newProp: string;
+    key?: string;
 }
 
 // @public (undocumented)

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -78,6 +78,18 @@ export type CommunicationParticipant = {
 // @public
 export const ControlBar: (props: ControlBarProps) => JSX.Element;
 
+// @public
+export const ControlBarButton: (props: ControlBarButtonProps) => JSX.Element;
+
+// @public
+export interface ControlBarButtonProps extends IButtonProps {
+    icon?: JSX.Element;
+    labelText?: string;
+    showLabel?: boolean;
+    toggledIcon?: JSX.Element;
+    toggledLabelText?: string;
+}
+
 // @public (undocumented)
 export type ControlBarLayoutType = 'horizontal' | 'vertical' | 'dockedTop' | 'dockedBottom' | 'dockedLeft' | 'dockedRight' | 'floatingTop' | 'floatingBottom' | 'floatingLeft' | 'floatingRight';
 
@@ -101,13 +113,16 @@ export type CustomMessagePayload = {
 export const darkTheme: PartialTheme & CallingTheme;
 
 // @public (undocumented)
+export const defaultControlButtonStyle: IButtonStyles;
+
+// @public (undocumented)
 export type DefaultMessageRendererType = (props: MessageProps) => JSX.Element;
 
 // @public
 export const EndCallButton: (props: EndCallButtonProps) => JSX.Element;
 
 // @public
-export interface EndCallButtonProps extends IButtonProps {
+export interface EndCallButtonProps extends ControlBarButtonProps {
     onHangUp?: () => Promise<void>;
     showLabel?: boolean;
 }

--- a/packages/react-components/src/components/ControlBarButton.tsx
+++ b/packages/react-components/src/components/ControlBarButton.tsx
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { concatStyleSets, DefaultButton, IButtonProps, Label, mergeStyles } from '@fluentui/react';
+import React from 'react';
+import { controlButtonLabelStyles, controlButtonStyles } from './styles/ControlBar.styles';
+
+/**
+ * Props for ControlBarButton component
+ */
+export interface ControlBarButtonProps extends IButtonProps {
+  /**
+   * Whether the label is displayed or not.
+   * @defaultValue `false`
+   */
+  showLabel?: boolean;
+
+  /**
+   * Button label text
+   */
+  labelText?: string;
+
+  /**
+   * Button label text
+   */
+  toggledLabelText?: string;
+
+  /**
+   * Button icon in the non-toggled state
+   */
+  icon?: JSX.Element;
+
+  /**
+   * Button icon when button is toggled
+   */
+  toggledIcon?: JSX.Element;
+}
+
+const emptyStyles = {};
+
+/**
+ * `ControlBarButton` allows you to easily create a component consistent with control bar buttons.
+ */
+export const ControlBarButton = (props: ControlBarButtonProps): JSX.Element => {
+  const {
+    showLabel = false,
+    styles,
+    onRenderIcon,
+    onRenderText,
+    labelText,
+    toggledLabelText,
+    icon,
+    toggledIcon
+  } = props;
+  const buttonStyles = concatStyleSets(controlButtonStyles, styles ?? emptyStyles);
+
+  const defaultRenderIcon = (props?: IButtonProps): JSX.Element => {
+    return (!props?.checked ? icon : toggledIcon ?? icon) ?? <></>;
+  };
+
+  const defaultRenderText = (props?: IButtonProps): JSX.Element => {
+    return (
+      <Label className={mergeStyles(controlButtonLabelStyles, props?.styles?.label)}>
+        {!props?.checked ? labelText : toggledLabelText ?? labelText}
+      </Label>
+    );
+  };
+
+  return (
+    <DefaultButton
+      {...props}
+      styles={buttonStyles}
+      onRenderIcon={onRenderIcon ?? defaultRenderIcon ?? undefined}
+      onRenderText={showLabel ? onRenderText ?? defaultRenderText : undefined}
+    />
+  );
+};

--- a/packages/react-components/src/components/EndCallButton.tsx
+++ b/packages/react-components/src/components/EndCallButton.tsx
@@ -2,16 +2,17 @@
 // Licensed under the MIT license.
 
 import React from 'react';
-import { DefaultButton, IButtonProps, Label, concatStyleSets, mergeStyles, useTheme } from '@fluentui/react';
+import { concatStyleSets, useTheme } from '@fluentui/react';
 import { CallEndIcon } from '@fluentui/react-northstar';
-import { controlButtonLabelStyles, endCallControlButtonStyles } from './styles/ControlBar.styles';
+import { endCallControlButtonStyles } from './styles/ControlBar.styles';
 import { lightTheme, darkTheme } from '../theming/themes';
 import { isDarkThemed } from '../theming/themeUtils';
+import { ControlBarButton, ControlBarButtonProps } from './ControlBarButton';
 
 /**
  * Props for EndCallButton component
  */
-export interface EndCallButtonProps extends IButtonProps {
+export interface EndCallButtonProps extends ControlBarButtonProps {
   /**
    * Whether the label is displayed or not.
    *
@@ -32,7 +33,7 @@ export interface EndCallButtonProps extends IButtonProps {
  * @param props - of type EndCallButtonProps
  */
 export const EndCallButton = (props: EndCallButtonProps): JSX.Element => {
-  const { showLabel = false, styles, onRenderIcon, onRenderText } = props;
+  const { styles } = props;
 
   const isDarkTheme = isDarkThemed(useTheme());
 
@@ -52,25 +53,13 @@ export const EndCallButton = (props: EndCallButtonProps): JSX.Element => {
     styles ?? {}
   );
 
-  const defaultRenderIcon = (): JSX.Element => {
-    return <CallEndIcon key={'callEndIconKey'} />;
-  };
-
-  const defaultRenderText = (props?: IButtonProps): JSX.Element => {
-    return (
-      <Label key={'callEndLabelKey'} className={mergeStyles(controlButtonLabelStyles, props?.styles?.label)}>
-        Leave
-      </Label>
-    );
-  };
-
   return (
-    <DefaultButton
+    <ControlBarButton
       {...props}
       onClick={props.onHangUp ?? props.onClick}
       styles={componentStyles}
-      onRenderIcon={onRenderIcon ?? defaultRenderIcon}
-      onRenderText={showLabel ? onRenderText ?? defaultRenderText : undefined}
+      icon={<CallEndIcon key={'callEndIconKey'} />}
+      labelText={'leave'}
     />
   );
 };

--- a/packages/react-components/src/components/index.ts
+++ b/packages/react-components/src/components/index.ts
@@ -57,3 +57,5 @@ export type { ScreenShareButtonProps } from './ScreenShareButton';
 
 export { VideoTile } from './VideoTile';
 export type { VideoTileProps, VideoTileStylesProps, PlaceholderProps } from './VideoTile';
+
+export { controlButtonStyles as defaultControlButtonStyle } from './styles/ControlBar.styles';

--- a/packages/react-components/src/components/index.ts
+++ b/packages/react-components/src/components/index.ts
@@ -40,6 +40,9 @@ export type { CameraButtonProps } from './CameraButton';
 export { ControlBar } from './ControlBar';
 export type { ControlBarProps, ControlBarLayoutType } from './ControlBar';
 
+export { ControlBarButton } from './ControlBarButton';
+export type { ControlBarButtonProps } from './ControlBarButton';
+
 export { EndCallButton } from './EndCallButton';
 export type { EndCallButtonProps } from './EndCallButton';
 

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -361,7 +361,7 @@ export const createAzureCommunicationChatAdapter: (userId: CommunicationUserIden
 // @public (undocumented)
 export interface CustomCallControlButton extends ControlBarButtonProps {
     // (undocumented)
-    newProp: string;
+    key?: string;
 }
 
 // @public (undocumented)

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -14,6 +14,7 @@ import type { ChatParticipant } from '@azure/communication-chat';
 import { ChatThreadClientState } from 'chat-stateful-client';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import type { CommunicationUserKind } from '@azure/communication-common';
+import { ControlBarButtonProps } from 'react-components';
 import { DeviceManagerState } from 'calling-stateful-client';
 import { GroupCallLocator } from '@azure/communication-calling';
 import type { MicrosoftTeamsUserKind } from '@azure/communication-common';
@@ -244,7 +245,14 @@ export type CallCompositeProps = {
     fluentTheme?: PartialTheme | Theme;
     callInvitationURL?: string;
     onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
+    overrideCallControlButtons?: (defaultButtons: CallControlButtonCollection) => CallControlButtonCollection;
 };
+
+// @public (undocumented)
+export type CallControlButton = DefaultCallControlButton | CustomCallControlButton;
+
+// @public (undocumented)
+export type CallControlButtonCollection = CallControlButton[];
 
 // @public (undocumented)
 export type CallEndedListener = (event: {
@@ -349,6 +357,15 @@ export const createAzureCommunicationCallAdapter: (userId: CommunicationUserIden
 
 // @public (undocumented)
 export const createAzureCommunicationChatAdapter: (userId: CommunicationUserIdentifier, token: string, endpointUrl: string, threadId: string, displayName: string, refreshTokenCallback?: (() => Promise<string>) | undefined) => Promise<ChatAdapter>;
+
+// @public (undocumented)
+export interface CustomCallControlButton extends ControlBarButtonProps {
+    // (undocumented)
+    newProp: string;
+}
+
+// @public (undocumented)
+export type DefaultCallControlButton = 'microphone' | 'camera' | 'screenShare' | 'participants' | 'leave';
 
 // @public (undocumented)
 export type DisplayNameChangedListener = (event: {

--- a/packages/react-composites/src/composites/CallComposite/Call.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Call.tsx
@@ -12,7 +12,7 @@ import { PlaceholderProps } from 'react-components';
 import { useSelector } from './hooks/useSelector';
 import { getPage } from './selectors/baseSelectors';
 import { FluentThemeProvider } from 'react-components';
-import { OverridableCallControlButton } from './CallControls';
+import { CallControlButtonCollection } from './CallControls';
 
 export type CallCompositeProps = {
   adapter: CallAdapter;
@@ -24,12 +24,12 @@ export type CallCompositeProps = {
   fluentTheme?: PartialTheme | Theme;
   callInvitationURL?: string;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
-  onRenderCallControlButtons?: (defaultButtons: OverridableCallControlButton[]) => JSX.Element[];
+  overrideCallControlButtons?: (defaultButtons: CallControlButtonCollection) => CallControlButtonCollection;
 };
 
 type MainScreenProps = {
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
-  onRenderCallControlButtons?: (defaultButtons: OverridableCallControlButton[]) => JSX.Element[];
+  overrideCallControlButtons?: (defaultButtons: CallControlButtonCollection) => CallControlButtonCollection;
   screenWidth: number;
   callInvitationURL?: string;
 };
@@ -38,7 +38,7 @@ const MainScreen = ({
   screenWidth,
   callInvitationURL,
   onRenderAvatar,
-  onRenderCallControlButtons
+  overrideCallControlButtons
 }: MainScreenProps): JSX.Element => {
   const page = useSelector(getPage);
   const adapter = useAdapter();
@@ -73,7 +73,7 @@ const MainScreen = ({
             customPage ? adapter.setPage(customPage) : adapter.setPage('error');
           }}
           onRenderAvatar={onRenderAvatar}
-          onRenderCallControlButtons={onRenderCallControlButtons}
+          overrideCallControlButtons={overrideCallControlButtons}
           screenWidth={screenWidth}
           showParticipants={true}
           callInvitationURL={callInvitationURL}
@@ -114,7 +114,7 @@ export const Call = (props: CallCompositeProps): JSX.Element => {
           <MainScreen
             screenWidth={screenWidth}
             onRenderAvatar={props.onRenderAvatar}
-            onRenderCallControlButtons={props.onRenderCallControlButtons}
+            overrideCallControlButtons={props.overrideCallControlButtons}
             callInvitationURL={callInvitationURL}
           />
         </Stack>

--- a/packages/react-composites/src/composites/CallComposite/Call.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Call.tsx
@@ -12,6 +12,7 @@ import { PlaceholderProps } from 'react-components';
 import { useSelector } from './hooks/useSelector';
 import { getPage } from './selectors/baseSelectors';
 import { FluentThemeProvider } from 'react-components';
+import { OverridableCallControlButton } from './CallControls';
 
 export type CallCompositeProps = {
   adapter: CallAdapter;
@@ -23,15 +24,22 @@ export type CallCompositeProps = {
   fluentTheme?: PartialTheme | Theme;
   callInvitationURL?: string;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
+  onRenderCallControlButtons?: (defaultButtons: OverridableCallControlButton[]) => JSX.Element[];
 };
 
 type MainScreenProps = {
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
+  onRenderCallControlButtons?: (defaultButtons: OverridableCallControlButton[]) => JSX.Element[];
   screenWidth: number;
   callInvitationURL?: string;
 };
 
-const MainScreen = ({ screenWidth, callInvitationURL, onRenderAvatar }: MainScreenProps): JSX.Element => {
+const MainScreen = ({
+  screenWidth,
+  callInvitationURL,
+  onRenderAvatar,
+  onRenderCallControlButtons
+}: MainScreenProps): JSX.Element => {
   const page = useSelector(getPage);
   const adapter = useAdapter();
   switch (page) {
@@ -65,6 +73,7 @@ const MainScreen = ({ screenWidth, callInvitationURL, onRenderAvatar }: MainScre
             customPage ? adapter.setPage(customPage) : adapter.setPage('error');
           }}
           onRenderAvatar={onRenderAvatar}
+          onRenderCallControlButtons={onRenderCallControlButtons}
           screenWidth={screenWidth}
           showParticipants={true}
           callInvitationURL={callInvitationURL}
@@ -105,6 +114,7 @@ export const Call = (props: CallCompositeProps): JSX.Element => {
           <MainScreen
             screenWidth={screenWidth}
             onRenderAvatar={props.onRenderAvatar}
+            onRenderCallControlButtons={props.onRenderCallControlButtons}
             callInvitationURL={callInvitationURL}
           />
         </Stack>

--- a/packages/react-composites/src/composites/CallComposite/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallControls.tsx
@@ -13,15 +13,27 @@ import {
 import { groupCallLeaveButtonCompressedStyle, groupCallLeaveButtonStyle } from './styles/CallControls.styles';
 import { usePropsFor } from './hooks/usePropsFor';
 
+export type OverridableCallControlButton = {
+  buttonType: 'microphone' | 'camera' | 'screenShare' | 'participants' | 'options' | 'leave';
+  defaultRender: () => JSX.Element;
+};
+
 export type GroupCallControlsProps = {
   onEndCallClick(): void;
   compressedMode: boolean;
   showParticipants?: boolean;
   callInvitationURL?: string;
+  onRenderCallControlButtons?: (defaultButtons: OverridableCallControlButton[]) => JSX.Element[];
 };
 
 export const CallControls = (props: GroupCallControlsProps): JSX.Element => {
-  const { callInvitationURL, compressedMode, showParticipants = false, onEndCallClick } = props;
+  const {
+    callInvitationURL,
+    compressedMode,
+    showParticipants = false,
+    onEndCallClick,
+    onRenderCallControlButtons
+  } = props;
 
   const microphoneButtonProps = usePropsFor(MicrophoneButton);
   const cameraButtonProps = usePropsFor(CameraButton);
@@ -33,24 +45,56 @@ export const CallControls = (props: GroupCallControlsProps): JSX.Element => {
     onEndCallClick();
   }, [hangUpButtonProps, onEndCallClick]);
 
+  const defaultCallControlButtons: OverridableCallControlButton[] = [
+    {
+      buttonType: 'camera',
+      defaultRender: () => <CameraButton key={'camera'} {...cameraButtonProps} showLabel={!compressedMode} />
+    },
+    {
+      buttonType: 'microphone',
+      defaultRender: () => (
+        <MicrophoneButton key={'microphone'} {...microphoneButtonProps} showLabel={!compressedMode} />
+      )
+    },
+    {
+      buttonType: 'screenShare',
+      defaultRender: () => (
+        <ScreenShareButton key={'screenshare'} {...screenShareButtonProps} showLabel={!compressedMode} />
+      )
+    },
+    {
+      buttonType: 'participants',
+      defaultRender: () =>
+        showParticipants ? (
+          <ParticipantsButton
+            key={'participants'}
+            {...participantsButtonProps}
+            showLabel={!compressedMode}
+            callInvitationURL={callInvitationURL}
+          />
+        ) : (
+          <></>
+        )
+    },
+    {
+      buttonType: 'leave',
+      defaultRender: () => (
+        <EndCallButton
+          key="leave"
+          {...hangUpButtonProps}
+          onHangUp={onHangUp}
+          styles={!compressedMode ? groupCallLeaveButtonStyle : groupCallLeaveButtonCompressedStyle}
+          showLabel={!compressedMode}
+        />
+      )
+    }
+  ];
+
   return (
     <ControlBar layout="dockedBottom">
-      <CameraButton {...cameraButtonProps} showLabel={!compressedMode} />
-      <MicrophoneButton {...microphoneButtonProps} showLabel={!compressedMode} />
-      <ScreenShareButton {...screenShareButtonProps} showLabel={!compressedMode} />
-      {showParticipants && (
-        <ParticipantsButton
-          {...participantsButtonProps}
-          showLabel={!compressedMode}
-          callInvitationURL={callInvitationURL}
-        />
-      )}
-      <EndCallButton
-        {...hangUpButtonProps}
-        onHangUp={onHangUp}
-        styles={!compressedMode ? groupCallLeaveButtonStyle : groupCallLeaveButtonCompressedStyle}
-        showLabel={!compressedMode}
-      />
+      {onRenderCallControlButtons
+        ? onRenderCallControlButtons(defaultCallControlButtons)
+        : defaultCallControlButtons.map((button) => button.defaultRender())}
     </ControlBar>
   );
 };

--- a/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
@@ -21,7 +21,7 @@ import { callStatusSelector } from './selectors/callStatusSelector';
 import { mediaGallerySelector } from './selectors/mediaGallerySelector';
 import { useHandlers } from './hooks/useHandlers';
 import { PlaceholderProps, VideoStreamOptions } from 'react-components';
-import { CallControls } from './CallControls';
+import { CallControls, OverridableCallControlButton } from './CallControls';
 import { ComplianceBanner } from './ComplianceBanner';
 import { lobbySelector } from './selectors/lobbySelector';
 import { Lobby } from './Lobby';
@@ -40,12 +40,21 @@ export interface CallScreenProps {
   endCallHandler(): void;
   callErrorHandler(customPage?: CallCompositePage): void;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
+  onRenderCallControlButtons?: (defaultButtons: OverridableCallControlButton[]) => JSX.Element[];
 }
 
 const spinnerLabel = 'Initializing call client...';
 
 export const CallScreen = (props: CallScreenProps): JSX.Element => {
-  const { callInvitationURL, screenWidth, showParticipants, endCallHandler, callErrorHandler, onRenderAvatar } = props;
+  const {
+    callInvitationURL,
+    screenWidth,
+    showParticipants,
+    endCallHandler,
+    callErrorHandler,
+    onRenderAvatar,
+    onRenderCallControlButtons
+  } = props;
 
   const [joinedCall, setJoinedCall] = useState<boolean>(false);
 
@@ -155,6 +164,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
                 compressedMode={screenWidth <= MINI_HEADER_WINDOW_WIDTH}
                 showParticipants={showParticipants}
                 callInvitationURL={callInvitationURL}
+                onRenderCallControlButtons={onRenderCallControlButtons}
               />
             </Stack>
           </Stack.Item>

--- a/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
@@ -21,7 +21,7 @@ import { callStatusSelector } from './selectors/callStatusSelector';
 import { mediaGallerySelector } from './selectors/mediaGallerySelector';
 import { useHandlers } from './hooks/useHandlers';
 import { PlaceholderProps, VideoStreamOptions } from 'react-components';
-import { CallControls, OverridableCallControlButton } from './CallControls';
+import { CallControls, CallControlButtonCollection } from './CallControls';
 import { ComplianceBanner } from './ComplianceBanner';
 import { lobbySelector } from './selectors/lobbySelector';
 import { Lobby } from './Lobby';
@@ -40,7 +40,7 @@ export interface CallScreenProps {
   endCallHandler(): void;
   callErrorHandler(customPage?: CallCompositePage): void;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
-  onRenderCallControlButtons?: (defaultButtons: OverridableCallControlButton[]) => JSX.Element[];
+  overrideCallControlButtons?: (defaultButtons: CallControlButtonCollection) => CallControlButtonCollection;
 }
 
 const spinnerLabel = 'Initializing call client...';
@@ -53,7 +53,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     endCallHandler,
     callErrorHandler,
     onRenderAvatar,
-    onRenderCallControlButtons
+    overrideCallControlButtons
   } = props;
 
   const [joinedCall, setJoinedCall] = useState<boolean>(false);
@@ -164,7 +164,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
                 compressedMode={screenWidth <= MINI_HEADER_WINDOW_WIDTH}
                 showParticipants={showParticipants}
                 callInvitationURL={callInvitationURL}
-                onRenderCallControlButtons={onRenderCallControlButtons}
+                overrideCallControlButtons={overrideCallControlButtons}
               />
             </Stack>
           </Stack.Item>

--- a/packages/react-composites/src/composites/CallComposite/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/index.ts
@@ -4,4 +4,10 @@
 export { Call as CallComposite } from './Call';
 export * from './adapter';
 
+export type {
+  CallControlButton,
+  CallControlButtonCollection,
+  CustomCallControlButton,
+  DefaultCallControlButton
+} from './CallControls';
 export type { CallCompositeProps } from './Call';

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -2,12 +2,19 @@
 // Licensed under the MIT license.
 
 import React, { useEffect, useRef, useState } from 'react';
-import { Spinner } from '@fluentui/react';
+import { Spinner, DefaultButton } from '@fluentui/react';
 import { GroupCallLocator, TeamsMeetingLinkLocator } from '@azure/communication-calling';
-import { CallAdapter, CallComposite, createAzureCommunicationCallAdapter } from '@azure/communication-react';
+import {
+  CallAdapter,
+  CallComposite,
+  createAzureCommunicationCallAdapter,
+  OverridableCallControlButton,
+  defaultControlButtonStyle
+} from '@azure/communication-react';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { refreshTokenAsync } from '../utils/refreshToken';
 import { useSwitchableFluentTheme } from '../theming/SwitchableFluentThemeProvider';
+import { ChatIcon } from '@fluentui/react-northstar';
 
 export interface CallScreenProps {
   token: string;
@@ -53,5 +60,29 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     return <Spinner label={'Creating adapter'} ariaLive="assertive" labelPosition="top" />;
   }
 
-  return <CallComposite adapter={adapter} fluentTheme={currentTheme.theme} callInvitationURL={window.location.href} />;
+  const chatButton = (
+    <DefaultButton
+      key={'chat'}
+      styles={defaultControlButtonStyle}
+      onRenderText={() => <>Chat</>}
+      onRenderIcon={() => <ChatIcon key="chatIcon" />}
+    />
+  );
+
+  const onRenderCallControlButtons = (defaultButtons: OverridableCallControlButton[]): JSX.Element[] => {
+    const newButtons = defaultButtons
+      .filter((button) => button.buttonType !== 'leave')
+      .map((button) => button.defaultRender());
+    newButtons.push(chatButton);
+    return newButtons;
+  };
+
+  return (
+    <CallComposite
+      adapter={adapter}
+      fluentTheme={currentTheme.theme}
+      callInvitationURL={window.location.href}
+      onRenderCallControlButtons={onRenderCallControlButtons}
+    />
+  );
 };


### PR DESCRIPTION
Result:
![image](https://user-images.githubusercontent.com/2684369/123339964-5eac5280-d500-11eb-89fd-5359876e334e.png)

Also see previous PoC with open function signature: #495 

Notes
* Developers are forced into rendering a controlbarbutton allowing us to keep styling and behavior of the button consistent with the other buttons
* Override fn takes an array of either defaultButtonNames (for the existing buttons we provider) or customButtons
* override function can just be a prop instead of a function (small implementation detail, ignore reviewing that)