### PR TITLE
Remove iframe.html from the storybook PR url

### DIFF
--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -3,11 +3,11 @@ name: 'Publish Chromatic'
 on:
   pull_request:
     branches: [main]
-    # paths: // removing for testing in PR
-    #   - packages/storybook/**
-    #   - packages/react-components/**
-    #   - packages/react-composites/**
-    #   - packages/communication-react/**
+    paths:
+      - packages/storybook/**
+      - packages/react-components/**
+      - packages/react-composites/**
+      - packages/communication-react/**
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -61,7 +61,6 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            # Create github comment
             github.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -45,20 +45,26 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
+      - name: Format storybook URL
+        id: storybook_url
+        # Get the url from chromatic job then remove the iframe.html at the end of the url (this looks like a bug)
+        run: |
+          storybookurl=${{ steps.publish_chromatic.outputs.storybookUrl }}
+          echo "Storybook URL before: $storybookurl"
+          newurl=${storybookurl/%iframe.html}
+          echo "Storybook URL after: $newurl"
+          echo "::set-output name=url::$newurl"
+
       - name: Add Storybook URL as Issue Comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            # Get url from chromatic job
-            storybookurl=${{ steps.publish_chromatic.outputs.storybookUrl }}
-            # Remove the iframe.html at the end of the url (this looks like a bug)
-            newurl=${storybookurl/%iframe.html}
             # Create github comment
             github.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Storybook URL $newurl'
+              body: 'Storybook URL ${{ steps.storybook_url.outputs.url }}'
             })

--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -3,11 +3,11 @@ name: 'Publish Chromatic'
 on:
   pull_request:
     branches: [main]
-    paths:
-      - packages/storybook/**
-      - packages/react-components/**
-      - packages/react-composites/**
-      - packages/communication-react/**
+    # paths: // removing for testing in PR
+    #   - packages/storybook/**
+    #   - packages/react-components/**
+    #   - packages/react-composites/**
+    #   - packages/communication-react/**
   push:
     branches: [main]
   workflow_dispatch:
@@ -51,9 +51,14 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
+            # Get url from chromatic job
+            storybookurl=${{ steps.publish_chromatic.outputs.storybookUrl }}
+            # Remove the iframe.html at the end of the url (this looks like a bug)
+            newurl=${storybookurl/%iframe.html}
+            # Create github comment
             github.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Storybook URL ${{ steps.publish_chromatic.outputs.storybookUrl }}'
+              body: 'Storybook URL $newurl'
             })


### PR DESCRIPTION
# What
Remove `iframe.html` from the storybook url.
i.e.
URL that was posted to the PR comment before
```
60c7ae6891f0e90039d7cd54-lmzgyjpbjk.chromatic.com/iframe.html
```
URL that is now posted to the PR comment
```
60c7ae6891f0e90039d7cd54-lmzgyjpbjk.chromatic.com/
```

# Why
Seems like a bug in the github action, but their repo doesn't have an issues section to post issues.

# How Tested
See storybook link in this PR