### PR TITLE
Add min height to call composite media gallery

### DIFF
--- a/change/@internal-react-composites-462d1b30-ad2c-4c9e-9dbe-c3ae13bc6da3.json
+++ b/change/@internal-react-composites-462d1b30-ad2c-4c9e-9dbe-c3ae13bc6da3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure call composite media gallery has a minimum height",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
@@ -4,7 +4,7 @@
 import { Spinner, Stack } from '@fluentui/react';
 import React, { useEffect, useRef, useState } from 'react';
 import {
-  activeContainerClassName,
+  mediaGalleryContainerStyles,
   containerStyles,
   callControlsStyles,
   subContainerStyles,
@@ -132,7 +132,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
             {callStatus === 'Connected' && (
               <>
                 <Stack styles={containerStyles} grow>
-                  <Stack.Item grow styles={activeContainerClassName}>
+                  <Stack.Item grow styles={mediaGalleryContainerStyles}>
                     <MediaGallery {...mediaGalleryProps} {...mediaGalleryHandlers} onRenderAvatar={onRenderAvatar} />
                   </Stack.Item>
                 </Stack>

--- a/packages/react-composites/src/composites/CallComposite/MediaGallery.tsx
+++ b/packages/react-composites/src/composites/CallComposite/MediaGallery.tsx
@@ -10,7 +10,8 @@ import { getIsPreviewCameraOn } from './selectors/baseSelectors';
 
 const VideoGalleryStyles = {
   root: {
-    height: 'auto'
+    height: '100%',
+    minHeight: '10rem' // space affordance to ensure media gallery is never collapsed
   }
 };
 

--- a/packages/react-composites/src/composites/CallComposite/styles/CallScreen.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/CallScreen.styles.ts
@@ -30,9 +30,7 @@ export const callControlsContainer = mergeStyles({
 export const containerStyles: IStackStyles = {
   root: {
     height: '100%',
-    width: '100%',
-    flexDirection: 'column',
-    display: 'flex'
+    width: '100%'
   }
 };
 
@@ -40,17 +38,14 @@ export const subContainerStyles: IStackStyles = {
   root: {
     overflow: 'hidden',
     width: '100%',
-    flexDirection: 'column',
-    display: 'flex',
-    flexBasis: '0'
+    height: '100%',
+    minHeight: '10rem' // space affordance to ensure media gallery has minimum space allocated
   }
 };
 
-export const activeContainerClassName: IStackItemStyles = {
+export const mediaGalleryContainerStyles: IStackItemStyles = {
   root: {
-    display: 'flex',
-    height: '100%',
-    position: 'relative'
+    height: '100%'
   }
 };
 

--- a/packages/storybook/stories/CallComposite/CallComposite.stories.tsx
+++ b/packages/storybook/stories/CallComposite/CallComposite.stories.tsx
@@ -64,9 +64,10 @@ const getDocs: () => JSX.Element = () => {
 
       <Heading>Styling</Heading>
       <Description>
-        CallComposite is designed to fill the space of the parent it is in. If your composite is living outside of any
-        parent container and you wish for it to fill the page, we recommend ensuring your react app is set to fill the
-        screen by adding the following css to your primary css file:
+        CallComposite is designed to fill the space of the parent it is in. By default these examples put the composite
+        in a container of a set height and width. If your composite is living outside of any parent container and you
+        wish for it to fill the page, we recommend ensuring your react app is set to fill the screen by adding the
+        following css to your primary css file:
       </Description>
       <Source code={cssSnippet} />
 

--- a/packages/storybook/stories/CallComposite/CallComposite.stories.tsx
+++ b/packages/storybook/stories/CallComposite/CallComposite.stories.tsx
@@ -12,6 +12,14 @@ import { COMPOSITE_FOLDER_PREFIX } from '../constants';
 const containerText = require('!!raw-loader!./snippets/Container.snippet.tsx').default;
 const serverText = require('!!raw-loader!./snippets/Server.snippet.tsx').default;
 
+const cssSnippet = `
+html,
+body,
+#root {
+  height: 100%;
+}
+`;
+
 export default {
   id: `${COMPOSITE_FOLDER_PREFIX}-call`,
   title: `${COMPOSITE_FOLDER_PREFIX}/CallComposite`,
@@ -53,6 +61,14 @@ const getDocs: () => JSX.Element = () => {
         client application that then passes it to the CallComposite.
       </Description>
       <Source code={serverText} />
+
+      <Heading>Styling</Heading>
+      <Description>
+        CallComposite is designed to fill the space of the parent it is in. If your composite is living outside of any
+        parent container and you wish for it to fill the page, we recommend ensuring your react app is set to fill the
+        screen by adding the following css to your primary css file:
+      </Description>
+      <Source code={cssSnippet} />
 
       <Heading>Theming</Heading>
       <Description>

--- a/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
@@ -63,7 +63,9 @@ export const ContosoCallContainer = (props: ContainerProps): JSX.Element => {
 
   if (adapter) {
     return (
-      <CallComposite adapter={adapter} fluentTheme={props.fluentTheme} callInvitationURL={props?.callInvitationURL} />
+      <div style={{ height: '90vh', width: '90vw' }}>
+        <CallComposite adapter={adapter} fluentTheme={props.fluentTheme} callInvitationURL={props?.callInvitationURL} />
+      </div>
     );
   }
   if (credential === undefined) {


### PR DESCRIPTION
# What
* Ensure media gallery has a minimum height - below which the composite is not usable so this still fits in our responsive design
* Update the composite documentation to ensure it has a set height and width by default so users copying and pasting have a good experience
* Mention this issue in the call composite styling documentation

# Why
If the parent of the call composite doesn't have a height set, the video gallery was not visible.

# How Tested
In storybook
| before (if no height is set) | after (if no height is set) | default experience
| -- | -- | -- |
| ![image](https://user-images.githubusercontent.com/2684369/126572555-021dc284-f598-402e-8c6e-ac64fbf8d273.png) | ![image](https://user-images.githubusercontent.com/2684369/126572499-de1407b1-a724-4b81-83e1-22c71a3d68eb.png) | ![image](https://user-images.githubusercontent.com/2684369/126571973-df43ba87-4e86-4706-a3b8-05d1dece6872.png) |