### PR TITLE
fixing markdown syntax for link

### DIFF
--- a/packages/storybook/stories/NonReact/NonReactComposites.stories.mdx
+++ b/packages/storybook/stories/NonReact/NonReactComposites.stories.mdx
@@ -48,7 +48,7 @@ Then you will be able to see 2 js bundle files:
 .\samples\StaticHtmlComposites\dist\callComposite.js
 ```
 
-There is also an example html for how to use it, you might want to allocate your own acs token before you embed the code piece to your own web app, check (Create and manage Communication Services resources)[https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp]:
+There is also an example html for how to use it, you might want to allocate your own acs token before you embed the code piece to your own web app, check [Create and manage Communication Services resources](https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp):
 
 ```
 .\samples\StaticHtmlComposites\index.html


### PR DESCRIPTION
# What
The link was not correctly formatted in the how-to non-react storybook page

# Why
It is rendering out in the documentation incorrectly

# How Tested
Tested locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->