### PR TITLE
Remove sendBoxMaxLength from chat composite

### DIFF
--- a/change/@internal-react-composites-a411978b-2d9a-46dc-ba8d-5d1c4bdf7df6.json
+++ b/change/@internal-react-composites-a411978b-2d9a-46dc-ba8d-5d1c4bdf7df6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove sendBoxMaxLength option from chat compsite\"",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -594,7 +594,6 @@ export type ChatObjectMethodNames<TName extends string, T> = {
 // @public
 export type ChatOptions = {
     showParticipantPane?: boolean;
-    sendBoxMaxLength?: number;
 };
 
 // @public (undocumented)

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -355,7 +355,6 @@ export type ChatErrorListener = (event: {
 // @public
 export type ChatOptions = {
     showParticipantPane?: boolean;
-    sendBoxMaxLength?: number;
 };
 
 // @public (undocumented)

--- a/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
@@ -36,8 +36,6 @@ export type ChatCompositeProps = {
 export type ChatOptions = {
   /** Choose to show the participant pane */
   showParticipantPane?: boolean;
-  /** Set a max width of the send box */ // TODO: we should remove this.
-  sendBoxMaxLength?: number;
 };
 
 export const ChatComposite = (props: ChatCompositeProps): JSX.Element => {
@@ -51,7 +49,6 @@ export const ChatComposite = (props: ChatCompositeProps): JSX.Element => {
           <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
           <ChatScreen
             showParticipantPane={options?.showParticipantPane}
-            sendBoxMaxLength={options?.sendBoxMaxLength}
             onRenderAvatar={onRenderAvatar}
             onRenderTypingIndicator={onRenderTypingIndicator}
             onRenderMessage={onRenderMessage}

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -29,21 +29,16 @@ import {
 
 export type ChatScreenProps = {
   showParticipantPane?: boolean;
-  sendBoxMaxLength?: number;
   onRenderAvatar?: (userId: string, avatarType?: 'chatThread' | 'participantList') => JSX.Element;
   onRenderMessage?: (messageProps: MessageProps, defaultOnRender?: DefaultMessageRendererType) => JSX.Element;
   onRenderTypingIndicator?: (typingUsers: CommunicationParticipant[]) => JSX.Element;
 };
 
 export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
-  const { onRenderAvatar, sendBoxMaxLength, onRenderMessage, onRenderTypingIndicator, showParticipantPane } = props;
+  const { onRenderAvatar, onRenderMessage, onRenderTypingIndicator, showParticipantPane } = props;
 
-  const pixelToRemConvertRatio = 16;
   const defaultNumberOfChatMessagesToReload = 5;
-  const sendBoxParentStyle = mergeStyles({
-    maxWidth: sendBoxMaxLength ? `${sendBoxMaxLength / pixelToRemConvertRatio}rem` : 'unset',
-    width: '100%'
-  });
+  const sendBoxParentStyle = mergeStyles({ width: '100%' });
 
   const adapter = useAdapter();
 


### PR DESCRIPTION
# What
Remove sendBoxMaxLength option from chat composite.

# Why
This doesn't follow responsive design and assumes that the REM value is 16px which it mightn't be.