### PR TITLE
Fix meeting pane overlapping the call control bar

### DIFF
--- a/change/@internal-react-composites-97fd5fa3-9485-48c4-9d3d-9d3b2b673be5.json
+++ b/change/@internal-react-composites-97fd5fa3-9485-48c4-9d3d-9d3b2b673be5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix meeting pane overlapping the call control bar",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -24,7 +24,8 @@ import {
   participantListWrapper,
   listHeader,
   participantListStack,
-  participantListStyle
+  participantListStyle,
+  participantListContainerPadding
 } from './styles/Chat.styles';
 
 export type ChatScreenProps = {
@@ -70,7 +71,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
   return (
     <Stack className={chatContainer} grow>
       {!!showTopic && <ChatHeader {...headerProps} />}
-      <Stack className={chatArea} horizontal grow>
+      <Stack className={chatArea} tokens={participantListContainerPadding} horizontal grow>
         <Stack className={chatWrapper} grow>
           {props.showErrorBar ? <ErrorBar {...errorBarProps} /> : <></>}
           <MessageThread

--- a/packages/react-composites/src/composites/ChatComposite/styles/Chat.styles.ts
+++ b/packages/react-composites/src/composites/ChatComposite/styles/Chat.styles.ts
@@ -31,7 +31,6 @@ export const chatArea = mergeStyles({
 export const chatWrapper = mergeStyles({
   height: '100%',
   width: '100%',
-  paddingBottom: '1rem',
   overflow: 'auto'
 });
 
@@ -58,9 +57,11 @@ export const topicNameLabelStyle = mergeStyles({
 export const participantListWrapper = mergeStyles({
   boxShadow: '0px 0.3px 0.9px rgba(0, 0, 0, 0.1), 0px 1.6px 3.6px rgba(0, 0, 0, 0.13)',
   width: '15rem',
-  height: '100%',
-  paddingLeft: '0.5rem'
+  height: '100%'
 });
+
+export const participantListContainerPadding = { childrenGap: '0.5rem' };
+
 export const listHeader = mergeStyles({
   fontSize: '1rem',
   margin: '1rem'

--- a/packages/react-composites/src/composites/ChatComposite/styles/Chat.styles.ts
+++ b/packages/react-composites/src/composites/ChatComposite/styles/Chat.styles.ts
@@ -32,8 +32,7 @@ export const chatWrapper = mergeStyles({
   height: '100%',
   width: '100%',
   paddingBottom: '1rem',
-  overflow: 'auto',
-  margin: '0 0.2rem'
+  overflow: 'auto'
 });
 
 export const chatHeaderContainerStyle = mergeStyles({
@@ -59,7 +58,8 @@ export const topicNameLabelStyle = mergeStyles({
 export const participantListWrapper = mergeStyles({
   boxShadow: '0px 0.3px 0.9px rgba(0, 0, 0, 0.1), 0px 1.6px 3.6px rgba(0, 0, 0, 0.13)',
   width: '15rem',
-  height: '100%'
+  height: '100%',
+  paddingLeft: '0.5rem'
 });
 export const listHeader = mergeStyles({
   fontSize: '1rem',

--- a/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
@@ -10,6 +10,7 @@ import { ChatAdapter } from '../ChatComposite';
 import { EmbeddedChatPane, EmbeddedPeoplePane } from './SidePane';
 import { MeetingCallControlBar } from './MeetingCallControlBar';
 import { CallState } from '@azure/communication-calling';
+import { compositeOuterContainerStyles } from './styles/MeetingCompositeStyles';
 
 /**
  * Props required for the {@link MeetingComposite}
@@ -64,8 +65,8 @@ export const MeetingComposite = (props: MeetingCompositeProps): JSX.Element => {
   };
 
   return (
-    <Stack styles={{ root: { width: '100%', height: '100%' } }}>
-      <Stack styles={{ root: { width: '100%', height: '100%' } }} horizontal>
+    <Stack grow styles={compositeOuterContainerStyles}>
+      <Stack horizontal grow>
         <Stack.Item grow>
           <CallCompositeInternal showCallControls={false} adapter={callAdapter} fluentTheme={fluentTheme} />
         </Stack.Item>

--- a/packages/react-composites/src/composites/MeetingComposite/SidePane.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/SidePane.tsx
@@ -8,11 +8,13 @@ import {
   sidePaneContainerStyles,
   sidePaneContainerTokens,
   sidePaneHeaderStyles,
-  sidePaneBodyStyles,
   peoplePaneContainerTokens,
-  peopleSubheadingStyle
+  peopleSubheadingStyle,
+  paneBodyContainer,
+  scrollableContainer,
+  scrollableContainerContents
 } from './styles/SidePane.styles';
-import { ParticipantList } from '@internal/react-components';
+import { CallParticipant, ParticipantList } from '@internal/react-components';
 import copy from 'copy-to-clipboard';
 import { usePropsFor } from '../CallComposite/hooks/usePropsFor';
 
@@ -29,7 +31,13 @@ const SidePane = (props: { headingText: string; children: React.ReactNode; onClo
           />
         </Stack>
       </Stack.Item>
-      <Stack.Item styles={sidePaneBodyStyles}>{props.children}</Stack.Item>
+      <Stack grow styles={paneBodyContainer}>
+        <Stack horizontal styles={scrollableContainer}>
+          <Stack.Item verticalFill styles={scrollableContainerContents}>
+            {props.children}
+          </Stack.Item>
+        </Stack>
+      </Stack>
     </Stack>
   );
 };

--- a/packages/react-composites/src/composites/MeetingComposite/SidePane.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/SidePane.tsx
@@ -14,7 +14,7 @@ import {
   scrollableContainer,
   scrollableContainerContents
 } from './styles/SidePane.styles';
-import { CallParticipant, ParticipantList } from '@internal/react-components';
+import { ParticipantList } from '@internal/react-components';
 import copy from 'copy-to-clipboard';
 import { usePropsFor } from '../CallComposite/hooks/usePropsFor';
 

--- a/packages/react-composites/src/composites/MeetingComposite/styles/MeetingCompositeStyles.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/styles/MeetingCompositeStyles.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { IStackStyles } from '@fluentui/react';
+
+export const compositeOuterContainerStyles: IStackStyles = { root: { width: '100%' } };

--- a/packages/react-composites/src/composites/MeetingComposite/styles/SidePane.styles.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/styles/SidePane.styles.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IButtonStyles, IContextualMenuItemStyles, IStackItemStyles, IStackTokens, getTheme } from '@fluentui/react';
+import { IContextualMenuItemStyles, IStackStyles, IStackItemStyles, IStackTokens, getTheme } from '@fluentui/react';
 
 const theme = getTheme();
 const palette = theme.palette;
@@ -9,6 +9,8 @@ const palette = theme.palette;
 export const sidePaneContainerStyles: IStackItemStyles = {
   root: {
     height: '100%',
+    paddingTop: '0.5rem',
+    paddingBottom: '0.5rem',
     width: '21.5rem'
   }
 };
@@ -32,11 +34,9 @@ export const sidePaneCloseButtonStyles: Partial<IContextualMenuItemStyles> = {
   iconPressed: { color: palette.neutralSecondary }
 };
 
-export const sidePaneBodyStyles: IButtonStyles = {
-  root: {
-    height: '100%'
-  }
-};
+export const paneBodyContainer: IStackStyles = { root: { flexDirection: 'column', display: 'flex' } };
+export const scrollableContainer: IStackStyles = { root: { flexBasis: '0', flexGrow: '1', overflowY: 'auto' } };
+export const scrollableContainerContents: IStackItemStyles = { root: { flexGrow: '1', flexBasis: '0' } };
 
 export const peopleSubheadingStyle: IStackItemStyles = {
   root: {


### PR DESCRIPTION
# What
Fix styling to ensure the meeting pane is a scrollable container whilst still spanning the height of its parent

Codepen to play around with how this works: https://codepen.io/jaburnsi/pen/ZEKaoLo
Credit to this users codepen for getting the solution: https://codepen.io/anon/pen/gpjReQ

# Why
We had an ugly issue where the chat/people pane was overlapping the call control bar (see "before" screenshot below)

# How Tested
Validation screenshots:

| test | screenshot |
| -- | -- |
| before | ![image](https://user-images.githubusercontent.com/2684369/126857927-d8d33878-c337-4c29-b7fa-06b11e05b9cd.png) |
| after - chat pane open | ![image](https://user-images.githubusercontent.com/2684369/126857898-f577c413-d66f-449a-b788-a62b00b5aa8d.png) |
| after - people pane open | ![image](https://user-images.githubusercontent.com/2684369/126857902-50b5d7ca-7e29-4ad0-b19d-ac4221635975.png) |
| after - chat composite | ![image](https://user-images.githubusercontent.com/2684369/126857894-4af48433-3ecd-441c-a57a-cdc5687bca03.png) |
