### PR TITLE
Fix more instances of trivial VideoTile render elements

### DIFF
--- a/change/@internal-react-composites-fab28728-d56a-40cf-b435-18423977bd20.json
+++ b/change/@internal-react-composites-fab28728-d56a-40cf-b435-18423977bd20.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix: Show avatar when video is off",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/Lobby.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Lobby.tsx
@@ -62,7 +62,7 @@ export const Lobby = (props: LobbyProps): JSX.Element => {
   return (
     <VideoTile
       styles={videoTileStyles}
-      renderElement={<StreamMedia videoStreamElement={renderElement ?? null} />}
+      renderElement={renderElement ? <StreamMedia videoStreamElement={renderElement} /> : undefined}
       onRenderPlaceholder={onRenderEmptyPlaceholder}
     >
       <div

--- a/packages/react-composites/src/composites/CallComposite/ScreenShare.tsx
+++ b/packages/react-composites/src/composites/CallComposite/ScreenShare.tsx
@@ -37,7 +37,7 @@ const memoizeAllRemoteParticipants = memoizeFnAll(
           <VideoTile
             styles={stackContainerParticipantVideoStyles}
             userId={userId}
-            renderElement={<StreamMedia videoStreamElement={renderElement ?? null} />}
+            renderElement={renderElement ? <StreamMedia videoStreamElement={renderElement} /> : undefined}
             displayName={displayName}
             isMuted={isMuted}
           />
@@ -86,7 +86,11 @@ export const ScreenShare = (props: ScreenShareProps): JSX.Element => {
       <VideoTile
         displayName={screenShareParticipant?.displayName}
         isMuted={screenShareParticipant?.isMuted}
-        renderElement={<StreamMedia videoStreamElement={screenShareStream?.renderElement ?? null} />}
+        renderElement={
+          screenShareStream?.renderElement ? (
+            <StreamMedia videoStreamElement={screenShareStream?.renderElement} />
+          ) : undefined
+        }
         onRenderPlaceholder={onRenderPlaceholder}
         styles={{
           overlayContainer: videoStreamStyle
@@ -112,7 +116,11 @@ export const ScreenShare = (props: ScreenShareProps): JSX.Element => {
       <VideoTile
         styles={stackContainerParticipantVideoStyles}
         isMuted={localParticipant?.isMuted}
-        renderElement={<StreamMedia videoStreamElement={localVideoStream?.renderElement ?? null} />}
+        renderElement={
+          localVideoStream?.renderElement ? (
+            <StreamMedia videoStreamElement={localVideoStream?.renderElement} />
+          ) : undefined
+        }
         displayName={localParticipant?.displayName}
       />
     );

--- a/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/Lobby.stories.storyshot
+++ b/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/Lobby.stories.storyshot
@@ -25,13 +25,9 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
       >
         <div
           className="ms-Stack css-7"
-        >
-          <div
-            className="css-71"
-          />
-        </div>
+        />
         <div
-          className="ms-Stack css-81 css-8"
+          className="ms-Stack css-80 css-8"
         >
           <div
             className="ms-Stack css-9"

--- a/packages/storybook/stories/Examples/TeamsInterop/snippets/Lobby.snippet.tsx
+++ b/packages/storybook/stories/Examples/TeamsInterop/snippets/Lobby.snippet.tsx
@@ -34,14 +34,15 @@ export const Lobby = (props: LobbyProps): JSX.Element => {
 
   // Helper code to make the storybook work. Replace with your own code for video stream element.
   const videoStreams = useVideoStreams(1);
-  const videoStreamElement = props.isVideoReady ? videoStreams[0] : null;
+  const videoStreamElement = props.isVideoReady ? videoStreams[0];
+  const videoRenderElement = videoStreamElement ? <StreamMedia videoStreamElement={videoStreamElement} /> : undefined;
 
   return (
     <VideoTile
       styles={videoTileStyles}
       isMirrored={true}
       onRenderPlaceholder={() => <></>}
-      renderElement={<StreamMedia videoStreamElement={videoStreamElement} />}
+      renderElement={videoRenderElement}
     >
       <div
         style={{

--- a/packages/storybook/stories/Examples/TeamsInterop/snippets/Lobby.snippet.tsx
+++ b/packages/storybook/stories/Examples/TeamsInterop/snippets/Lobby.snippet.tsx
@@ -34,7 +34,7 @@ export const Lobby = (props: LobbyProps): JSX.Element => {
 
   // Helper code to make the storybook work. Replace with your own code for video stream element.
   const videoStreams = useVideoStreams(1);
-  const videoStreamElement = props.isVideoReady ? videoStreams[0];
+  const videoStreamElement = props.isVideoReady ? videoStreams[0] : undefined;
   const videoRenderElement = videoStreamElement ? <StreamMedia videoStreamElement={videoStreamElement} /> : undefined;
 
   return (

--- a/packages/storybook/stories/Examples/Themes/snippets/TeamsTheme.snippet.tsx
+++ b/packages/storybook/stories/Examples/Themes/snippets/TeamsTheme.snippet.tsx
@@ -140,7 +140,7 @@ const App: () => JSX.Element = () => {
         </Stack.Item>
       </Stack>
       <GridLayout>
-        <VideoTile renderElement={null} displayName={'Michael'} styles={videoTileStyle} />
+        <VideoTile displayName={'Michael'} styles={videoTileStyle} />
       </GridLayout>
     </Stack>
   );

--- a/packages/storybook/stories/GridLayout/GridLayout.stories.tsx
+++ b/packages/storybook/stories/GridLayout/GridLayout.stories.tsx
@@ -56,18 +56,13 @@ const GridLayoutStory = (args): JSX.Element => {
   const participantsComponents = useMemo(() => {
     let videoStreamElementIndex = 0;
     return args.participants.map((participant, index) => {
-      let videoStreamElement: HTMLElement | null = null;
+      let videoRenderElement: JSX.Element | undefined = undefined;
       if (participant.isVideoReady) {
-        videoStreamElement = videoStreamElements[videoStreamElementIndex];
+        const videoStreamElement = videoStreamElements[videoStreamElementIndex];
         videoStreamElementIndex++;
+        videoRenderElement = <StreamMedia videoStreamElement={videoStreamElement} />;
       }
-      return (
-        <VideoTile
-          renderElement={<StreamMedia videoStreamElement={videoStreamElement} />}
-          displayName={participant.displayName}
-          key={index}
-        />
-      );
+      return <VideoTile renderElement={videoRenderElement} displayName={participant.displayName} key={index} />;
     });
   }, [args.participants, videoStreamElements]);
 

--- a/packages/storybook/stories/GridLayout/__snapshots__/GridLayout.stories.storyshot
+++ b/packages/storybook/stories/GridLayout/__snapshots__/GridLayout.stories.storyshot
@@ -44,23 +44,65 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               className="ms-Stack css-7"
             >
               <div
-                className="css-71"
-              />
-            </div>
-            <div
-              className="ms-Stack css-81 css-8"
-            >
-              <div
                 className="ms-Stack css-9"
               >
+                <div
+                  aria-label=""
+                  className="ms-Persona ms-Persona--size48 root-10"
+                  style={
+                    Object {
+                      "height": 100,
+                      "minWidth": 100,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-Persona-coin ms-Persona--size48 coin-17"
+                    role="presentation"
+                  >
+                    <div
+                      className="ms-Persona-imageArea imageArea-19"
+                      role="presentation"
+                      style={
+                        Object {
+                          "height": 100,
+                          "width": 100,
+                        }
+                      }
+                    >
+                      <div
+                        aria-hidden="true"
+                        className="ms-Persona-initials initials-22"
+                        style={
+                          Object {
+                            "height": 100,
+                            "width": 100,
+                          }
+                        }
+                      >
+                        <span>
+                          M
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Stack css-80 css-25"
+            >
+              <div
+                className="ms-Stack css-26"
+              >
                 <span
-                  className="css-10"
+                  className="css-27"
                 >
                   Michael
                 </span>
               </div>
               <div
-                className="ms-Stack css-11"
+                className="ms-Stack css-28"
               />
             </div>
           </div>
@@ -71,23 +113,65 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               className="ms-Stack css-7"
             >
               <div
-                className="css-71"
-              />
-            </div>
-            <div
-              className="ms-Stack css-81 css-8"
-            >
-              <div
                 className="ms-Stack css-9"
               >
+                <div
+                  aria-label=""
+                  className="ms-Persona ms-Persona--size48 root-10"
+                  style={
+                    Object {
+                      "height": 100,
+                      "minWidth": 100,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-Persona-coin ms-Persona--size48 coin-17"
+                    role="presentation"
+                  >
+                    <div
+                      className="ms-Persona-imageArea imageArea-19"
+                      role="presentation"
+                      style={
+                        Object {
+                          "height": 100,
+                          "width": 100,
+                        }
+                      }
+                    >
+                      <div
+                        aria-hidden="true"
+                        className="ms-Persona-initials initials-29"
+                        style={
+                          Object {
+                            "height": 100,
+                            "width": 100,
+                          }
+                        }
+                      >
+                        <span>
+                          J
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Stack css-80 css-25"
+            >
+              <div
+                className="ms-Stack css-26"
+              >
                 <span
-                  className="css-10"
+                  className="css-27"
                 >
                   Jim
                 </span>
               </div>
               <div
-                className="ms-Stack css-11"
+                className="ms-Stack css-28"
               />
             </div>
           </div>
@@ -98,23 +182,65 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               className="ms-Stack css-7"
             >
               <div
-                className="css-71"
-              />
-            </div>
-            <div
-              className="ms-Stack css-81 css-8"
-            >
-              <div
                 className="ms-Stack css-9"
               >
+                <div
+                  aria-label=""
+                  className="ms-Persona ms-Persona--size48 root-10"
+                  style={
+                    Object {
+                      "height": 100,
+                      "minWidth": 100,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-Persona-coin ms-Persona--size48 coin-17"
+                    role="presentation"
+                  >
+                    <div
+                      className="ms-Persona-imageArea imageArea-19"
+                      role="presentation"
+                      style={
+                        Object {
+                          "height": 100,
+                          "width": 100,
+                        }
+                      }
+                    >
+                      <div
+                        aria-hidden="true"
+                        className="ms-Persona-initials initials-30"
+                        style={
+                          Object {
+                            "height": 100,
+                            "width": 100,
+                          }
+                        }
+                      >
+                        <span>
+                          P
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Stack css-80 css-25"
+            >
+              <div
+                className="ms-Stack css-26"
+              >
                 <span
-                  className="css-10"
+                  className="css-27"
                 >
                   Pam
                 </span>
               </div>
               <div
-                className="ms-Stack css-11"
+                className="ms-Stack css-28"
               />
             </div>
           </div>
@@ -125,23 +251,65 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               className="ms-Stack css-7"
             >
               <div
-                className="css-71"
-              />
-            </div>
-            <div
-              className="ms-Stack css-81 css-8"
-            >
-              <div
                 className="ms-Stack css-9"
               >
+                <div
+                  aria-label=""
+                  className="ms-Persona ms-Persona--size48 root-10"
+                  style={
+                    Object {
+                      "height": 100,
+                      "minWidth": 100,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-Persona-coin ms-Persona--size48 coin-17"
+                    role="presentation"
+                  >
+                    <div
+                      className="ms-Persona-imageArea imageArea-19"
+                      role="presentation"
+                      style={
+                        Object {
+                          "height": 100,
+                          "width": 100,
+                        }
+                      }
+                    >
+                      <div
+                        aria-hidden="true"
+                        className="ms-Persona-initials initials-31"
+                        style={
+                          Object {
+                            "height": 100,
+                            "width": 100,
+                          }
+                        }
+                      >
+                        <span>
+                          D
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Stack css-80 css-25"
+            >
+              <div
+                className="ms-Stack css-26"
+              >
                 <span
-                  className="css-10"
+                  className="css-27"
                 >
                   Dwight
                 </span>
               </div>
               <div
-                className="ms-Stack css-11"
+                className="ms-Stack css-28"
               />
             </div>
           </div>

--- a/packages/storybook/stories/QuickStarts/snippets/CallingComponents.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/CallingComponents.tsx
@@ -40,7 +40,7 @@ export const CallingComponents = (): JSX.Element => {
       {/* GridLayout Component relies on the parent's height and width, so it's required to set the height and width on its parent. */}
       <div style={{ height: '30rem', width: '30rem', border: '1px solid' }}>
         <GridLayout>
-          <VideoTile renderElement={null} displayName={'Michael'} />
+          <VideoTile displayName={'Michael'} />
         </GridLayout>
       </div>
 


### PR DESCRIPTION
# What
* Fix more places where I'd missed replacing trivial render elements with undefined values props

# Why
* Undefined prop is used to detect when avatar should be shown instead of the rendered video.
 
# How Tested
storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->