### PR TITLE
Remove references to internal packlets in storybook package.json

### DIFF
--- a/change/@internal-storybook-07ac2e33-211b-4b5a-8631-e380b8f440ac.json
+++ b/change/@internal-storybook-07ac2e33-211b-4b5a-8631-e380b8f440ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "remove unused deps",
+  "packageName": "@internal/storybook",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -31,12 +31,7 @@
     "@microsoft/applicationinsights-react-js": "~3.0.5",
     "@microsoft/applicationinsights-web": "~2.6.2",
     "@uifabric/react-hooks": "~7.13.11",
-    "classnames": "^2.2.6",
-    "copy-to-clipboard": "~3.3.1",
-    "history": "~5.0.0",
-    "react-aria-live": "^2.0.5",
-    "react-linkify": "^1.0.0-alpha",
-    "lodash": "~4.17.21"
+    "copy-to-clipboard": "~3.3.1"
   },
   "devDependencies": {
     "@babel/core": "7.13.10",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -27,6 +27,7 @@
     "@fluentui/react": "~8.17.2",
     "@fluentui/react-icons": "~1.1.137",
     "@fluentui/react-northstar": "^0.57.0",
+    "@fluentui/theme-samples": "8.1.5",
     "@microsoft/applicationinsights-react-js": "~3.0.5",
     "@microsoft/applicationinsights-web": "~2.6.2",
     "@uifabric/react-hooks": "~7.13.11",
@@ -35,7 +36,6 @@
     "history": "~5.0.0",
     "react-aria-live": "^2.0.5",
     "react-linkify": "^1.0.0-alpha",
-    "@fluentui/theme-samples": "8.1.5",
     "lodash": "~4.17.21"
   },
   "devDependencies": {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -27,8 +27,6 @@
     "@fluentui/react": "~8.17.2",
     "@fluentui/react-icons": "~1.1.137",
     "@fluentui/react-northstar": "^0.57.0",
-    "@internal/chat-component-bindings": "1.0.0-beta.4",
-    "@internal/react-composites": "1.0.0-beta.4",
     "@microsoft/applicationinsights-react-js": "~3.0.5",
     "@microsoft/applicationinsights-web": "~2.6.2",
     "@uifabric/react-hooks": "~7.13.11",


### PR DESCRIPTION
# What
Cleanup
* Remove references to internal packlets in storybook 
* Remove unused dependencies

# Why
Storybook should only reference exports from the meta package
