### PR TITLE
Remove redundant `show` prefix from `visualElements` fields

### DIFF
--- a/change/@internal-react-composites-3d05cbe2-320d-4ac9-ac5b-8a35f47c72de.json
+++ b/change/@internal-react-composites-3d05cbe2-320d-4ac9-ac5b-8a35f47c72de.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Drop `show` prefix from `visualElements` fields",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -313,7 +313,7 @@ export interface CallCompositeStrings {
 
 // @public
 export type CallCompositeVisualElements = {
-    showErrorBar?: boolean;
+    errorBar?: boolean;
 };
 
 // @public (undocumented)
@@ -571,9 +571,9 @@ export interface ChatCompositeProps extends BaseCompositeProps {
 
 // @public
 export type ChatCompositeVisualElements = {
-    showErrorBar?: boolean;
-    showParticipantPane?: boolean;
-    showTopic?: boolean;
+    errorBar?: boolean;
+    participantPane?: boolean;
+    topic?: boolean;
 };
 
 // @public

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -215,7 +215,7 @@ export interface CallCompositeStrings {
 
 // @public
 export type CallCompositeVisualElements = {
-    showErrorBar?: boolean;
+    errorBar?: boolean;
 };
 
 // @public (undocumented)
@@ -317,9 +317,9 @@ export interface ChatCompositeProps extends BaseCompositeProps {
 
 // @public
 export type ChatCompositeVisualElements = {
-    showErrorBar?: boolean;
-    showParticipantPane?: boolean;
-    showTopic?: boolean;
+    errorBar?: boolean;
+    participantPane?: boolean;
+    topic?: boolean;
 };
 
 // @public

--- a/packages/react-composites/src/composites/CallComposite/Call.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Call.tsx
@@ -42,7 +42,7 @@ export type CallCompositeVisualElements = {
    *
    * @defaultValue false
    */
-  showErrorBar?: boolean;
+  errorBar?: boolean;
 };
 
 type MainScreenProps = {
@@ -51,7 +51,7 @@ type MainScreenProps = {
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   visualElements: {
     showCallControls: boolean;
-    showErrorBar: boolean;
+    errorBar: boolean;
   };
 };
 
@@ -141,7 +141,7 @@ export const CallCompositeInternal = (props: CallInternalProps): JSX.Element => 
         onFetchAvatarPersonaData={onFetchAvatarPersonaData}
         visualElements={{
           showCallControls: props.showCallControls,
-          showErrorBar: props.visualElements?.showErrorBar ?? false
+          errorBar: props.visualElements?.errorBar ?? false
         }}
       />
     </CallAdapterProvider>

--- a/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
@@ -42,7 +42,7 @@ export interface CallScreenProps {
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   visualElements: {
     showCallControls: boolean;
-    showErrorBar: boolean;
+    errorBar: boolean;
   };
 }
 
@@ -137,7 +137,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
               cameraPermissionGranted={devicePermissions.video}
             />
           </Stack.Item>
-          {props.visualElements.showErrorBar && (
+          {props.visualElements.errorBar && (
             <Stack.Item style={{ width: '100%' }}>
               <ErrorBar {...errorBarProps} />
             </Stack.Item>

--- a/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
@@ -40,17 +40,17 @@ export type ChatCompositeVisualElements = {
    *
    * @defaultValue false
    */
-  showErrorBar?: boolean;
+  errorBar?: boolean;
   /**
    * Choose to show the participant pane
    * @defaultValue false
    */
-  showParticipantPane?: boolean;
+  participantPane?: boolean;
   /**
    * Choose to show the topic at the top of the chat
    * @defaultValue false
    */
-  showTopic?: boolean;
+  topic?: boolean;
 };
 
 export const ChatComposite = (props: ChatCompositeProps): JSX.Element => {
@@ -60,9 +60,9 @@ export const ChatComposite = (props: ChatCompositeProps): JSX.Element => {
     <BaseComposite {...props}>
       <ChatAdapterProvider adapter={adapter}>
         <ChatScreen
-          showErrorBar={visualElements?.showErrorBar}
-          showParticipantPane={visualElements?.showParticipantPane}
-          showTopic={visualElements?.showTopic}
+          errorBar={visualElements?.errorBar}
+          participantPane={visualElements?.participantPane}
+          topic={visualElements?.topic}
           onFetchAvatarPersonaData={onFetchAvatarPersonaData}
           onRenderTypingIndicator={onRenderTypingIndicator}
           onRenderMessage={onRenderMessage}

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -30,16 +30,16 @@ import {
 import { AvatarPersonaDataCallback, AvatarPersona } from '../common/AvatarPersona';
 
 export type ChatScreenProps = {
-  showErrorBar?: boolean;
-  showParticipantPane?: boolean;
-  showTopic?: boolean;
+  errorBar?: boolean;
+  participantPane?: boolean;
+  topic?: boolean;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   onRenderMessage?: (messageProps: MessageProps, defaultOnRender?: DefaultMessageRendererType) => JSX.Element;
   onRenderTypingIndicator?: (typingUsers: CommunicationParticipant[]) => JSX.Element;
 };
 
 export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
-  const { onFetchAvatarPersonaData, onRenderMessage, onRenderTypingIndicator, showParticipantPane, showTopic } = props;
+  const { onFetchAvatarPersonaData, onRenderMessage, onRenderTypingIndicator, participantPane, topic } = props;
 
   const defaultNumberOfChatMessagesToReload = 5;
   const sendBoxParentStyle = mergeStyles({ width: '100%' });
@@ -66,10 +66,10 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
 
   return (
     <Stack className={chatContainer} grow>
-      {!!showTopic && <ChatHeader {...headerProps} />}
+      {!!topic && <ChatHeader {...headerProps} />}
       <Stack className={chatArea} tokens={participantListContainerPadding} horizontal grow>
         <Stack className={chatWrapper} grow>
-          {props.showErrorBar ? <ErrorBar {...errorBarProps} /> : <></>}
+          {props.errorBar ? <ErrorBar {...errorBarProps} /> : <></>}
           <MessageThread
             {...messageThreadProps}
             onRenderAvatar={onRenderAvatarCallback}
@@ -87,7 +87,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
             <SendBox {...sendBoxProps} />
           </Stack.Item>
         </Stack>
-        {showParticipantPane && (
+        {participantPane && (
           <Stack.Item className={participantListWrapper}>
             <Stack className={participantListStack}>
               <Stack.Item className={listHeader}>In this chat</Stack.Item>

--- a/packages/react-composites/tests/browser/chat/app/index.tsx
+++ b/packages/react-composites/tests/browser/chat/app/index.tsx
@@ -46,7 +46,7 @@ function App(): JSX.Element {
       {chatAdapter && (
         <ChatComposite
           adapter={chatAdapter}
-          visualElements={{ showErrorBar: true, showParticipantPane: true, showTopic: true }}
+          visualElements={{ errorBar: true, participantPane: true, topic: true }}
           onRenderTypingIndicator={
             customDataModel
               ? () => <text id="custom-data-model-typing-indicator">Someone is typing...</text>

--- a/packages/storybook/stories/CallComposite/BasicExample.stories.tsx
+++ b/packages/storybook/stories/CallComposite/BasicExample.stories.tsx
@@ -40,7 +40,7 @@ const BasicStory = (args, context): JSX.Element => {
           {...containerProps}
           callInvitationURL={args.callInvitationURL}
           locale={compositeLocale(locale)}
-          visualElements={{ showErrorBar: args.showErrorBar }}
+          visualElements={{ errorBar: args.errorBar }}
         />
       ) : (
         <ConfigHintBanner />
@@ -59,7 +59,7 @@ export default {
     connectionString: controlsToAdd.connectionString,
     displayName: controlsToAdd.displayName,
     callInvitationURL: controlsToAdd.callInvitationURL,
-    showErrorBar: controlsToAdd.showErrorBar,
+    errorBar: controlsToAdd.errorBar,
     // Hiding auto-generated controls
     ...defaultCallCompositeHiddenControls
   },

--- a/packages/storybook/stories/CallComposite/JoinExistingCall.stories.tsx
+++ b/packages/storybook/stories/CallComposite/JoinExistingCall.stories.tsx
@@ -29,7 +29,7 @@ const JoinExistingCallStory = (args, context): JSX.Element => {
           displayName={args.displayName}
           callInvitationURL={args.callInvitationURL}
           locale={compositeLocale(locale)}
-          visualElements={{ showErrorBar: true }}
+          visualElements={{ errorBar: true }}
         />
       ) : (
         <ConfigJoinCallHintBanner />

--- a/packages/storybook/stories/CallComposite/ThemeExample.stories.tsx
+++ b/packages/storybook/stories/CallComposite/ThemeExample.stories.tsx
@@ -48,7 +48,7 @@ const ThemeExampleStory = (args, context): JSX.Element => {
           {...containerProps}
           callInvitationURL={args.callInvitationURL}
           locale={compositeLocale(locale)}
-          visualElements={{ showErrorBar: true }}
+          visualElements={{ errorBar: true }}
         />
       ) : (
         <ConfigHintBanner />

--- a/packages/storybook/stories/ChatComposite/BasicExample.stories.tsx
+++ b/packages/storybook/stories/ChatComposite/BasicExample.stories.tsx
@@ -47,9 +47,9 @@ const BasicStory = (args, context): JSX.Element => {
           fluentTheme={context.theme}
           {...containerProps}
           locale={compositeLocale(locale)}
-          showErrorBar={args.showErrorBar}
+          errorBar={args.errorBar}
           showParticipants={args.showParticipants}
-          showTopic={args.showTopic}
+          topic={args.topic}
         />
       ) : (
         <ConfigHintBanner />
@@ -67,9 +67,9 @@ export default {
   argTypes: {
     connectionString: controlsToAdd.connectionString,
     displayName: controlsToAdd.displayName,
-    showErrorBar: controlsToAdd.showErrorBar,
+    errorBar: controlsToAdd.errorBar,
     showParticipants: controlsToAdd.showChatParticipants,
-    showTopic: controlsToAdd.showChatTopic,
+    topic: controlsToAdd.showChatTopic,
     // Hiding auto-generated controls
     ...defaultChatCompositeHiddenControls
   },

--- a/packages/storybook/stories/ChatComposite/CustomBehaviorExampleContainer.tsx
+++ b/packages/storybook/stories/ChatComposite/CustomBehaviorExampleContainer.tsx
@@ -63,7 +63,7 @@ export const ContosoChatContainer = (props: ContainerProps): JSX.Element => {
           fluentTheme={props.fluentTheme}
           locale={props.locale}
           adapter={adapter}
-          visualElements={{ showErrorBar: true, showParticipantPane: true, showTopic: true }}
+          visualElements={{ errorBar: true, participantPane: true, topic: true }}
         />
       ) : (
         <h3>Loading...</h3>

--- a/packages/storybook/stories/ChatComposite/JoinExistingChatThread.stories.tsx
+++ b/packages/storybook/stories/ChatComposite/JoinExistingChatThread.stories.tsx
@@ -30,9 +30,9 @@ const JoinExistingChatThreadStory = (args, context): JSX.Element => {
           token={args.token}
           displayName={args.displayName}
           locale={compositeLocale(locale)}
-          showErrorBar={true}
+          errorBar={true}
           showParticipants={true}
-          showTopic={true}
+          topic={true}
         />
       ) : (
         <ConfigJoinChatThreadHintBanner />

--- a/packages/storybook/stories/ChatComposite/ThemesExample.stories.tsx
+++ b/packages/storybook/stories/ChatComposite/ThemesExample.stories.tsx
@@ -55,9 +55,9 @@ const ThemeStory = (args, context): JSX.Element => {
           {...containerProps}
           fluentTheme={theme}
           locale={compositeLocale(locale)}
-          showErrorBar={true}
+          errorBar={true}
           showParticipants={true}
-          showTopic={true}
+          topic={true}
         />
       ) : (
         <ConfigHintBanner />

--- a/packages/storybook/stories/ChatComposite/snippets/Container.snippet.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/Container.snippet.tsx
@@ -19,9 +19,9 @@ export type ContainerProps = {
   endpointUrl: string;
   threadId: string;
   fluentTheme?: PartialTheme | Theme;
-  showErrorBar?: boolean;
+  errorBar?: boolean;
   showParticipants?: boolean;
-  showTopic?: boolean;
+  topic?: boolean;
   locale?: CompositeLocale;
 };
 
@@ -62,9 +62,9 @@ export const ContosoChatContainer = (props: ContainerProps): JSX.Element => {
         adapter={adapter}
         fluentTheme={props.fluentTheme}
         visualElements={{
-          showErrorBar: props.showErrorBar,
-          showParticipantPane: props.showParticipants,
-          showTopic: props.showTopic
+          errorBar: props.errorBar,
+          participantPane: props.showParticipants,
+          topic: props.topic
         }}
         locale={props.locale}
       />

--- a/packages/storybook/stories/ChatComposite/snippets/CustomDataModelExampleContainer.snippet.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/CustomDataModelExampleContainer.snippet.tsx
@@ -72,7 +72,7 @@ export const CustomDataModelExampleContainer = (props: CustomDataModelExampleCon
           fluentTheme={props.fluentTheme}
           adapter={adapter}
           onFetchAvatarPersonaData={onFetchAvatarPersonaData}
-          visualElements={{ showErrorBar: true, showParticipantPane: true, showTopic: true }}
+          visualElements={{ errorBar: true, participantPane: true, topic: true }}
           locale={props.locale}
         />
       ) : (

--- a/packages/storybook/stories/ChatComposite/snippets/CustomizeBehavior.snippet.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/CustomizeBehavior.snippet.tsx
@@ -54,7 +54,7 @@ export const ContosoChatContainer = (props: ContainerProps): JSX.Element => {
         <ChatComposite
           adapter={adapter}
           locale={props.locale}
-          visualElements={{ showErrorBar: true, showParticipantPane: true, showTopic: true }}
+          visualElements={{ errorBar: true, participantPane: true, topic: true }}
         />
       ) : (
         <h3>Loading...</h3>

--- a/packages/storybook/stories/ErrorBar/ErrorBar.stories.tsx
+++ b/packages/storybook/stories/ErrorBar/ErrorBar.stories.tsx
@@ -25,7 +25,7 @@ const getDocs: () => JSX.Element = () => {
         `ErrorBar` is a wrapper on fluent UI's `MessageBar` with additional features for surfacing Azure Communication
         Services errors on the UI consistently.
       </Description>
-      <Description>Set the `showErrorBar` feature for `ChatComposite` to use an `ErrorBar` to show errors.</Description>
+      <Description>Set the `errorBar` feature for `ChatComposite` to use an `ErrorBar` to show errors.</Description>
       <Subheading>Localization</Subheading>
       <Description>
         Similar to other UI components in this library, `ErrorBarProps` accepts all strings shown on the UI as a

--- a/packages/storybook/stories/controlsUtils.ts
+++ b/packages/storybook/stories/controlsUtils.ts
@@ -263,7 +263,7 @@ export const controlsToAdd = {
   },
   showChatParticipants: { control: 'boolean', defaultValue: true, name: 'Show Participants Pane' },
   showChatTopic: { control: 'boolean', defaultValue: true, name: 'Show Topic' },
-  showErrorBar: { control: 'boolean', defaultValue: true, name: 'Show ErrorBar' },
+  errorBar: { control: 'boolean', defaultValue: true, name: 'Show ErrorBar' },
   showLabel: { control: 'boolean', defaultValue: false, name: 'Show label' },
   showMessageDate: { control: 'boolean', defaultValue: true, name: 'Enable Message Date' },
   showMessageStatus: { control: 'boolean', defaultValue: true, name: 'Enable Message Status Indicator' },

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -58,7 +58,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
       fluentTheme={currentTheme.theme}
       rtl={currentRtl}
       callInvitationURL={window.location.href}
-      visualElements={{ showErrorBar: true }}
+      visualElements={{ errorBar: true }}
     />
   );
 };

--- a/samples/Chat/src/app/ChatScreen.tsx
+++ b/samples/Chat/src/app/ChatScreen.tsx
@@ -101,7 +101,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
           <ChatComposite
             adapter={adapter}
             fluentTheme={currentTheme.theme}
-            visualElements={{ showParticipantPane: showParticipants, showTopic: true, showErrorBar: true }}
+            visualElements={{ participantPane: showParticipants, topic: true, errorBar: true }}
             onFetchAvatarPersonaData={onFetchAvatarPersonaData}
           />
         </Stack.Item>

--- a/samples/StaticHtmlComposites/index.html
+++ b/samples/StaticHtmlComposites/index.html
@@ -47,7 +47,7 @@
         token: token
       },
       document.getElementById('chat-container'),
-      { visualElements: { showParticipantPane: true, showTopic: false } }
+      { visualElements: { participantPane: true, topic: false } }
     );
 
     await chatAdapter.sendMessage('Hello to you! 👋');


### PR DESCRIPTION
# What
* Drops the redundant prefix, also removing the confusion around enabled-by-default vs disabled-by-default visual elements.

Thanks to @anjulgarg for a review comment to this effect.