### PR TITLE
Persisting options button in sample app to avoid hiding

### DIFF
--- a/change/@internal-react-composites-5054ce4b-aa3d-4d15-bdd8-ad01edd627cc.json
+++ b/change/@internal-react-composites-5054ce4b-aa3d-4d15-bdd8-ad01edd627cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bugfix to prevent options menu from getting hidden every time a participant joins or leaves",
+  "packageName": "@internal/react-composites",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallControls.tsx
@@ -47,6 +47,7 @@ export const CallControls = (props: GroupCallControlsProps): JSX.Element => {
           callInvitationURL={callInvitationURL}
         />
       )}
+      {/* By setting `persistMenu` to true, we prevent options menu from getting hidden everytime a participant joins or leaves. */}
       <OptionsButton persistMenu={true} {...optionsButtonProps} showLabel={!compressedMode} />
       <EndCallButton
         {...hangUpButtonProps}

--- a/packages/react-composites/src/composites/CallComposite/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallControls.tsx
@@ -47,7 +47,7 @@ export const CallControls = (props: GroupCallControlsProps): JSX.Element => {
           callInvitationURL={callInvitationURL}
         />
       )}
-      <OptionsButton {...optionsButtonProps} showLabel={!compressedMode} />
+      <OptionsButton persistMenu={true} {...optionsButtonProps} showLabel={!compressedMode} />
       <EndCallButton
         {...hangUpButtonProps}
         onHangUp={onHangUp}


### PR DESCRIPTION
# What
Persist the options button to avoid hiding it on re-renders.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->