### PR TITLE
Cherry-Pick: Bind all methods of ChatAdapter on construction

### DIFF
--- a/change/@internal-react-composites-778b3a8d-478b-49b5-9f0c-1ab07aef4974.json
+++ b/change/@internal-react-composites-778b3a8d-478b-49b5-9f0c-1ab07aef4974.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bind all methods of ChatAdaptor on construction",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -87,6 +87,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   private emitter: EventEmitter = new EventEmitter();
 
   constructor(chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient) {
+    this.bindAllPublicMethods();
     this.chatClient = chatClient;
     this.chatThreadClient = chatThreadClient;
     this.context = new ChatContext(chatClient.getState(), chatThreadClient.threadId);
@@ -103,6 +104,22 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
 
     this.chatClient.onStateChange(onStateChange);
     this.subscribeAllEvents();
+  }
+
+  private bindAllPublicMethods() {
+    this.onStateChange = this.onStateChange.bind(this);
+    this.offStateChange = this.offStateChange.bind(this);
+    this.getState = this.getState.bind(this);
+    this.dispose = this.dispose.bind(this);
+    this.fetchInitialData = this.fetchInitialData.bind(this);
+    this.sendMessage = this.sendMessage.bind(this);
+    this.sendReadReceipt = this.sendReadReceipt.bind(this);
+    this.sendTypingIndicator = this.sendTypingIndicator.bind(this);
+    this.removeParticipant = this.removeParticipant.bind(this);
+    this.setTopic = this.setTopic.bind(this);
+    this.loadPreviousChatMessages = this.loadPreviousChatMessages.bind(this);
+    this.on = this.on.bind(this);
+    this.off = this.off.bind(this);
   }
 
   dispose(): void {
@@ -195,21 +212,21 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   }
 
   private subscribeAllEvents(): void {
-    this.chatClient.on('chatThreadPropertiesUpdated', this.chatThreadPropertiesUpdatedListener);
-    this.chatClient.on('participantsAdded', this.participantsAddedListener);
-    this.chatClient.on('participantsRemoved', this.participantsRemovedListener);
-    this.chatClient.on('chatMessageReceived', this.messageReceivedListener);
-    this.chatClient.on('readReceiptReceived', this.messageReadListener);
-    this.chatClient.on('participantsRemoved', this.participantsRemovedListener);
+    this.chatClient.on('chatThreadPropertiesUpdated', this.chatThreadPropertiesUpdatedListener.bind(this));
+    this.chatClient.on('participantsAdded', this.participantsAddedListener.bind(this));
+    this.chatClient.on('participantsRemoved', this.participantsRemovedListener.bind(this));
+    this.chatClient.on('chatMessageReceived', this.messageReceivedListener.bind(this));
+    this.chatClient.on('readReceiptReceived', this.messageReadListener.bind(this));
+    this.chatClient.on('participantsRemoved', this.participantsRemovedListener.bind(this));
   }
 
   private unsubscribeAllEvents(): void {
-    this.chatClient.off('chatThreadPropertiesUpdated', this.chatThreadPropertiesUpdatedListener);
-    this.chatClient.off('participantsAdded', this.participantsAddedListener);
-    this.chatClient.off('participantsRemoved', this.participantsRemovedListener);
-    this.chatClient.off('chatMessageReceived', this.messageReceivedListener);
-    this.chatClient.off('readReceiptReceived', this.messageReadListener);
-    this.chatClient.off('participantsRemoved', this.participantsRemovedListener);
+    this.chatClient.off('chatThreadPropertiesUpdated', this.chatThreadPropertiesUpdatedListener.bind(this));
+    this.chatClient.off('participantsAdded', this.participantsAddedListener.bind(this));
+    this.chatClient.off('participantsRemoved', this.participantsRemovedListener.bind(this));
+    this.chatClient.off('chatMessageReceived', this.messageReceivedListener.bind(this));
+    this.chatClient.off('readReceiptReceived', this.messageReadListener.bind(this));
+    this.chatClient.off('participantsRemoved', this.participantsRemovedListener.bind(this));
   }
 
   on(event: 'messageReceived', listener: MessageReceivedListener): void;

--- a/packages/react-composites/src/composites/ChatComposite/hooks/useHandlers.ts
+++ b/packages/react-composites/src/composites/ChatComposite/hooks/useHandlers.ts
@@ -20,11 +20,11 @@ export const useHandlers = <PropsT>(
 
 const createCompositeHandlers = memoizeOne(
   (adapter: ChatAdapter): DefaultChatHandlers => ({
-    onSendMessage: adapter.sendMessage.bind(adapter),
-    onLoadPreviousChatMessages: adapter.loadPreviousChatMessages.bind(adapter),
-    onMessageSeen: adapter.sendReadReceipt.bind(adapter),
-    onTyping: adapter.sendTypingIndicator.bind(adapter),
-    onParticipantRemove: adapter.removeParticipant.bind(adapter),
-    updateThreadTopicName: adapter.setTopic.bind(adapter)
+    onSendMessage: adapter.sendMessage,
+    onLoadPreviousChatMessages: adapter.loadPreviousChatMessages,
+    onMessageSeen: adapter.sendReadReceipt,
+    onTyping: adapter.sendTypingIndicator,
+    onParticipantRemove: adapter.removeParticipant,
+    updateThreadTopicName: adapter.setTopic
   })
 );


### PR DESCRIPTION
# What
Cherry-pick of #557

# Why
Fixes serious correctness problem -- without this PR, Chat composite does not get notifications from the SDK.

# How Tested
storybook.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->