### PR TITLE
when a user leaves a chat they are out of the chat thread and you can…

### DIFF
--- a/samples/Chat/src/app/App.tsx
+++ b/samples/Chat/src/app/App.tsx
@@ -78,6 +78,7 @@ export default (): JSX.Element => {
           <ChatThreadClientProvider chatThreadClient={chatThreadClient}>
             <ChatScreen
               endChatHandler={() => {
+                chatThreadClient.removeParticipant({ communicationUserId: userId });
                 setPage('end');
                 // Send up signal that the user wants to leave the chat
                 // Move to to next screen on success
@@ -95,7 +96,7 @@ export default (): JSX.Element => {
       return (
         <EndScreen
           rejoinHandler={() => {
-            setPage('chat'); // use store information to attempt to rejoin the chat thread
+            setPage('configuration'); // use store information to attempt to rejoin the chat thread
           }}
           homeHandler={() => {
             window.location.href = window.location.origin;


### PR DESCRIPTION
… rejoin to config screen

# What
When a participant leaves the chat they were still in the chat thread. We want to remove the participant from the chat thread. When a user wants to rejoin we want to get them to rejoin the thread. We do this by leveraging this functionality on the configuration screen.

# Why
Participants that had left the chat thread were not actually removed. This fix solves this by removing them.

# How Tested
Ran locally with two instances

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [x ] This change causes current functionality to break.
If a participant leaves the chat, they are now removed from the chat thread