### PR TITLE
Have storybook URLs on all PRs

### DIFF
--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -2,7 +2,6 @@ name: 'Publish Chromatic'
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - packages/storybook/**
       - packages/react-components/**


### PR DESCRIPTION
# What
Update GitHub action workflow file to create storybook URLs on all PRs not just PRs into main

# Why
The primary (possibly only) PRs that aren't directly into main are stacked PRs and release branch PRs. For both of these we still want the storybook URL feature.

# How Tested
Didn't, but same syntax as: https://github.com/Azure/communication-ui-library/blob/1fe8f23718cb98a847df798da3682fae3d132f9e/.github/workflows/ci.yml#L8