### PR TITLE
Update GitHub action to not comment about visual regression tests if build fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,13 @@ jobs:
         env:
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
       - name: Upload snapshot diff
-        if: ${{ steps.visualregressiontests.outcome != 'success' }}
+        if: ${{ always() && steps.visualregressiontests.outcome != 'success' }}
         uses: actions/upload-artifact@v2
         with:
           name: snapshots
           path: samples/StaticHtmlComposites/test-results/ # or path/to/artifact
       - name: Comment on PR
-        if: ${{ github.event_name == 'pull_request' && steps.visualregressiontests.outcome != 'success' && !contains( github.event.pull_request.labels.*.name, 'ui change') }}
+        if: ${{ github.event_name == 'pull_request' && always() && steps.visualregressiontests.outcome != 'success' && !contains( github.event.pull_request.labels.*.name, 'ui change') }}
         uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,19 +160,20 @@ jobs:
       - name: Build
         run: rush build -t sample-static-html-composites
       - name: Visual Regression Tests
+        id: visualregressiontests
         run: |
           cd samples/StaticHtmlComposites
           rushx test:e2e
         env:
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
       - name: Upload snapshot diff
-        if: failure()
+        if: steps.visualregressiontests.outcome != 'success'
         uses: actions/upload-artifact@v2
         with:
           name: snapshots
           path: samples/StaticHtmlComposites/test-results/ # or path/to/artifact
       - name: Comment on PR
-        if: ${{ github.event_name == 'pull_request' && failure() && !contains( github.event.pull_request.labels.*.name, 'ui change') }}
+        if: ${{ github.event_name == 'pull_request' && steps.visualregressiontests.outcome != 'success' && !contains( github.event.pull_request.labels.*.name, 'ui change') }}
         uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         env:
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
       - name: Upload snapshot diff
-        if: ${{ failure() && steps.visualregressiontests.outcome != 'success' }}
+        if: ${{ steps.visualregressiontests.outcome != 'success' }}
         uses: actions/upload-artifact@v2
         with:
           name: snapshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,8 @@ jobs:
         run: rush build -t sample-static-html-composites
       - name: Visual Regression Tests
         id: visualregressiontests
-        run: this run will fail but should comment on PR
+        run: |
+          false
         env:
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
       - name: Upload snapshot diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,18 +154,16 @@ jobs:
         with:
           node-version: '14.x'
       - name: Install rush
-        run: |
-          true
+        run: npm install -g @microsoft/rush@5.47.0
       - name: Install dependencies
-        run: |
-          true
+        run: rush install
       - name: Build
-        run: |
-          true
+        run: rush build -t sample-static-html-composites
       - name: Visual Regression Tests
         id: visualregressiontests
         run: |
-          true
+          cd samples/StaticHtmlComposites
+          rushx test:e2e
         env:
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
       - name: Upload snapshot diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           true
       - name: Build
         run: |
-          false
+          true
       - name: Visual Regression Tests
         id: visualregressiontests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,13 @@ jobs:
         env:
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
       - name: Upload snapshot diff
-        if: ${{ always() && steps.visualregressiontests.outcome != 'success' }}
+        if: ${{ always() && steps.visualregressiontests.outcome == 'failure' }}
         uses: actions/upload-artifact@v2
         with:
           name: snapshots
           path: samples/StaticHtmlComposites/test-results/ # or path/to/artifact
       - name: Comment on PR
-        if: ${{ github.event_name == 'pull_request' && always() && steps.visualregressiontests.outcome != 'success' && !contains( github.event.pull_request.labels.*.name, 'ui change') }}
+        if: ${{ github.event_name == 'pull_request' && always() && steps.visualregressiontests.outcome == 'failure' && !contains( github.event.pull_request.labels.*.name, 'ui change') }}
         uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,14 @@ jobs:
         with:
           node-version: '14.x'
       - name: Install rush
-        run: npm install -g @microsoft/rush@5.47.0
+        run: |
+          true
       - name: Install dependencies
-        run: rush install
+        run: |
+          true
       - name: Build
-        run: rush build -t sample-static-html-composites
+        run: |
+          true
       - name: Visual Regression Tests
         id: visualregressiontests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Install dependencies
         run: rush install
       - name: Build
-        run: rush build -t sample-static-html-composites
+        run: this will fail
       - name: Visual Regression Tests
         id: visualregressiontests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,11 +161,11 @@ jobs:
           true
       - name: Build
         run: |
-          true
+          false
       - name: Visual Regression Tests
         id: visualregressiontests
         run: |
-          false
+          true
         env:
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
       - name: Upload snapshot diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         env:
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
       - name: Upload snapshot diff
-        if: steps.visualregressiontests.outcome != 'success'
+        if: ${{ failure() && steps.visualregressiontests.outcome != 'success' }}
         uses: actions/upload-artifact@v2
         with:
           name: snapshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,12 +158,10 @@ jobs:
       - name: Install dependencies
         run: rush install
       - name: Build
-        run: this will fail
+        run: rush build -t sample-static-html-composites
       - name: Visual Regression Tests
         id: visualregressiontests
-        run: |
-          cd samples/StaticHtmlComposites
-          rushx test:e2e
+        run: this run will fail but should comment on PR
         env:
           CONNECTION_STRING: ${{ secrets.CONNECTION_STRING }}
       - name: Upload snapshot diff


### PR DESCRIPTION
# What
Quick fix to ensure github action only comments about visual regression tests when the tests fail and not the build fails

# Why
When the packages build fails you would get a PR comment saying that you should update the UI tests. This comment should only happen if the _tests_ fail and not if the build step fails

# How Tested
Many CI runs, verified:
* All passes - no comment
* Build failes - no comment
* Build passes but tests fail - adds the comment
