### PR TITLE
The LocalStream PIP is a pretty substantial delta from our core experience and it should be optional

### DIFF
--- a/change/@internal-react-composites-dfdcf3d3-f971-41f2-aced-7a81e4c654d5.json
+++ b/change/@internal-react-composites-dfdcf3d3-f971-41f2-aced-7a81e4c654d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "enabling localstream pip via composite options",
+  "packageName": "@internal/react-composites",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -338,6 +338,7 @@ export type CallCompositeProps = {
     locale?: Locale;
     callInvitationURL?: string;
     onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
+    options?: CallOptions;
     identifiers?: Identifiers;
 };
 
@@ -371,6 +372,11 @@ export interface CallingTheme {
         callRedDarker: string;
     };
 }
+
+// @public
+export type CallOptions = {
+    showFloatingVideo?: "floatingLocalVideo" | "default";
+};
 
 // @public
 export type CallParticipant = CommunicationParticipant & {

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -254,6 +254,7 @@ export type CallCompositeProps = {
     locale?: Locale;
     callInvitationURL?: string;
     onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
+    options?: CallOptions;
     identifiers?: Identifiers;
 };
 
@@ -269,6 +270,11 @@ export type CallIdChangedListener = (event: {
 
 // @public (undocumented)
 export type CallIdentifierKinds = CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind;
+
+// @public
+export type CallOptions = {
+    showFloatingVideo?: "floatingLocalVideo" | "default";
+};
 
 // @public (undocumented)
 export interface ChatAdapter {

--- a/packages/react-composites/src/composites/CallComposite/Call.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Call.tsx
@@ -45,7 +45,7 @@ export type CallOptions = {
    *
    * @defaultValue "default"
    */
-  showFloatingVideo?: string;
+  showFloatingVideo?: 'floatingLocalVideo' | 'default';
 };
 
 type MainScreenProps = {
@@ -58,6 +58,9 @@ type MainScreenProps = {
 const MainScreen = ({ showCallControls, callInvitationURL, onRenderAvatar, options }: MainScreenProps): JSX.Element => {
   const page = useSelector(getPage);
   const adapter = useAdapter();
+  const layoutOptions: 'default' | 'floatingLocalVideo' =
+    options !== undefined && options.showFloatingVideo !== undefined ? options?.showFloatingVideo : 'default';
+
   switch (page) {
     case 'configuration':
       return <ConfigurationScreen startCallHandler={(): void => adapter.setPage('call')} />;
@@ -91,7 +94,7 @@ const MainScreen = ({ showCallControls, callInvitationURL, onRenderAvatar, optio
           }}
           onRenderAvatar={onRenderAvatar}
           callInvitationURL={callInvitationURL}
-          localStreamLayout={options?.showFloatingVideo}
+          localStreamLayout={layoutOptions}
         />
       );
   }

--- a/packages/react-composites/src/composites/CallComposite/Call.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Call.tsx
@@ -29,16 +29,33 @@ export type CallCompositeProps = {
   locale?: Locale;
   callInvitationURL?: string;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
+  options?: CallOptions;
   identifiers?: Identifiers;
+};
+
+/**
+ * Additional customizations for the chat composite
+ */
+export type CallOptions = {
+  /**
+   * UNSTABLE: Feature flag for the local stream to be in a PIP (picture in picture) floating on the bottom right corner.
+   *
+   * This option will be removed once VideoGallery is stable.
+   * @experimental
+   *
+   * @defaultValue "default"
+   */
+  showFloatingVideo?: string;
 };
 
 type MainScreenProps = {
   showCallControls: boolean;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
   callInvitationURL?: string;
+  options?: CallOptions;
 };
 
-const MainScreen = ({ showCallControls, callInvitationURL, onRenderAvatar }: MainScreenProps): JSX.Element => {
+const MainScreen = ({ showCallControls, callInvitationURL, onRenderAvatar, options }: MainScreenProps): JSX.Element => {
   const page = useSelector(getPage);
   const adapter = useAdapter();
   switch (page) {
@@ -74,6 +91,7 @@ const MainScreen = ({ showCallControls, callInvitationURL, onRenderAvatar }: Mai
           }}
           onRenderAvatar={onRenderAvatar}
           callInvitationURL={callInvitationURL}
+          localStreamLayout={options?.showFloatingVideo}
         />
       );
   }
@@ -99,7 +117,7 @@ interface CallInternalProps extends CallCompositeProps {
  * @internal
  */
 export const CallCompositeInternal = (props: CallInternalProps): JSX.Element => {
-  const { adapter, callInvitationURL, fluentTheme, locale, identifiers } = props;
+  const { adapter, callInvitationURL, fluentTheme, locale, identifiers, options } = props;
 
   useEffect(() => {
     (async () => {
@@ -118,6 +136,7 @@ export const CallCompositeInternal = (props: CallInternalProps): JSX.Element => 
             showCallControls={props.showCallControls}
             onRenderAvatar={props.onRenderAvatar}
             callInvitationURL={callInvitationURL}
+            options={options}
           />
         </CallAdapterProvider>
       </IdentifierProvider>

--- a/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
@@ -37,6 +37,7 @@ export interface CallScreenProps {
   endCallHandler(): void;
   callErrorHandler(customPage?: CallCompositePage): void;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
+  localStreamLayout?: string;
 }
 
 const spinnerLabel = 'Initializing call client...';
@@ -133,7 +134,12 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
               <>
                 <Stack styles={containerStyles} grow>
                   <Stack.Item grow styles={mediaGalleryContainerStyles}>
-                    <MediaGallery {...mediaGalleryProps} {...mediaGalleryHandlers} onRenderAvatar={onRenderAvatar} />
+                    <MediaGallery
+                      {...mediaGalleryProps}
+                      {...mediaGalleryHandlers}
+                      localStreamLayout={props.localStreamLayout}
+                      onRenderAvatar={onRenderAvatar}
+                    />
                   </Stack.Item>
                 </Stack>
                 {isScreenShareOn ? (

--- a/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
@@ -37,7 +37,7 @@ export interface CallScreenProps {
   endCallHandler(): void;
   callErrorHandler(customPage?: CallCompositePage): void;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
-  localStreamLayout?: string;
+  localStreamLayout: 'default' | 'floatingLocalVideo';
 }
 
 const spinnerLabel = 'Initializing call client...';

--- a/packages/react-composites/src/composites/CallComposite/MediaGallery.tsx
+++ b/packages/react-composites/src/composites/CallComposite/MediaGallery.tsx
@@ -29,7 +29,7 @@ export interface MediaGalleryProps {
   isMicrophoneChecked?: boolean;
   onStartLocalVideo: () => Promise<void>;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
-  localStreamLayout?: string;
+  localStreamLayout: 'default' | 'floatingLocalVideo';
 }
 
 export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
@@ -52,7 +52,7 @@ export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
     return (
       <VideoGallery
         {...videoGalleryProps}
-        layout={props.localStreamLayout ?? 'default'}
+        layout={props.localStreamLayout}
         localVideoViewOption={localVideoViewOption}
         remoteVideoViewOption={remoteVideoViewOption}
         styles={VideoGalleryStyles}

--- a/packages/react-composites/src/composites/CallComposite/MediaGallery.tsx
+++ b/packages/react-composites/src/composites/CallComposite/MediaGallery.tsx
@@ -29,6 +29,7 @@ export interface MediaGalleryProps {
   isMicrophoneChecked?: boolean;
   onStartLocalVideo: () => Promise<void>;
   onRenderAvatar?: (props: PlaceholderProps, defaultOnRender: (props: PlaceholderProps) => JSX.Element) => JSX.Element;
+  localStreamLayout?: string;
 }
 
 export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
@@ -51,10 +52,10 @@ export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
     return (
       <VideoGallery
         {...videoGalleryProps}
+        layout={props.localStreamLayout ?? 'default'}
         localVideoViewOption={localVideoViewOption}
         remoteVideoViewOption={remoteVideoViewOption}
         styles={VideoGalleryStyles}
-        layout="floatingLocalVideo"
         onRenderAvatar={props.onRenderAvatar}
       />
     );

--- a/packages/react-composites/src/composites/CallComposite/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
 export { Call as CallComposite } from './Call';
+export type { CallOptions } from './Call';
 export * from './adapter';
 
 export type { CallCompositeProps } from './Call';

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -52,5 +52,12 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     return <Spinner label={'Creating adapter'} ariaLive="assertive" labelPosition="top" />;
   }
 
-  return <CallComposite adapter={adapter} fluentTheme={currentTheme.theme} callInvitationURL={window.location.href} />;
+  return (
+    <CallComposite
+      adapter={adapter}
+      fluentTheme={currentTheme.theme}
+      callInvitationURL={window.location.href}
+      options={{ showFloatingVideo: 'floatingLocalVideo' }}
+    />
+  );
 };


### PR DESCRIPTION
# What
I want to make the layout of how we render the local stream rendering to be by default in the grid and changeable to a floating PIP through options in the call composite.

# Why
In our video gallery customers started seeing a super different  behavior. The Local stream was not longer in the grid and was in a small picture in picture floating modal.

# How Tested
Locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->