### PR TITLE
Fix: scrollTop does not exist on undefined object

### DIFF
--- a/change/react-components-abdd529f-6afe-4f5b-971a-97443379f1db.json
+++ b/change/react-components-abdd529f-6afe-4f5b-971a-97443379f1db.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bug fix: MesageThread scrollTop throws exception when chat composite is hidden",
+  "packageName": "react-components",
+  "email": "mail@jamesburnside.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -613,7 +613,7 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
   }, [sendMessageStatusIfAtBottom]);
 
   const handleScroll = (): void => {
-    if (chatScrollDivRef.current === undefined) {
+    if (!chatScrollDivRef.current) {
       return;
     }
 

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -605,7 +605,7 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
 
   const scrollToBottom = useCallback((): void => {
     if (chatScrollDivRef.current) {
-      chatScrollDivRef.current.scrollTop = chatScrollDivRef?.current.scrollHeight;
+      chatScrollDivRef.current.scrollTop = chatScrollDivRef.current.scrollHeight;
     }
     setExistsNewChatMessage(false);
     setIsAtBottomOfScrollRef(true);
@@ -631,7 +631,7 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
     setIsAtTopOfScrollRef(atTop);
 
     // Make sure we do not stuck at the top if more messages are being fetched.
-    if (chatScrollDivRef.current && chatScrollDivRef.current.scrollTop === 0 && !isAllChatMessagesLoadedRef.current) {
+    if (chatScrollDivRef.current.scrollTop === 0 && !isAllChatMessagesLoadedRef.current) {
       chatScrollDivRef.current.scrollTop = 5;
     }
 


### PR DESCRIPTION
# What
Remove `any` types on message thread and fix null checks

# Why
I recall @ddematheu2 hitting an error when playing around with composites that scrollTop was called on an undefined object after hiding a chat window.
Looks to be because we have an async function performing work on a ref that will have been cleaned up - fixing the `any` types as these would've caught this error.

# How Tested
🤞