### PR TITLE
Extract test helpers module

### DIFF
--- a/change/chat-stateful-client-081fed3a-3527-4bfa-b623-7da85ea465f4.json
+++ b/change/chat-stateful-client-081fed3a-3527-4bfa-b623-7da85ea465f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Extract test helpers",
+  "packageName": "chat-stateful-client",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-stateful-client/src/StatefulChatClient.test.ts
+++ b/packages/chat-stateful-client/src/StatefulChatClient.test.ts
@@ -366,19 +366,6 @@ describe('stateful chatClient tees errors to state', () => {
     const latestError = listener.state.latestErrors['ChatClient.startRealtimeNotifications'];
     expect(latestError).toBeDefined();
   });
-
-  test('when stopRealtimeNotifications fails', async () => {
-    const baseClient = createMockChatClient();
-    baseClient.stopRealtimeNotifications = async () => {
-      throw Error('injected error');
-    };
-    const client = createStatefulChatClientWithDeps(baseClient, defaultClientArgs);
-    const listener = new StateChangeListener(client);
-    await expect(client.stopRealtimeNotifications()).rejects.toThrow();
-    expect(listener.onChangeCalledCount).toBe(2);
-    const latestError = listener.state.latestErrors['ChatClient.stopRealtimeNotifications'];
-    expect(latestError).toBeDefined();
-  });
 });
 
 describe('complex error handling for startRealtimeNotifications', () => {

--- a/packages/chat-stateful-client/src/StatefulChatClient.test.ts
+++ b/packages/chat-stateful-client/src/StatefulChatClient.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ChatClient, ChatThreadItem } from '@azure/communication-chat';
+import { ChatThreadItem } from '@azure/communication-chat';
 import {
   ChatMessageDeletedEvent,
   ChatMessageEditedEvent,
@@ -15,107 +15,24 @@ import {
   ReadReceiptReceivedEvent,
   TypingIndicatorReceivedEvent
 } from '@azure/communication-signaling';
-import { createStatefulChatClientWithDeps, StatefulChatClient, StatefulChatClientArgs } from './StatefulChatClient';
+import { createStatefulChatClientWithDeps } from './StatefulChatClient';
 import { ChatClientState, ChatError } from './ChatClientState';
 import { Constants } from './Constants';
-import { createMockChatThreadClient } from './mocks/createMockChatThreadClient';
-import { createMockIterator } from './mocks/createMockIterator';
-import { MockCommunicationUserCredential } from './mocks/MockCommunicationUserCredential';
+import {
+  StateChangeListener,
+  StatefulChatClientWithEventTrigger,
+  createMockChatClient,
+  createStatefulChatClientMock,
+  defaultClientArgs,
+  mockChatThreads
+} from './TestHelpers';
 
 jest.useFakeTimers();
-
-// [1, 2 ... 5] array
-const seedArray = Array.from(Array(5).keys());
-
-const mockChatThreads: ChatThreadItem[] = seedArray.map((seed) => ({
-  id: 'chatThreadId' + seed,
-  topic: 'topic' + seed,
-  createdOn: new Date(seed * 10000),
-  createdBy: { communicationUserId: 'user' + seed }
-}));
 
 const mockParticipants: ChatParticipant[] = [
   { id: { kind: 'communicationUser', communicationUserId: 'user1' }, displayName: 'user1' },
   { id: { kind: 'communicationUser', communicationUserId: 'user2' }, displayName: 'user1' }
 ];
-
-const mockListChatThreads = (): any => {
-  return createMockIterator(mockChatThreads);
-};
-
-const emptyAsyncFunctionWithResponse = async (): Promise<any> => {
-  return { _response: {} as any };
-};
-
-const mockEventHandlersRef = { value: {} };
-beforeEach(() => {
-  mockEventHandlersRef.value = {};
-});
-
-export function createMockChatClient(): ChatClient {
-  const mockChatClient: ChatClient = {} as any;
-
-  mockChatClient.createChatThread = async (request) => {
-    return {
-      chatThread: {
-        id: 'chatThreadId',
-        topic: request.topic,
-        createdOn: new Date(0),
-        createdBy: { kind: 'communicationUser', communicationUserId: 'user1' }
-      }
-    };
-  };
-
-  mockChatClient.listChatThreads = mockListChatThreads;
-
-  mockChatClient.deleteChatThread = emptyAsyncFunctionWithResponse;
-
-  mockChatClient.getChatThreadClient = (threadId) => {
-    return createMockChatThreadClient(threadId);
-  };
-
-  mockChatClient.on = ((event: Parameters<ChatClient['on']>[0], listener: (e: Event) => void) => {
-    mockEventHandlersRef.value[event] = listener;
-  }) as any;
-
-  mockChatClient.off = ((event: Parameters<ChatClient['on']>[0], listener: (e: Event) => void) => {
-    if (mockEventHandlersRef.value[event] === listener) {
-      mockEventHandlersRef.value[event] = undefined;
-    }
-  }) as any;
-
-  mockChatClient.startRealtimeNotifications = emptyAsyncFunctionWithResponse;
-  mockChatClient.stopRealtimeNotifications = emptyAsyncFunctionWithResponse;
-
-  return mockChatClient;
-}
-
-type StatefulChatClientWithEventTrigger = StatefulChatClient & {
-  triggerEvent: (eventName: string, e: any) => Promise<void>;
-};
-
-const createStatefulChatClientMock = (): StatefulChatClientWithEventTrigger => {
-  mockEventHandlersRef.value = {};
-  const client = createStatefulChatClientWithDeps(createMockChatClient(), defaultClientArgs);
-
-  Object.defineProperty(client, 'triggerEvent', {
-    value: async (eventName: string, e: any): Promise<void> => {
-      const handler = mockEventHandlersRef.value[eventName];
-      if (handler !== undefined) {
-        await handler(e);
-      }
-    }
-  });
-
-  return client as StatefulChatClientWithEventTrigger;
-};
-
-export const defaultClientArgs: StatefulChatClientArgs = {
-  displayName: '',
-  userId: { kind: 'communicationUser', communicationUserId: 'userId1' },
-  endpoint: '',
-  credential: new MockCommunicationUserCredential()
-};
 
 describe('declarative chatThread list iterators', () => {
   test('declarative listChatThreads should proxy listChatThreads iterator and store it in internal state', async () => {
@@ -449,6 +366,19 @@ describe('stateful chatClient tees errors to state', () => {
     const latestError = listener.state.latestErrors['ChatClient.startRealtimeNotifications'];
     expect(latestError).toBeDefined();
   });
+
+  test('when startRealtimeNotifications fails', async () => {
+    const baseClient = createMockChatClient();
+    baseClient.stopRealtimeNotifications = async () => {
+      throw Error('injected error');
+    };
+    const client = createStatefulChatClientWithDeps(baseClient, defaultClientArgs);
+    const listener = new StateChangeListener(client);
+    await expect(client.stopRealtimeNotifications()).rejects.toThrow();
+    expect(listener.onChangeCalledCount).toBe(1);
+    const latestError = listener.state.latestErrors['ChatClient.stopRealtimeNotifications'];
+    expect(latestError).toBeDefined();
+  });
 });
 
 describe('complex error handling for startRealtimeNotifications', () => {
@@ -495,18 +425,3 @@ describe('complex error handling for startRealtimeNotifications', () => {
     expect(latestError).toBeUndefined();
   });
 });
-
-export class StateChangeListener {
-  state: ChatClientState;
-  onChangeCalledCount = 0;
-
-  constructor(client: StatefulChatClient) {
-    this.state = client.getState();
-    client.onStateChange(this.onChange.bind(this));
-  }
-
-  private onChange(newState: ChatClientState): void {
-    this.onChangeCalledCount++;
-    this.state = newState;
-  }
-}

--- a/packages/chat-stateful-client/src/StatefulChatClient.test.ts
+++ b/packages/chat-stateful-client/src/StatefulChatClient.test.ts
@@ -375,7 +375,7 @@ describe('stateful chatClient tees errors to state', () => {
     const client = createStatefulChatClientWithDeps(baseClient, defaultClientArgs);
     const listener = new StateChangeListener(client);
     await expect(client.stopRealtimeNotifications()).rejects.toThrow();
-    expect(listener.onChangeCalledCount).toBe(1);
+    expect(listener.onChangeCalledCount).toBe(2);
     const latestError = listener.state.latestErrors['ChatClient.stopRealtimeNotifications'];
     expect(latestError).toBeDefined();
   });

--- a/packages/chat-stateful-client/src/StatefulChatClient.test.ts
+++ b/packages/chat-stateful-client/src/StatefulChatClient.test.ts
@@ -367,7 +367,7 @@ describe('stateful chatClient tees errors to state', () => {
     expect(latestError).toBeDefined();
   });
 
-  test('when startRealtimeNotifications fails', async () => {
+  test('when stopRealtimeNotifications fails', async () => {
     const baseClient = createMockChatClient();
     baseClient.stopRealtimeNotifications = async () => {
       throw Error('injected error');

--- a/packages/chat-stateful-client/src/StatefulChatThreadClient.test.ts
+++ b/packages/chat-stateful-client/src/StatefulChatThreadClient.test.ts
@@ -11,7 +11,7 @@ import {
   mockParticipants,
   mockReadReceipts
 } from './mocks/createMockChatThreadClient';
-import { createMockChatClient, defaultClientArgs, StateChangeListener } from './StatefulChatClient.test';
+import { createMockChatClient, defaultClientArgs, StateChangeListener } from './TestHelpers';
 import { createStatefulChatClientWithDeps, StatefulChatClient } from './StatefulChatClient';
 
 const threadId = '1';

--- a/packages/chat-stateful-client/src/TestHelpers.ts
+++ b/packages/chat-stateful-client/src/TestHelpers.ts
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ChatClient, ChatThreadItem } from '@azure/communication-chat';
+import { ChatClientState } from './ChatClientState';
+import { createStatefulChatClientWithDeps, StatefulChatClient, StatefulChatClientArgs } from './StatefulChatClient';
+import { createMockChatThreadClient } from './mocks/createMockChatThreadClient';
+import { createMockIterator } from './mocks/createMockIterator';
+import { MockCommunicationUserCredential } from './mocks/MockCommunicationUserCredential';
+
+export class StateChangeListener {
+  state: ChatClientState;
+  onChangeCalledCount = 0;
+
+  constructor(client: StatefulChatClient) {
+    this.state = client.getState();
+    client.onStateChange(this.onChange.bind(this));
+  }
+
+  private onChange(newState: ChatClientState): void {
+    this.onChangeCalledCount++;
+    this.state = newState;
+  }
+}
+
+export const defaultClientArgs: StatefulChatClientArgs = {
+  displayName: '',
+  userId: { kind: 'communicationUser', communicationUserId: 'userId1' },
+  endpoint: '',
+  credential: new MockCommunicationUserCredential()
+};
+
+export type StatefulChatClientWithEventTrigger = StatefulChatClient & {
+  triggerEvent: (eventName: string, e: any) => Promise<void>;
+};
+
+export const createStatefulChatClientMock = (): StatefulChatClientWithEventTrigger => {
+  return createStatefulChatClientWithDeps(
+    createMockChatClient(),
+    defaultClientArgs
+  ) as StatefulChatClientWithEventTrigger;
+};
+
+export type ChatClientWithEventTrigger = ChatClient & {
+  triggerEvent: (eventName: string, e: any) => Promise<void>;
+};
+
+export function createMockChatClient(): ChatClientWithEventTrigger {
+  const mockEventHandlersRef = { value: {} };
+  const mockChatClient: ChatClientWithEventTrigger = {} as any;
+
+  mockChatClient.createChatThread = async (request) => {
+    return {
+      chatThread: {
+        id: 'chatThreadId',
+        topic: request.topic,
+        createdOn: new Date(0),
+        createdBy: { kind: 'communicationUser', communicationUserId: 'user1' }
+      }
+    };
+  };
+
+  mockChatClient.listChatThreads = mockListChatThreads;
+
+  mockChatClient.deleteChatThread = emptyAsyncFunctionWithResponse;
+
+  mockChatClient.getChatThreadClient = (threadId) => {
+    return createMockChatThreadClient(threadId);
+  };
+
+  mockChatClient.on = ((event: Parameters<ChatClient['on']>[0], listener: (e: Event) => void) => {
+    mockEventHandlersRef.value[event] = listener;
+  }) as any;
+
+  mockChatClient.off = ((event: Parameters<ChatClient['on']>[0], listener: (e: Event) => void) => {
+    if (mockEventHandlersRef.value[event] === listener) {
+      mockEventHandlersRef.value[event] = undefined;
+    }
+  }) as any;
+
+  mockChatClient.startRealtimeNotifications = emptyAsyncFunctionWithResponse;
+  mockChatClient.stopRealtimeNotifications = emptyAsyncFunctionWithResponse;
+
+  mockChatClient.triggerEvent = async (eventName: string, e: any): Promise<void> => {
+    const handler = mockEventHandlersRef.value[eventName];
+    if (handler !== undefined) {
+      await handler(e);
+    }
+  };
+
+  return mockChatClient;
+}
+
+const mockListChatThreads = (): any => {
+  return createMockIterator(mockChatThreads);
+};
+
+// [1, 2 ... 5] array
+const seedArray = Array.from(Array(5).keys());
+
+export const mockChatThreads: ChatThreadItem[] = seedArray.map((seed) => ({
+  id: 'chatThreadId' + seed,
+  topic: 'topic' + seed,
+  createdOn: new Date(seed * 10000),
+  createdBy: { communicationUserId: 'user' + seed }
+}));
+
+const emptyAsyncFunctionWithResponse = async (): Promise<any> => {
+  return { _response: {} as any };
+};


### PR DESCRIPTION
# What
Refactor some test helpers in their own module

# Why
* Before this PR, helpers were imported from one test module to another. This import confuses jest and it ends up running the tests from the imported module twice. This makes the tests run longer / adds confusion on failure.
* The mocks / helpers here could be cleaned up quite a bit, but restricting myself (mostly) to just moving the helpers for now.

# How Tested
`rush test`

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->