### PR TITLE
Add first participant directly when creating thread

### DIFF
--- a/packages/storybook/stories/ChatComposite/snippets/Server.snippet.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/Server.snippet.tsx
@@ -10,11 +10,15 @@ export const createUserAndThread = async (resourceConnectionString: string, disp
 
   const endpointUrl = new URL(resourceConnectionString.replace('endpoint=', '').split(';')[0]).toString();
   const chatClient = new ChatClient(endpointUrl, new AzureCommunicationTokenCredential(user.token));
-  const threadId = (await chatClient.createChatThread({ topic: 'DemoThread' })).chatThread?.id ?? '';
-  await chatClient.getChatThreadClient(threadId).addParticipants({
-    participants: [{ id: user.user, displayName: displayName }]
-  });
-  await chatClient.getChatThreadClient(threadId).updateTopic('Chat with a friendly bot');
+  const threadId =
+    (
+      await chatClient.createChatThread(
+        { topic: 'Chat with a friendly bot' },
+        {
+          participants: [{ id: user.user, displayName: displayName }]
+        }
+      )
+    ).chatThread?.id ?? '';
 
   return {
     userId: user.user,


### PR DESCRIPTION
# What
Another place where first chat thread participant didn't have a name.
This one was benign because the only participant who would see users without names was the bot.

# Why

<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->