### PR TITLE
Upgrade to calling sdk v1.2.0-beta.1

### DIFF
--- a/change/calling-component-bindings-be768872-ddf9-4c11-b21b-9bef1247242a.json
+++ b/change/calling-component-bindings-be768872-ddf9-4c11-b21b-9bef1247242a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Upgrade to calling sdk v1.2.0-beta.1",
+  "packageName": "calling-component-bindings",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/calling-stateful-client-6f9c5303-b90d-4c32-b60d-defebd39ce2d.json
+++ b/change/calling-stateful-client-6f9c5303-b90d-4c32-b60d-defebd39ce2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Upgrade to calling sdk v1.2.0-beta.1",
+  "packageName": "calling-stateful-client",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/react-composites-f300868a-32e7-4052-90cd-a7aa36274b38.json
+++ b/change/react-composites-f300868a-32e7-4052-90cd-a7aa36274b38.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Upgrade to calling sdk v1.2.0-beta.1",
+  "packageName": "react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -24,13 +24,13 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==
-  /@azure/communication-calling/1.1.0-beta.2:
+  /@azure/communication-calling/1.2.0-beta.1:
     dependencies:
       '@azure/communication-common': 1.0.0
       '@azure/logger': 1.0.2
     dev: false
     resolution:
-      integrity: sha512-Gjt2Ym8S/WrlL5e6Qe/gAbDa5d9acmOnOm8jPDaRZVn7oS6j8AfSYMvCdx+ILKGjjzThXdN+1/v1ReZfEjzE+A==
+      integrity: sha512-qeqb+YwgDi8DbImqyo40cK5TODeqwibZNwqOO0rCKaOtaD0x+Fkj6q0Il1+4uMwIxQZ89ucqt8WMFSN385Hl+g==
   /@azure/communication-chat/1.0.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -16709,6 +16709,7 @@ packages:
     resolution:
       integrity: sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
   /querystring/0.2.0:
+    deprecated: The
     dev: false
     engines:
       node: '>=0.4.x'
@@ -21047,7 +21048,7 @@ packages:
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
     dependencies:
-      '@azure/communication-calling': 1.1.0-beta.2
+      '@azure/communication-calling': 1.2.0-beta.1
       '@azure/communication-common': 1.0.0
       '@microsoft/api-documenter': 7.12.22
       '@types/jest': 26.0.23
@@ -21071,12 +21072,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-pJvD0LM/x+POsRRH8tcGGpAZydVY7j9s/pPjfDP5kWY3lRv67Y1Q/3s2hFv4UF9SYD0rP3jxjw+Rpa12/a9PcQ==
+      integrity: sha512-MhT9EHn8u4R6YWd0c+FyZpenGYeYE1r4SVFOmohIM29OsIDmv15J32vb8xvxWoZ61aOock9CCgsJXsSapEUWsw==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
     dependencies:
-      '@azure/communication-calling': 1.1.0-beta.2
+      '@azure/communication-calling': 1.2.0-beta.1
       '@azure/communication-common': 1.0.0
       '@microsoft/api-documenter': 7.12.22
       '@types/jest': 26.0.23
@@ -21099,12 +21100,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-+50DJAnrYB1mCzoy7KszTnAM5f8s8pSfhl2CQmD+d6BSh5HNibeS7Nmpahk3lcVY8AMYa2NH+2nYhxqm3queQg==
+      integrity: sha512-PHjMLQCNgLdGR6/x+OTFrgqgcUXjUEvJBunlfyHFr3DGFMw1Gj9HO5rxPhmYq6K4p0y5z/C6/cmiX58nKNTXMg==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
     dependencies:
-      '@azure/communication-calling': 1.1.0-beta.2
+      '@azure/communication-calling': 1.2.0-beta.1
       '@azure/communication-common': 1.0.0
       '@azure/communication-identity': 1.0.0
       '@azure/core-http': 1.2.4
@@ -21168,7 +21169,7 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-AfVhl2z4nLa4y/jzxbXiXMpyAr5AncVsBBD3ByPbt3OPMAj5+dLk4NnmQtPxx3uPp01cKOYv/ywdtvW9RXtAzQ==
+      integrity: sha512-ehjGINblg0RjbJF6SHYqxKdrIf31z8+fF3tvWrFPYwdnfKt5QNXVqxoz/aU7o8/7eksIKSU4k4SNiHVFcsYA3Q==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -21294,7 +21295,7 @@ packages:
     version: 0.0.0
   file:projects/communication-react.tgz:
     dependencies:
-      '@azure/communication-calling': 1.1.0-beta.2
+      '@azure/communication-calling': 1.2.0-beta.1
       '@azure/communication-chat': 1.0.0
       '@azure/communication-common': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.5
@@ -21362,7 +21363,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-6HrPFHN3xgNRe1ZwH36WnIXd7Gtk8SqeGeDrTfK/W//nJSDNHjPrtpEJvclgYrYARHowsdZiRvLkoRdPI1bibQ==
+      integrity: sha512-dLvzn4E+4acbflIzgC73eyDIBHgpms4bCHrd9np5uiTljhhb19xN/OI/UYSqUKfZDMWYNHCRHmZrVsNG3cclxQ==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/react-components.tgz:
@@ -21439,7 +21440,7 @@ packages:
     version: 0.0.0
   file:projects/react-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.1.0-beta.2
+      '@azure/communication-calling': 1.2.0-beta.1
       '@azure/communication-chat': 1.0.0
       '@azure/communication-common': 1.0.0
       '@azure/communication-identity': 1.0.0
@@ -21521,7 +21522,7 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-YBTiLtsPxmRABXKv+PDDs44ryXVGbQ0VLC9wL1XXVzrY3dbtdmRnyfe4kTSh8CL4xSLpRFmubjz+FCltK4rmvQ==
+      integrity: sha512-zcbjsP7j/UunXUcXLmtpGefRy/ysihuWMHLsDW7AEdZ690Drs6LlLIlglChVenRy8iVpi5jc/G0fY5naxulLTA==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
@@ -21592,7 +21593,7 @@ packages:
     version: 0.0.0
   file:projects/storybook.tgz:
     dependencies:
-      '@azure/communication-calling': 1.1.0-beta.2
+      '@azure/communication-calling': 1.2.0-beta.1
       '@azure/communication-chat': 1.0.0
       '@azure/communication-common': 1.0.0
       '@azure/communication-identity': 1.0.0
@@ -21682,7 +21683,7 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-o/u46AT0q/Mu+y+JPEwJnHkWwSztFpOQZeklISEAu+sGsNsD91KcZD5teS10Evr6ory93El1ZPtO3u4W2H1RHg==
+      integrity: sha512-z6FP8EWLtQsAT+nz2LJXjdHozLDShymjSTlpjEquThpG5xixZu6sNUo/fjySA52xICsCOyZd4Z1Fws/D958Y8w==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:

--- a/packages/calling-component-bindings/package.json
+++ b/packages/calling-component-bindings/package.json
@@ -24,7 +24,7 @@
     "acs-ui-common": "1.0.0-beta.1",
     "calling-stateful-client": "~1.0.0-beta.1",
     "@azure/communication-common": "1.0.0",
-    "@azure/communication-calling": "1.1.0-beta.2",
+    "@azure/communication-calling": "1.2.0-beta.1",
     "reselect": "~4.0.0",
     "memoize-one": "~5.2.1",
     "react-components": "1.0.0-beta.1"

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@azure/communication-common": "1.0.0",
-    "@azure/communication-calling": "1.1.0-beta.2",
+    "@azure/communication-calling": "1.2.0-beta.1",
     "acs-ui-common": "1.0.0-beta.1",
     "events": "~3.3.0",
     "immer": "~8.0.1"

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -23,7 +23,7 @@
   },
   "types": "dist/communication-react.d.ts",
   "dependencies": {
-    "@azure/communication-calling": "1.1.0-beta.2",
+    "@azure/communication-calling": "1.2.0-beta.1",
     "@azure/communication-chat": "1.0.0",
     "@azure/communication-common": "1.0.0",
     "@azure/communication-signaling": "1.0.0-beta.5",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -30,7 +30,7 @@
     "acs-ui-common": "1.0.0-beta.1",
     "calling-stateful-client": "~1.0.0-beta.1",
     "calling-component-bindings": "~1.0.0-beta.1",
-    "@azure/communication-calling": "1.1.0-beta.2",
+    "@azure/communication-calling": "1.2.0-beta.1",
     "@azure/communication-chat": "1.0.0",
     "@azure/communication-common": "1.0.0",
     "@azure/communication-signaling": "1.0.0-beta.5",

--- a/packages/react-composites/src/mocks/CallingTypeMocks.ts
+++ b/packages/react-composites/src/mocks/CallingTypeMocks.ts
@@ -3,7 +3,6 @@
 
 import {
   AddPhoneNumberOptions,
-  Call,
   CallApiFeature,
   CallDirection,
   CallEndReason,
@@ -278,7 +277,7 @@ export declare interface MockCallAgent {
   startCall(
     participants: (CommunicationUserIdentifier | PhoneNumberIdentifier | UnknownIdentifier)[],
     options?: StartCallOptions
-  ): Call;
+  ): MockCall;
   /**
    * Join a group call.
    * To join a group call just use a groupId.
@@ -286,7 +285,7 @@ export declare interface MockCallAgent {
    * @param options - Call start options.
    * @returns The Call object associated with the call.
    */
-  join(groupLocator: GroupLocator, options?: JoinCallOptions): Call;
+  join(groupLocator: GroupLocator, options?: JoinCallOptions): MockCall;
   /**
    * Join a group chat call.
    * To join a group chat call just use a threadId.
@@ -295,7 +294,7 @@ export declare interface MockCallAgent {
    * @returns The Call object associated with the call.
    * @beta
    */
-  join(groupChatCallLocator: GroupChatCallLocator, options?: JoinCallOptions): Call;
+  join(groupChatCallLocator: GroupChatCallLocator, options?: JoinCallOptions): MockCall;
   /**
    * Join a meeting.
    * @param meetingLocator - Meeting information.
@@ -303,7 +302,7 @@ export declare interface MockCallAgent {
    * @returns The Call object associated with the call.
    * @beta
    */
-  join(meetingLocator: MeetingLocator, options?: JoinCallOptions): Call;
+  join(meetingLocator: MeetingLocator, options?: JoinCallOptions): MockCall;
   /**
    * Dispose this CallAgent ( required to create another new CallAgent)
    */
@@ -320,7 +319,7 @@ export declare interface MockCallAgent {
    * @param listener - callback fn that will be called when this collection will change,
    * it will pass arrays of added and removed elements
    */
-  on(event: 'callsUpdated', listener: CollectionUpdatedEvent<Call>): void;
+  on(event: 'callsUpdated', listener: CollectionUpdatedEvent<MockCall>): void;
   /**
    * Unsubscribe function for incomingCall event.
    * @param event - event name.
@@ -332,5 +331,5 @@ export declare interface MockCallAgent {
    * @param event - event name.
    * @param listener - allback fn that was used to subscribe to this event.
    */
-  off(event: 'callsUpdated', listener: CollectionUpdatedEvent<Call>): void;
+  off(event: 'callsUpdated', listener: CollectionUpdatedEvent<MockCall>): void;
 }

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "chat-component-bindings": "~1.0.0-beta.1",
     "@azure/communication-identity": "1.0.0",
-    "@azure/communication-calling": "1.1.0-beta.2",
+    "@azure/communication-calling": "1.2.0-beta.1",
     "@azure/communication-chat": "1.0.0",
     "@azure/communication-common": "1.0.0",
     "@azure/communication-react": "1.0.0-beta.1",

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "calling-component-bindings": "~1.0.0-beta.1",
     "@azure/communication-identity": "1.0.0",
-    "@azure/communication-calling": "1.1.0-beta.2",
+    "@azure/communication-calling": "1.2.0-beta.1",
     "@azure/communication-common": "1.0.0",
     "@azure/communication-react": "1.0.0-beta.1",
     "@azure/core-http": "1.2.4",


### PR DESCRIPTION
# What
Upgrade to calling sdk v1.2.0-beta.1
* Fix some test errors
  * The SDK `Call` object now has a beta property `totalParticipantCount`. Moved to our mock object using our mock call instead of the underlying sdk call object.

# Why
Ask from calling SDK team.

See changelog here: https://github.com/Azure/Communication/blob/master/releasenotes/acs-javascript-calling-library-release-notes.md

# How Tested
* Unit tests
* verified call composite in PR storybook.