### PR TITLE
Fix button flyouts going out of bounds of the screen

### DIFF
--- a/change/@internal-react-components-c63ff8cf-fd22-4351-af00-1ab51186a30a.json
+++ b/change/@internal-react-components-c63ff8cf-fd22-4351-af00-1ab51186a30a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix button menu flyouts exceeding screen width",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/OptionsButton.tsx
+++ b/packages/react-components/src/components/OptionsButton.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { MoreHorizontal20Filled, Video20Regular } from '@fluentui/react-icons';
-import { IContextualMenuItem, ContextualMenuItemType, Theme } from '@fluentui/react';
+import { IContextualMenuItem, IContextualMenuProps, ContextualMenuItemType, Theme } from '@fluentui/react';
 import { useTheme } from '../theming';
 import { useLocale } from '../localization';
 import { ControlBarButton, ControlBarButtonProps } from './ControlBarButton';
@@ -126,7 +126,13 @@ const generateDefaultMenuProps = (
     onSelectSpeaker
   } = props;
 
-  const defaultMenuProps: { items: IContextualMenuItem[] } = { items: [] };
+  const defaultMenuProps: IContextualMenuProps = {
+    items: [],
+
+    // Confine the menu to the parents bounds.
+    // More info: https://github.com/microsoft/fluentui/issues/18835
+    calloutProps: { styles: { root: { maxWidth: '100%' } } }
+  };
 
   if (cameras && selectedCamera && onSelectCamera) {
     defaultMenuProps.items.push({

--- a/packages/react-components/src/components/ParticipantsButton.tsx
+++ b/packages/react-components/src/components/ParticipantsButton.tsx
@@ -168,7 +168,11 @@ export const ParticipantsButton = (props: ParticipantsButtonProps): JSX.Element 
         name: formatString(strings.participantsListButtonLabel, { numParticipants: `${participantCountWithoutMe}` }),
         iconProps: { iconName: 'People' },
         subMenuProps: {
-          items: generateDefaultParticipantsSubMenuProps()
+          items: generateDefaultParticipantsSubMenuProps(),
+
+          // Confine the menu to the parents bounds.
+          // More info: https://github.com/microsoft/fluentui/issues/18835
+          calloutProps: { styles: { root: { maxWidth: '100%' } } }
         }
       });
     }

--- a/samples/Calling/src/index.css
+++ b/samples/Calling/src/index.css
@@ -21,15 +21,6 @@ html,
   justify-content: center;
 }
 
-/*
-  This is a quick fix for: https://github.com/microsoft/fluentui/issues/18835.
-  WARNING: this is being applied to the sample, customers using the composite will
-  still hit this.
-*/
-.ms-Callout {
-  max-width: 100%;
-}
-
 .ui-provider {
   height: 0;
 }


### PR DESCRIPTION
# What
Confine button flyouts to parents width

# Why
Button flyouts can exceed the screen/parent (see screenshots)

More info: https://github.com/microsoft/fluentui/issues/18835

# How Tested
| before | after |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/2684369/129073478-6efcdb47-18ed-4715-bca6-cbcbbe6b5d9f.png) | ![image](https://user-images.githubusercontent.com/2684369/129073470-9f91601f-5987-48ac-8b40-064d1be54f2e.png) |
| ![image](https://user-images.githubusercontent.com/2684369/129073496-f766001a-5638-41f9-8a67-fd89d75396bc.png) | ![image](https://user-images.githubusercontent.com/2684369/129073490-595a6706-895e-4f85-8664-9f135022deb5.png) |
