### PR TITLE
Only trigger 'error' event on errors teed to state

### DIFF
--- a/change/react-composites-178141e7-610a-457e-bff0-4f0b5cec4b3d.json
+++ b/change/react-composites-178141e7-610a-457e-bff0-4f0b5cec4b3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Only emit 'error' on errors teed to state",
+  "packageName": "react-composites",
+  "email": "prprabhu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -242,9 +242,9 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
     try {
       return await f();
     } catch (error) {
-      // Stateful chat client wraps all relevant errors as `ChatError`.
-      const e = error as ChatError;
-      this.emitter.emit('error', { operation: e.target, error: e.inner });
+      if (isChatError(error)) {
+        this.emitter.emit('error', { operation: error.target, error: error.inner });
+      }
       throw error;
     }
   }
@@ -283,4 +283,8 @@ export const createAzureCommunicationChatAdapter = async (
 
   const adapter = new AzureCommunicationChatAdapter(chatClient, chatThreadClient);
   return adapter;
+};
+
+const isChatError = (e: Error): e is ChatError => {
+  return e['target'] !== undefined && e['inner'] !== undefined;
 };


### PR DESCRIPTION
# Why
Some stateful methods, e.g. `getChatThreadClient()`, will never tee errors to state. Before this PR, the composite error handling code would blow up for these errors. Instead, we now ignore those errors when triggering `'errror'` event. This makes the error reporting more consistent in state vs events.

# How Tested
Unittests.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->