### PR TITLE
Disable TD builds on pushes and PRs. Reduce PR checks time.

### DIFF
--- a/.github/workflows/touchdown-pipeline/touchdown-build-components.yml
+++ b/.github/workflows/touchdown-pipeline/touchdown-build-components.yml
@@ -1,6 +1,7 @@
 # Touchdown build pipeline for components
 
-trigger: [main]
+trigger: none
+pr: none
 
 pool:
   vmImage: ubuntu-latest

--- a/.github/workflows/touchdown-pipeline/touchdown-build-composites.yml
+++ b/.github/workflows/touchdown-pipeline/touchdown-build-composites.yml
@@ -1,6 +1,7 @@
 # Touchdown build pipeline for composites
 
-trigger: [main]
+trigger: none
+pr: none
 
 pool:
   vmImage: ubuntu-latest


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Disable TD builds on pushes and PRs because too many jobs are being queued and holding up the checks for our PRs.
Based on YAML schema docs:
-https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#push-trigger
-https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#pr-trigger

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Stop holding up the PRs with unnecessary checks

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->