### PR TITLE
Update `createAzureCommunicationCallAdapter` ctor to take an object instead of many params

### DIFF
--- a/change/@internal-react-composites-5cd5f3a1-0589-4eb6-a434-31ccd4314017.json
+++ b/change/@internal-react-composites-5cd5f3a1-0589-4eb6-a434-31ccd4314017.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update createAzureCommunicationCallAdapter constructor to take in a named object instead of seperate args",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -166,6 +166,15 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
     unmute(): Promise<void>;
 }
 
+// @public (undocumented)
+export type AzureCommunicationCallAdapterArgs = {
+    userId: CommunicationUserKind;
+    displayName: string;
+    credential: CommunicationTokenCredential;
+    locator: TeamsMeetingLinkLocator | GroupCallLocator;
+    callClientOptions?: CallClientOptions;
+};
+
 // @public
 export interface BaseCustomStylesProps {
     root?: IStyle;
@@ -734,7 +743,7 @@ export interface ControlBarProps {
 }
 
 // @public (undocumented)
-export const createAzureCommunicationCallAdapter: (userId: CommunicationUserKind, displayName: string, credential: CommunicationTokenCredential, locator: TeamsMeetingLinkLocator | GroupCallLocator, callClientOptions?: CallClientOptions | undefined) => Promise<CallAdapter>;
+export const createAzureCommunicationCallAdapter: ({ userId, displayName, credential, locator, callClientOptions }: AzureCommunicationCallAdapterArgs) => Promise<CallAdapter>;
 
 // @public (undocumented)
 export const createAzureCommunicationChatAdapter: (endpointUrl: string, userId: CommunicationIdentifierKind, displayName: string, credential: CommunicationTokenCredential, threadId: string) => Promise<ChatAdapter>;

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -132,6 +132,15 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
 }
 
 // @public (undocumented)
+export type AzureCommunicationCallAdapterArgs = {
+    userId: CommunicationUserKind;
+    displayName: string;
+    credential: CommunicationTokenCredential;
+    locator: TeamsMeetingLinkLocator | GroupCallLocator;
+    callClientOptions?: CallClientOptions;
+};
+
+// @public (undocumented)
 export interface CallAdapter {
     // (undocumented)
     askDevicePermission(constrain: PermissionConstraints): Promise<void>;
@@ -372,7 +381,7 @@ export type ChatUIState = {
 };
 
 // @public (undocumented)
-export const createAzureCommunicationCallAdapter: (userId: CommunicationUserKind, displayName: string, credential: CommunicationTokenCredential, locator: TeamsMeetingLinkLocator | GroupCallLocator, callClientOptions?: CallClientOptions | undefined) => Promise<CallAdapter>;
+export const createAzureCommunicationCallAdapter: ({ userId, displayName, credential, locator, callClientOptions }: AzureCommunicationCallAdapterArgs) => Promise<CallAdapter>;
 
 // @public (undocumented)
 export const createAzureCommunicationChatAdapter: (endpointUrl: string, userId: CommunicationIdentifierKind, displayName: string, credential: CommunicationTokenCredential, threadId: string) => Promise<ChatAdapter>;

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -468,13 +468,21 @@ const isPreviewOn = (deviceManager: DeviceManagerState): boolean => {
   return deviceManager.unparentedViews.length > 0 && deviceManager.unparentedViews[0].view !== undefined;
 };
 
-export const createAzureCommunicationCallAdapter = async (
-  userId: CommunicationUserKind,
-  displayName: string,
-  credential: CommunicationTokenCredential,
-  locator: TeamsMeetingLinkLocator | GroupCallLocator,
-  callClientOptions?: CallClientOptions
-): Promise<CallAdapter> => {
+export type AzureCommunicationCallAdapterArgs = {
+  userId: CommunicationUserKind;
+  displayName: string;
+  credential: CommunicationTokenCredential;
+  locator: TeamsMeetingLinkLocator | GroupCallLocator;
+  callClientOptions?: CallClientOptions;
+};
+
+export const createAzureCommunicationCallAdapter = async ({
+  userId,
+  displayName,
+  credential,
+  locator,
+  callClientOptions
+}: AzureCommunicationCallAdapterArgs): Promise<CallAdapter> => {
   const callClient = createStatefulCallClient({ userId }, { callClientOptions });
   const deviceManager = (await callClient.getDeviceManager()) as StatefulDeviceManager;
   const callAgent = await callClient.createCallAgent(credential, { displayName });

--- a/packages/react-composites/tests/browser/call/app/index.tsx
+++ b/packages/react-composites/tests/browser/call/app/index.tsx
@@ -23,12 +23,12 @@ function App(): JSX.Element {
   useEffect(() => {
     const initialize = async (): Promise<void> => {
       setCallAdapter(
-        await createAzureCommunicationCallAdapter(
-          { kind: 'communicationUser', communicationUserId: userId },
+        await createAzureCommunicationCallAdapter({
+          userId: { kind: 'communicationUser', communicationUserId: userId },
           displayName,
-          new AzureCommunicationTokenCredential(token),
-          { groupId: groupId }
-        )
+          credential: new AzureCommunicationTokenCredential(token),
+          locator: { groupId: groupId }
+        })
       );
     };
 

--- a/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
@@ -34,12 +34,12 @@ export const ContosoCallContainer = (props: ContainerProps): JSX.Element => {
           : { groupId: props.locator };
         const createAdapter = async (credential: AzureCommunicationTokenCredential): Promise<void> => {
           setAdapter(
-            await createAzureCommunicationCallAdapter(
-              { kind: 'communicationUser', communicationUserId: props.userId.communicationUserId },
-              props.displayName,
+            await createAzureCommunicationCallAdapter({
+              userId: { kind: 'communicationUser', communicationUserId: props.userId.communicationUserId },
+              displayName: props.displayName,
               credential,
-              callLocator
-            )
+              locator: callLocator
+            })
           );
         };
         createAdapter(credential);

--- a/packages/storybook/stories/CallComposite/snippets/CustomDataModelExampleContainer.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/CustomDataModelExampleContainer.snippet.tsx
@@ -26,12 +26,12 @@ export const CustomDataModelExampleContainer = (props: ContainerProps): JSX.Elem
         : { groupId: props.locator };
       const createAdapter = async (): Promise<void> => {
         setAdapter(
-          await createAzureCommunicationCallAdapter(
-            { kind: 'communicationUser', communicationUserId: props.userId.communicationUserId },
-            props.displayName,
-            new AzureCommunicationTokenCredential(props.token),
-            callLocator
-          )
+          await createAzureCommunicationCallAdapter({
+            userId: { kind: 'communicationUser', communicationUserId: props.userId.communicationUserId },
+            displayName: props.displayName,
+            credential: new AzureCommunicationTokenCredential(props.token),
+            locator: callLocator
+          })
         );
       };
       createAdapter();

--- a/packages/storybook/stories/MeetingComposite/snippets/Meeting.snippet.tsx
+++ b/packages/storybook/stories/MeetingComposite/snippets/Meeting.snippet.tsx
@@ -46,12 +46,12 @@ export const MeetingExperience = (props: MeetingExampleProps): JSX.Element => {
     ) {
       const createAdapters = async (): Promise<void> => {
         setCallAdapter(
-          await createAzureCommunicationCallAdapter(
-            { kind: 'communicationUser', communicationUserId: props.userId.communicationUserId },
-            props.displayName,
+          await createAzureCommunicationCallAdapter({
+            userId: { kind: 'communicationUser', communicationUserId: props.userId.communicationUserId },
+            displayName: props.displayName,
             credential,
-            props.locator
-          )
+            locator: props.locator
+          })
         );
 
         setChatAdapter(

--- a/packages/storybook/stories/QuickStarts/snippets/QuickstartCompositeAdapter.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/QuickstartCompositeAdapter.snippet.tsx
@@ -45,12 +45,12 @@ function App(): JSX.Element {
           )
         );
         setCallAdapter(
-          await createAzureCommunicationCallAdapter(
-            { kind: 'communicationUser', communicationUserId: userId },
+          await createAzureCommunicationCallAdapter({
+            userId: { kind: 'communicationUser', communicationUserId: userId },
             displayName,
             credential,
-            { groupId }
-          )
+            locator: { groupId }
+          })
         );
       };
       createAdapter(credential);

--- a/packages/storybook/stories/QuickStarts/snippets/QuickstartCompositeComplete.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/QuickstartCompositeComplete.snippet.tsx
@@ -46,12 +46,12 @@ function App(): JSX.Element {
         )
       );
       setCallAdapter(
-        await createAzureCommunicationCallAdapter(
-          { kind: 'communicationUser', communicationUserId: userId },
+        await createAzureCommunicationCallAdapter({
+          userId: { kind: 'communicationUser', communicationUserId: userId },
           displayName,
-          new AzureCommunicationTokenCredential(token),
-          { groupId }
-        )
+          credential: new AzureCommunicationTokenCredential(token),
+          locator: { groupId }
+        })
       );
     };
     createAdapter();

--- a/packages/storybook/stories/Stateful Client/snippets/CallAdapterExample.snippet.tsx
+++ b/packages/storybook/stories/Stateful Client/snippets/CallAdapterExample.snippet.tsx
@@ -16,12 +16,12 @@ export const CallAdapterExample = (props: CallAdapterExampleProps): JSX.Element 
     if (props) {
       const createAdapter = async (): Promise<void> => {
         setCallAdapter(
-          await createAzureCommunicationCallAdapter(
-            { kind: 'communicationUser', communicationUserId: props.userId.communicationUserId },
-            props.displayName,
-            new AzureCommunicationTokenCredential(props.accessToken),
-            props.callLocator
-          )
+          await createAzureCommunicationCallAdapter({
+            userId: { kind: 'communicationUser', communicationUserId: props.userId.communicationUserId },
+            displayName: props.displayName,
+            credential: new AzureCommunicationTokenCredential(props.accessToken),
+            locator: props.callLocator
+          })
         );
       };
       createAdapter();

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -26,12 +26,12 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
 
   useEffect(() => {
     (async () => {
-      const adapter = await createAzureCommunicationCallAdapter(
-        { kind: 'communicationUser', communicationUserId: userId.communicationUserId },
-        displayName,
-        createAutoRefreshingCredential(userId.communicationUserId, token),
-        callLocator
-      );
+      const adapter = await createAzureCommunicationCallAdapter({
+        userId: { kind: 'communicationUser', communicationUserId: userId.communicationUserId },
+        displayName: displayName,
+        credential: createAutoRefreshingCredential(userId.communicationUserId, token),
+        locator: callLocator
+      });
       adapter.on('callEnded', () => {
         onCallEnded();
       });

--- a/samples/StaticHtmlComposites/src/callComposite.js
+++ b/samples/StaticHtmlComposites/src/callComposite.js
@@ -7,7 +7,12 @@ import { CallComposite, createAzureCommunicationCallAdapter } from '@azure/commu
 
 export const loadCallComposite = async function (args, htmlElement) {
   const { userId, token, groupId, displayName } = args;
-  const adapter = await createAzureCommunicationCallAdapter(userId, token, { groupId }, displayName ?? 'anonymous');
+  const adapter = await createAzureCommunicationCallAdapter({
+    userId,
+    credential: token,
+    locator: { groupId },
+    displayName: displayName ?? 'anonymous'
+  });
   ReactDOM.render(React.createElement(CallComposite, { adapter }, null), htmlElement);
   return adapter;
 };


### PR DESCRIPTION
# What
Update `createAzureCommunicationCallAdapter` ctor to take an object instead of many params

# Why
It currently takes in too many args for them not to be named