### PR TITLE
Fix undefined selected camera

### DIFF
--- a/change/calling-stateful-client-95dd015d-8ef1-46c3-b56b-e99bad22cb27.json
+++ b/change/calling-stateful-client-95dd015d-8ef1-46c3-b56b-e99bad22cb27.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix stateful client selected camera assignment.",
+  "packageName": "calling-stateful-client",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -574,7 +574,7 @@ export class CallContext {
          * camera permissions are granted. So selectedCamera will have this value before the actual cameras are obtained. Therefore we should reset
          * selectedCamera to the first camera when there are cameras AND when current selectedCamera does not exist in the new array of cameras **/
         if (cameras.length > 0 && !cameras.some((camera) => camera.id === draft.deviceManager.selectedCamera?.id)) {
-          this.setDeviceManagerSelectedCamera(cameras[0]);
+          draft.deviceManager.selectedCamera = cameras[0];
         }
         draft.deviceManager.cameras = cameras;
       })


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Assigning the selected camera on the same draft.deviceManager instead of calling this.setDeviceManagerSelectedCamera seems to fix the issue.

# Why
Fixes #497 
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
To fix bug where cameras were not being in the OptionsButton during a call.
https://user-images.githubusercontent.com/79475487/123460174-16db0900-d59c-11eb-8fc6-d5db6b35ff85.mp4
because selectedCamera is undefined in this [line of code](https://github.com/Azure/communication-ui-library/blob/main/packages/react-components/src/components/OptionsButton.tsx#L99)
After this one-line fix
https://user-images.githubusercontent.com/79475487/123460248-33774100-d59c-11eb-879a-cd3ab48f8482.mp4

# How Tested
<!--- How did you test your change. What tests have you added. -->
Manually on sample app

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->