### PR TITLE
Quick Fix: Video in lobby story should use local video instead of throwing an exception

### DIFF
--- a/packages/storybook/stories/Examples/TeamsInterop/snippets/Lobby.snippet.tsx
+++ b/packages/storybook/stories/Examples/TeamsInterop/snippets/Lobby.snippet.tsx
@@ -9,6 +9,7 @@ import {
 } from '@azure/communication-react';
 import { useTheme } from '@fluentui/react';
 import React from 'react';
+import { useVideoStreams } from '../../../utils';
 
 export interface LobbyProps {
   isVideoReady: boolean;
@@ -29,16 +30,14 @@ export const Lobby = (props: LobbyProps): JSX.Element => {
     root: { background: theme.palette.white, minHeight: '4.25rem', alignItems: 'center' }
   };
 
+  const videoStreamElement = useVideoStreams(1)[0];
   return (
     <VideoTile
       styles={videoTileStyles}
       isMirrored={true}
       isVideoReady={props.isVideoReady}
       onRenderPlaceholder={() => <></>}
-      renderElement={
-        // Replace with your own html local video render element.
-        <StreamMedia videoStreamElement={{} as any} />
-      }
+      renderElement={<StreamMedia videoStreamElement={videoStreamElement} />}
     >
       <div
         style={{


### PR DESCRIPTION
# What
Fix Lobby story page to use the local video feed when the video is started


# Why
Starting video in the lobby page causes an exception:
![image](https://user-images.githubusercontent.com/2684369/124517263-64bff000-dd98-11eb-8623-8c1c5e29e182.png)

Now:
![image](https://user-images.githubusercontent.com/2684369/124517436-d009c200-dd98-11eb-826d-068f3f3923df.png)


# How Tested
Locally (see screenshot above) very quickly (no extensive testing performed)