### PR TITLE
[Github issue] Allow 'html' type messages

### DIFF
--- a/change/@internal-chat-component-bindings-21410ea3-fee1-45bc-aa89-e114ece3a38d.json
+++ b/change/@internal-chat-component-bindings-21410ea3-fee1-45bc-aa89-e114ece3a38d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed MessageThread selector to allow messages of type 'html'.",
+  "packageName": "@internal/chat-component-bindings",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-component-bindings/src/chatThreadSelector.ts
+++ b/packages/chat-component-bindings/src/chatThreadSelector.ts
@@ -46,6 +46,7 @@ export const chatThreadSelector = createSelector(
         .filter(
           (message) =>
             message.type.toLowerCase() === 'text' ||
+            message.type.toLowerCase() === 'html' ||
             message.type.toLowerCase() === 'richtext/html' ||
             message.clientMessageId !== undefined
         )


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
We are parsing 'html' type messages in MessageThread here: https://github.com/Azure/communication-ui-library/blob/7ecfabab6d4ef3a6e6b2466c07093288c8154253/packages/react-components/src/components/MessageThread.tsx#L245
So the MessageThread selector should also allow type 'html'
I also confirmed that messages from Teams can either be 'html' or 'richtext/html'

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Fix #583 

# How Tested
<!--- How did you test your change. What tests have you added. -->
Using the meetings composite in this PR: https://github.com/Azure/communication-ui-library/pull/511

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->