### PR TITLE
Alcail/fix flickering messages

### DIFF
--- a/change/@internal-react-components-d8ef1481-7641-4a56-9b3c-b52ea21405c4.json
+++ b/change/@internal-react-components-d8ef1481-7641-4a56-9b3c-b52ea21405c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix comment spelling in MessageThreadProps",
+  "packageName": "@internal/react-components",
+  "email": "alcail@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-storybook-0931274a-a35f-4940-bd07-250fc6b99ef0.json
+++ b/change/@internal-storybook-0931274a-a35f-4940-bd07-250fc6b99ef0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix infinite render of previous messages",
+  "packageName": "@internal/storybook",
+  "email": "alcail@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -468,7 +468,7 @@ export type MessageThreadProps = {
    */
   showMessageStatus?: boolean;
   /**
-   * Number of chat messaegs to reload each time onLoadPreviousChatMessages is called.
+   * Number of chat messages to reload each time onLoadPreviousChatMessages is called.
    *
    * @defaultValue 0
    */

--- a/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
+++ b/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
@@ -175,8 +175,10 @@ const MessageThreadStory = (args): JSX.Element => {
   };
 
   const onLoadPreviousMessages = async (): Promise<boolean> => {
-    setChatMessages([...GenerateMockHistoryChatMessages(), ...chatMessages]);
-    return false;
+    return new Promise((resolve) => {
+      setChatMessages([...GenerateMockHistoryChatMessages(), ...chatMessages]);
+      resolve(true);
+    });
   };
 
   const onSendNewSystemMessage = (): void => {


### PR DESCRIPTION
# What
onLoadPreviousMessages from MessageThread now resolves with 'true' once rendered to avoid re-rendering the previous messages again and again.

Also fixed a spelling error in MessageThreadProps

# Why
bug https://skype.visualstudio.com/SPOOL/_workitems/edit/2553477
onLoadPreviousMessages from MessageThread component was returning false in MessageThread story ending up with an infinite re-render of those previous messages, thus the flickering avatars (red rectangle)
![image](https://user-images.githubusercontent.com/82416644/131591806-69394a0c-454a-480b-bd7e-b0a411bd0367.png)


# How Tested
ran storybook locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->