### PR TITLE
FluentThemeProvider prop 'applyTo' exposed. Fix dark theme on IphoneSE.

### DIFF
--- a/change/@internal-react-components-44adc20f-59cd-436e-93c2-91db5fb9277d.json
+++ b/change/@internal-react-components-44adc20f-59cd-436e-93c2-91db5fb9277d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "FluentThemeProvider prop 'applyTo' exposed to give option on scope of theme application.",
+  "packageName": "@internal/react-components",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -897,6 +897,7 @@ export const FluentThemeProvider: (props: FluentThemeProviderProps) => JSX.Eleme
 
 // @public
 export interface FluentThemeProviderProps {
+    applyTo?: 'element' | 'body' | 'none';
     children: React_2.ReactNode;
     fluentTheme?: PartialTheme | Theme;
 }

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -202,6 +202,7 @@ export const FluentThemeProvider: (props: FluentThemeProviderProps) => JSX.Eleme
 
 // @public
 export interface FluentThemeProviderProps {
+    applyTo?: 'element' | 'body' | 'none';
     children: React_2.ReactNode;
     fluentTheme?: PartialTheme | Theme;
 }

--- a/packages/react-components/src/theming/FluentThemeProvider.tsx
+++ b/packages/react-components/src/theming/FluentThemeProvider.tsx
@@ -14,6 +14,15 @@ export interface FluentThemeProviderProps {
   children: React.ReactNode;
   /** Theme for components. Defaults to a light theme if not provided. */
   fluentTheme?: PartialTheme | Theme;
+  /**
+   * Defines where body-related theme is applied to.
+   * Setting to 'element' will apply body styles to the root element of ThemeProvider.
+   * Setting to 'body' will apply body styles to document body.
+   * Setting to 'none' will not apply body styles to either element or body.
+   *
+   * @defaultvalue 'element'
+   */
+  applyTo?: 'element' | 'body' | 'none';
 }
 
 const wrapper = mergeStyles({
@@ -43,7 +52,7 @@ const initialFluentNorthstarTheme = mergeNorthstarThemes(teamsTheme, {
  * This provider handles applying any theme provided to both the underlying Fluent UI controls, as well as the Fluent React Northstar controls.
  */
 export const FluentThemeProvider = (props: FluentThemeProviderProps): JSX.Element => {
-  const { fluentTheme, children } = props;
+  const { fluentTheme, applyTo, children } = props;
   // if fluentTheme is not provided, default to light theme
   const fluentUITheme: Theme = mergeThemes(defaultTheme, fluentTheme);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -78,7 +87,7 @@ export const FluentThemeProvider = (props: FluentThemeProviderProps): JSX.Elemen
 
   return (
     <ThemeContext.Provider value={fluentUITheme}>
-      <ThemeProvider theme={fluentUITheme} className={wrapper}>
+      <ThemeProvider theme={fluentUITheme} applyTo={applyTo} className={wrapper}>
         <Provider theme={fluentNorthstarTheme} className={wrapper} dir={rtl ? 'rtl' : 'ltr'}>
           {children}
         </Provider>

--- a/samples/Calling/src/app/theming/SwitchableFluentThemeProvider.tsx
+++ b/samples/Calling/src/app/theming/SwitchableFluentThemeProvider.tsx
@@ -131,7 +131,9 @@ export const SwitchableFluentThemeProvider = (props: SwitchableFluentThemeProvid
 
   return (
     <SwitchableFluentThemeContext.Provider value={state}>
-      <FluentThemeProvider fluentTheme={currentTheme.theme}>{children}</FluentThemeProvider>
+      <FluentThemeProvider fluentTheme={currentTheme.theme} applyTo="body">
+        {children}
+      </FluentThemeProvider>
     </SwitchableFluentThemeContext.Provider>
   );
 };

--- a/samples/Chat/src/app/theming/SwitchableFluentThemeProvider.tsx
+++ b/samples/Chat/src/app/theming/SwitchableFluentThemeProvider.tsx
@@ -131,7 +131,9 @@ export const SwitchableFluentThemeProvider = (props: SwitchableFluentThemeProvid
 
   return (
     <SwitchableFluentThemeContext.Provider value={state}>
-      <FluentThemeProvider fluentTheme={currentTheme.theme}>{children}</FluentThemeProvider>
+      <FluentThemeProvider fluentTheme={currentTheme.theme} applyTo="body">
+        {children}
+      </FluentThemeProvider>
     </SwitchableFluentThemeContext.Provider>
   );
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
FluentThemeProvider prop 'applyTo' exposed to give option on scope of theme application. This allows us to fix bug https://skype.visualstudio.com/SPOOL/_workitems/edit/2525645.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
For bug: https://skype.visualstudio.com/SPOOL/_workitems/edit/2525645

# How Tested
<!--- How did you test your change. What tests have you added. -->
Manual testing.
IPhoneSE view on Chrome.
![image](https://user-images.githubusercontent.com/79475487/127578948-441e9f1c-feed-4ee0-887d-18d2b0be1861.png)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->