### PR TITLE
Fix partially composed chat messages being lost

### DIFF
--- a/packages/react-components/src/components/styles/SendBox.styles.ts
+++ b/packages/react-components/src/components/styles/SendBox.styles.ts
@@ -41,7 +41,7 @@ export const suppressIconStyle = {
 };
 
 export const sendBoxStyle = mergeStyles({
-  minHeight: '0',
+  minHeight: '2.25rem', // prevents the input text box from being sized to 0px when the meeting composite chat pane is closed.
   maxHeight: '8.25rem',
   outline: 'red 5px',
   fontWeight: 400,

--- a/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
@@ -31,7 +31,7 @@ export type MeetingCompositeProps = {
  * Meeting Composite brings together key components to provide a full meeting experience out of the box.
  */
 export const MeetingComposite = (props: MeetingCompositeProps): JSX.Element => {
-  const { callAdapter, fluentTheme } = props;
+  const { callAdapter, chatAdapter, fluentTheme } = props;
 
   const [currentCallState, setCurrentCallState] = useState<CallState>();
   const [currentPage, setCurrentPage] = useState<CallCompositePage>();
@@ -70,12 +70,17 @@ export const MeetingComposite = (props: MeetingCompositeProps): JSX.Element => {
         <Stack.Item grow>
           <CallCompositeInternal showCallControls={false} adapter={callAdapter} fluentTheme={fluentTheme} />
         </Stack.Item>
-        {showChat && (
-          <EmbeddedChatPane chatAdapter={props.chatAdapter} fluentTheme={props.fluentTheme} onClose={closePane} />
+        {chatAdapter && (
+          <EmbeddedChatPane
+            hidden={!showChat}
+            chatAdapter={chatAdapter}
+            fluentTheme={props.fluentTheme}
+            onClose={closePane}
+          />
         )}
-        {showPeople && (
-          <CallAdapterProvider adapter={props.callAdapter}>
-            <EmbeddedPeoplePane inviteLink={props.meetingInvitationURL} onClose={closePane} />
+        {callAdapter && (
+          <CallAdapterProvider adapter={callAdapter}>
+            <EmbeddedPeoplePane hidden={!showPeople} inviteLink={props.meetingInvitationURL} onClose={closePane} />
           </CallAdapterProvider>
         )}
       </Stack>

--- a/packages/react-composites/src/composites/MeetingComposite/SidePane.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/SidePane.tsx
@@ -2,9 +2,10 @@
 // Licensed under the MIT license.
 import React from 'react';
 import { ChatComposite, ChatAdapter } from '../ChatComposite';
-import { CommandBarButton, DefaultButton, PartialTheme, Theme, Stack } from '@fluentui/react';
+import { CommandBarButton, DefaultButton, PartialTheme, Theme, Stack, mergeStyles } from '@fluentui/react';
 import {
   sidePaneCloseButtonStyles,
+  sidePaneContainerHiddenStyles,
   sidePaneContainerStyles,
   sidePaneContainerTokens,
   sidePaneHeaderStyles,
@@ -18,9 +19,18 @@ import { ParticipantList } from '@internal/react-components';
 import copy from 'copy-to-clipboard';
 import { usePropsFor } from '../CallComposite/hooks/usePropsFor';
 
-const SidePane = (props: { headingText: string; children: React.ReactNode; onClose: () => void }): JSX.Element => {
+const SidePane = (props: {
+  headingText: string;
+  children: React.ReactNode;
+  onClose: () => void;
+  hidden: boolean;
+}): JSX.Element => {
+  // We hide the side pane instead of not rendering the entire pane to persist certain elements
+  // between renders. An example of this is composing a chat message - a chat message that has been
+  // typed but not sent should not be lost if the side panel is closed and then reopened.
+  const sidePaneStyles = props.hidden ? sidePaneContainerHiddenStyles : sidePaneContainerStyles;
   return (
-    <Stack styles={sidePaneContainerStyles} tokens={sidePaneContainerTokens}>
+    <Stack styles={sidePaneStyles} tokens={sidePaneContainerTokens}>
       <Stack.Item>
         <Stack horizontal horizontalAlign="space-between" styles={sidePaneHeaderStyles}>
           <Stack.Item>{props.headingText}</Stack.Item>
@@ -42,11 +52,15 @@ const SidePane = (props: { headingText: string; children: React.ReactNode; onClo
   );
 };
 
-export const EmbeddedPeoplePane = (props: { inviteLink?: string; onClose: () => void }): JSX.Element => {
+export const EmbeddedPeoplePane = (props: {
+  inviteLink?: string;
+  onClose: () => void;
+  hidden: boolean;
+}): JSX.Element => {
   const { inviteLink } = props;
   const participantListProps = usePropsFor(ParticipantList);
   return (
-    <SidePane headingText={'People'} onClose={props.onClose}>
+    <SidePane hidden={props.hidden} headingText={'People'} onClose={props.onClose}>
       <Stack tokens={peoplePaneContainerTokens}>
         {inviteLink && (
           <DefaultButton text="Copy invite link" iconProps={{ iconName: 'Link' }} onClick={() => copy(inviteLink)} />
@@ -61,10 +75,11 @@ export const EmbeddedPeoplePane = (props: { inviteLink?: string; onClose: () => 
 export const EmbeddedChatPane = (props: {
   chatAdapter: ChatAdapter;
   fluentTheme?: PartialTheme | Theme;
+  hidden: boolean;
   onClose: () => void;
 }): JSX.Element => {
   return (
-    <SidePane headingText={'Chat'} onClose={props.onClose}>
+    <SidePane hidden={props.hidden} headingText={'Chat'} onClose={props.onClose}>
       <ChatComposite adapter={props.chatAdapter} fluentTheme={props.fluentTheme} />
     </SidePane>
   );

--- a/packages/react-composites/src/composites/MeetingComposite/styles/SidePane.styles.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/styles/SidePane.styles.ts
@@ -15,6 +15,13 @@ export const sidePaneContainerStyles: IStackItemStyles = {
   }
 };
 
+export const sidePaneContainerHiddenStyles: IStackItemStyles = {
+  root: {
+    ...sidePaneContainerStyles,
+    display: 'none'
+  }
+};
+
 export const sidePaneContainerTokens: IStackTokens = {
   childrenGap: '0.5rem'
 };


### PR DESCRIPTION
# What
Only hide the side panes in the meeting composite instead of not rendering them completely

# Why
Partially composed chat messages are lost when the chat pane is opened and closed in meeting composite

# How Tested
In storybook > Meeting Composite > Basic Example > Open Chat > Type Message > Close Chat > Open Chat -- typed message is still there