### PR TITLE
Fix meeting composite chat pane being squashed by permission banner

### DIFF
--- a/packages/react-composites/src/composites/MeetingComposite/SidePane.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/SidePane.tsx
@@ -20,8 +20,8 @@ import { usePropsFor } from '../CallComposite/hooks/usePropsFor';
 
 const SidePane = (props: { headingText: string; children: React.ReactNode; onClose: () => void }): JSX.Element => {
   return (
-    <Stack styles={sidePaneContainerStyles} tokens={sidePaneContainerTokens}>
-      <Stack.Item>
+    <Stack.Item disableShrink verticalFill styles={sidePaneContainerStyles} tokens={sidePaneContainerTokens}>
+      <Stack verticalFill>
         <Stack horizontal horizontalAlign="space-between" styles={sidePaneHeaderStyles}>
           <Stack.Item>{props.headingText}</Stack.Item>
           <CommandBarButton
@@ -30,15 +30,15 @@ const SidePane = (props: { headingText: string; children: React.ReactNode; onClo
             onClick={props.onClose}
           />
         </Stack>
-      </Stack.Item>
-      <Stack grow styles={paneBodyContainer}>
-        <Stack horizontal styles={scrollableContainer}>
-          <Stack.Item verticalFill styles={scrollableContainerContents}>
-            {props.children}
-          </Stack.Item>
-        </Stack>
+        <Stack.Item verticalFill grow styles={paneBodyContainer}>
+          <Stack horizontal styles={scrollableContainer}>
+            <Stack.Item verticalFill styles={scrollableContainerContents}>
+              {props.children}
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
       </Stack>
-    </Stack>
+    </Stack.Item>
   );
 };
 

--- a/packages/react-composites/src/composites/common/styles/PermissionsBanner.styles.ts
+++ b/packages/react-composites/src/composites/common/styles/PermissionsBanner.styles.ts
@@ -8,7 +8,16 @@ export const permissionsBannerContainerStyle = {
 };
 
 export const permissionsBannerMessageBarStyle: IStyleFunctionOrObject<IMessageBarStyleProps, IMessageBarStyles> = {
-  content: { alignItems: 'center', justifyContent: 'center', position: 'relative' },
-  text: { flexGrow: '0' },
-  actions: { position: 'absolute', right: '0px' }
+  root: {
+    // Constrain permission banner height if there is a long error message in a narrow space.
+    maxHeight: '5rem'
+  },
+  text: {
+    // Ensure the dismiss action button is aligned to the right hand side by allowing text to grow to available space
+    flexGrow: '1',
+
+    // Allow errors to be multi-line. We use this property instead of `isMultiline={true}` to ensure the action button
+    // does not take a new line and is instead placed to the right hand side of the error message.
+    span: { whiteSpace: 'normal' }
+  }
 };


### PR DESCRIPTION
# What
Update permission banner styles:
* Allow multiline
  * Give a max height to ensure it isn't ridiculously sized
* Update dismiss button position to be right-aligned by the grow property of the text and not positioned in a fixed manner to the right hand side
  * This fixed text going below the dismiss button:
  ![image](https://user-images.githubusercontent.com/2684369/128955267-574b584d-52e5-48b4-8e40-a89a15242120.png)

Fix chat being squashed by the permission banner:
* Disable shrink of the side panel (by restructuring the side panel stacks and applying `disableShrink` prop)

# Why
Error messages were causing the chat side panel to be squashed:
![image](https://user-images.githubusercontent.com/2684369/128955473-a6333eed-bc78-4de0-9aad-8fc42fdfdace.png)

# How Tested
Screenshots after fix:
| narrow | wide |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/2684369/128955533-6638724b-8a6a-4ea8-a30c-2a75e2410a4f.png) | ![image](https://user-images.githubusercontent.com/2684369/128955543-4075abfd-d0cd-48db-a87f-293c993450a8.png) |