### PR TITLE
Fix: "Warning: React does not recognize the `primaryFill` prop on a DOM element"

### DIFF
--- a/change/@internal-react-components-270d0b69-fa01-489e-bd3e-cef7519b37c1.json
+++ b/change/@internal-react-components-270d0b69-fa01-489e-bd3e-cef7519b37c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update to @fluent/react-icons 1.1.137 that has fix for setting primaryFill prop",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-composites-cc4ebb09-c9c3-409a-86a2-ee9187fd5fef.json
+++ b/change/@internal-react-composites-cc4ebb09-c9c3-409a-86a2-ee9187fd5fef.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update to @fluent/react-icons 1.1.137 that has fix for setting primaryFill prop",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2921,10 +2921,10 @@ packages:
       react-dom: ^16.8.0
     resolution:
       integrity: sha512-9p0DQcGng+CA/sTnjxxaGWC8CH/OhwZCIEwp3srMeIkPaeWG7jKIOCTjRh87l5XhaeaYds6b88zET7axAHoXvw==
-  /@fluentui/react-icons/1.1.135:
+  /@fluentui/react-icons/1.1.137:
     dev: false
     resolution:
-      integrity: sha512-Gs1GeUjK05WMvhLjBTM5mk/9Mo5yQ706/EYhwGPzGdXbKiEvQ/JwJEYmCRsJoo4062w5ksDiUpUCGW3LSpm5oA==
+      integrity: sha512-IPT2aOIPRN3BT+qaTUUpd1p3dUxdgAkaxmOaX2gFVeHT2A0fGYoPiu3VJ/YSNTpqtxFWtxOZLPltMdjbHEitjw==
   /@fluentui/react-northstar-fela-renderer/0.51.7_react-dom@16.13.1+react@16.14.0:
     dependencies:
       '@babel/runtime': 7.14.8
@@ -9307,6 +9307,7 @@ packages:
       mime: 1.6.0
       minimist: 1.2.5
       url-join: 2.0.5
+    deprecated: This package is unmaintained and deprecated. See the GH Issue 259.
     dev: false
     hasBin: true
     resolution:
@@ -9319,6 +9320,7 @@ packages:
       minimist: 1.2.5
       on-finished: 2.3.0
       url-join: 4.0.1
+    deprecated: This package is unmaintained and deprecated. See the GH Issue 259.
     dev: false
     hasBin: true
     resolution:
@@ -19445,7 +19447,7 @@ packages:
       '@babel/preset-env': 7.13.10_@babel+core@7.13.10
       '@babel/preset-react': 7.14.5_@babel+core@7.13.10
       '@fluentui/react': 8.17.4_ab7a3a40ae1570509bc3553567e361ed
-      '@fluentui/react-icons': 1.1.135
+      '@fluentui/react-icons': 1.1.137
       '@testing-library/react-hooks': 3.7.0_98e0eb37a9f7280a1c5a6c886619f5b4
       '@types/jest': 26.0.24
       '@types/node': 14.17.5
@@ -19499,7 +19501,7 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-319kQptDZfz1tAX+FAx+9spnnm3s0c3mLVB7y8y5w2IRxtfslRv9ZKbQQnh75q+XpgothdEOkJYDhAQouoaNvA==
+      integrity: sha512-ekjYeoKvWI/QEziBT+YeCGIluKVHyxNPoFrrwBSSfmyv3Tg9PbhzCNZ1LzYcLfhicXGQA9DREMhPY9rDNq/jhg==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19571,7 +19573,7 @@ packages:
       '@azure/communication-signaling': 1.0.0-beta.5
       '@azure/core-http': 1.2.4
       '@fluentui/react': 8.17.4_ab7a3a40ae1570509bc3553567e361ed
-      '@fluentui/react-icons': 1.1.135
+      '@fluentui/react-icons': 1.1.137
       '@testing-library/jest-dom': 5.14.1
       '@testing-library/react-hooks': 3.7.0_98e0eb37a9f7280a1c5a6c886619f5b4
       '@types/jest': 26.0.24
@@ -19620,7 +19622,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-NDKeWJ8cNLh1FT3WDhfNeTGsen3ZiY5ibKeXVVJTEdnqOWppxKScWGqAC1vpZ2ebdt7i81C+K8qCJ+o05Np6xg==
+      integrity: sha512-XRo8saYe07dHh9taaAQ4cL79heyk8z8q5TNQqoSugDbSZDasAwW+LV23sU8OPH+v9gCwa/JFzwgDZoIpKB7jQw==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19648,7 +19650,7 @@ packages:
       '@azure/core-http': 1.2.4
       '@azure/core-paging': 1.1.3
       '@fluentui/react': 8.17.4_ab7a3a40ae1570509bc3553567e361ed
-      '@fluentui/react-icons': 1.1.135
+      '@fluentui/react-icons': 1.1.137
       '@fluentui/react-northstar': 0.51.7_ab7a3a40ae1570509bc3553567e361ed
       '@microsoft/api-documenter': 7.12.22
       '@microsoft/api-extractor': 7.18.4
@@ -19709,7 +19711,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-g4S8GgR71OT49VnXtuLQ4Vw/lHinQO21jV+9uUszag6AZQyJAPtpi2ZRbfVcEFee1WnbYu3Nd37FddtiGJXfgw==
+      integrity: sha512-xwryyDKOMDonxVbiOJqe75k644xzNu1/sqyyrvqb8RBYrlxinTsvEdnpyWqtH5mtOtDKevAX7OIMegfkqiXznw==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/react-components.tgz:
@@ -19717,7 +19719,7 @@ packages:
       '@babel/core': 7.13.10
       '@babel/preset-env': 7.13.10_@babel+core@7.13.10
       '@fluentui/react': 8.17.4_ab7a3a40ae1570509bc3553567e361ed
-      '@fluentui/react-icons': 1.1.135
+      '@fluentui/react-icons': 1.1.137
       '@fluentui/react-northstar': 0.51.7_ab7a3a40ae1570509bc3553567e361ed
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@microsoft/api-documenter': 7.12.22
@@ -19783,7 +19785,7 @@ packages:
     dev: false
     name: '@rush-temp/react-components'
     resolution:
-      integrity: sha512-8J7drOqhxP4ovlDuGPc9y40r6GveihYTMmbOUG5/Qxi/9aocgu/q4MJEweeyBMFIXRz82xMoWH+BgEVyFU19mw==
+      integrity: sha512-sC0ahyGGGHjELwbvToIxPJsJpCRlCPuWuwtMRvURmI9Haq2WSBEhciMFO+s8iOR163yL0NI39JQJ9X2dDoQaGQ==
       tarball: file:projects/react-components.tgz
     version: 0.0.0
   file:projects/react-composites.tgz:
@@ -19798,7 +19800,7 @@ packages:
       '@babel/core': 7.13.10
       '@babel/preset-env': 7.13.10_@babel+core@7.13.10
       '@fluentui/react': 8.17.4_ab7a3a40ae1570509bc3553567e361ed
-      '@fluentui/react-icons': 1.1.135
+      '@fluentui/react-icons': 1.1.137
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@microsoft/api-documenter': 7.12.22
       '@microsoft/api-extractor': 7.18.4
@@ -19871,7 +19873,7 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-pLxsk6PViXApo0Yd1INJ9WswTP1epnDMXf2vMp6OLdhD4SQ20CxJfGpH3EtHfCwkDSWlq3Xi8wu4zC/bSNw0vw==
+      integrity: sha512-u0CFyvmbTkT6S8jndjVW5+oVSS5zleTC103HRa0ESbC7wijKROfjRVZOuJnHrAdLf4rQWpPNuGaEMNeOZoxCMA==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
@@ -19964,7 +19966,7 @@ packages:
       '@babel/core': 7.13.10
       '@babel/preset-env': 7.13.10_@babel+core@7.13.10
       '@fluentui/react': 8.17.4_ab7a3a40ae1570509bc3553567e361ed
-      '@fluentui/react-icons': 1.1.135
+      '@fluentui/react-icons': 1.1.137
       '@fluentui/react-northstar': 0.51.7_ab7a3a40ae1570509bc3553567e361ed
       '@fluentui/theme-samples': 8.1.5_ab7a3a40ae1570509bc3553567e361ed
       '@mdx-js/react': 1.6.22_react@16.14.0
@@ -20048,7 +20050,7 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-xilzQ6g5eNJIjjpRGYofGAmLulxo63j9RcQqRMYj9TLCka814yOVnJxtSykIy26BJ5h0SO5yXtLh2AQukVw61g==
+      integrity: sha512-A5Yx089sAFhr4IOJ7tulm33ojyFvMkROD8VhPTu/91s0whXSbfG2op9xv2KgVwMhaEQMSLJUQ/7pk/LztLq+Jg==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -30,7 +30,7 @@
     "@azure/core-http": "1.2.4",
     "@azure/core-paging": "~1.1.3",
     "@fluentui/react": "~8.17.2",
-    "@fluentui/react-icons": "~1.1.134",
+    "@fluentui/react-icons": "~1.1.137",
     "@fluentui/react-northstar": "^0.51.2",
     "@uifabric/react-hooks": "~7.13.11",
     "copy-to-clipboard": "~3.3.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@fluentui/react": "~8.17.2",
-    "@fluentui/react-icons": "~1.1.134",
+    "@fluentui/react-icons": "~1.1.137",
     "@fluentui/react-northstar": "^0.51.2",
     "@uifabric/react-hooks": "~7.13.11",
     "copy-to-clipboard": "~3.3.1",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -36,7 +36,7 @@
     "@azure/core-http": "1.2.4",
     "@azure/core-paging": "~1.1.3",
     "@fluentui/react": "~8.17.2",
-    "@fluentui/react-icons": "~1.1.134",
+    "@fluentui/react-icons": "~1.1.137",
     "@internal/acs-ui-common": "1.0.0-beta.2",
     "@internal/calling-stateful-client": "1.0.0-beta.3",
     "@internal/calling-component-bindings": "1.0.0-beta.3",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -26,7 +26,7 @@
     "@azure/communication-signaling": "1.0.0-beta.5",
     "@azure/core-http": "1.2.4",
     "@fluentui/react": "~8.17.2",
-    "@fluentui/react-icons": "~1.1.134",
+    "@fluentui/react-icons": "~1.1.137",
     "@fluentui/react-northstar": "^0.51.2",
     "@internal/chat-component-bindings": "1.0.0-beta.3",
     "@internal/react-composites": "1.0.0-beta.3",

--- a/packages/storybook/stories/ControlBar/Buttons/ControlBarButton/__snapshots__/ControlBarButton.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/ControlBarButton/__snapshots__/ControlBarButton.stories.storyshot
@@ -38,7 +38,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/De
           <span
             aria-hidden={true}
             className="root-span"
-            primaryFill="currentColor"
           >
             <svg
               className="svg"

--- a/packages/storybook/stories/ControlBar/Buttons/EndCall/__snapshots__/EndCall.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/EndCall/__snapshots__/EndCall.stories.storyshot
@@ -38,7 +38,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/En
           <span
             aria-hidden={true}
             className="root-span"
-            primaryFill="currentColor"
           >
             <svg
               className="svg"

--- a/packages/storybook/stories/ControlBar/Buttons/Microphone/__snapshots__/Microphone.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Microphone/__snapshots__/Microphone.stories.storyshot
@@ -38,7 +38,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/Mi
           <span
             aria-hidden={true}
             className="root-span"
-            primaryFill="currentColor"
           >
             <svg
               className="svg"

--- a/packages/storybook/stories/ControlBar/Buttons/Options/__snapshots__/Options.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Options/__snapshots__/Options.stories.storyshot
@@ -41,7 +41,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/Op
           <span
             aria-hidden={true}
             className="root-span"
-            primaryFill="currentColor"
           >
             <svg
               className="svg"

--- a/packages/storybook/stories/ControlBar/Buttons/Participants/__snapshots__/Participants.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Participants/__snapshots__/Participants.stories.storyshot
@@ -41,7 +41,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/Pa
           <span
             aria-hidden={true}
             className="root-span"
-            primaryFill="currentColor"
           >
             <svg
               className="svg"

--- a/packages/storybook/stories/ControlBar/Buttons/ScreenShare/__snapshots__/ScreenShare.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/ScreenShare/__snapshots__/ScreenShare.stories.storyshot
@@ -38,7 +38,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar/Buttons/Sc
           <span
             aria-hidden={true}
             className="root-span"
-            primaryFill="currentColor"
           >
             <svg
               className="svg"

--- a/packages/storybook/stories/ControlBar/__snapshots__/ControlBar.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/__snapshots__/ControlBar.stories.storyshot
@@ -56,7 +56,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar Control Ba
                 <span
                   aria-hidden={true}
                   className="root-span"
-                  primaryFill="currentColor"
                 >
                   <svg
                     className="svg"
@@ -97,7 +96,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar Control Ba
                 <span
                   aria-hidden={true}
                   className="root-span"
-                  primaryFill="currentColor"
                 >
                   <svg
                     className="svg"
@@ -138,7 +136,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar Control Ba
                 <span
                   aria-hidden={true}
                   className="root-span"
-                  primaryFill="currentColor"
                 >
                   <svg
                     className="svg"
@@ -176,7 +173,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar Control Ba
                 <span
                   aria-hidden={true}
                   className="root-span"
-                  primaryFill="currentColor"
                 >
                   <svg
                     className="svg"
@@ -227,7 +223,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar Control Ba
                 <span
                   aria-hidden={true}
                   className="root-span"
-                  primaryFill="currentColor"
                 >
                   <svg
                     className="svg"
@@ -281,7 +276,6 @@ exports[`storybook snapshot tests Storyshots UI Components/ControlBar Control Ba
                 <span
                   aria-hidden={true}
                   className="root-span"
-                  primaryFill="currentColor"
                 >
                   <svg
                     className="svg"

--- a/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallModal.stories.storyshot
+++ b/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallModal.stories.storyshot
@@ -270,7 +270,6 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                                 <span
                                   aria-hidden={true}
                                   className="root-span"
-                                  primaryFill="currentColor"
                                 >
                                   <svg
                                     className="svg"

--- a/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallToast.stories.storyshot
+++ b/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallToast.stories.storyshot
@@ -108,7 +108,6 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                 <span
                   aria-hidden={true}
                   className="root-span"
-                  primaryFill="currentColor"
                 >
                   <svg
                     className="svg"
@@ -143,7 +142,6 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                 <span
                   aria-hidden={true}
                   className="root-span"
-                  primaryFill="currentColor"
                 >
                   <svg
                     className="svg"

--- a/packages/storybook/stories/Examples/LocalPreview/__snapshots__/LocalPreview.stories.storyshot
+++ b/packages/storybook/stories/Examples/LocalPreview/__snapshots__/LocalPreview.stories.storyshot
@@ -90,7 +90,6 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                             <span
                               aria-hidden={true}
                               className="root-span"
-                              primaryFill="currentColor"
                             >
                               <svg
                                 className="svg"
@@ -128,7 +127,6 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                             <span
                               aria-hidden={true}
                               className="root-span"
-                              primaryFill="currentColor"
                             >
                               <svg
                                 className="svg"

--- a/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/Lobby.stories.storyshot
+++ b/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/Lobby.stories.storyshot
@@ -115,7 +115,6 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   <span
                     aria-hidden={true}
                     className="root-span"
-                    primaryFill="currentColor"
                   >
                     <svg
                       className="svg"
@@ -158,7 +157,6 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   <span
                     aria-hidden={true}
                     className="root-span"
-                    primaryFill="currentColor"
                   >
                     <svg
                       className="svg"
@@ -201,7 +199,6 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   <span
                     aria-hidden={true}
                     className="root-span"
-                    primaryFill="currentColor"
                   >
                     <svg
                       className="svg"
@@ -266,7 +263,6 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   <span
                     aria-hidden={true}
                     className="root-span"
-                    primaryFill="currentColor"
                   >
                     <svg
                       className="svg"

--- a/packages/storybook/stories/Examples/Themes/__snapshots__/TeamsTheme.stories.storyshot
+++ b/packages/storybook/stories/Examples/Themes/__snapshots__/TeamsTheme.stories.storyshot
@@ -78,7 +78,6 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           <span
                             aria-hidden={true}
                             className="root-span"
-                            primaryFill="currentColor"
                           >
                             <svg
                               className="svg"
@@ -119,7 +118,6 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           <span
                             aria-hidden={true}
                             className="root-span"
-                            primaryFill="currentColor"
                           >
                             <svg
                               className="svg"
@@ -160,7 +158,6 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           <span
                             aria-hidden={true}
                             className="root-span"
-                            primaryFill="currentColor"
                           >
                             <svg
                               className="svg"
@@ -195,7 +192,6 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           <span
                             aria-hidden={true}
                             className="root-span"
-                            primaryFill="currentColor"
                           >
                             <svg
                               className="svg"

--- a/packages/storybook/stories/MessageStatusIndicator/__snapshots__/MessageStatusIndicator.stories.storyshot
+++ b/packages/storybook/stories/MessageStatusIndicator/__snapshots__/MessageStatusIndicator.stories.storyshot
@@ -31,7 +31,6 @@ exports[`storybook snapshot tests Storyshots UI Components/Message Status Indica
         <span
           aria-hidden={true}
           className="root-span css-63"
-          primaryFill="currentColor"
         >
           <svg
             className="svg"

--- a/packages/storybook/stories/SendBox/__snapshots__/SendBox.stories.storyshot
+++ b/packages/storybook/stories/SendBox/__snapshots__/SendBox.stories.storyshot
@@ -75,7 +75,6 @@ exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`]
               <span
                 aria-hidden={true}
                 className="root-span css-60 css-2"
-                primaryFill="currentColor"
               >
                 <svg
                   className="svg"

--- a/packages/storybook/stories/VideoGallery/__snapshots__/VideoGallery.stories.storyshot
+++ b/packages/storybook/stories/VideoGallery/__snapshots__/VideoGallery.stories.storyshot
@@ -103,7 +103,6 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 <span
                   aria-hidden={true}
                   className="root-span"
-                  primaryFill="currentColor"
                 >
                   <svg
                     className="svg"

--- a/packages/storybook/stories/VideoTile/__snapshots__/VideoTile.stories.storyshot
+++ b/packages/storybook/stories/VideoTile/__snapshots__/VideoTile.stories.storyshot
@@ -90,7 +90,6 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
             <span
               aria-hidden={true}
               className="root-span"
-              primaryFill="currentColor"
             >
               <svg
                 className="svg"

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -24,7 +24,7 @@
     "@azure/core-http": "1.2.4",
     "@babel/preset-react": "^7.12.7",
     "@fluentui/react": "~8.17.2",
-    "@fluentui/react-icons": "~1.1.134",
+    "@fluentui/react-icons": "~1.1.137",
     "@internal/acs-ui-common": "1.0.0-beta.2",
     "@internal/calling-component-bindings": "1.0.0-beta.3",
     "@internal/calling-stateful-client": "1.0.0-beta.3",

--- a/samples/Chat/package.json
+++ b/samples/Chat/package.json
@@ -23,7 +23,7 @@
     "@azure/communication-signaling": "1.0.0-beta.5",
     "@azure/core-http": "1.2.4",
     "@fluentui/react": "~8.17.2",
-    "@fluentui/react-icons": "~1.1.134",
+    "@fluentui/react-icons": "~1.1.137",
     "@internal/acs-ui-common": "1.0.0-beta.2",
     "@internal/chat-stateful-client": "1.0.0-beta.3",
     "@internal/chat-component-bindings": "1.0.0-beta.3",

--- a/samples/StaticHtmlComposites/package-lock.json
+++ b/samples/StaticHtmlComposites/package-lock.json
@@ -14,7 +14,7 @@
         "@azure/core-http": "1.2.4",
         "@azure/core-paging": "~1.1.3",
         "@fluentui/react": "~8.17.2",
-        "@fluentui/react-icons": "~1.1.134",
+        "@fluentui/react-icons": "~1.1.137",
         "@fluentui/react-northstar": "^0.51.2",
         "@uifabric/react-hooks": "~7.13.11",
         "copy-to-clipboard": "~3.3.1",
@@ -2598,7 +2598,7 @@
               "version": "1.0.0-beta.1",
               "requires": {
                 "@fluentui/react": "~8.17.2",
-                "@fluentui/react-icons": "~1.1.134",
+                "@fluentui/react-icons": "~1.1.137",
                 "@fluentui/react-northstar": "^0.51.2",
                 "@uifabric/react-hooks": "~7.13.11",
                 "acs-ui-common": "1.0.0-beta.1",
@@ -3188,7 +3188,7 @@
               "version": "1.0.0-beta.1",
               "requires": {
                 "@fluentui/react": "~8.17.2",
-                "@fluentui/react-icons": "~1.1.134",
+                "@fluentui/react-icons": "~1.1.137",
                 "@fluentui/react-northstar": "^0.51.2",
                 "@uifabric/react-hooks": "~7.13.11",
                 "acs-ui-common": "1.0.0-beta.1",
@@ -3533,7 +3533,7 @@
         "react-components": {
           "requires": {
             "@fluentui/react": "~8.17.2",
-            "@fluentui/react-icons": "~1.1.134",
+            "@fluentui/react-icons": "~1.1.137",
             "@fluentui/react-northstar": "^0.51.2",
             "@uifabric/react-hooks": "~7.13.11",
             "acs-ui-common": "1.0.0-beta.1",
@@ -3656,7 +3656,7 @@
             "@azure/communication-signaling": "1.0.0-beta.5",
             "@azure/core-http": "1.2.4",
             "@fluentui/react": "~8.17.2",
-            "@fluentui/react-icons": "~1.1.134",
+            "@fluentui/react-icons": "~1.1.137",
             "@uifabric/react-hooks": "~7.13.11",
             "acs-ui-common": "1.0.0-beta.1",
             "calling-component-bindings": "~1.0.0-beta.1",
@@ -3905,7 +3905,7 @@
                   "version": "1.0.0-beta.1",
                   "requires": {
                     "@fluentui/react": "~8.17.2",
-                    "@fluentui/react-icons": "~1.1.134",
+                    "@fluentui/react-icons": "~1.1.137",
                     "@fluentui/react-northstar": "^0.51.2",
                     "@uifabric/react-hooks": "~7.13.11",
                     "acs-ui-common": "1.0.0-beta.1",
@@ -4067,7 +4067,7 @@
                   "version": "1.0.0-beta.1",
                   "requires": {
                     "@fluentui/react": "~8.17.2",
-                    "@fluentui/react-icons": "~1.1.134",
+                    "@fluentui/react-icons": "~1.1.137",
                     "@fluentui/react-northstar": "^0.51.2",
                     "@uifabric/react-hooks": "~7.13.11",
                     "acs-ui-common": "1.0.0-beta.1",
@@ -4202,7 +4202,7 @@
               "version": "1.0.0-beta.1",
               "requires": {
                 "@fluentui/react": "~8.17.2",
-                "@fluentui/react-icons": "~1.1.134",
+                "@fluentui/react-icons": "~1.1.137",
                 "@fluentui/react-northstar": "^0.51.2",
                 "@uifabric/react-hooks": "~7.13.11",
                 "acs-ui-common": "1.0.0-beta.1",


### PR DESCRIPTION
## What
Update to @fluent/react-icons 1.1.137 that has fix for setting primaryFill prop
Was fixed by: https://github.com/microsoft/fluentui-system-icons/pull/301

# Why
Fix this console error happening all the time:
![image](https://user-images.githubusercontent.com/2684369/129590281-0d9a912b-8cbc-442c-86ae-bef42a6d14a5.png)

More info: https://github.com/microsoft/fluentui/issues/17804

# How Tested
No longer present in unit test output