### PR TITLE
Explicitly list error targets in chat stateful client

### DIFF
--- a/change/@internal-chat-stateful-client-1590f6eb-8e49-4add-8856-500109777482.json
+++ b/change/@internal-chat-stateful-client-1590f6eb-8e49-4add-8856-500109777482.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Remove type blocking usage of the package on older typescript versions",
-  "packageName": "@internal/chat-stateful-client",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@internal-chat-stateful-client-4ab8067f-e02d-4ae7-af21-7644e44a1c93.json
+++ b/change/@internal-chat-stateful-client-4ab8067f-e02d-4ae7-af21-7644e44a1c93.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add explicit string literals for error targets",
+  "packageName": "@internal/chat-stateful-client",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-stateful-client/review/chat-stateful-client.api.md
+++ b/packages/chat-stateful-client/review/chat-stateful-client.api.md
@@ -50,7 +50,9 @@ export type ChatMessageWithStatus = ChatMessage & {
 export type ChatMethodName<T, K extends keyof T> = T[K] extends Function ? (K extends string ? K : never) : never;
 
 // @public
-export type ChatObjectMethodNames<TName extends string, T> = any;
+export type ChatObjectMethodNames<TName extends string, T> = {
+    [K in keyof T]: `${TName}.${ChatMethodName<T, K>}`;
+}[keyof T];
 
 // @public (undocumented)
 export type ChatThreadClientState = {

--- a/packages/chat-stateful-client/review/chat-stateful-client.api.md
+++ b/packages/chat-stateful-client/review/chat-stateful-client.api.md
@@ -9,7 +9,6 @@ import { ChatClientOptions } from '@azure/communication-chat';
 import { ChatMessage } from '@azure/communication-chat';
 import { ChatMessageReadReceipt } from '@azure/communication-chat';
 import { ChatParticipant } from '@azure/communication-chat';
-import { ChatThreadClient } from '@azure/communication-chat';
 import { CommunicationIdentifierKind } from '@azure/communication-common';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { MessageStatus } from '@internal/acs-ui-common';
@@ -38,21 +37,13 @@ export type ChatErrors = {
 };
 
 // @public
-export type ChatErrorTargets = ChatObjectMethodNames<'ChatClient', ChatClient> | ChatObjectMethodNames<'ChatThreadClient', ChatThreadClient>;
+export type ChatErrorTargets = 'ChatClient.createChatThread' | 'ChatClient.deleteChatThread' | 'ChatClient.getChatThreadClient' | 'ChatClient.listChatThreads' | 'ChatClient.off' | 'ChatClient.on' | 'ChatClient.startRealtimeNotifications' | 'ChatClient.stopRealtimeNotifications' | 'ChatThreadClient.addParticipants' | 'ChatThreadClient.deleteMessage' | 'ChatThreadClient.getMessage' | 'ChatThreadClient.getProperties' | 'ChatThreadClient.listMessages' | 'ChatThreadClient.listParticipants' | 'ChatThreadClient.listReadReceipts' | 'ChatThreadClient.removeParticipant' | 'ChatThreadClient.sendMessage' | 'ChatThreadClient.sendReadReceipt' | 'ChatThreadClient.sendTypingNotification' | 'ChatThreadClient.updateMessage' | 'ChatThreadClient.updateTopic';
 
 // @public (undocumented)
 export type ChatMessageWithStatus = ChatMessage & {
     clientMessageId?: string;
     status: MessageStatus;
 };
-
-// @public
-export type ChatMethodName<T, K extends keyof T> = T[K] extends Function ? (K extends string ? K : never) : never;
-
-// @public
-export type ChatObjectMethodNames<TName extends string, T> = {
-    [K in keyof T]: `${TName}.${ChatMethodName<T, K>}`;
-}[keyof T];
 
 // @public (undocumented)
 export type ChatThreadClientState = {

--- a/packages/chat-stateful-client/src/ChatClientState.ts
+++ b/packages/chat-stateful-client/src/ChatClientState.ts
@@ -98,14 +98,10 @@ export type ChatErrorTargets =
 
 /**
  * Helper type to build a string literal type containing methods of an object.
- * @experimental
  */
-// TODO: this was set to `any` from:
-//  { [K in keyof T]: `${TName}.${ChatMethodName<T, K>}`; }[keyof T];
-// However this notation is only supported in typescript 4.1+ and is blocking some customers.
-// GitHub issue: https://github.com/Azure/communication-ui-library/issues/619
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export declare type ChatObjectMethodNames<TName extends string, T> = any;
+export type ChatObjectMethodNames<TName extends string, T> = {
+  [K in keyof T]: `${TName}.${ChatMethodName<T, K>}`;
+}[keyof T];
 
 /**
  * Helper type to build a string literal type containing methods of an object.

--- a/packages/chat-stateful-client/src/ChatClientState.ts
+++ b/packages/chat-stateful-client/src/ChatClientState.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ChatClient, ChatMessageReadReceipt, ChatParticipant, ChatThreadClient } from '@azure/communication-chat';
+import { ChatMessageReadReceipt, ChatParticipant } from '@azure/communication-chat';
 import { CommunicationIdentifierKind } from '@azure/communication-common';
 import { ChatMessageWithStatus } from './types/ChatMessageWithStatus';
 import { TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
@@ -93,19 +93,24 @@ export class ChatError extends Error {
  * String literal type for all permissible keys in {@Link ChatErrors}.
  */
 export type ChatErrorTargets =
-  | ChatObjectMethodNames<'ChatClient', ChatClient>
-  | ChatObjectMethodNames<'ChatThreadClient', ChatThreadClient>;
-
-/**
- * Helper type to build a string literal type containing methods of an object.
- */
-export type ChatObjectMethodNames<TName extends string, T> = {
-  [K in keyof T]: `${TName}.${ChatMethodName<T, K>}`;
-}[keyof T];
-
-/**
- * Helper type to build a string literal type containing methods of an object.
- */
-// eslint complains on all uses of `Function`. Using it as a type constraint is legitimate.
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type ChatMethodName<T, K extends keyof T> = T[K] extends Function ? (K extends string ? K : never) : never;
+  | 'ChatClient.createChatThread'
+  | 'ChatClient.deleteChatThread'
+  | 'ChatClient.getChatThreadClient'
+  | 'ChatClient.listChatThreads'
+  | 'ChatClient.off'
+  | 'ChatClient.on'
+  | 'ChatClient.startRealtimeNotifications'
+  | 'ChatClient.stopRealtimeNotifications'
+  | 'ChatThreadClient.addParticipants'
+  | 'ChatThreadClient.deleteMessage'
+  | 'ChatThreadClient.getMessage'
+  | 'ChatThreadClient.getProperties'
+  | 'ChatThreadClient.listMessages'
+  | 'ChatThreadClient.listParticipants'
+  | 'ChatThreadClient.listReadReceipts'
+  | 'ChatThreadClient.removeParticipant'
+  | 'ChatThreadClient.sendMessage'
+  | 'ChatThreadClient.sendReadReceipt'
+  | 'ChatThreadClient.sendTypingNotification'
+  | 'ChatThreadClient.updateMessage'
+  | 'ChatThreadClient.updateTopic';

--- a/packages/chat-stateful-client/src/TypeAssertions.ts
+++ b/packages/chat-stateful-client/src/TypeAssertions.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ChatClient, ChatThreadClient } from '@azure/communication-chat';
+import { ChatErrorTargets } from './ChatClientState';
+
+/**
+ * Internal type-assertion that explicitly listed {@Link ChatErrorTargets} correspond to the underlying base SDK API.
+ */
+export const ensureChatErrorTargetsContainsOnlyValidValues = (target: ChatErrorTargets): InferredChatErrorTargets =>
+  target;
+
+/**
+ * Internal type-assertion that explicitly listed {@Link ChatErrorTargets} correspond to the underlying base SDK API.
+ */
+export const ensureChatErrorTargetsContainsAllValidValues = (target: InferredChatErrorTargets): ChatErrorTargets =>
+  target;
+
+/**
+ * String literal type for all permissible keys in {@Link ChatErrors}.
+ */
+type InferredChatErrorTargets =
+  | ChatObjectMethodNames<'ChatClient', ChatClient>
+  | ChatObjectMethodNames<'ChatThreadClient', ChatThreadClient>;
+
+/**
+ * Helper type to build a string literal type containing methods of an object.
+ */
+export type ChatObjectMethodNames<TName extends string, T> = {
+  [K in keyof T]: `${TName}.${ChatMethodName<T, K>}`;
+}[keyof T];
+
+/**
+ * Helper type to build a string literal type containing methods of an object.
+ */
+// eslint complains on all uses of `Function`. Using it as a type constraint is legitimate.
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type ChatMethodName<T, K extends keyof T> = T[K] extends Function ? (K extends string ? K : never) : never;

--- a/packages/chat-stateful-client/src/index.ts
+++ b/packages/chat-stateful-client/src/index.ts
@@ -11,7 +11,5 @@ export type {
   ChatErrors,
   ChatThreadClientState,
   ChatThreadProperties,
-  ChatErrorTargets,
-  ChatMethodName,
-  ChatObjectMethodNames
+  ChatErrorTargets
 } from './ChatClientState';

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -571,7 +571,7 @@ export type ChatErrors = {
 };
 
 // @public
-export type ChatErrorTargets = ChatObjectMethodNames<'ChatClient', ChatClient> | ChatObjectMethodNames<'ChatThreadClient', ChatThreadClient>;
+export type ChatErrorTargets = 'ChatClient.createChatThread' | 'ChatClient.deleteChatThread' | 'ChatClient.getChatThreadClient' | 'ChatClient.listChatThreads' | 'ChatClient.off' | 'ChatClient.on' | 'ChatClient.startRealtimeNotifications' | 'ChatClient.stopRealtimeNotifications' | 'ChatThreadClient.addParticipants' | 'ChatThreadClient.deleteMessage' | 'ChatThreadClient.getMessage' | 'ChatThreadClient.getProperties' | 'ChatThreadClient.listMessages' | 'ChatThreadClient.listParticipants' | 'ChatThreadClient.listReadReceipts' | 'ChatThreadClient.removeParticipant' | 'ChatThreadClient.sendMessage' | 'ChatThreadClient.sendReadReceipt' | 'ChatThreadClient.sendTypingNotification' | 'ChatThreadClient.updateMessage' | 'ChatThreadClient.updateTopic';
 
 // @public (undocumented)
 export type ChatMessage = Message<'chat'>;
@@ -595,14 +595,6 @@ export type ChatMessageWithStatus = ChatMessage_2 & {
     clientMessageId?: string;
     status: MessageStatus;
 };
-
-// @public
-export type ChatMethodName<T, K extends keyof T> = T[K] extends Function ? (K extends string ? K : never) : never;
-
-// @public
-export type ChatObjectMethodNames<TName extends string, T> = {
-    [K in keyof T]: `${TName}.${ChatMethodName<T, K>}`;
-}[keyof T];
 
 // @public
 export type ChatOptions = {

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -600,7 +600,9 @@ export type ChatMessageWithStatus = ChatMessage_2 & {
 export type ChatMethodName<T, K extends keyof T> = T[K] extends Function ? (K extends string ? K : never) : never;
 
 // @public
-export type ChatObjectMethodNames<TName extends string, T> = any;
+export type ChatObjectMethodNames<TName extends string, T> = {
+    [K in keyof T]: `${TName}.${ChatMethodName<T, K>}`;
+}[keyof T];
 
 // @public
 export type ChatOptions = {


### PR DESCRIPTION
# What
Re-introduce the string literal union of all error targets.

Instead of exposing advanced types to infer the literals, explicitly list them and internally assert that they're the exact error targets from the base SDK.

# Why
Useful features like intellisense for customers && ensures that the list of targets is accurate.

# How Tested
`rush build`

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->