### PR TITLE
Show participants in ChatComposite stories

### DIFF
--- a/packages/storybook/stories/ChatComposite/ThemesExample.tsx
+++ b/packages/storybook/stories/ChatComposite/ThemesExample.tsx
@@ -55,7 +55,7 @@ export const ThemeExample: () => JSX.Element = () => {
   return (
     <div style={COMPOSITE_EXPERIENCE_CONTAINER_STYLE}>
       {containerProps ? (
-        <ContosoChatContainer {...containerProps} fluentTheme={getTheme(knobs.current.theme)} />
+        <ContosoChatContainer {...containerProps} fluentTheme={getTheme(knobs.current.theme)} showParticipants={true} />
       ) : (
         <ConfigHintBanner />
       )}

--- a/packages/storybook/stories/ChatComposite/snippets/CustomDataModelExampleContainer.snippet.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/CustomDataModelExampleContainer.snippet.tsx
@@ -51,5 +51,13 @@ export const CustomDataModelExampleContainer = (props: CustomDataModelExampleCon
     },
     [props.botUserId, props.botAvatar]
   );
-  return <>{adapter ? <ChatComposite adapter={adapter} onRenderAvatar={onRenderAvatar} /> : <h3>Loading...</h3>}</>;
+  return (
+    <>
+      {adapter ? (
+        <ChatComposite adapter={adapter} onRenderAvatar={onRenderAvatar} options={{ showParticipantPane: true }} />
+      ) : (
+        <h3>Loading...</h3>
+      )}
+    </>
+  );
 };

--- a/packages/storybook/stories/ChatComposite/snippets/CustomizeBehavior.snippet.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/CustomizeBehavior.snippet.tsx
@@ -38,5 +38,7 @@ export const ContosoChatContainer = (props: ContainerProps): JSX.Element => {
     createAdapter();
   }, [props]);
 
-  return <>{adapter ? <ChatComposite adapter={adapter} /> : <h3>Loading...</h3>}</>;
+  return (
+    <>{adapter ? <ChatComposite adapter={adapter} options={{ showParticipantPane: true }} /> : <h3>Loading...</h3>}</>
+  );
 };

--- a/packages/storybook/stories/ChatComposite/snippets/JoinExistingChatThread.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/JoinExistingChatThread.tsx
@@ -32,6 +32,7 @@ export const JoinExistingChatThread: () => JSX.Element = () => {
           userId={{ communicationUserId: knobs.current.userId }}
           token={knobs.current.token}
           displayName={knobs.current.displayName}
+          showParticipants={true}
         />
       ) : (
         <ConfigJoinChatThreadHintBanner />


### PR DESCRIPTION
# What
Show participants in ChatComposite stories. 

# Why
The basic canvas allows turning the participants pane off, but it's useful to have it on in the other canvases.

# How Tested
Local storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->