### PR TITLE
changelog for beta3

### DIFF
--- a/packages/communication-react/CHANGELOG.md
+++ b/packages/communication-react/CHANGELOG.md
@@ -11,7 +11,20 @@ Thu, 22 Jul 2021 17:42:41 GMT
 
 ### Changes
 
-- Bump @internal/chat-stateful-client to v1.0.0-beta.3 ([PR #554](https://github.com/azure/communication-ui-library/pull/554) by 2684369+JamesBurnside@users.noreply.github.com)
+* [Breaking change] Call Composite and Chat Composite adapters now take in a `CommunicationTokenCredential` in the constructor instead of the token
+
+* [Breaking change] Call Composite and Chat Composite adapters take in an object containing all of the parameters instead of passing in the parameters individually
+
+* Fixing the sendbox component where the padding would overlap with the icon
+
+* Fixing the local preview overlapping the call control bar
+
+* Setting minHeight on the call composite media gallery
+
+* Adding a small fix for supporting typescript < 4.1
+
+### Storybook page changes
+* Fixing link in "Using Composites in a non-react environment"
 
 ## [1.0.0-beta.2](https://github.com/azure/communication-ui-library/tree/@azure/communication-react_v1.0.0-beta.2)
 


### PR DESCRIPTION
# What
We need to describe the changes in 1.0.0-beta3

# Why
Developers need to understand what has changed. There are two breaking changes in our API around composites and it is important to point these out.

# How Tested
Ran locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

Yes, there is an API change in the composites. Since there are a number of parameters in the composite that are growing, we decided to put it into an object of properties.

We are also using the `CommunicationTokenCredential` over keep the token as a string