### PR TITLE
fix broken internal links in storybook

### DIFF
--- a/packages/storybook/stories/ControlBar/Buttons/Participants/Participants.stories.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/Participants/Participants.stories.tsx
@@ -104,7 +104,7 @@ const getDocs: () => JSX.Element = () => {
       <Description>
         You can change the render of the `ParticipantsButton` as you would do for any Button (onRenderIcon,
         onRenderText, etc... ) with the addition of customizing the render of the participant list (see
-        [ParticipantList](/?path=/docs/ui-components-participantlist--participant-list) component).
+        [ParticipantList](./?path=/docs/ui-components-participantlist--participant-list) component).
       </Description>
       <Canvas mdxSource={ParticipantsButtonWithCustomRenderExampleText}>
         <ParticipantsButtonWithCustomRenderExample />

--- a/packages/storybook/stories/CustomUserDataModel.stories.mdx
+++ b/packages/storybook/stories/CustomUserDataModel.stories.mdx
@@ -17,14 +17,14 @@ This provides developers the most flexibility when building truly custom experie
 User data model injection is available for those components that expose user information, particularly their display name and their avatar.
 Below you will find a table with the components that support injection and the pattern/method used to inject information.
 
-| UI Components                                                                     | Display Name                                       | Avatar         |
-| --------------------------------------------------------------------------------- | -------------------------------------------------- | -------------- |
-| [Video Tile](/?path=/story/ui-components-videotile--video-tile)                   | displayName                                        | placeholder    |
-| [Video Gallery](/?path=/story/ui-components-videogallery--video-gallery)          | onRenderRemoteVideoTile and onRenderLocalVideoTile | onRenderAvatar |
-| [Message Thread](/?path=/story/ui-components-messagethread--message-thread)       | onRenderMessage                                    | onRenderAvatar |
-| [Typing Indicator](/?path=/story/ui-components-typingindicator--typing-indicator) | onRenderUsers                                      | onRenderUsers  |
-| [Participant Item](/?path=/story/ui-components-participantitem--participant-item) | displayName                                        | onRenderAvatar |
-| [Participant List](/?path=/story/ui-components-participantlist--participant-list) | onRenderParticipant                                | onRenderAvatar |
+| UI Components                                                                      | Display Name                                       | Avatar         |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------- | -------------- |
+| [Video Tile](./?path=/story/ui-components-videotile--video-tile)                   | displayName                                        | placeholder    |
+| [Video Gallery](./?path=/story/ui-components-videogallery--video-gallery)          | onRenderRemoteVideoTile and onRenderLocalVideoTile | onRenderAvatar |
+| [Message Thread](./?path=/story/ui-components-messagethread--message-thread)       | onRenderMessage                                    | onRenderAvatar |
+| [Typing Indicator](./?path=/story/ui-components-typingindicator--typing-indicator) | onRenderUsers                                      | onRenderUsers  |
+| [Participant Item](./?path=/story/ui-components-participantitem--participant-item) | displayName                                        | onRenderAvatar |
+| [Participant List](./?path=/story/ui-components-participantlist--participant-list) | onRenderParticipant                                | onRenderAvatar |
 
 For additional examples on how this user data model injection pattern works, visit the individual component pages for each component.
 

--- a/packages/storybook/stories/IdentityManagement/IdentityManagement.stories.mdx
+++ b/packages/storybook/stories/IdentityManagement/IdentityManagement.stories.mdx
@@ -28,7 +28,7 @@ A typical implementation of the backend service that mints the user token might 
 <Source code={CallBackendText} />
 
 The following utility canvas is backed by the same logic to mint tokens. You can use this to generate the data needed for
-the [`CallComposite` stories in this storybook](/?path=/story/composites-call-basicexample--basic-example).
+the [`CallComposite` stories in this storybook](./?path=/story/composites-call-basicexample--basic-example).
 
 <Canvas withSource="none">
   <Story story={stories.CallBackend} />
@@ -44,7 +44,7 @@ A typical implementation of the backend service that mints the user tokens and a
 <Source code={ChatBackendText} />
 
 The following utility canvas is backed by the same logic to mint tokens and create threads. You can use this to generate the
-data needed for the [`ChatComposite` stories in this storybook](/?path=/docs/composites-chat-basicexample--basic-example).
+data needed for the [`ChatComposite` stories in this storybook](./?path=/docs/composites-chat-basicexample--basic-example).
 
 <Canvas withSource="none">
   <Story story={stories.ChatBackend} />

--- a/packages/storybook/stories/NonReact/NonReactComposites.stories.mdx
+++ b/packages/storybook/stories/NonReact/NonReactComposites.stories.mdx
@@ -48,9 +48,9 @@ After importing chat/calling composite bundle, you are able to load composites u
     )
 ```
 
-Check [Chat Composite Basic Example](/?path=/docs/composites-chat-basicexample--basic-example) and [Call Composite Basic Example](/?path=/docs/composites-call-basicexample--basic-example) to see optional props of composites
+Check [Chat Composite Basic Example](./?path=/docs/composites-chat-basicexample--basic-example) and [Call Composite Basic Example](./?path=/docs/composites-call-basicexample--basic-example) to see optional props of composites
 
-For more details of adapter, check [Adapters for Composites](/?path=/story/statefulclient-reacthooks-adapters--page)
+For more details of adapter, check [Adapters for Composites](./?path=/story/statefulclient-reacthooks-adapters--page)
 
 ## Example html code
 

--- a/packages/storybook/stories/Overview.stories.mdx
+++ b/packages/storybook/stories/Overview.stories.mdx
@@ -52,7 +52,7 @@ These UI client libraries all use [Microsoft's Fluent design language](https://d
 In conjunction to the UI components, the UI Library exposes a _stateful client library_ for calling and chat.
 This client is agnostic to any specific state management framework and can be integrated with common state managers like Redux or React Context.
 This stateful client library can be used with the UI Components to pass props and methods for the UI Components to render data.
-For more information, see [Stateful Client Overview](/?path=/story/statefulclient-overview--page).
+For more information, see [Stateful Client Overview](./?path=/story/statefulclient-overview--page).
 
 ## Installing UI Library
 
@@ -65,28 +65,28 @@ npm i --save @azure/communication-react
 Composites are higher-level components composed of UI components that deliver turn-key solutions for common communication scenarios using Azure Communication Services.
 Developers can easily instantiate the Composite using an Azure Communication Services access token and the required configuration attributed for call or chat.
 
-| Composite                                                                  | Use Cases                                                                                                                                                                                                                                                                                                    |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [CallComposite](/?path=/story/composites-call-basicexample--basic-example) | Calling experience that allows users to start or join a call. Inside the experience users can configure their devices, participate in the call with video and see other participants, including those with video turn on. For Teams Interop is includes lobby functionality for user to wait to be admitted. |
-| [ChatComposite](/?path=/story/composites-chat-basicexample--basic-example) | Chat experience where user can send and receive messages. Thread events like typing, reads, participants entering and leaving are displayed to the user as part of the chat thread.                                                                                                                          |
+| Composite                                                                   | Use Cases                                                                                                                                                                                                                                                                                                    |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [CallComposite](./?path=/story/composites-call-basicexample--basic-example) | Calling experience that allows users to start or join a call. Inside the experience users can configure their devices, participate in the call with video and see other participants, including those with video turn on. For Teams Interop is includes lobby functionality for user to wait to be admitted. |
+| [ChatComposite](./?path=/story/composites-chat-basicexample--basic-example) | Chat experience where user can send and receive messages. Thread events like typing, reads, participants entering and leaving are displayed to the user as part of the chat thread.                                                                                                                          |
 
 ## UI Component Overview
 
 Pure UI Components that can be used by developers to compose communication experiences, from stitching video tiles into a grid to showcase remote participants, to organizing components to fit your applications specifications.
 UI Components support customization to give the components the right feel and look to match an applications branding and style.
 
-| Area    | Component                                                                                                | Description                                                                                        |
-| ------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| Calling | [Grid Layout](/?path=/story/ui-components-gridlayout--grid-layout)                                       | Grid component to organize Video Tiles into an NxN grid                                            |
-|         | [Video Tile](/?path=/story/ui-components-videotile--video-tile)                                          | Component that displays video stream when available and a default static component when not        |
-|         | [Control Bar](/?path=/story/ui-components-controlbar--control-bar)                                       | Container to organize DefaultButtons to hook up to specific call actions like mute or share screen |
-|         | [Video Gallery](/?path=/story/ui-components-videogallery--video-gallery)                                 | Turn-key video gallery component which dynamically changes as participants are added               |
-| Chat    | [Message Thread](/?path=/story/ui-components-messagethread--message-thread)                              | Container that renders chat messages, system messages, and custom messages                         |
-|         | [Send Box](/?path=/story/ui-components-sendbox--send-box)                                                | Text input component with a discrete send button                                                   |
-|         | [Message Status Indicator](/?path=/story/ui-components-messagestatusindicator--message-status-indicator) | Multi-state message status indicator component to show status of sent message                      |
-|         | [Typing indicator](/?path=/story/ui-components-typingindicator--typing-indicator)                        | Text component to render the participants who are actively typing on a thread                      |
-| Common  | [Participant Item](/?path=/story/ui-components-participantitem--participant-item)                        | Common component to render a call or chat participant including avatar and display name            |
-|         | [Participant List](/?path=/story/ui-components-participantlist--participant-list)                        | Common component to render a call or chat participant list including avatar and display name       |
+| Area    | Component                                                                                                 | Description                                                                                        |
+| ------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Calling | [Grid Layout](./?path=/story/ui-components-gridlayout--grid-layout)                                       | Grid component to organize Video Tiles into an NxN grid                                            |
+|         | [Video Tile](./?path=/story/ui-components-videotile--video-tile)                                          | Component that displays video stream when available and a default static component when not        |
+|         | [Control Bar](./?path=/story/ui-components-controlbar--control-bar)                                       | Container to organize DefaultButtons to hook up to specific call actions like mute or share screen |
+|         | [Video Gallery](./?path=/story/ui-components-videogallery--video-gallery)                                 | Turn-key video gallery component which dynamically changes as participants are added               |
+| Chat    | [Message Thread](./?path=/story/ui-components-messagethread--message-thread)                              | Container that renders chat messages, system messages, and custom messages                         |
+|         | [Send Box](./?path=/story/ui-components-sendbox--send-box)                                                | Text input component with a discrete send button                                                   |
+|         | [Message Status Indicator](./?path=/story/ui-components-messagestatusindicator--message-status-indicator) | Multi-state message status indicator component to show status of sent message                      |
+|         | [Typing indicator](./?path=/story/ui-components-typingindicator--typing-indicator)                        | Text component to render the participants who are actively typing on a thread                      |
+| Common  | [Participant Item](./?path=/story/ui-components-participantitem--participant-item)                        | Common component to render a call or chat participant including avatar and display name            |
+|         | [Participant List](./?path=/story/ui-components-participantlist--participant-list)                        | Common component to render a call or chat participant list including avatar and display name       |
 
 ## What UI Artifact is Best for my Project?
 
@@ -95,7 +95,7 @@ Understanding these requirements will help you choose the right client library:
 - **How much customization do you desire?** Azure Communication core client libraries don't have a UX and are designed so you can build whatever UX you want. UI Library components provide UI assets at the cost of reduced customization.
 - **What platforms are you targeting?** Different platforms have different capabilities.
 
-Details about feature availability in the [UI Library is available here](/?path=/story/usecases--page), but key trade-offs are summarized below.
+Details about feature availability in the [UI Library is available here](./?path=/story/usecases--page), but key trade-offs are summarized below.
 
 | Client library / SDK  | Implementation Complexity | Customization Ability | Calling | Chat | [Teams Interop](https://docs.microsoft.com/en-us/azure/communication-services/concepts/teams-interop) |
 | --------------------- | ------------------------- | --------------------- | ------- | ---- | ----------------------------------------------------------------------------------------------------- |

--- a/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
@@ -66,10 +66,10 @@ npm run start
 
 The following classes and interfaces handle some of the major features of the Azure Communication Services UI client library:
 
-| Name                                                                       | Description                                                                                  |
-| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [CallComposite](/?path=/story/composites-call-basicexample--basic-example) | Composite component that renders a calling experience with participant gallery and controls. |
-| [ChatComposite](/?path=/story/composites-chat-basicexample--basic-example) | Composite component that renders a chat experience with chat thread and input                |
+| Name                                                                        | Description                                                                                  |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [CallComposite](./?path=/story/composites-call-basicexample--basic-example) | Composite component that renders a calling experience with participant gallery and controls. |
+| [ChatComposite](./?path=/story/composites-chat-basicexample--basic-example) | Composite component that renders a chat experience with chat thread and input                |
 
 ## Set Up Adapters
 
@@ -121,11 +121,11 @@ Learn more about [cleaning up resources](https://docs.microsoft.com/azure/commun
 
 ## Next Steps
 
-[Try UI Library UI Components](/?path=/story/quickstarts-uicomponents--page)
+[Try UI Library UI Components](./?path=/story/quickstarts-uicomponents--page)
 
 For more information, see the following resources:
 
-- [UI Library Use Cases](/?path=/story/use-cases--page)
-- [UI Library Styling](/?path=/story/styling--page)
-- [UI Library Theming](/?path=/story/theming--page)
-- [UI Library Localization](/?path=/story/localization--page#composites)
+- [UI Library Use Cases](./?path=/story/use-cases--page)
+- [UI Library Styling](./?path=/story/styling--page)
+- [UI Library Theming](./?path=/story/theming--page)
+- [UI Library Localization](./?path=/story/localization--page#composites)

--- a/packages/storybook/stories/QuickStarts/QuickstartStateful.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStateful.stories.mdx
@@ -11,18 +11,18 @@ import ChatAppStatefulComplete from '!!raw-loader!./snippets/ChatAppStatefulComp
 
 Get started with Azure Communication Services by using the UI Library to quickly integrate communication experiences into your applications.
 In this quickstart, you'll learn how to integrate UI Library stateful clients into your application to build communication experiences.
-To learn more about how to build applications with UI Library UI Components, see [Get started with UI Components](/?path=/docs/quickstarts-uicomponents--page)
+To learn more about how to build applications with UI Library UI Components, see [Get started with UI Components](./?path=/docs/quickstarts-uicomponents--page)
 Stateful clients make it easier for developers to build UI applications on top of Azure Communication Services by providing built-in state that UI components can use to render.
-Find more information about [Stateful client here.](/?path=/docs/statefulclient-overview--page).
+Find more information about [Stateful client here.](./?path=/docs/statefulclient-overview--page).
 
 ## Prerequisites
 
 - An Azure account with an active subscription. [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
 - [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 12 Recommended).
 - An active Communication Services resource. [Create a Communication Services resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp).
-- Knowledge of [UI Library Components](/?path=/story/quickstarts-uicomponents--page). We will be using the UI Components in this quickstart.
+- Knowledge of [UI Library Components](./?path=/story/quickstarts-uicomponents--page). We will be using the UI Components in this quickstart.
 - Knowledge of Azure Communication Services [Chat patterns](https://docs.microsoft.com/azure/communication-services/concepts/chat/concepts).
-  You will need to create a thread and a user to that thread to use the UI Library. Look at the [recommended architecture for the UI Library](/?path=/docs/usecases--page#recommended-architecture)
+  You will need to create a thread and a user to that thread to use the UI Library. Look at the [recommended architecture for the UI Library](./?path=/docs/usecases--page#recommended-architecture)
 
 ## Setting Up
 
@@ -72,10 +72,10 @@ The following classes and interfaces from the Azure Communication Services UI cl
 | Name                                                                                                                            | Description                                                                              |
 | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
 | [ChatClient](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-communication-chat/1.0.0/classes/chatclient.html) | Low-level chat library client.                                                           |
-| [createStatefulChatClient](/?path=/story/statefulclient-overview--page)                                                         | Method to translate low-level library client into a stateful client for the UI Library   |
-| [ChatClientProvider](/?path=/story/statefulclient-reacthooks-setup--page)                                                       | Provider allows access to the Stateful Chat Client to the components inside of it        |
-| [ChatThreadClientProvider](/?path=/story/statefulclient-reacthooks-setup--page)                                                 | Provider allows access to the Stateful Chat Thread Client to the components inside of it |
-| [usePropsFor](/?path=/story/statefulclient-reacthooks-usepropsfor--page)                                                        | Hook to generate required props to enable UI Components                                  |
+| [createStatefulChatClient](./?path=/story/statefulclient-overview--page)                                                        | Method to translate low-level library client into a stateful client for the UI Library   |
+| [ChatClientProvider](./?path=/story/statefulclient-reacthooks-setup--page)                                                      | Provider allows access to the Stateful Chat Client to the components inside of it        |
+| [ChatThreadClientProvider](./?path=/story/statefulclient-reacthooks-setup--page)                                                | Provider allows access to the Stateful Chat Thread Client to the components inside of it |
+| [usePropsFor](./?path=/story/statefulclient-reacthooks-usepropsfor--page)                                                       | Hook to generate required props to enable UI Components                                  |
 
 ## Instantiate Stateful Chat Client and Chat Thread Client
 
@@ -101,14 +101,14 @@ Third, the `ChatThreadClientProvider` which provides state from the `statefulCha
 <Source code={ChatAppStatefulProviders} />
 
 Similarly to how we used chat providers for this example, you can use calling providers.
-For more information on [Calling Providers](/?path=/story/statefulclient-reacthooks-setup--page).
+For more information on [Calling Providers](./?path=/story/statefulclient-reacthooks-setup--page).
 
 ## Compose Chat Components
 
 Now that we have our structure ready, we will now create our chat experience using UI Components.
-For Chat, we will use the [MessageThread](/?path=/docs/ui-components-messagethread--message-thread) and [SendBox](/?path=/docs/ui-components-sendbox--send-box) components.
+For Chat, we will use the [MessageThread](./?path=/docs/ui-components-messagethread--message-thread) and [SendBox](./?path=/docs/ui-components-sendbox--send-box) components.
 To start add the code below to a new file `ChatComponentsStateful.tsx`.
-For more information on getting started with UI Components follow the [quickstart](/?path=/story/quickstarts-uicomponents--page)
+For more information on getting started with UI Components follow the [quickstart](./?path=/story/quickstarts-uicomponents--page)
 Here we will use the `usePropsFor` hook to connect our components to the stateful clients.
 The `usePropsFor` method takes in the component for which we want props generated, in this case `MessageThread` and `SendBox`.
 
@@ -117,7 +117,7 @@ The `usePropsFor` method takes in the component for which we want props generate
 <Source code={ChatComponentsStateful} />
 
 Similarly to how we used `usePropsFor` with chat UI Components, it can be used for calling UI Components.
-For more information on [usePropsFor](/?path=/story/statefulclient-reacthooks-usepropsfor--page).
+For more information on [usePropsFor](./?path=/story/statefulclient-reacthooks-usepropsfor--page).
 
 ## Add Components to App
 
@@ -146,10 +146,10 @@ Learn more about [cleaning up resources](https://docs.microsoft.com/azure/commun
 
 ## Next Steps
 
-[Try UI Library Composite Components](/?path=/docs/quickstarts-composites--page)
+[Try UI Library Composite Components](./?path=/docs/quickstarts-composites--page)
 
 For more information, see the following resources:
 
-- [UI Library Use Cases](/?path=/story/use-cases--page)
-- [UI Library Styling](/?path=/story/styling--page)
-- [UI Library Theming](/?path=/story/theming--page)
+- [UI Library Use Cases](./?path=/story/use-cases--page)
+- [UI Library Styling](./?path=/story/styling--page)
+- [UI Library Theming](./?path=/story/theming--page)

--- a/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
@@ -70,19 +70,19 @@ npm run start
 
 The following classes and interfaces handle some of the major features of the Azure Communication Services UI client library:
 
-| Name                                                                       | Description                                                                              |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| [FluentThemeProvider](/?path=/story/theming--page)                         | Provider that controls Theming on the components. Can be used to override theme          |
-| [GridLayout](/?path=/story/ui-components-gridlayout--grid-layout)          | Base component that organizes video tiles into a grid                                    |
-| [VideoTile](/?path=/story/ui-components-videotile--video-tile)             | Base component to render participants either with or without video                       |
-| [ControlBar](/?path=/story/ui-components-controlbar--control-bar)          | Base component to control call including mute, video, share screen                       |
-| [MessageThread](/?path=/story/ui-components-messagethread--message-thread) | Base component that renders a chat thread with typing indicators, read receipts, etc.    |
-| [SendBox](/?path=/story/ui-components-sendbox--send-box)                   | Base component that allows user to input messages that will be sent to the joined thread |
+| Name                                                                        | Description                                                                              |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [FluentThemeProvider](./?path=/story/theming--page)                         | Provider that controls Theming on the components. Can be used to override theme          |
+| [GridLayout](./?path=/story/ui-components-gridlayout--grid-layout)          | Base component that organizes video tiles into a grid                                    |
+| [VideoTile](./?path=/story/ui-components-videotile--video-tile)             | Base component to render participants either with or without video                       |
+| [ControlBar](./?path=/story/ui-components-controlbar--control-bar)          | Base component to control call including mute, video, share screen                       |
+| [MessageThread](./?path=/story/ui-components-messagethread--message-thread) | Base component that renders a chat thread with typing indicators, read receipts, etc.    |
+| [SendBox](./?path=/story/ui-components-sendbox--send-box)                   | Base component that allows user to input messages that will be sent to the joined thread |
 
 ## Set Up Fluent Theme Provider
 
 The `FluentThemeProvider` is a required wrapper around the UI Library components to provide theming that makes the components look amazing!
-It is in charge of allowing developer customize the theme of the components as well. Check out [Theming](/?path=/story/theming--page) for more information. `FluentThemeProvider` defaults to using light theme.
+It is in charge of allowing developer customize the theme of the components as well. Check out [Theming](./?path=/story/theming--page) for more information. `FluentThemeProvider` defaults to using light theme.
 
 `App.tsx`
 
@@ -94,7 +94,7 @@ You can customize the layout of these components and add any other custom compon
 
 ## Calling UI Components
 
-For Calling, we'll use the [`GridLayout`](/?path=/story/ui-components-gridlayout--grid-layout-component) and [`ControlBar`](/?path=/story/ui-components-controlbar--control-bar) components.
+For Calling, we'll use the [`GridLayout`](./?path=/story/ui-components-gridlayout--grid-layout-component) and [`ControlBar`](./?path=/story/ui-components-controlbar--control-bar) components.
 To start, in the `src` folder, create a new file called `CallingComponents.tsx`.
 Here we'll initialize a function component that will hold our base components to then import in `app.tsx`.
 You can add extra layout and styling around the components.
@@ -107,7 +107,7 @@ For this example we added a single `Video Tile` to the grid, but additional can 
 
 ## Chat UI Components
 
-For Chat, we will use the [`MessageThread`](/?path=/docs/ui-components-chatthread--chat-thread-component) and [`SendBox`](/?path=/docs/ui-components-sendbox--send-box-story-book-component) components.
+For Chat, we will use the [`MessageThread`](./?path=/docs/ui-components-chatthread--chat-thread-component) and [`SendBox`](./?path=/docs/ui-components-sendbox--send-box-story-book-component) components.
 To start, in the `src` folder, create a new file called `ChatComponents.tsx`.
 Here we'll initialize a function component that will hold our base components to then import in `app.tsx`.
 
@@ -144,10 +144,10 @@ Learn more about [cleaning up resources](https://docs.microsoft.com/azure/commun
 
 ## Next Steps
 
-[Try UI Library Stateful Client](/?path=/story/quickstarts-statefulclient--page)
+[Try UI Library Stateful Client](./?path=/story/quickstarts-statefulclient--page)
 
 For more information, see the following resources:
 
-- [UI Library Use Cases](/?path=/story/use-cases--page)
-- [UI Library Styling](/?path=/story/styling--page)
-- [UI Library Theming](/?path=/story/theming--page)
+- [UI Library Use Cases](./?path=/story/use-cases--page)
+- [UI Library Styling](./?path=/story/styling--page)
+- [UI Library Theming](./?path=/story/theming--page)

--- a/packages/storybook/stories/Stateful Client/Adapters.stories.mdx
+++ b/packages/storybook/stories/Stateful Client/Adapters.stories.mdx
@@ -9,8 +9,8 @@ const CallAdapterExampleText = require('!!raw-loader!./snippets/CallAdapterExamp
 
 Composites deliver turn-key communication experiences for developers.
 They make it easy for developers to add end-to-end communication experiences to their apps with only a couple lines of code.
-To power Composites, the UI library provides `Adapters`, one for the calling composite [here](/?path=/docs/composites-call-basicexample--basic-example) and one for chat composite
-[here](/?path=/docs/composites-chat-basicexample--basic-example).
+To power Composites, the UI library provides `Adapters`, one for the calling composite [here](./?path=/docs/composites-call-basicexample--basic-example) and one for chat composite
+[here](./?path=/docs/composites-chat-basicexample--basic-example).
 These adapters make use of the stateful clients for calling and chat in conjunction with React Hooks like usePropsFor to provide developers a single interface to configure Composites.
 
 ## Setting Up Adapters

--- a/packages/storybook/stories/Stateful Client/OverviewStateful.stories.mdx
+++ b/packages/storybook/stories/Stateful Client/OverviewStateful.stories.mdx
@@ -13,7 +13,7 @@ Stateful clients are agnostic to any specific state management framework.
 
 ## Component Binding with Stateful Clients
 
-To make it simpler to connect the stateful client with UI Components, the UI Library exposes helpers, [`usePropsFor`](/?path=/docs/statefulclient-reacthooks-usepropsfor--page), to generate props
+To make it simpler to connect the stateful client with UI Components, the UI Library exposes helpers, [`usePropsFor`](./?path=/docs/statefulclient-reacthooks-usepropsfor--page), to generate props
 These helpers aid in extracting the correct set of props required for different UI Components.
 They expose both data for the UI Components to render such as a message list or a participants remote video, and default handlers for UI Components action such as sending a message.
 

--- a/packages/storybook/stories/Stateful Client/SettingUpReactHooks.stories.mdx
+++ b/packages/storybook/stories/Stateful Client/SettingUpReactHooks.stories.mdx
@@ -8,7 +8,7 @@ import { Canvas, Description, Heading, Props, Source, Title } from '@storybook/a
 [React Hooks](https://reactjs.org/docs/hooks-intro.html) allows developers to use state and other react features without writing a class component.
 
 While you can choose any state management library such as Redux, we also provide a simple way to power react components with our Stateful SDK.
-We provide two [custom hooks](https://reactjs.org/docs/hooks-custom.html) in our library, [usePropsFor()](/?path=/docs/statefulclient-reacthooks-usepropsfor--page) and [useSelector()](/?path=/docs/statefulclient-reacthooks-useselector--page), that allow you to subscribe to changes in the SDK state and bind to our UI components.
+We provide two [custom hooks](https://reactjs.org/docs/hooks-custom.html) in our library, [usePropsFor()](./?path=/docs/statefulclient-reacthooks-usepropsfor--page) and [useSelector()](./?path=/docs/statefulclient-reacthooks-useselector--page), that allow you to subscribe to changes in the SDK state and bind to our UI components.
 After binding with the custom hooks a SDK state change will trigger a re-render of the UI component, and events on the component will call into the SDK clients.
 
 ## Before you Start
@@ -21,7 +21,7 @@ There are different Providers for building apps with varying functionality:
 
 For your Chat app, use the `ChatClientProvider` and `ChatThreadClientProvider` to give hooks access to the `ChatClient` and `ChatThreadClient`.
 `statefulChatClient` and `chatThreadClient` instances need to be passed to the Provider when you wrap your app.
-For more information on creating them, see [Overview](/?path=/docs/statefulclient-overview--page)
+For more information on creating them, see [Overview](./?path=/docs/statefulclient-overview--page)
 
 ```tsx
 ReactDOM.render(
@@ -38,7 +38,7 @@ ReactDOM.render(
 
 For your Chat app, use the `CallClientProvider`, `CallAgentProvider` and `CallProvider` to give hooks access to the `CallClient`, `CallAgentClient` and `Call`.
 `statefulCallClient`, `callAgent` and `call` instances need to be passed to the Provider when you wrap your app.
-For more information on creating them, see [Overview](/?path=/docs/statefulclient-overview--page)
+For more information on creating them, see [Overview](./?path=/docs/statefulclient-overview--page)
 
 ```tsx
 ReactDOM.render(
@@ -57,4 +57,4 @@ ReactDOM.render(
 
 Once you have wrapped your entire app with providers, you are now can use the usePropsFor() method inside of your app to connect your components to the state.
 
-To see a full end-to-end example using providers, see [Getting Started with StatefulClient](/?path=/docs/quickstarts-statefulclient--page)
+To see a full end-to-end example using providers, see [Getting Started with StatefulClient](./?path=/docs/quickstarts-statefulclient--page)

--- a/packages/storybook/stories/Stateful Client/UsePropsForHook.stories.mdx
+++ b/packages/storybook/stories/Stateful Client/UsePropsForHook.stories.mdx
@@ -9,7 +9,7 @@ If you are using React Component from our communication-react components, usePro
 It provides all the required props to power a feature component.
 It subscribes to state changes of stateful clients, gets props designed for your component, and triggers a re-render whenever the props change.
 
-To see a full end-to-end example using usePropsFor, see [Getting Started with StatefulClient](/?path=/docs/quickstarts-statefulclient--page)
+To see a full end-to-end example using usePropsFor, see [Getting Started with StatefulClient](./?path=/docs/quickstarts-statefulclient--page)
 
 ## _usePropsFor_ Calling App Example
 
@@ -39,20 +39,20 @@ export const ChatScreen = () => {
 
 _Chat_
 
-- [MessageThread](/?path=/docs/ui-components-messagethread--message-thread)
-- [SendBox](/?path=/docs/ui-components-sendbox--send-box)
-- [TypingIndicator](/?path=/docs/ui-components-typingindicator--typing-indicator)
-- [ParticipantList](/?path=/docs/ui-components-participantlist--participant-list)
+- [MessageThread](./?path=/docs/ui-components-messagethread--message-thread)
+- [SendBox](./?path=/docs/ui-components-sendbox--send-box)
+- [TypingIndicator](./?path=/docs/ui-components-typingindicator--typing-indicator)
+- [ParticipantList](./?path=/docs/ui-components-participantlist--participant-list)
 
 _Calling_
 
-- [VideoGallery](/?path=/docs/ui-components-videogallery--video-gallery)
-- [ParticipantList](/?path=/docs/ui-components-participantlist--participant-list)
-- [CameraButton](/?path=/docs/ui-components-controlbar-buttons-camera--camera)
-- [EndCallButton](/?path=/docs/ui-components-controlbar-buttons-endcall--end-call)
-- [MicrophoneButton](/?path=/docs/ui-components-controlbar-buttons-microphone--microphone)
-- [OptionsButton](/?path=/docs/ui-components-controlbar-buttons-options--options)
-- [ScreenShareButton](/?path=/docs/ui-components-controlbar-buttons-screenshare--screen-share)
+- [VideoGallery](./?path=/docs/ui-components-videogallery--video-gallery)
+- [ParticipantList](./?path=/docs/ui-components-participantlist--participant-list)
+- [CameraButton](./?path=/docs/ui-components-controlbar-buttons-camera--camera)
+- [EndCallButton](./?path=/docs/ui-components-controlbar-buttons-endcall--end-call)
+- [MicrophoneButton](./?path=/docs/ui-components-controlbar-buttons-microphone--microphone)
+- [OptionsButton](./?path=/docs/ui-components-controlbar-buttons-options--options)
+- [ScreenShareButton](./?path=/docs/ui-components-controlbar-buttons-screenshare--screen-share)
 
 ## Choose your target
 
@@ -91,4 +91,4 @@ You can use the usePropsFor function for your own custom components by matching 
 By passing the component that matches your custom components prop structure, you can then use the outputted props on your own custom component.
 This means you could build your own `Video Gallery` with a custom layout using our `Grid Layout` and `Video Tile` components, and still leverage our usePropsFor helper.
 In cases, where matching the prop structure is not possible, the stateful clients can still be leveraged to extract and maintain your own props.
-For more information, see [useSelector](/?path=/docs/statefulclient-reacthooks-useselector--page).
+For more information, see [useSelector](./?path=/docs/statefulclient-reacthooks-useselector--page).

--- a/packages/storybook/stories/UseCases.stories.mdx
+++ b/packages/storybook/stories/UseCases.stories.mdx
@@ -65,9 +65,9 @@ See the diagram below for guidance:
 When using UI Components to deliver Teams Interop experiences, UI Library provides examples for key pieces of the experience.
 For example:
 
-- [Lobby Example](/?path=/story/examples-teamsinterop-lobby--lobby): Sample lobby for participant to wait to be admitted to the call.
-- [Compliance banner](/?path=/story/examples-teamsinterop-compliancebanner--compliance-banner): Sample banner to show the user whether the call is being recorded or not.
-- [Teams Theme](/?path=/story/examples-themes-teams--teams): Sample theme that makes the UI Library looks like Microsoft Teams.
+- [Lobby Example](./?path=/story/examples-teamsinterop-lobby--lobby): Sample lobby for participant to wait to be admitted to the call.
+- [Compliance banner](./?path=/story/examples-teamsinterop-compliancebanner--compliance-banner): Sample banner to show the user whether the call is being recorded or not.
+- [Teams Theme](./?path=/story/examples-themes-teams--teams): Sample theme that makes the UI Library looks like Microsoft Teams.
 
 ## Customization
 


### PR DESCRIPTION
# What
changed path of internal links in storybook (from '/?path=/' to './?path=/')

# Why
all links in storybook were broken. URL was with '.../?path=/?path=/...'
bug: https://skype.visualstudio.com/SPOOL/_workitems/edit/2553576

# How Tested
Ran storybook locally and also tested through this PR Storybook link :)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->