### PR TITLE
[Github issue] Remove truncation of MessageThread system message

### DIFF
--- a/change/@internal-react-components-fbf28d65-dbdf-4d2d-83c4-af232ec4bf21.json
+++ b/change/@internal-react-components-fbf28d65-dbdf-4d2d-83c4-af232ec4bf21.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removed truncation from MessageThread system message.",
+  "packageName": "@internal/react-components",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/SystemMessage.tsx
+++ b/packages/react-components/src/components/SystemMessage.tsx
@@ -4,7 +4,7 @@
 import { IStyle, FontIcon, mergeStyles, Stack } from '@fluentui/react';
 import { ComponentSlotStyle } from '@fluentui/react-northstar';
 import React from 'react';
-import { systemMessageContentStyle, systemMessageIconStyle } from './styles/SystemMessage.styles';
+import { systemMessageIconStyle } from './styles/SystemMessage.styles';
 
 // Todo: We need to add more types of system messages that we support.
 export type SystemMessageIconTypes = 'PeopleAdd' | 'PeopleBlock' | 'Edit';
@@ -31,7 +31,7 @@ export const SystemMessage = (props: SystemMessageProps): JSX.Element => {
   return (
     <Stack horizontal className={mergeStyles(props?.containerStyle as IStyle)}>
       {Icon}
-      <span className={mergeStyles(systemMessageContentStyle)}>{content}</span>
+      <span>{content}</span>
     </Stack>
   );
 };

--- a/packages/react-components/src/components/styles/SystemMessage.styles.ts
+++ b/packages/react-components/src/components/styles/SystemMessage.styles.ts
@@ -6,9 +6,3 @@ import { mergeStyles } from '@fluentui/react';
 export const systemMessageIconStyle = mergeStyles({
   margin: '0 0.688rem 0 0'
 });
-
-export const systemMessageContentStyle = mergeStyles({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap'
-});

--- a/packages/storybook/stories/CallComposite/__snapshots__/CallComposite.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/CallComposite.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite Basic Example 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -48,10 +48,10 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite Basic Exam
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite Custom Data Model Example 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -94,10 +94,10 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite Custom Dat
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite Join Existing Call 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -140,10 +140,10 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite Join Exist
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite Theme Example 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/ChatComposite/__snapshots__/ChatComposite.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/ChatComposite.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite Basic Example 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -48,10 +48,10 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite Basic Exam
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite Custom Behavior Example 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -94,10 +94,10 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite Custom Beh
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite Custom Data Model Example 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -140,10 +140,10 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite Custom Dat
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite Join Existing Chat Thread 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -186,10 +186,10 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite Join Exist
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite Theme Example 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/ControlBar/Buttons/EndCall/__snapshots__/EndCall.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/EndCall/__snapshots__/EndCall.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/End Call End Call 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/ControlBar/Buttons/Microphone/__snapshots__/Microphone.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Microphone/__snapshots__/Microphone.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/Microphone Microphone 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/ControlBar/Buttons/Options/__snapshots__/Options.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Options/__snapshots__/Options.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/Options Options 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/ControlBar/Buttons/Participants/__snapshots__/Participants.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Participants/__snapshots__/Participants.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/Participants Participants 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/ControlBar/Buttons/ScreenShare/__snapshots__/ScreenShare.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/ScreenShare/__snapshots__/ScreenShare.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/Screen Share Screen Share 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/ControlBar/__snapshots__/ControlBar.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/__snapshots__/ControlBar.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/ControlBar Control Bar 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/Examples/DevicesDropdown/__snapshots__/DeviceSettingsDropDown.stories.storyshot
+++ b/packages/storybook/stories/Examples/DevicesDropdown/__snapshots__/DeviceSettingsDropDown.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Device Settings Device Settings 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -23,10 +23,10 @@ exports[`storybook snapshot tests Storyshots Examples/Device Settings Device Set
         className="ms-Stack css-1"
       >
         <div
-          className="css-82 body-0"
+          className="css-81 body-0"
         >
           <div
-            className="css-82"
+            className="css-81"
             data-uses-unhanded-props={true}
             dir="ltr"
           >

--- a/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallAlerts.stories.storyshot
+++ b/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallAlerts.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts Incoming Call Modal 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -236,7 +236,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts Incom
                           </div>
                         </div>
                         <div
-                          className="ms-Stack css-117 css-47"
+                          className="ms-Stack css-116 css-47"
                         >
                           <div
                             className="ms-Stack css-53"
@@ -245,11 +245,11 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts Incom
                               className="ms-Stack css-54"
                             >
                               <div
-                                className="css-71"
+                                className="css-70"
                               />
                             </div>
                             <div
-                              className="ms-Stack css-81 css-55"
+                              className="ms-Stack css-80 css-55"
                             >
                               <div
                                 className="ms-Stack css-47"
@@ -423,10 +423,10 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts Incom
 
 exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts Incoming Call Toast 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -444,10 +444,10 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts Incom
         className="ms-Stack css-1"
       >
         <div
-          className="ms-Stack css-113 css-2"
+          className="ms-Stack css-112 css-2"
         >
           <div
-            className="ms-Stack css-114 css-3"
+            className="ms-Stack css-113 css-3"
           >
             <div
               aria-label="John Doe"
@@ -511,7 +511,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts Incom
             className="ms-Stack css-20"
           >
             <button
-              className="ms-Button ms-Button--default css-116 root-21"
+              className="ms-Button ms-Button--default css-115 root-21"
               data-is-focusable={true}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -546,7 +546,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts Incom
               </span>
             </button>
             <button
-              className="ms-Button ms-Button--default css-115 root-21"
+              className="ms-Button ms-Button--default css-114 root-21"
               data-is-focusable={true}
               onClick={[Function]}
               onKeyDown={[Function]}

--- a/packages/storybook/stories/Examples/Layouts/__snapshots__/Layouts.stories.storyshot
+++ b/packages/storybook/stories/Examples/Layouts/__snapshots__/Layouts.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Layouts One To One Call Layout 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -64,7 +64,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts One To One Call La
             </div>
           </div>
           <div
-            className="ms-Stack css-80 css-28"
+            className="ms-Stack css-79 css-28"
           >
             <div
               className="ms-Stack css-29"
@@ -112,7 +112,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts One To One Call La
                 </div>
               </div>
               <div
-                className="ms-Stack css-80 css-28"
+                className="ms-Stack css-79 css-28"
               >
                 <div
                   className="ms-Stack css-29"
@@ -132,10 +132,10 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts One To One Call La
 
 exports[`storybook snapshot tests Storyshots Examples/Layouts Screen Share Layout 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -201,7 +201,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts Screen Share Layou
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-80 css-34"
+                    className="ms-Stack css-79 css-34"
                   >
                     <div
                       className="ms-Stack css-35"
@@ -255,7 +255,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts Screen Share Layou
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-80 css-34"
+                    className="ms-Stack css-79 css-34"
                   >
                     <div
                       className="ms-Stack css-35"
@@ -309,7 +309,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts Screen Share Layou
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-80 css-34"
+                    className="ms-Stack css-79 css-34"
                   >
                     <div
                       className="ms-Stack css-35"
@@ -363,7 +363,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts Screen Share Layou
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-80 css-34"
+                    className="ms-Stack css-79 css-34"
                   >
                     <div
                       className="ms-Stack css-35"
@@ -417,7 +417,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts Screen Share Layou
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-80 css-34"
+                    className="ms-Stack css-79 css-34"
                   >
                     <div
                       className="ms-Stack css-35"
@@ -471,7 +471,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts Screen Share Layou
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-80 css-34"
+                    className="ms-Stack css-79 css-34"
                   >
                     <div
                       className="ms-Stack css-35"
@@ -525,7 +525,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts Screen Share Layou
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-80 css-34"
+                    className="ms-Stack css-79 css-34"
                   >
                     <div
                       className="ms-Stack css-35"
@@ -565,7 +565,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts Screen Share Layou
               </div>
             </div>
             <div
-              className="ms-Stack css-80 css-34"
+              className="ms-Stack css-79 css-34"
             >
               <div
                 className="ms-Stack css-35"
@@ -607,7 +607,7 @@ exports[`storybook snapshot tests Storyshots Examples/Layouts Screen Share Layou
                   </div>
                 </div>
                 <div
-                  className="ms-Stack css-80 css-34"
+                  className="ms-Stack css-79 css-34"
                 >
                   <div
                     className="ms-Stack css-35"

--- a/packages/storybook/stories/Examples/LocalPreview/__snapshots__/LocalPreview.stories.storyshot
+++ b/packages/storybook/stories/Examples/LocalPreview/__snapshots__/LocalPreview.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Preview 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -20,10 +20,10 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
       }
     >
       <div
-        className="css-82 body-0"
+        className="css-81 body-0"
       >
         <div
-          className="css-82"
+          className="css-81"
           data-uses-unhanded-props={true}
           dir="ltr"
         >
@@ -49,11 +49,11 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                     className="ms-Stack css-12"
                   >
                     <div
-                      className="css-71"
+                      className="css-70"
                     />
                   </div>
                   <div
-                    className="ms-Stack css-81 css-13"
+                    className="ms-Stack css-80 css-13"
                   >
                     <div
                       className="ms-Stack css-14"

--- a/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/ComplianceBanner.stories.storyshot
+++ b/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/ComplianceBanner.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance Banner Compliance Banner 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/Lobby.stories.storyshot
+++ b/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/Lobby.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -26,7 +26,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
           className="ms-Stack css-7"
         />
         <div
-          className="ms-Stack css-80 css-8"
+          className="ms-Stack css-79 css-8"
         >
           <div
             className="ms-Stack css-9"

--- a/packages/storybook/stories/Examples/Themes/__snapshots__/TeamsTheme.stories.storyshot
+++ b/packages/storybook/stories/Examples/Themes/__snapshots__/TeamsTheme.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -30,10 +30,10 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
         }
       >
         <div
-          className="css-82 body-1"
+          className="css-81 body-1"
         >
           <div
-            className="css-82"
+            className="css-81"
             data-uses-unhanded-props={true}
             dir="ltr"
           >
@@ -268,7 +268,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-80 css-43"
+                    className="ms-Stack css-79 css-43"
                   >
                     <div
                       className="ms-Stack css-3"

--- a/packages/storybook/stories/GridLayout/__snapshots__/GridLayout.stories.storyshot
+++ b/packages/storybook/stories/GridLayout/__snapshots__/GridLayout.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layout 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -71,7 +71,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-80 css-25"
+              className="ms-Stack css-79 css-25"
             >
               <div
                 className="ms-Stack css-26"
@@ -122,7 +122,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-80 css-25"
+              className="ms-Stack css-79 css-25"
             >
               <div
                 className="ms-Stack css-26"
@@ -173,7 +173,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-80 css-25"
+              className="ms-Stack css-79 css-25"
             >
               <div
                 className="ms-Stack css-26"
@@ -224,7 +224,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-80 css-25"
+              className="ms-Stack css-79 css-25"
             >
               <div
                 className="ms-Stack css-26"

--- a/packages/storybook/stories/MessageStatusIndicator/__snapshots__/MessageStatusIndicator.stories.storyshot
+++ b/packages/storybook/stories/MessageStatusIndicator/__snapshots__/MessageStatusIndicator.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Message Status Indicator Message Status Indicator 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/ParticipantItem/__snapshots__/ParticipantItem.stories.storyshot
+++ b/packages/storybook/stories/ParticipantItem/__snapshots__/ParticipantItem.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Participant Item Participant Item 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -27,7 +27,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
         }
       >
         <div
-          className="css-73"
+          className="css-72"
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -85,7 +85,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
             </div>
           </div>
           <div
-            className="ms-Stack css-76 css-20"
+            className="ms-Stack css-75 css-20"
           >
             <div
               className="ms-Stack css-21"

--- a/packages/storybook/stories/ParticipantList/__snapshots__/ParticipantList.stories.storyshot
+++ b/packages/storybook/stories/ParticipantList/__snapshots__/ParticipantList.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Participant List Participant List 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -23,11 +23,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
         className="ms-Stack css-1"
       >
         <div
-          className="ms-Stack css-77 css-1"
+          className="ms-Stack css-76 css-1"
           data-ui-id="participant-list"
         >
           <div
-            className="css-73"
+            className="css-72"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
           >
@@ -89,7 +89,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
               </div>
             </div>
             <div
-              className="ms-Stack css-76 css-22"
+              className="ms-Stack css-75 css-22"
             >
               <span
                 className="ms-layer"
@@ -221,7 +221,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             </div>
           </div>
           <div
-            className="css-73"
+            className="css-72"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
           >
@@ -283,7 +283,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
               </div>
             </div>
             <div
-              className="ms-Stack css-76 css-22"
+              className="ms-Stack css-75 css-22"
             >
               <span
                 className="ms-layer"
@@ -415,7 +415,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             </div>
           </div>
           <div
-            className="css-73"
+            className="css-72"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
           >
@@ -477,7 +477,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
               </div>
             </div>
             <div
-              className="ms-Stack css-76 css-22"
+              className="ms-Stack css-75 css-22"
             >
               <span
                 className="ms-layer"
@@ -609,7 +609,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             </div>
           </div>
           <div
-            className="css-73"
+            className="css-72"
             onMouseEnter={[Function]}
             onMouseLeave={[Function]}
           >
@@ -676,7 +676,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
               (you)
             </div>
             <div
-              className="ms-Stack css-76 css-22"
+              className="ms-Stack css-75 css-22"
             />
           </div>
         </div>

--- a/packages/storybook/stories/SendBox/__snapshots__/SendBox.stories.storyshot
+++ b/packages/storybook/stories/SendBox/__snapshots__/SendBox.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/TypingIndicator/__snapshots__/TypingIndicator.stories.storyshot
+++ b/packages/storybook/stories/TypingIndicator/__snapshots__/TypingIndicator.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Typing Indicator Typing Indicator 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >

--- a/packages/storybook/stories/VideoGallery/__snapshots__/VideoGallery.stories.storyshot
+++ b/packages/storybook/stories/VideoGallery/__snapshots__/VideoGallery.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video Gallery 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -29,7 +29,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
         }
       >
         <div
-          className="ms-Stack css-79 css-1"
+          className="ms-Stack css-78 css-1"
         >
           <div
             className="ms-Stack css-7"
@@ -66,7 +66,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
               </div>
             </div>
             <div
-              className="ms-Stack css-80 css-26"
+              className="ms-Stack css-79 css-26"
             >
               <div
                 className="ms-Stack css-27"

--- a/packages/storybook/stories/VideoTile/__snapshots__/VideoTile.stories.storyshot
+++ b/packages/storybook/stories/VideoTile/__snapshots__/VideoTile.stories.storyshot
@@ -2,10 +2,10 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile 1`] = `
 <div
-  className="css-82 body-0"
+  className="css-81 body-0"
 >
   <div
-    className="css-82"
+    className="css-81"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -54,7 +54,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
           </div>
         </div>
         <div
-          className="ms-Stack css-80 css-25"
+          className="ms-Stack css-79 css-25"
         >
           <div
             className="ms-Stack css-26"


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
After confirming with Alex P., we should allow text wrapping in system message like so 
![image](https://user-images.githubusercontent.com/79475487/125519482-aa895e9e-0689-42b8-b5f3-b06979f0da09.png)

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Fix #573 
https://skype.visualstudio.com/SPOOL/_workitems/edit/2506625R

# How Tested
<!--- How did you test your change. What tests have you added. -->
Manual testing on storybook.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->