### PR TITLE
Strongly type errors from adapters

### DIFF
--- a/change/@internal-react-composites-fd451fd1-2cca-4264-92ef-e597effabb14.json
+++ b/change/@internal-react-composites-fd451fd1-2cca-4264-92ef-e597effabb14.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Strongly type errors from adapters",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -79,6 +79,18 @@ export interface AdapterDisposal {
 }
 
 // @public
+export interface AdapterError extends Error {
+    inner: Error;
+    target: string;
+    timestamp: Date;
+}
+
+// @public
+export type AdapterErrors = {
+    [target: string]: AdapterError;
+};
+
+// @public
 export interface AdapterPages<TPage> {
     // (undocumented)
     setPage(page: TPage): void;
@@ -195,7 +207,7 @@ export type CallAdapterClientState = {
     call?: CallState;
     devices: DeviceManagerState;
     endedCall?: CallState;
-    latestErrors: CallAdapterErrors;
+    latestErrors: AdapterErrors;
 };
 
 // @public
@@ -215,11 +227,6 @@ export interface CallAdapterDeviceManagement {
     // (undocumented)
     setSpeaker(sourceId: AudioDeviceInfo): Promise<void>;
 }
-
-// @public
-export type CallAdapterErrors = {
-    [operation: string]: Error;
-};
 
 // @public (undocumented)
 export type CallAdapterState = CallAdapterUiState & CallAdapterClientState;
@@ -243,7 +250,7 @@ export interface CallAdapterSubscribers {
     // (undocumented)
     off(event: 'callEnded', listener: CallEndedListener): void;
     // (undocumented)
-    off(event: 'error', listener: (e: Error) => void): void;
+    off(event: 'error', listener: (e: AdapterError) => void): void;
     // (undocumented)
     on(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
     // (undocumented)
@@ -261,7 +268,7 @@ export interface CallAdapterSubscribers {
     // (undocumented)
     on(event: 'callEnded', listener: CallEndedListener): void;
     // (undocumented)
-    on(event: 'error', listener: (e: Error) => void): void;
+    on(event: 'error', listener: (e: AdapterError) => void): void;
 }
 
 // @public
@@ -495,11 +502,6 @@ export interface CameraButtonStrings {
 export interface ChatAdapter extends ChatAdapterThreadManagement, AdapterState<ChatAdapterState>, AdapterDisposal, ChatAdapterSubscribers {
 }
 
-// @public
-export type ChatAdapterErrors = {
-    [operation: string]: Error;
-};
-
 // @public (undocumented)
 export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
 
@@ -518,7 +520,7 @@ export interface ChatAdapterSubscribers {
     // (undocumented)
     off(event: 'topicChanged', listener: TopicChangedListener): void;
     // (undocumented)
-    off(event: 'error', listener: ChatErrorListener): void;
+    off(event: 'error', listener: (e: AdapterError) => void): void;
     // (undocumented)
     on(event: 'messageReceived', listener: MessageReceivedListener): void;
     // (undocumented)
@@ -532,7 +534,7 @@ export interface ChatAdapterSubscribers {
     // (undocumented)
     on(event: 'topicChanged', listener: TopicChangedListener): void;
     // (undocumented)
-    on(event: 'error', listener: ChatErrorListener): void;
+    on(event: 'error', listener: (e: AdapterError) => void): void;
 }
 
 // @public
@@ -594,7 +596,7 @@ export type ChatCompositeClientState = {
     userId: string;
     displayName: string;
     thread: ChatThreadClientState;
-    latestErrors: ChatAdapterErrors;
+    latestErrors: AdapterErrors;
 };
 
 // @public (undocumented)
@@ -631,12 +633,6 @@ activeErrors: ActiveError[];
 }, (res: ChatErrors) => {
 activeErrors: ActiveError[];
 }>;
-
-// @public
-export type ChatErrorListener = (event: {
-    operation: string;
-    error: Error;
-}) => void;
 
 // @public
 export type ChatErrors = {

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -38,6 +38,19 @@ export interface AdapterDisposal {
 }
 
 // @public
+export class AdapterError extends Error {
+    constructor(target: string, inner: Error, timestamp: Date);
+    inner: Error;
+    target: string;
+    timestamp: Date;
+}
+
+// @public
+export type AdapterErrors = {
+    [target: string]: AdapterError;
+};
+
+// @public
 export interface AdapterPages<TPage> {
     // (undocumented)
     setPage(page: TPage): void;
@@ -132,7 +145,7 @@ export type CallAdapterClientState = {
     call?: CallState;
     devices: DeviceManagerState;
     endedCall?: CallState;
-    latestErrors: CallAdapterErrors;
+    latestErrors: AdapterErrors;
 };
 
 // @public
@@ -152,11 +165,6 @@ export interface CallAdapterDeviceManagement {
     // (undocumented)
     setSpeaker(sourceId: AudioDeviceInfo): Promise<void>;
 }
-
-// @public
-export type CallAdapterErrors = {
-    [operation: string]: Error;
-};
 
 // @public (undocumented)
 export type CallAdapterState = CallAdapterUiState & CallAdapterClientState;
@@ -180,7 +188,7 @@ export interface CallAdapterSubscribers {
     // (undocumented)
     off(event: 'callEnded', listener: CallEndedListener): void;
     // (undocumented)
-    off(event: 'error', listener: (e: Error) => void): void;
+    off(event: 'error', listener: (e: AdapterError) => void): void;
     // (undocumented)
     on(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
     // (undocumented)
@@ -198,7 +206,7 @@ export interface CallAdapterSubscribers {
     // (undocumented)
     on(event: 'callEnded', listener: CallEndedListener): void;
     // (undocumented)
-    on(event: 'error', listener: (e: Error) => void): void;
+    on(event: 'error', listener: (e: AdapterError) => void): void;
 }
 
 // @public

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -38,8 +38,7 @@ export interface AdapterDisposal {
 }
 
 // @public
-export class AdapterError extends Error {
-    constructor(target: string, inner: Error, timestamp: Date);
+export interface AdapterError extends Error {
     inner: Error;
     target: string;
     timestamp: Date;

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -263,11 +263,6 @@ export type CallIdChangedListener = (event: {
 export interface ChatAdapter extends ChatAdapterThreadManagement, AdapterState<ChatAdapterState>, AdapterDisposal, ChatAdapterSubscribers {
 }
 
-// @public
-export type ChatAdapterErrors = {
-    [operation: string]: Error;
-};
-
 // @public (undocumented)
 export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
 
@@ -286,7 +281,7 @@ export interface ChatAdapterSubscribers {
     // (undocumented)
     off(event: 'topicChanged', listener: TopicChangedListener): void;
     // (undocumented)
-    off(event: 'error', listener: ChatErrorListener): void;
+    off(event: 'error', listener: (e: AdapterError) => void): void;
     // (undocumented)
     on(event: 'messageReceived', listener: MessageReceivedListener): void;
     // (undocumented)
@@ -300,7 +295,7 @@ export interface ChatAdapterSubscribers {
     // (undocumented)
     on(event: 'topicChanged', listener: TopicChangedListener): void;
     // (undocumented)
-    on(event: 'error', listener: ChatErrorListener): void;
+    on(event: 'error', listener: (e: AdapterError) => void): void;
 }
 
 // @public
@@ -338,7 +333,7 @@ export type ChatCompositeClientState = {
     userId: string;
     displayName: string;
     thread: ChatThreadClientState;
-    latestErrors: ChatAdapterErrors;
+    latestErrors: AdapterErrors;
 };
 
 // @public (undocumented)
@@ -360,12 +355,6 @@ export type ChatCompositeVisualElements = {
     showParticipantPane?: boolean;
     showTopic?: boolean;
 };
-
-// @public
-export type ChatErrorListener = (event: {
-    operation: string;
-    error: Error;
-}) => void;
 
 // @public
 export const COMPOSITE_LOCALE_DE_DE: CompositeLocale;

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -46,6 +46,7 @@ import {
   CommunicationUserKind
 } from '@azure/communication-common';
 import { ParticipantSubscriber } from './ParticipantSubcriber';
+import { AdapterError } from '../../common/adapters';
 
 // Context of Chat, which is a centralized context for all state updates
 class CallContext {
@@ -393,7 +394,7 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
   on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   on(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   on(event: 'callEnded', listener: CallEndedListener): void;
-  on(event: 'error', errorHandler: (e: Error) => void): void;
+  on(event: 'error', errorHandler: (e: AdapterError) => void): void;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public on(event: CallEvent, listener: (e: any) => void): void {
@@ -476,7 +477,7 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
   off(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   off(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   off(event: 'callEnded', listener: CallEndedListener): void;
-  off(event: 'error', errorHandler: (e: Error) => void): void;
+  off(event: 'error', errorHandler: (e: AdapterError) => void): void;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public off(event: CallEvent, listener: (e: any) => void): void {
@@ -488,7 +489,7 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
       return await f();
     } catch (error) {
       if (isCallError(error)) {
-        this.emitter.emit('error', { operation: error.target, error: error.inner });
+        this.emitter.emit('error', error as AdapterError);
       }
       throw error;
     }

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -12,7 +12,7 @@ import type {
 
 import { VideoStreamOptions } from '@internal/react-components';
 import type { CommunicationUserKind, CommunicationIdentifierKind } from '@azure/communication-common';
-import type { AdapterState, AdapterDisposal, AdapterPages } from '../../common/adapters';
+import type { AdapterState, AdapterDisposal, AdapterPages, AdapterError, AdapterErrors } from '../../common/adapters';
 
 export type CallCompositePage = 'configuration' | 'call' | 'error' | 'errorJoiningTeamsMeeting' | 'removed';
 
@@ -36,17 +36,10 @@ export type CallAdapterClientState = {
   /**
    * Latest error encountered for each operation performed via the adapter.
    */
-  latestErrors: CallAdapterErrors;
+  latestErrors: AdapterErrors;
 };
 
 export type CallAdapterState = CallAdapterUiState & CallAdapterClientState;
-
-/**
- * CallAdapter stores the latest error for each operation in the state.
- *
- * `operation` is a CallAdapter defined string for each unique operation performed by the adapter.
- */
-export type CallAdapterErrors = { [operation: string]: Error };
 
 export type IncomingCallListener = (event: {
   callId: string;
@@ -128,7 +121,7 @@ export interface CallAdapterSubscribers {
   on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   on(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   on(event: 'callEnded', listener: CallEndedListener): void;
-  on(event: 'error', listener: (e: Error) => void): void;
+  on(event: 'error', listener: (e: AdapterError) => void): void;
 
   off(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
   off(event: 'participantsLeft', listener: ParticipantLeftListener): void;
@@ -138,7 +131,7 @@ export interface CallAdapterSubscribers {
   off(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   off(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   off(event: 'callEnded', listener: CallEndedListener): void;
-  off(event: 'error', listener: (e: Error) => void): void;
+  off(event: 'error', listener: (e: AdapterError) => void): void;
 }
 
 /**

--- a/packages/react-composites/src/composites/CallComposite/adapter/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/index.ts
@@ -7,7 +7,6 @@ export type { AzureCommunicationCallAdapterArgs } from './AzureCommunicationCall
 export type {
   CallAdapter,
   CallAdapterClientState,
-  CallAdapterErrors,
   CallAdapterState,
   CallAdapterUiState,
   CallAdapterCallManagement,

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.test.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.test.ts
@@ -7,6 +7,7 @@ import { CommunicationTokenCredential } from '@azure/communication-common';
 import { createAzureCommunicationChatAdapter } from './AzureCommunicationChatAdapter';
 import { ChatAdapter, ChatAdapterState } from './ChatAdapter';
 import { StubChatClient, StubChatThreadClient, failingPagedAsyncIterator, pagedAsyncIterator } from './StubChatClient';
+import { AdapterError } from '../../common/adapters';
 
 jest.useFakeTimers();
 jest.mock('@azure/communication-chat');
@@ -30,7 +31,7 @@ describe('Error is reflected in state and events', () => {
     const latestError = stateListener.state.latestErrors['ChatThreadClient.sendMessage'];
     expect(latestError).toBeDefined();
     expect(errorListener.errors.length).toBe(1);
-    expect(errorListener.errors[0].operation).toBe('ChatThreadClient.sendMessage');
+    expect(errorListener.errors[0].target).toBe('ChatThreadClient.sendMessage');
   });
 
   it('when removeParticipant fails', async () => {
@@ -48,7 +49,7 @@ describe('Error is reflected in state and events', () => {
     const latestError = stateListener.state.latestErrors['ChatThreadClient.removeParticipant'];
     expect(latestError).toBeDefined();
     expect(errorListener.errors.length).toBe(1);
-    expect(errorListener.errors[0].operation).toBe('ChatThreadClient.removeParticipant');
+    expect(errorListener.errors[0].target).toBe('ChatThreadClient.removeParticipant');
   });
 
   it('when setTopic fails', async () => {
@@ -66,7 +67,7 @@ describe('Error is reflected in state and events', () => {
     const latestError = stateListener.state.latestErrors['ChatThreadClient.updateTopic'];
     expect(latestError).toBeDefined();
     expect(errorListener.errors.length).toBe(1);
-    expect(errorListener.errors[0].operation).toBe('ChatThreadClient.updateTopic');
+    expect(errorListener.errors[0].target).toBe('ChatThreadClient.updateTopic');
   });
 
   it('when listMessages fails on iteration', async () => {
@@ -84,7 +85,7 @@ describe('Error is reflected in state and events', () => {
     const latestError = stateListener.state.latestErrors['ChatThreadClient.listMessages'];
     expect(latestError).toBeDefined();
     expect(errorListener.errors.length).toBe(1);
-    expect(errorListener.errors[0].operation).toBe('ChatThreadClient.listMessages');
+    expect(errorListener.errors[0].target).toBe('ChatThreadClient.listMessages');
   });
 
   it('when listMessages fails immediately', async () => {
@@ -102,7 +103,7 @@ describe('Error is reflected in state and events', () => {
     const latestError = stateListener.state.latestErrors['ChatThreadClient.listMessages'];
     expect(latestError).toBeDefined();
     expect(errorListener.errors.length).toBe(1);
-    expect(errorListener.errors[0].operation).toBe('ChatThreadClient.listMessages');
+    expect(errorListener.errors[0].target).toBe('ChatThreadClient.listMessages');
 
     threadClient.listMessages = (): PagedAsyncIterableIterator<ChatMessage> => {
       return pagedAsyncIterator([]);
@@ -153,13 +154,13 @@ class StateChangeListener {
 }
 
 class ErrorListener {
-  errors: { operation: string; error: Error }[] = [];
+  errors: AdapterError[] = [];
 
   constructor(client: ChatAdapter) {
     client.on('error', this.onError.bind(this));
   }
 
-  private onError(event: { operation: string; error: Error }): void {
-    this.errors.push({ operation: event.operation, error: event.error });
+  private onError(e: AdapterError): void {
+    this.errors.push(e);
   }
 }

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -23,13 +23,13 @@ import {
   ChatAdapter,
   ChatEvent,
   ChatAdapterState,
-  ChatErrorListener,
   MessageReadListener,
   MessageReceivedListener,
   ParticipantsAddedListener,
   ParticipantsRemovedListener,
   TopicChangedListener
 } from './ChatAdapter';
+import { AdapterError } from '../../common/adapters';
 
 // Context of Chat, which is a centralized context for all state updates
 class ChatContext {
@@ -260,7 +260,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   on(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
   on(event: 'participantsRemoved', listener: ParticipantsRemovedListener): void;
   on(event: 'topicChanged', listener: TopicChangedListener): void;
-  on(event: 'error', listener: ChatErrorListener): void;
+  on(event: 'error', listener: (e: AdapterError) => void): void;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   on(event: ChatEvent, listener: (e: any) => void): void {
@@ -273,7 +273,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   off(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
   off(event: 'participantsRemoved', listener: ParticipantsRemovedListener): void;
   off(event: 'topicChanged', listener: TopicChangedListener): void;
-  off(event: 'error', listener: ChatErrorListener): void;
+  off(event: 'error', listener: (e: AdapterError) => void): void;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   off(event: ChatEvent, listener: (e: any) => void): void {
@@ -285,7 +285,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
       return await f();
     } catch (error) {
       if (isChatError(error)) {
-        this.emitter.emit('error', { operation: error.target, error: error.inner });
+        this.emitter.emit('error', error as AdapterError);
       }
       throw error;
     }

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
@@ -4,7 +4,7 @@
 import { ChatThreadClientState } from '@internal/chat-stateful-client';
 import type { ChatMessage, ChatParticipant } from '@azure/communication-chat';
 import type { CommunicationUserKind } from '@azure/communication-common';
-import type { AdapterState, AdapterDisposal } from '../../common/adapters';
+import type { AdapterState, AdapterDisposal, AdapterErrors, AdapterError } from '../../common/adapters';
 
 export type ChatAdapterUiState = {
   // FIXME(Delete?)
@@ -20,15 +20,8 @@ export type ChatCompositeClientState = {
   /**
    * Latest error encountered for each operation performed via the adapter.
    */
-  latestErrors: ChatAdapterErrors;
+  latestErrors: AdapterErrors;
 };
-
-/**
- * ChatAdapter stores the latest error for each operation in the state.
- *
- * `operation` is a ChatAdapter defined string for each unique operation performed by the adapter.
- */
-export type ChatAdapterErrors = { [operation: string]: Error };
 
 export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
 
@@ -62,7 +55,7 @@ export interface ChatAdapterSubscribers {
   on(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
   on(event: 'participantsRemoved', listener: ParticipantsRemovedListener): void;
   on(event: 'topicChanged', listener: TopicChangedListener): void;
-  on(event: 'error', listener: ChatErrorListener): void;
+  on(event: 'error', listener: (e: AdapterError) => void): void;
 
   off(event: 'messageReceived', listener: MessageReceivedListener): void;
   off(event: 'messageSent', listener: MessageSentListener): void;
@@ -70,7 +63,7 @@ export interface ChatAdapterSubscribers {
   off(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
   off(event: 'participantsRemoved', listener: ParticipantsRemovedListener): void;
   off(event: 'topicChanged', listener: TopicChangedListener): void;
-  off(event: 'error', listener: ChatErrorListener): void;
+  off(event: 'error', listener: (e: AdapterError) => void): void;
 }
 
 /**
@@ -93,14 +86,6 @@ export type ParticipantsRemovedListener = (event: {
   participantsRemoved: ChatParticipant[];
   removedBy: ChatParticipant;
 }) => void;
-/**
- * Listener for error events.
- *
- * Each failed operation in the {@link ChatAdapter} triggers an 'error' event.
- * `operation` is a {@link ChatAdapter} defined string for each unique operation performed
- * by the adapter.
- */
-export type ChatErrorListener = (event: { operation: string; error: Error }) => void;
 export type TopicChangedListener = (event: { topic: string }) => void;
 export type ChatEvent =
   | 'messageReceived'

--- a/packages/react-composites/src/composites/ChatComposite/index.ts
+++ b/packages/react-composites/src/composites/ChatComposite/index.ts
@@ -9,13 +9,11 @@ export type { ChatCompositeProps, ChatCompositeVisualElements } from './ChatComp
 
 export type {
   ChatAdapter,
-  ChatAdapterErrors,
   ChatAdapterSubscribers,
   ChatAdapterThreadManagement,
   ChatCompositeClientState,
   ChatAdapterState,
   ChatAdapterUiState,
-  ChatErrorListener,
   MessageReadListener,
   MessageReceivedListener,
   MessageSentListener,

--- a/packages/react-composites/src/composites/common/adapters.ts
+++ b/packages/react-composites/src/composites/common/adapters.ts
@@ -27,28 +27,19 @@ export interface AdapterDisposal {
 /**
  * Error reported via error events and stored in adapter state.
  */
-export class AdapterError extends Error {
+export interface AdapterError extends Error {
   /**
    * The operation that failed.
    */
-  public target: string;
+  target: string;
   /**
    * Error thrown by the failed operation.
    */
-  public inner: Error;
+  inner: Error;
   /**
    * Timestamp added to the error in the adapter implementation.
    */
-  public timestamp: Date;
-
-  constructor(target: string, inner: Error, timestamp: Date) {
-    super();
-    this.target = target;
-    this.inner = inner;
-    this.timestamp = timestamp;
-    this.name = 'AdapterError';
-    this.message = `${this.target}: ${this.inner.message}`;
-  }
+  timestamp: Date;
 }
 
 /**

--- a/packages/react-composites/src/composites/common/adapters.ts
+++ b/packages/react-composites/src/composites/common/adapters.ts
@@ -23,3 +23,37 @@ export interface AdapterPages<TPage> {
 export interface AdapterDisposal {
   dispose(): void;
 }
+
+/**
+ * Error reported via error events and stored in adapter state.
+ */
+export class AdapterError extends Error {
+  /**
+   * The operation that failed.
+   */
+  public target: string;
+  /**
+   * Error thrown by the failed operation.
+   */
+  public inner: Error;
+  /**
+   * Timestamp added to the error in the adapter implementation.
+   */
+  public timestamp: Date;
+
+  constructor(target: string, inner: Error, timestamp: Date) {
+    super();
+    this.target = target;
+    this.inner = inner;
+    this.timestamp = timestamp;
+    this.name = 'AdapterError';
+    this.message = `${this.target}: ${this.inner.message}`;
+  }
+}
+
+/**
+ * Adapters stores the latest error for each operation in the state.
+ *
+ * `target` is an adapter defined string for each unique operation performed by the adapter.
+ */
+export type AdapterErrors = { [target: string]: AdapterError };

--- a/packages/react-composites/src/composites/index.ts
+++ b/packages/react-composites/src/composites/index.ts
@@ -10,4 +10,5 @@ export type { AvatarPersonaData, AvatarPersonaDataCallback } from './common/Avat
 export * from './common/icons';
 export * from './localization/locales';
 export type { CompositeStrings, CompositeLocale } from './localization';
+export type { AdapterError, AdapterErrors } from './common/adapters';
 export type { BaseCompositeProps } from './common/Composite';


### PR DESCRIPTION
# What

* Add types for errors emitted from adapters
* Use same types for errors stored in adapter state
* Change field name: `operation` -> `target` to align with stateful error objects.

# Why

Allows for better client code.
Using the same name makes for easy conversion to-fro stateful and adapter errors and also avoids user confusion.

# How Tested

`rush test`

**Is this a breaking change?**

- [x] This change causes current functionality to break.
  Changes error related adapter API signature