### PR TITLE
Provide participants when creating chat thread

### DIFF
--- a/packages/storybook/stories/IdentityManagement/snippets/ChatBackend.snippet.ts
+++ b/packages/storybook/stories/IdentityManagement/snippets/ChatBackend.snippet.ts
@@ -18,10 +18,15 @@ export const createUserAndThread = async (resourceConnectionString: string, disp
   }
 
   const chatClient = new ChatClient(endpointUrl, new AzureCommunicationTokenCredential(userAndTokens[0].token));
-  const threadId = (await chatClient.createChatThread({ topic: 'DemoThread' })).chatThread?.id ?? '';
-  await chatClient.getChatThreadClient(threadId).addParticipants({
-    participants: displayNames.map((displayName, i) => ({ id: userAndTokens[i].user, displayName: displayName }))
-  });
+  const threadId =
+    (
+      await chatClient.createChatThread(
+        { topic: 'DemoThread' },
+        {
+          participants: displayNames.map((displayName, i) => ({ id: userAndTokens[i].user, displayName: displayName }))
+        }
+      )
+    ).chatThread?.id ?? '';
 
   return displayNames.map((displayName, i) => ({
     userId: userAndTokens[i].user,


### PR DESCRIPTION
# What
Storybook: Use a different API method to add participants to thread.

# Why
Avoids a bug: The user that creates the thread gets added automatically to the thread, without a display name. Display name can't be changed after that.

# How Tested
Storybook.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->