### PR TITLE
Fix tsdoc comments in codebase: `@Link` -> `@link`

### DIFF
--- a/change/@internal-calling-component-bindings-a155b314-74c8-422d-957e-d04dcc2cfe84.json
+++ b/change/@internal-calling-component-bindings-a155b314-74c8-422d-957e-d04dcc2cfe84.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix tsdoc comments - rename @Link -> @link",
+  "packageName": "@internal/calling-component-bindings",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-calling-stateful-client-20f63968-c3c3-4534-85a8-7e11634744d3.json
+++ b/change/@internal-calling-stateful-client-20f63968-c3c3-4534-85a8-7e11634744d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix tsdoc comments - rename @Link -> @link",
+  "packageName": "@internal/calling-stateful-client",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-chat-stateful-client-f5a05abe-efe5-4541-9124-fa0d81d7ce8b.json
+++ b/change/@internal-chat-stateful-client-f5a05abe-efe5-4541-9124-fa0d81d7ce8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix tsdoc comments - rename @Link -> @link",
+  "packageName": "@internal/chat-stateful-client",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-components-9f9f7dcd-11d8-4778-a6f0-8fe2d51f52c6.json
+++ b/change/@internal-react-components-9f9f7dcd-11d8-4778-a6f0-8fe2d51f52c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix tsdoc comments - rename @Link -> @link",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-composites-93b7e61d-3f1b-43d0-aac0-5d18c36333de.json
+++ b/change/@internal-react-composites-93b7e61d-3f1b-43d0-aac0-5d18c36333de.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix tsdoc comments - rename @Link -> @link",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/calling-component-bindings/src/handlers/createHandlers.ts
+++ b/packages/calling-component-bindings/src/handlers/createHandlers.ts
@@ -308,7 +308,7 @@ const isPreviewOn = (deviceManager: DeviceManagerState): boolean => {
  * DeclarativeCall may be undefined. If undefined, their associated handlers will not be created and returned.
  *
  * @param callClient - StatefulCallClient returned from
- *   {@link @internal/calling-stateful-client#createStatefulCallClient}.
+ *   {@link @azure/communication-react#createStatefulCallClient}.
  * @param callAgent - Instance of {@link @azure/communication-calling#CallClient}.
  * @param deviceManager - Instance of {@link @azure/communication-calling#DeviceManager}.
  * @param call - Instance of {@link @azure/communication-calling#Call}.

--- a/packages/calling-component-bindings/src/handlers/createHandlers.ts
+++ b/packages/calling-component-bindings/src/handlers/createHandlers.ts
@@ -308,10 +308,10 @@ const isPreviewOn = (deviceManager: DeviceManagerState): boolean => {
  * DeclarativeCall may be undefined. If undefined, their associated handlers will not be created and returned.
  *
  * @param callClient - StatefulCallClient returned from
- *   {@Link @internal/calling-stateful-client#createStatefulCallClient}.
- * @param callAgent - Instance of {@Link @azure/communication-calling#CallClient}.
- * @param deviceManager - Instance of {@Link @azure/communication-calling#DeviceManager}.
- * @param call - Instance of {@Link @azure/communication-calling#Call}.
+ *   {@link @internal/calling-stateful-client#createStatefulCallClient}.
+ * @param callAgent - Instance of {@link @azure/communication-calling#CallClient}.
+ * @param deviceManager - Instance of {@link @azure/communication-calling#DeviceManager}.
+ * @param call - Instance of {@link @azure/communication-calling#Call}.
  * @param _ - React component that you want to generate handlers for.
  * @returns
  */

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -25,7 +25,7 @@ import {
 } from '@azure/communication-common';
 
 /**
- * State only version of {@Link @azure/communication-calling#TransferRequestedEventArgs}. At the time of writing
+ * State only version of {@link @azure/communication-calling#TransferRequestedEventArgs}. At the time of writing
  * Transfer Call is experimental. Not tested and not ready for consumption.
  */
 export interface TransferRequest {
@@ -33,7 +33,7 @@ export interface TransferRequest {
 }
 
 /**
- * State only version of {@Link @azure/communication-calling#Transfer}. At the time of writing Transfer Call is
+ * State only version of {@link @azure/communication-calling#Transfer}. At the time of writing Transfer Call is
  * experimental. Not tested and not ready for consumption.
  */
 export interface Transfer {
@@ -42,35 +42,35 @@ export interface Transfer {
    */
   id: number;
   /**
-   * Added by {@Link StatefulClientClient}, stores the targetParticipant passed to
-   * {@Link @azure/communication-calling#TransferCallFeature.transfer}
+   * Added by {@link StatefulClientClient}, stores the targetParticipant passed to
+   * {@link @azure/communication-calling#TransferCallFeature.transfer}
    */
   targetParticipant: CommunicationUserIdentifier | PhoneNumberIdentifier;
   /**
-   * Proxy of {@Link @azure/communication-calling#Transfer.state}.
+   * Proxy of {@link @azure/communication-calling#Transfer.state}.
    */
   state: TransferState;
   /**
-   * Proxy of {@Link @azure/communication-calling#Transfer.error}.
+   * Proxy of {@link @azure/communication-calling#Transfer.error}.
    */
   error?: TransferErrorCode;
 }
 
 /**
- * Holds all the state found in {@Link @azure/communication-calling#TransferCallFeature} and
- * {@Link @azure/communication-calling#Transfer}. At the time of writing Transfer Call is experimental. Not tested and
+ * Holds all the state found in {@link @azure/communication-calling#TransferCallFeature} and
+ * {@link @azure/communication-calling#Transfer}. At the time of writing Transfer Call is experimental. Not tested and
  * not ready for consumption.
  */
 export interface TransferCallFeature {
   /**
-   * These are requests received in the {@Link @azure/communication-calling#TransferCallFeature}'s 'transferRequested'
+   * These are requests received in the {@link @azure/communication-calling#TransferCallFeature}'s 'transferRequested'
    * event. Only MAX_TRANSFER_REQUEST_LENGTH number of TransferRequest are kept in this array with the older ones being
-   * replaced by newer ones. To accept/reject a transfer request, the {@Link @azure/communication-calling#Call} must be
+   * replaced by newer ones. To accept/reject a transfer request, the {@link @azure/communication-calling#Call} must be
    * used (TODO: do we want to provide an API?).
    */
   receivedTransferRequests: TransferRequest[];
   /**
-   * These are requests initiated by the local user using {@Link StatefulCallClient.transfer}. Only
+   * These are requests initiated by the local user using {@link StatefulCallClient.transfer}. Only
    * MAX_TRANSFER_REQUEST_LENGTH number of TransferRequest are kept in this array with the older ones being replaced by
    * newer ones.
    */
@@ -78,208 +78,208 @@ export interface TransferCallFeature {
 }
 
 /**
- * State only version of {@Link @azure/communication-calling#CallAgent} except calls is moved to be a child directly of
- * {@Link CallClientState} and not included here. The reason to have CallAgent's state proxied is to provide access to
+ * State only version of {@link @azure/communication-calling#CallAgent} except calls is moved to be a child directly of
+ * {@link CallClientState} and not included here. The reason to have CallAgent's state proxied is to provide access to
  * displayName. We don't flatten CallAgent.displayName and put it in CallClientState because it would be ambiguious that
  * displayName is actually reliant on the creation/existence of CallAgent to be available.
  */
 export interface CallAgentState {
   /**
-   * Proxy of {@Link @azure/communication-calling#CallAgent.displayName}.
+   * Proxy of {@link @azure/communication-calling#CallAgent.displayName}.
    */
   displayName?: string;
 }
 
 /**
- * State only version of {@Link @azure/communication-calling#TranscriptionCallFeature}. {@Link StatefulCallClient} will
- * automatically listen for transcription state of the call and update the state exposed by {@Link StatefulCallClient}
+ * State only version of {@link @azure/communication-calling#TranscriptionCallFeature}. {@link StatefulCallClient} will
+ * automatically listen for transcription state of the call and update the state exposed by {@link StatefulCallClient}
  * accordingly.
  */
 export interface TranscriptionCallFeature {
   /**
-   * Proxy of {@Link @azure/communication-calling#TranscriptionCallFeature.isTranscriptionActive}.
+   * Proxy of {@link @azure/communication-calling#TranscriptionCallFeature.isTranscriptionActive}.
    */
   isTranscriptionActive: boolean;
 }
 
 /**
- * State only version of {@Link @azure/communication-calling#RecordingCallFeature}. {@Link StatefulCallClient} will
- * automatically listen for recording state of the call and update the state exposed by {@Link StatefulCallClient} accordingly.
+ * State only version of {@link @azure/communication-calling#RecordingCallFeature}. {@link StatefulCallClient} will
+ * automatically listen for recording state of the call and update the state exposed by {@link StatefulCallClient} accordingly.
  */
 export interface RecordingCallFeature {
   /**
-   * Proxy of {@Link @azure/communication-calling#RecordingCallFeature.isRecordingActive}.
+   * Proxy of {@link @azure/communication-calling#RecordingCallFeature.isRecordingActive}.
    */
   isRecordingActive: boolean;
 }
 
 /**
- * State only version of {@Link @azure/communication-calling#LocalVideoStream}.
+ * State only version of {@link @azure/communication-calling#LocalVideoStream}.
  */
 export interface LocalVideoStreamState {
   /**
-   * Proxy of {@Link @azure/communication-calling#LocalVideoStream.source}.
+   * Proxy of {@link @azure/communication-calling#LocalVideoStream.source}.
    */
   source: VideoDeviceInfo;
   /**
-   * Proxy of {@Link @azure/communication-calling#LocalVideoStream.mediaStreamType}.
+   * Proxy of {@link @azure/communication-calling#LocalVideoStream.mediaStreamType}.
    */
   mediaStreamType: MediaStreamType;
   /**
-   * {@Link VideoStreamRendererView} that is managed by createView/disposeView in {@Link StatefulCallClient}
+   * {@link VideoStreamRendererView} that is managed by createView/disposeView in {@link StatefulCallClient}
    * API. This can be undefined if the stream has not yet been rendered and defined after createView creates the view.
    */
   view?: VideoStreamRendererViewState;
 }
 
 /**
- * State only version of {@Link @azure/communication-calling#RemoteVideoStream}.
+ * State only version of {@link @azure/communication-calling#RemoteVideoStream}.
  */
 export interface RemoteVideoStreamState {
   /**
-   * Proxy of {@Link @azure/communication-calling#RemoteVideoStream.id}.
+   * Proxy of {@link @azure/communication-calling#RemoteVideoStream.id}.
    */
   id: number;
   /**
-   * Proxy of {@Link @azure/communication-calling#RemoteVideoStream.mediaStreamType}.
+   * Proxy of {@link @azure/communication-calling#RemoteVideoStream.mediaStreamType}.
    */
   mediaStreamType: MediaStreamType;
   /**
-   * Proxy of {@Link @azure/communication-calling#RemoteVideoStream.isAvailable}.
+   * Proxy of {@link @azure/communication-calling#RemoteVideoStream.isAvailable}.
    */
   isAvailable: boolean;
   /**
-   * {@Link VideoStreamRendererView} that is managed by createView/disposeView in {@Link StatefulCallClient}
+   * {@link VideoStreamRendererView} that is managed by createView/disposeView in {@link StatefulCallClient}
    * API. This can be undefined if the stream has not yet been rendered and defined after createView creates the view.
    */
   view?: VideoStreamRendererViewState;
 }
 
 /**
- * State only version of {@Link @azure/communication-calling#VideoStreamRendererView}. Currently no API is provided to
- * modify scalingMode after the stream as been rendered by {@Link StatefulCallClient}. In order to change scalingMode
+ * State only version of {@link @azure/communication-calling#VideoStreamRendererView}. Currently no API is provided to
+ * modify scalingMode after the stream as been rendered by {@link StatefulCallClient}. In order to change scalingMode
  * stop rendering the stream and re-start it using the desired scalingMode. This property is added to the state exposed
- * by {@Link StatefulCallClient} by {@Link StatefulCallClient.createView} and removed by
- * {@Link StatefulCallClient.disposeView}.
+ * by {@link StatefulCallClient} by {@link StatefulCallClient.createView} and removed by
+ * {@link StatefulCallClient.disposeView}.
  */
 export interface VideoStreamRendererViewState {
   /**
-   * Proxy of {@Link @azure/communication-calling#VideoStreamRendererView.scalingMode}.
+   * Proxy of {@link @azure/communication-calling#VideoStreamRendererView.scalingMode}.
    */
   scalingMode: ScalingMode;
   /**
-   * Proxy of {@Link @azure/communication-calling#VideoStreamRendererView.isMirrored}.
+   * Proxy of {@link @azure/communication-calling#VideoStreamRendererView.isMirrored}.
    */
   isMirrored: boolean;
   /**
-   * Proxy of {@Link @azure/communication-calling#VideoStreamRendererView.target}.
+   * Proxy of {@link @azure/communication-calling#VideoStreamRendererView.target}.
    */
   target: HTMLElement;
 }
 
 /**
- * State only version of {@Link @azure/communication-calling#RemoteParticipant}. {@Link StatefulCallClient} will
- * automatically retrieve RemoteParticipants and add their state to the state exposed by {@Link StatefulCallClient}.
+ * State only version of {@link @azure/communication-calling#RemoteParticipant}. {@link StatefulCallClient} will
+ * automatically retrieve RemoteParticipants and add their state to the state exposed by {@link StatefulCallClient}.
  */
 export interface RemoteParticipantState {
   /**
-   * Proxy of {@Link @azure/communication-calling#RemoteParticipant.identifier}.
+   * Proxy of {@link @azure/communication-calling#RemoteParticipant.identifier}.
    */
   identifier: CommunicationUserKind | PhoneNumberKind | MicrosoftTeamsUserKind | UnknownIdentifierKind;
   /**
-   * Proxy of {@Link @azure/communication-calling#RemoteParticipant.displayName}.
+   * Proxy of {@link @azure/communication-calling#RemoteParticipant.displayName}.
    */
   displayName?: string;
   /**
-   * Proxy of {@Link @azure/communication-calling#RemoteParticipant.state}.
+   * Proxy of {@link @azure/communication-calling#RemoteParticipant.state}.
    */
   state: RemoteParticipantStatus;
   /**
-   * Proxy of {@Link @azure/communication-calling#RemoteParticipant.callEndReason}.
+   * Proxy of {@link @azure/communication-calling#RemoteParticipant.callEndReason}.
    */
   callEndReason?: CallEndReason;
   /**
-   * Proxy of {@Link @azure/communication-calling#RemoteParticipant.videoStreams} as an object with
-   * {@Link RemoteVideoStream} fields keyed by {@Link @azure/communication-calling#RemoteVideoStream.id}.
+   * Proxy of {@link @azure/communication-calling#RemoteParticipant.videoStreams} as an object with
+   * {@link RemoteVideoStream} fields keyed by {@link @azure/communication-calling#RemoteVideoStream.id}.
    */
   videoStreams: { [key: number]: RemoteVideoStreamState };
   /**
-   * Proxy of {@Link @azure/communication-calling#RemoteParticipant.isMuted}.
+   * Proxy of {@link @azure/communication-calling#RemoteParticipant.isMuted}.
    */
   isMuted: boolean;
   /**
-   * Proxy of {@Link @azure/communication-calling#RemoteParticipant.isSpeaking}.
+   * Proxy of {@link @azure/communication-calling#RemoteParticipant.isSpeaking}.
    */
   isSpeaking: boolean;
 }
 
 /**
- * State only version of {@Link @azure/communication-calling#Call}. {@Link StatefulCallClient} will automatically
- * retrieve Call's state and add it to the state exposed by {@Link StatefulCallClient}.
+ * State only version of {@link @azure/communication-calling#Call}. {@link StatefulCallClient} will automatically
+ * retrieve Call's state and add it to the state exposed by {@link StatefulCallClient}.
  */
 export interface CallState {
   /**
-   * Proxy of {@Link @azure/communication-calling#Call.id}.
+   * Proxy of {@link @azure/communication-calling#Call.id}.
    */
   id: string;
   /**
-   * Proxy of {@Link @azure/communication-calling#Call.callerInfo}.
+   * Proxy of {@link @azure/communication-calling#Call.callerInfo}.
    */
   callerInfo: CallerInfo;
   /**
-   * Proxy of {@Link @azure/communication-calling#Call.state}.
+   * Proxy of {@link @azure/communication-calling#Call.state}.
    */
   state: CallStatus;
   /**
-   * Proxy of {@Link @azure/communication-calling#Call.callEndReason}.
+   * Proxy of {@link @azure/communication-calling#Call.callEndReason}.
    */
   callEndReason?: CallEndReason;
   /**
-   * Proxy of {@Link @azure/communication-calling#Call.direction}.
+   * Proxy of {@link @azure/communication-calling#Call.direction}.
    */
   direction: CallDirection;
   /**
-   * Proxy of {@Link @azure/communication-calling#Call.isMuted}.
+   * Proxy of {@link @azure/communication-calling#Call.isMuted}.
    */
   isMuted: boolean;
   /**
-   * Proxy of {@Link @azure/communication-calling#Call.isScreenSharingOn}.
+   * Proxy of {@link @azure/communication-calling#Call.isScreenSharingOn}.
    */
   isScreenSharingOn: boolean;
   /**
-   * Proxy of {@Link @azure/communication-calling#Call.localVideoStreams}.
+   * Proxy of {@link @azure/communication-calling#Call.localVideoStreams}.
    */
   localVideoStreams: LocalVideoStreamState[];
   /**
-   * Proxy of {@Link @azure/communication-calling#Call.remoteParticipants}.
-   * Object with {@Link RemoteParticipant} fields keyed by flattened {@Link RemoteParticipantState.identifier}.
-   * To obtain a flattened {@Link RemoteParticipantState.identifier}, use
-   * {@Link @azure/communication-react#toFlatCommunicationIdentifier}.
+   * Proxy of {@link @azure/communication-calling#Call.remoteParticipants}.
+   * Object with {@link RemoteParticipant} fields keyed by flattened {@link RemoteParticipantState.identifier}.
+   * To obtain a flattened {@link RemoteParticipantState.identifier}, use
+   * {@link @azure/communication-react#toFlatCommunicationIdentifier}.
    */
   remoteParticipants: { [keys: string]: RemoteParticipantState };
   /**
    * Stores remote participants that have left the call so that the callEndReason could be retrieved.
-   * Object with {@Link RemoteParticipant} fields keyed by flattened {@Link RemoteParticipantState.identifier}.
-   * To obtain a flattened {@Link RemoteParticipantState.identifier}, use
-   * {@Link @azure/communication-react#toFlatCommunicationIdentifier}.
+   * Object with {@link RemoteParticipant} fields keyed by flattened {@link RemoteParticipantState.identifier}.
+   * To obtain a flattened {@link RemoteParticipantState.identifier}, use
+   * {@link @azure/communication-react#toFlatCommunicationIdentifier}.
    */
   remoteParticipantsEnded: { [keys: string]: RemoteParticipantState };
   /**
-   * Proxy of {@Link @azure/communication-calling#TranscriptionCallFeature}.
+   * Proxy of {@link @azure/communication-calling#TranscriptionCallFeature}.
    */
   transcription: TranscriptionCallFeature;
   /**
-   * Proxy of {@Link @azure/communication-calling#RecordingCallFeature}.
+   * Proxy of {@link @azure/communication-calling#RecordingCallFeature}.
    */
   recording: RecordingCallFeature;
   /**
-   * Proxy of {@Link @azure/communication-calling#TransferCallFeature} with some differences see
-   * {@Link TransferCallFeature} for details.
+   * Proxy of {@link @azure/communication-calling#TransferCallFeature} with some differences see
+   * {@link TransferCallFeature} for details.
    */
   transfer: TransferCallFeature;
   /**
    * Stores the currently active screenshare participant's key. If there is no screenshare active, then this will be
-   * undefined. You can use this key to access the remoteParticipant data in {@Link CallState.remoteParticipants} object.
+   * undefined. You can use this key to access the remoteParticipant data in {@link CallState.remoteParticipants} object.
    *
    * Note this only applies to ScreenShare in RemoteParticipant. A local ScreenShare being active will not affect this
    * property.
@@ -300,20 +300,20 @@ export interface CallState {
 }
 
 /**
- * State only version of {@Link @azure/communication-calling#IncomingCall}. {@Link StatefulCallClient} will
- * automatically detect incoming calls and add their state to the state exposed by {@Link StatefulCallClient}.
+ * State only version of {@link @azure/communication-calling#IncomingCall}. {@link StatefulCallClient} will
+ * automatically detect incoming calls and add their state to the state exposed by {@link StatefulCallClient}.
  */
 export interface IncomingCallState {
   /**
-   * Proxy of {@Link @azure/communication-calling#IncomingCall.id}.
+   * Proxy of {@link @azure/communication-calling#IncomingCall.id}.
    */
   id: string;
   /**
-   * Proxy of {@Link @azure/communication-calling#IncomingCall.callerInfo}.
+   * Proxy of {@link @azure/communication-calling#IncomingCall.callerInfo}.
    */
   callerInfo: CallerInfo;
   /**
-   * Set to the state returned by 'callEnded' event on {@Link @azure/communication-calling#IncomingCall} when received.
+   * Set to the state returned by 'callEnded' event on {@link @azure/communication-calling#IncomingCall} when received.
    * This property is added by the stateful layer and is not a proxy of SDK state.
    */
   callEndReason?: CallEndReason;
@@ -330,103 +330,103 @@ export interface IncomingCallState {
 }
 
 /**
- * This type is meant to encapsulate all the state inside {@Link @azure/communication-calling#DeviceManager}. For
+ * This type is meant to encapsulate all the state inside {@link @azure/communication-calling#DeviceManager}. For
  * optional parameters they may not be available until permission is granted by the user. The cameras, microphones,
  * speakers, and deviceAccess states will be empty until the corresponding
- * {@Link @azure/communication-calling#DeviceManager}'s getCameras, getMicrophones, getSpeakers, and askDevicePermission
+ * {@link @azure/communication-calling#DeviceManager}'s getCameras, getMicrophones, getSpeakers, and askDevicePermission
  * APIs are called and completed.
  */
 export type DeviceManagerState = {
   /**
-   * Proxy of {@Link @azure/communication-calling#DeviceManager.isSpeakerSelectionAvailable}.
+   * Proxy of {@link @azure/communication-calling#DeviceManager.isSpeakerSelectionAvailable}.
    */
   isSpeakerSelectionAvailable: boolean;
   /**
-   * Proxy of {@Link @azure/communication-calling#DeviceManager.selectedMicrophone}.
+   * Proxy of {@link @azure/communication-calling#DeviceManager.selectedMicrophone}.
    */
   selectedMicrophone?: AudioDeviceInfo;
   /**
-   * Proxy of {@Link @azure/communication-calling#DeviceManager.selectedSpeaker}.
+   * Proxy of {@link @azure/communication-calling#DeviceManager.selectedSpeaker}.
    */
   selectedSpeaker?: AudioDeviceInfo;
   /**
    * Stores the selected camera device info. This is added by the stateful layer and does not exist in the Calling SDK.
    * It is meant as a convenience to the developer. It must be explicitly set before it has any value and does not
-   * persist across instances of the {@Link StatefulCallClient}. The developer controls entirely what this value holds
+   * persist across instances of the {@link StatefulCallClient}. The developer controls entirely what this value holds
    * at any time.
    */
   selectedCamera?: VideoDeviceInfo;
   /**
-   * Stores any cameras data returned from {@Link @azure/communication-calling#DeviceManager.getCameras}.
+   * Stores any cameras data returned from {@link @azure/communication-calling#DeviceManager.getCameras}.
    */
   cameras: VideoDeviceInfo[];
   /**
-   * Stores any microphones data returned from {@Link @azure/communication-calling#DeviceManager.getMicrophones}.
+   * Stores any microphones data returned from {@link @azure/communication-calling#DeviceManager.getMicrophones}.
    */
   microphones: AudioDeviceInfo[];
   /**
-   * Stores any speakers data returned from {@Link @azure/communication-calling#DeviceManager.getSpeakers}.
+   * Stores any speakers data returned from {@link @azure/communication-calling#DeviceManager.getSpeakers}.
    */
   speakers: AudioDeviceInfo[];
   /**
-   * Stores deviceAccess data returned from {@Link @azure/communication-calling#DeviceManager.askDevicePermission}.
+   * Stores deviceAccess data returned from {@link @azure/communication-calling#DeviceManager.askDevicePermission}.
    */
   deviceAccess?: DeviceAccess;
   /**
-   * Stores created views that are not associated with any CallState (when {@Link StatefulCallClient.createView} is
+   * Stores created views that are not associated with any CallState (when {@link StatefulCallClient.createView} is
    * called with undefined callId, undefined participantId, and defined LocalVideoStream).
    *
-   * The values in this array are generated internally when {@Link StatefulCallClient.createView} is called and are
+   * The values in this array are generated internally when {@link StatefulCallClient.createView} is called and are
    * considered immutable.
    */
   unparentedViews: LocalVideoStreamState[];
 };
 
 /**
- * Container for all of the state data proxied by {@Link StatefulCallClient}. The calls, callsEnded, incomingCalls, and
+ * Container for all of the state data proxied by {@link StatefulCallClient}. The calls, callsEnded, incomingCalls, and
  * incomingCallsEnded states will be automatically provided if a callAgent has been created. The deviceManager will be
- * empty initially until populated see {@Link DeviceManagerState}. The userId state is provided as a convenience for the
+ * empty initially until populated see {@link DeviceManagerState}. The userId state is provided as a convenience for the
  * developer and is completely controled and set by the developer.
  */
 export interface CallClientState {
   /**
-   * Proxy of {@Link @azure/communication-calling#CallAgent.calls} as an object with CallState {@Link CallState} fields.
-   * It is keyed by {@Link @azure/communication-calling#Call.id}. Please note that
-   * {@Link @azure/communication-calling#Call.id} could change. You should not cache the id itself but the entire
-   * {@Link @azure/communication-calling#Call} and then use the id contained to look up data in this map.
+   * Proxy of {@link @azure/communication-calling#CallAgent.calls} as an object with CallState {@link CallState} fields.
+   * It is keyed by {@link @azure/communication-calling#Call.id}. Please note that
+   * {@link @azure/communication-calling#Call.id} could change. You should not cache the id itself but the entire
+   * {@link @azure/communication-calling#Call} and then use the id contained to look up data in this map.
    */
   calls: { [key: string]: CallState };
   /**
    * Calls that have ended are stored here so the callEndReason could be checked. It is an array of CallState
-   * {@Link CallState}. Calls are pushed on to the array as they end, meaning this is sorted by endTime ascending. Only
-   * {@Link MAX_CALL_HISTORY_LENGTH} number of Calls are kept in this array with the older ones being replaced by newer
+   * {@link CallState}. Calls are pushed on to the array as they end, meaning this is sorted by endTime ascending. Only
+   * {@link MAX_CALL_HISTORY_LENGTH} number of Calls are kept in this array with the older ones being replaced by newer
    * ones.
    */
   callsEnded: CallState[];
   /**
-   * Proxy of {@Link @azure/communication-calling#IncomingCall} as an object with IncomingCall {@Link IncomingCall} fields.
-   * It is keyed by {@Link @azure/communication-calling#IncomingCall.id}.
+   * Proxy of {@link @azure/communication-calling#IncomingCall} as an object with IncomingCall {@link IncomingCall} fields.
+   * It is keyed by {@link @azure/communication-calling#IncomingCall.id}.
    */
   incomingCalls: { [key: string]: IncomingCallState };
   /**
    * Incoming Calls that have ended are stored here so the callEndReason could be checked. It is a array of IncomingCall
-   * {@Link IncomingCall} received in the event 'incomingCall' emitted by
-   * {@Link @azure/communication-calling#CallAgent}. IncomingCalls are pushed on to the array as they end, meaning this
+   * {@link IncomingCall} received in the event 'incomingCall' emitted by
+   * {@link @azure/communication-calling#CallAgent}. IncomingCalls are pushed on to the array as they end, meaning this
    * is sorted by endTime ascending. Only MAX_CALL_HISTORY_LENGTH number of IncomingCalls are kept in this array with
    * the older ones being replaced by newer ones.
    */
   incomingCallsEnded: IncomingCallState[];
   /**
-   * Proxy of {@Link @azure/communication-calling#DeviceManager}. Please review {@Link DeviceManagerState}.
+   * Proxy of {@link @azure/communication-calling#DeviceManager}. Please review {@link DeviceManagerState}.
    */
   deviceManager: DeviceManagerState;
   /**
-   * Proxy of {@Link @azure/communication-calling#CallAgent}. Please review {@Link CallAgentState}.
+   * Proxy of {@link @azure/communication-calling#CallAgent}. Please review {@link CallAgentState}.
    */
   callAgent: CallAgentState | undefined;
   /**
-   * Stores a userId. This is not used by the {@Link StatefulCallClient} and is provided here as a convenience for the
-   * developer for easier access to userId. Must be passed in at initialization of the {@Link StatefulCallClient}.
+   * Stores a userId. This is not used by the {@link StatefulCallClient} and is provided here as a convenience for the
+   * developer for easier access to userId. Must be passed in at initialization of the {@link StatefulCallClient}.
    * Completely controlled by the developer.
    */
   userId: CommunicationUserKind;

--- a/packages/calling-stateful-client/src/DeviceManagerDeclarative.ts
+++ b/packages/calling-stateful-client/src/DeviceManagerDeclarative.ts
@@ -5,13 +5,13 @@ import { AudioDeviceInfo, DeviceAccess, DeviceManager, VideoDeviceInfo } from '@
 import { CallContext } from './CallContext';
 
 /**
- * Defines the additional methods added by the stateful on top of {@Link @azure/communication-calling#DeviceManager}.
+ * Defines the additional methods added by the stateful on top of {@link @azure/communication-calling#DeviceManager}.
  */
 export interface StatefulDeviceManager extends DeviceManager {
   /**
-   * Sets the selectedCamera in the {@Link DeviceManagerState}. This is completely developer driven and is not tied in
-   * any way to {@Link @azure/communication-calling#DeviceManager}. It is entirely contained in
-   * {@Link StatefulDeviceManager}. See also {@Link DeviceManagerState.selectedCamera}.
+   * Sets the selectedCamera in the {@link DeviceManagerState}. This is completely developer driven and is not tied in
+   * any way to {@link @azure/communication-calling#DeviceManager}. It is entirely contained in
+   * {@link StatefulDeviceManager}. See also {@link DeviceManagerState.selectedCamera}.
    */
   selectCamera: (VideoDeviceInfo) => void;
 }

--- a/packages/calling-stateful-client/src/RequestedTransferSubscriber.ts
+++ b/packages/calling-stateful-client/src/RequestedTransferSubscriber.ts
@@ -5,7 +5,7 @@ import { Call, Transfer } from '@azure/communication-calling';
 import { CallContext } from './CallContext';
 
 /**
- * Subscribe to 'stateChanged' events in {@Link @azure/communication-calling#Transfer}. These are outgoing or sent
+ * Subscribe to 'stateChanged' events in {@link @azure/communication-calling#Transfer}. These are outgoing or sent
  * requests.
  */
 export class RequestedTransferSubscriber {

--- a/packages/calling-stateful-client/src/StatefulCallClient.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.ts
@@ -17,13 +17,13 @@ import { createView, disposeView } from './StreamUtils';
 import { CommunicationIdentifierKind, CommunicationUserKind } from '@azure/communication-common';
 
 /**
- * Defines the methods that allow CallClient {@Link @azure/communication-calling#CallClient} to be used statefully.
+ * Defines the methods that allow CallClient {@link @azure/communication-calling#CallClient} to be used statefully.
  * The interface provides access to proxied state and also allows registering a handler for state change events. For
- * state definition see {@Link CallClientState}.
+ * state definition see {@link CallClientState}.
  *
  * State change events are driven by:
- * - Returned data from {@Link @azure/communication-calling#DeviceManager} APIs.
- * - Returned data from {@Link @azure/communication-calling#CallAgent} APIs.
+ * - Returned data from {@link @azure/communication-calling#DeviceManager} APIs.
+ * - Returned data from {@link @azure/communication-calling#CallAgent} APIs.
  * - Listeners automatically attached to various azure communication-calling objects:
  *   - CallAgent 'incomingCall'
  *   - CallAgent 'callsUpdated'
@@ -51,8 +51,8 @@ import { CommunicationIdentifierKind, CommunicationUserKind } from '@azure/commu
  */
 export interface StatefulCallClient extends CallClient {
   /**
-   * Holds all the state that we could proxy from CallClient {@Link @azure/communication-calling#CallClient} as
-   * CallClientState {@Link CallClientState}.
+   * Holds all the state that we could proxy from CallClient {@link @azure/communication-calling#CallClient} as
+   * CallClientState {@link CallClientState}.
    */
   getState(): CallClientState;
   /**
@@ -68,33 +68,33 @@ export interface StatefulCallClient extends CallClient {
    */
   offStateChange(handler: (state: CallClientState) => void): void;
   /**
-   * Renders a {@Link RemoteVideoStreamState} or {@Link LocalVideoStreamState} and stores the resulting
-   * {@Link VideoStreamRendererViewState} under the relevant {@Link RemoteVideoStreamState} or
-   * {@Link LocalVideoStreamState} or as unparented view in the state. Under the hood calls
-   * {@Link @azure/communication-calling#VideoStreamRenderer.createView}.
+   * Renders a {@link RemoteVideoStreamState} or {@link LocalVideoStreamState} and stores the resulting
+   * {@link VideoStreamRendererViewState} under the relevant {@link RemoteVideoStreamState} or
+   * {@link LocalVideoStreamState} or as unparented view in the state. Under the hood calls
+   * {@link @azure/communication-calling#VideoStreamRenderer.createView}.
    *
    * Scenario 1: Render RemoteVideoStreamState
    * - CallId is required, participantId is required, and stream of type RemoteVideoStreamState is required
-   * - Resulting {@Link VideoStreamRendererViewState} is stored in the given callId and participantId in
-   * {@Link CallClientState}
+   * - Resulting {@link VideoStreamRendererViewState} is stored in the given callId and participantId in
+   * {@link CallClientState}
    *
    * Scenario 2: Render LocalVideoStreamState for a call
    * - CallId is required, participantId must be undefined, and stream of type LocalVideoStreamState is required.
-   * - The {@Link @azure/communication-calling#Call.localVideoStreams} must already be started using
-   *   {@Link @azure/communication-calling#Call.startVideo}.
-   * - Resulting {@Link VideoStreamRendererViewState} is stored in the given callId {@Link CallState.localVideoStreams}
-   *   in {@Link CallClientState}.
+   * - The {@link @azure/communication-calling#Call.localVideoStreams} must already be started using
+   *   {@link @azure/communication-calling#Call.startVideo}.
+   * - Resulting {@link VideoStreamRendererViewState} is stored in the given callId {@link CallState.localVideoStreams}
+   *   in {@link CallClientState}.
    *
    * - Scenario 2: Render LocalVideoStreamState not part of a call (example rendering camera for local preview)
    * - CallId must be undefined, participantId must be undefined, and stream of type LocalVideoStreamState is required.
-   * - Resulting {@Link VideoStreamRendererViewState} is stored in under the given LocalVideoStreamState in
-   *   {@Link CallClientState.deviceManager.unparentedViews}
+   * - Resulting {@link VideoStreamRendererViewState} is stored in under the given LocalVideoStreamState in
+   *   {@link CallClientState.deviceManager.unparentedViews}
    *
    * @param callId - CallId for the given stream. Can be undefined if the stream is not part of any call.
-   * @param participantId - {@Link RemoteParticipant.identifier} associated with the given RemoteVideoStreamState. Could
+   * @param participantId - {@link RemoteParticipant.identifier} associated with the given RemoteVideoStreamState. Could
    *   be undefined if rendering LocalVideoStreamState.
    * @param stream - The LocalVideoStreamState or RemoteVideoStreamState to start rendering.
-   * @param options - Options that are passed to the {@Link @azure/communication-calling#VideoStreamRenderer}.
+   * @param options - Options that are passed to the {@link @azure/communication-calling#VideoStreamRenderer}.
    */
   createView(
     callId: string | undefined,
@@ -103,11 +103,11 @@ export interface StatefulCallClient extends CallClient {
     options?: CreateViewOptions
   ): Promise<void>;
   /**
-   * Stops rendering a {@Link RemoteVideoStreamState} or {@Link LocalVideoStreamState} and removes the
-   * {@Link VideoStreamRendererView} from the relevant {@Link RemoteVideoStreamState} in {@Link CallClientState} or
-   * {@Link LocalVideoStream} in {@Link CallClientState} or appropriate
-   * {@Link CallClientState.deviceManager.unparentedViews} Under the hood calls
-   * {@Link @azure/communication-calling#VideoStreamRenderer.dispose}.
+   * Stops rendering a {@link RemoteVideoStreamState} or {@link LocalVideoStreamState} and removes the
+   * {@link VideoStreamRendererView} from the relevant {@link RemoteVideoStreamState} in {@link CallClientState} or
+   * {@link LocalVideoStream} in {@link CallClientState} or appropriate
+   * {@link CallClientState.deviceManager.unparentedViews} Under the hood calls
+   * {@link @azure/communication-calling#VideoStreamRenderer.dispose}.
    *
    * Its important to disposeView to clean up resources properly.
    *
@@ -122,7 +122,7 @@ export interface StatefulCallClient extends CallClient {
    * - LocalVideoStreamState must be the original one passed to createView.
    *
    * @param callId - CallId for the given stream. Can be undefined if the stream is not part of any call.
-   * @param participantId - {@Link RemoteParticipant.identifier} associated with the given RemoteVideoStreamState. Could
+   * @param participantId - {@link RemoteParticipant.identifier} associated with the given RemoteVideoStreamState. Could
    *   be undefined if disposing LocalVideoStreamState.
    * @param stream - The LocalVideoStreamState or RemoteVideoStreamState to dispose.
    */
@@ -134,7 +134,7 @@ export interface StatefulCallClient extends CallClient {
 }
 
 /**
- * ProxyCallClient proxies CallClient {@Link @azure/communication-calling#CallClient} and subscribes to all events that
+ * ProxyCallClient proxies CallClient {@link @azure/communication-calling#CallClient} and subscribes to all events that
  * affect state. ProxyCallClient keeps its own copy of the call state and when state is updated, ProxyCallClient emits
  * the event 'stateChanged'.
  */
@@ -218,16 +218,16 @@ export type StatefulCallClientOptions = {
 };
 
 /**
- * Creates a StatefulCallClient {@Link StatefulCallClient} by proxying CallClient
- * {@Link @azure/communication-calling#CallClient} with ProxyCallClient {@Link ProxyCallClient} which then allows access
+ * Creates a StatefulCallClient {@link StatefulCallClient} by proxying CallClient
+ * {@link @azure/communication-calling#CallClient} with ProxyCallClient {@link ProxyCallClient} which then allows access
  * to state in a declarative way.
  *
- * It is important to use the {@Link @azure/communication-calling#DeviceManager} and
- * {@Link @azure/communication-calling#CallAgent} and {@Link @azure/communication-calling#Call} (and etc.) that are
+ * It is important to use the {@link @azure/communication-calling#DeviceManager} and
+ * {@link @azure/communication-calling#CallAgent} and {@link @azure/communication-calling#Call} (and etc.) that are
  * obtained from the StatefulCallClient in order for their state changes to be proxied properly.
  *
- * @param args - {@Link StatefulCallClientArgs}
- * @param options - {@Link StatefulCallClientOptions}
+ * @param args - {@link StatefulCallClientArgs}
+ * @param options - {@link StatefulCallClientOptions}
  * @returns
  */
 export const createStatefulCallClient = (

--- a/packages/chat-stateful-client/src/ChatClientState.ts
+++ b/packages/chat-stateful-client/src/ChatClientState.ts
@@ -11,13 +11,13 @@ export type ChatClientState = {
   displayName: string;
   /**
    * Chat threads joined by the current user.
-   * Object with {@Link ChatThreadClientState} fields, keyed by {@Link ChatThreadClientState.threadId}.
+   * Object with {@link ChatThreadClientState} fields, keyed by {@link ChatThreadClientState.threadId}.
    */
   threads: { [key: string]: ChatThreadClientState };
   /**
    * Stores the latest error for each API method.
    *
-   * See documentation of {@Link ChatErrors} for details.
+   * See documentation of {@link ChatErrors} for details.
    */
   latestErrors: ChatErrors;
 };
@@ -25,16 +25,16 @@ export type ChatClientState = {
 export type ChatThreadClientState = {
   /**
    * Messages in this thread.
-   * Object with {@Link ChatMessageWithStatus} entries
-   * Local messages are keyed by keyed by {@Link ChatMessageWithStatus.clientMessageId}.
-   * Remote messages are keyed by {@Link @azure/communication-chat#ChatMessage.id}.
+   * Object with {@link ChatMessageWithStatus} entries
+   * Local messages are keyed by keyed by {@link ChatMessageWithStatus.clientMessageId}.
+   * Remote messages are keyed by {@link @azure/communication-chat#ChatMessage.id}.
    */
   chatMessages: { [key: string]: ChatMessageWithStatus };
   /**
    * Participants of this chat thread.
    *
-   * Object with {@Link @azure/communication-chat#ChatParticipant} fields,
-   * keyed by {@Link @azure/communication-chat#ChatParticipant.id}.
+   * Object with {@link @azure/communication-chat#ChatParticipant} fields,
+   * keyed by {@link @azure/communication-chat#ChatParticipant.id}.
    */
   participants: { [key: string]: ChatParticipant };
   threadId: string;
@@ -57,7 +57,7 @@ export type ChatThreadProperties = {
  *
  * Each property in the object stores the latest error for a particular SDK API method.
  *
- * Errors from this object can be cleared by calling the TODO(implement me) {@Link clearError} method.
+ * Errors from this object can be cleared by calling the TODO(implement me) {@link clearError} method.
  * Additionally, errors are automatically cleared when:
  * - The state is cleared.
  * - Subsequent calls to related API methods succeed.
@@ -90,7 +90,7 @@ export class ChatError extends Error {
 }
 
 /**
- * String literal type for all permissible keys in {@Link ChatErrors}.
+ * String literal type for all permissible keys in {@link ChatErrors}.
  */
 export type ChatErrorTargets =
   | 'ChatClient.createChatThread'

--- a/packages/chat-stateful-client/src/StatefulChatClient.ts
+++ b/packages/chat-stateful-client/src/StatefulChatClient.ts
@@ -101,7 +101,7 @@ const proxyChatClient: ProxyHandler<ChatClient> = {
 };
 
 /**
- * Required arguments to construct the {@Link StatefulChatClient}.
+ * Required arguments to construct the {@link StatefulChatClient}.
  */
 export type StatefulChatClientArgs = {
   userId: CommunicationIdentifierKind;
@@ -111,11 +111,11 @@ export type StatefulChatClientArgs = {
 };
 
 /**
- * Options to construct the {@Link StatefulChatClient} with.
+ * Options to construct the {@link StatefulChatClient} with.
  */
 export type StatefulChatClientOptions = {
   /**
-   * Options to construct the {@Link @azure/communication-chat#ChatClient} with.
+   * Options to construct the {@link @azure/communication-chat#ChatClient} with.
    */
   chatClientOptions: ChatClientOptions;
   /**
@@ -126,8 +126,8 @@ export type StatefulChatClientOptions = {
 };
 
 /**
- * Creates a stateful ChatClient {@Link StatefulChatClient} by proxying ChatClient
- * {@Link @azure/communication-chat#ChatClient} with ProxyChatClient {@Link ProxyChatClient} which then allows access
+ * Creates a stateful ChatClient {@link StatefulChatClient} by proxying ChatClient
+ * {@link @azure/communication-chat#ChatClient} with ProxyChatClient {@link ProxyChatClient} which then allows access
  * to state in a declarative way.
  */
 export const createStatefulChatClient = (
@@ -142,7 +142,7 @@ export const createStatefulChatClient = (
 };
 
 /**
- * Internal implementation of {@Link createStatefulChatClient} for dependency injection.
+ * Internal implementation of {@link createStatefulChatClient} for dependency injection.
  *
  * Used by tests. Should not be exported out of this package.
  */

--- a/packages/chat-stateful-client/src/TypeAssertions.ts
+++ b/packages/chat-stateful-client/src/TypeAssertions.ts
@@ -5,19 +5,19 @@ import { ChatClient, ChatThreadClient } from '@azure/communication-chat';
 import { ChatErrorTargets } from './ChatClientState';
 
 /**
- * Internal type-assertion that explicitly listed {@Link ChatErrorTargets} correspond to the underlying base SDK API.
+ * Internal type-assertion that explicitly listed {@link ChatErrorTargets} correspond to the underlying base SDK API.
  */
 export const ensureChatErrorTargetsContainsOnlyValidValues = (target: ChatErrorTargets): InferredChatErrorTargets =>
   target;
 
 /**
- * Internal type-assertion that explicitly listed {@Link ChatErrorTargets} correspond to the underlying base SDK API.
+ * Internal type-assertion that explicitly listed {@link ChatErrorTargets} correspond to the underlying base SDK API.
  */
 export const ensureChatErrorTargetsContainsAllValidValues = (target: InferredChatErrorTargets): ChatErrorTargets =>
   target;
 
 /**
- * String literal type for all permissible keys in {@Link ChatErrors}.
+ * String literal type for all permissible keys in {@link ChatErrors}.
  */
 type InferredChatErrorTargets =
   | ChatObjectMethodNames<'ChatClient', ChatClient>

--- a/packages/chat-stateful-client/src/iterators/createDecoratedIterator.ts
+++ b/packages/chat-stateful-client/src/iterators/createDecoratedIterator.ts
@@ -62,8 +62,8 @@ export const createDecoratedIterator = <ItemType, OptionsType>(
  *
  * @param iteratorCreator Function that creates the base iteartor
  * @param context The ChatContext that stores all internal state.
- * @param target See {@Link ChatContext.asyncTeeErrorToState}.
- * @param clearTargets See {@Link ChatContext.asyncTeeErrorToState}.
+ * @param target See {@link ChatContext.asyncTeeErrorToState}.
+ * @param clearTargets See {@link ChatContext.asyncTeeErrorToState}.
  * @returns A function to create an iterator that handles errors when iterting over the iterator from `iteratorCreator`.
  */
 export const createErrorHandlingIterator = <ItemType, OptionsType>(

--- a/packages/react-components/src/components/ErrorBar.tsx
+++ b/packages/react-components/src/components/ErrorBar.tsx
@@ -6,10 +6,10 @@ import { IMessageBarProps, MessageBar, MessageBarType, Stack } from '@fluentui/r
 import { useLocale } from '../localization';
 
 /**
- * {@Link ErrorBar} properties.
+ * {@link ErrorBar} properties.
  *
- * In addition to the following, {@Link ErrorBar} forwards all
- * {@Link @fluentui/react#IMessageBarProps} to the underlying {@Link @fluentui/react#MessageBar}.
+ * In addition to the following, {@link ErrorBar} forwards all
+ * {@link @fluentui/react#IMessageBarProps} to the underlying {@link @fluentui/react#MessageBar}.
  */
 export interface ErrorBarProps extends IMessageBarProps {
   /**
@@ -20,18 +20,18 @@ export interface ErrorBarProps extends IMessageBarProps {
   /**
    * Currently active errors.
    *
-   * When the error is cleared, the {@Link ErrorBar} must be removed instead of clearing {@Link ErrorBarProps.activeError}.
+   * When the error is cleared, the {@link ErrorBar} must be removed instead of clearing {@link ErrorBarProps.activeError}.
    */
   activeErrors: ErrorType[];
 
   /**
-   * Callback trigerred when the {@Link MessageBar} for an active error is dismissed.
+   * Callback trigerred when the {@link MessageBar} for an active error is dismissed.
    */
   onDismissErrors: (errorTypes: ErrorType[]) => void;
 }
 
 /**
- * All strings that may be shown on the UI in the {@Link ErrorBar}.
+ * All strings that may be shown on the UI in the {@link ErrorBar}.
  */
 export interface ErrorBarStrings {
   /**
@@ -52,7 +52,7 @@ export interface ErrorBarStrings {
   /**
    * User is no longer on the thread.
    *
-   * See also: {@Link ErrorBarStrings.sendMessageNotInThisThread} for a more specific error.
+   * See also: {@link ErrorBarStrings.sendMessageNotInThisThread} for a more specific error.
    */
   userNotInThisThread: string;
 
@@ -69,16 +69,16 @@ export interface ErrorBarStrings {
 }
 
 /**
- * All errors that can be shown in the {@Link ErrorBar}.
+ * All errors that can be shown in the {@link ErrorBar}.
  */
 export type ErrorType = keyof ErrorBarStrings;
 
 /**
  * A component to show error messages on the UI.
- * All strings that can be shown are accepted as the {@Link ErrorBarProps.strings} so that they can be localized.
- * Active errors are selected by {@Link ErrorBarProps.activeErrors}.
+ * All strings that can be shown are accepted as the {@link ErrorBarProps.strings} so that they can be localized.
+ * Active errors are selected by {@link ErrorBarProps.activeErrors}.
  *
- * Uses {@Link @fluentui/react#MessageBar} UI element.
+ * Uses {@link @fluentui/react#MessageBar} UI element.
  */
 export const ErrorBar = (props: ErrorBarProps): JSX.Element => {
   const localeStrings = useLocale().strings.errorBar;

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
@@ -50,7 +50,7 @@ export interface ChatAdapter {
   setTopic(topicName: string): Promise<void>;
   loadPreviousChatMessages(messagesToLoad: number): Promise<boolean>;
   /**
-   * Clear errors for given error types from {@Link ChatAdapter.getState.latestErrors}.
+   * Clear errors for given error types from {@link ChatAdapter.getState.latestErrors}.
    */
   clearErrors(errorTypes: ErrorType[]): void;
   on(event: 'messageReceived', listener: MessageReceivedListener): void;
@@ -84,8 +84,8 @@ export type ParticipantsRemovedListener = (event: {
 /**
  * Listener for error events.
  *
- * Each failed operation in the {@Link ChatAdapter} triggers an 'error' event.
- * `operation` is a {@Link ChatAdapter} defined string for each unique operation performed
+ * Each failed operation in the {@link ChatAdapter} triggers an 'error' event.
+ * `operation` is a {@link ChatAdapter} defined string for each unique operation performed
  * by the adapter.
  */
 export type ChatErrorListener = (event: { operation: string; error: Error }) => void;

--- a/packages/react-composites/src/composites/common/PermissionsBanner.tsx
+++ b/packages/react-composites/src/composites/common/PermissionsBanner.tsx
@@ -61,7 +61,7 @@ export const getPermissionsBannerMessage = (
  * assumed to not happen by this component. If the banner was dismissed, it will be dismissed for the current state of
  * the props and stay dismissed even if permission change after dismissal.
  *
- * @param props {@Link PermissionsBannerProps}
+ * @param props {@link PermissionsBannerProps}
  */
 export const PermissionsBanner = (props: PermissionsBannerProps): JSX.Element => {
   const { cameraPermissionGranted, microphonePermissionGranted } = props;


### PR DESCRIPTION
# What
Update typos where we have `@Link` instead of `@link`

(just a big find and replace)

# Why
Our docs our available on dcom and `@Link` does not work. Also fixes documentation links in vscode intellisense.
