### PR TITLE
Disable `ErrorBar` in `ChatComposite` by default

### DIFF
--- a/change/@internal-react-composites-491ad7ca-2c02-400c-9cb9-752fa7f42a5e.json
+++ b/change/@internal-react-composites-491ad7ca-2c02-400c-9cb9-752fa7f42a5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Hide ErrorBar in ChatComposite behind a feature flag",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -598,6 +598,7 @@ export type ChatObjectMethodNames<TName extends string, T> = {
 
 // @public
 export type ChatOptions = {
+    showErrorBar?: boolean;
     showParticipantPane?: boolean;
     showTopic?: boolean;
 };

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -357,6 +357,7 @@ export type ChatErrorListener = (event: {
 
 // @public
 export type ChatOptions = {
+    showErrorBar?: boolean;
     showParticipantPane?: boolean;
     showTopic?: boolean;
 };

--- a/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
@@ -64,6 +64,7 @@ export const ChatComposite = (props: ChatCompositeProps): JSX.Element => {
         <ChatAdapterProvider adapter={adapter}>
           <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
           <ChatScreen
+            showErrorBar={options?.showErrorBar}
             showParticipantPane={options?.showParticipantPane}
             showTopic={options?.showTopic}
             onRenderAvatar={onRenderAvatar}

--- a/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
@@ -35,6 +35,14 @@ export type ChatCompositeProps = {
  */
 export type ChatOptions = {
   /**
+   * UNSTABLE: Feature flag to enable ErrorBar.
+   *
+   * This option will be removed once ErrorBar is stable.
+   *
+   * @defaultValue false
+   */
+  showErrorBar?: boolean;
+  /**
    * Choose to show the participant pane
    * @defaultValue false
    */

--- a/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
@@ -38,6 +38,7 @@ export type ChatOptions = {
    * UNSTABLE: Feature flag to enable ErrorBar.
    *
    * This option will be removed once ErrorBar is stable.
+   * @experimental
    *
    * @defaultValue false
    */

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -28,6 +28,7 @@ import {
 } from './styles/Chat.styles';
 
 export type ChatScreenProps = {
+  showErrorBar?: boolean;
   showParticipantPane?: boolean;
   showTopic?: boolean;
   onRenderAvatar?: (userId: string, avatarType?: 'chatThread' | 'participantList') => JSX.Element;
@@ -71,7 +72,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
       {!!showTopic && <ChatHeader {...headerProps} />}
       <Stack className={chatArea} horizontal grow>
         <Stack className={chatWrapper} grow>
-          <ErrorBar {...errorBarProps} />
+          {props.showErrorBar ? <ErrorBar {...errorBarProps} /> : <></>}
           <MessageThread
             {...messageThreadProps}
             onRenderAvatar={onRenderMessageAvatar}

--- a/packages/react-composites/tests/browser/chat/app/index.tsx
+++ b/packages/react-composites/tests/browser/chat/app/index.tsx
@@ -46,7 +46,7 @@ function App(): JSX.Element {
         <ChatComposite
           identifiers={IDS}
           adapter={chatAdapter}
-          options={{ showParticipantPane: true, showTopic: true }}
+          options={{ showErrorBar: true, showParticipantPane: true, showTopic: true }}
           onRenderTypingIndicator={
             customDataModel
               ? () => <text id="custom-data-model-typing-indicator">Someone is typing...</text>

--- a/packages/storybook/stories/ErrorBar/ErrorBar.stories.tsx
+++ b/packages/storybook/stories/ErrorBar/ErrorBar.stories.tsx
@@ -25,10 +25,7 @@ const getDocs: () => JSX.Element = () => {
         `ErrorBar` is a wrapper on fluent UI's `MessageBar` with additional features for surfacing Azure Communication
         Services errors on the UI consistently.
       </Description>
-      <Description>
-        Set the `showErrorBar` option for `ChatComposite` to use an `ErrorBar` to show errors. This feature is still
-        unstable and the API and options field are subject to change.
-      </Description>
+      <Description>Set the `showErrorBar` option for `ChatComposite` to use an `ErrorBar` to show errors.</Description>
       <Subheading>Localization</Subheading>
       <Description>
         Similar to other UI components in this library, `ErrorBarProps` accepts all strings shown on the UI as a

--- a/packages/storybook/stories/ErrorBar/ErrorBar.stories.tsx
+++ b/packages/storybook/stories/ErrorBar/ErrorBar.stories.tsx
@@ -25,6 +25,10 @@ const getDocs: () => JSX.Element = () => {
         `ErrorBar` is a wrapper on fluent UI's `MessageBar` with additional features for surfacing Azure Communication
         Services errors on the UI consistently.
       </Description>
+      <Description>
+        Set the `showErrorBar` option for `ChatComposite` to use an `ErrorBar` to show errors. This feature is still
+        unstable and the API and options field are subject to change.
+      </Description>
       <Subheading>Localization</Subheading>
       <Description>
         Similar to other UI components in this library, `ErrorBarProps` accepts all strings shown on the UI as a


### PR DESCRIPTION
# What
Disable `ErrorBar` in `ChatComposite` and add a feature flag to enable it.
Also enable it in automated tests, so that `ErrorBar` tests continue to provide coverage.

# Why
Error reporting work is still WIP so we don't want to include it in the next beta release.

# How Tested
Automated tests with/without feature flag to enable the ErrorBar.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->