### PR TITLE
Fix icon warnings in tests (and two other v. small test errors)

### DIFF
--- a/change/@internal-react-components-99932551-eb89-4750-895f-0f11b2c9777f.json
+++ b/change/@internal-react-components-99932551-eb89-4750-895f-0f11b2c9777f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix icon warning in tests",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-composites-b0437ad7-242c-4712-93cc-81e04687e21d.json
+++ b/change/@internal-react-composites-b0437ad7-242c-4712-93cc-81e04687e21d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix icon warning in tests",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/OptionsButton.test.tsx
+++ b/packages/react-components/src/components/OptionsButton.test.tsx
@@ -6,6 +6,13 @@ import { OptionsButton, OptionsButtonProps } from './OptionsButton';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { createTestLocale, mountWithLocalization } from './utils/testUtils';
+import { setIconOptions } from '@fluentui/react';
+
+// Suppress icon warnings for tests. Icons are fetched from CDN which we do not want to perform during tests.
+// More information: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
+setIconOptions({
+  disableWarnings: true
+});
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/packages/react-components/src/components/ParticipantsButton.test.tsx
+++ b/packages/react-components/src/components/ParticipantsButton.test.tsx
@@ -6,6 +6,13 @@ import { ParticipantsButton } from './ParticipantsButton';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { createTestLocale, mountWithLocalization } from './utils/testUtils';
+import { setIconOptions } from '@fluentui/react';
+
+// Suppress icon warnings for tests. Icons are fetched from CDN which we do not want to perform during tests.
+// More information: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
+setIconOptions({
+  disableWarnings: true
+});
 
 Enzyme.configure({ adapter: new Adapter() });
 

--- a/packages/react-composites/src/composites/common/ErrorBar.test.tsx
+++ b/packages/react-composites/src/composites/common/ErrorBar.test.tsx
@@ -5,6 +5,13 @@ import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import { ErrorBar } from './ErrorBar';
+import { setIconOptions } from '@fluentui/react';
+
+// Suppress icon warnings for tests. Icons are fetched from CDN which we do not want to perform during tests.
+// More information: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
+setIconOptions({
+  disableWarnings: true
+});
 
 let container: HTMLDivElement;
 beforeEach(() => {

--- a/packages/storybook/stories/Examples/Layouts/OneToOneCallLayout.tsx
+++ b/packages/storybook/stories/Examples/Layouts/OneToOneCallLayout.tsx
@@ -46,7 +46,6 @@ export const OneToOneCallLayout: () => JSX.Element = () => {
           overlayContainer: videoStreamStyle
         }}
         displayName={'Holly'}
-        showDisplayName={false}
       >
         {/* Video component for my video stream stream */}
         <VideoTile

--- a/packages/storybook/stories/MessageStatusIndicator/MessageStatusIndicator.stories.tsx
+++ b/packages/storybook/stories/MessageStatusIndicator/MessageStatusIndicator.stories.tsx
@@ -61,10 +61,12 @@ const MessageStatusIndicatorStory = (): JSX.Element => {
   return (
     <MessageStatusIndicatorComponent
       status={select<MessageStatus>('Message Status', ['delivered', 'sending', 'seen', 'failed'], 'delivered')}
-      deliveredTooltipText={text('Delivered icon tooltip text', 'Sent')}
-      sendingTooltipText={text('Sending icon tooltip text', 'Sending')}
-      seenTooltipText={text('Seen icon tooltip text', 'Seen')}
-      failedToSendTooltipText={text('Failed to send icon tooltip text', 'Failed to send')}
+      strings={{
+        deliveredTooltipText: text('Delivered icon tooltip text', 'Sent'),
+        sendingTooltipText: text('Sending icon tooltip text', 'Sending'),
+        seenTooltipText: text('Seen icon tooltip text', 'Seen'),
+        failedToSendTooltipText: text('Failed to send icon tooltip text', 'Failed to send')
+      }}
     />
   );
 };


### PR DESCRIPTION
# What
Fix icon warnings by suppressing them in tests (we don't want to fetch icons from a cdn during tests).
Two other small build errors

# Why
Cleaning up test warnings - ideally all warnings will fail tests but that is proving to be a longer work item so putting this PR up to quickly clean up some (but not all) existing warnings.

# How Tested
Locally, npm run test