### PR TITLE
Temporarily allow different package version for storybook

### DIFF
--- a/common/scripts/ensure-consistent-versions.js
+++ b/common/scripts/ensure-consistent-versions.js
@@ -56,8 +56,8 @@ function ensureTelemetryVersionMatches(version) {
     }
 }
 
-function main(){
-    const packages = findAllPackageJSON(PACKAGES_DIR);
+function main() {
+    const packages = removeBrokenPackages(findAllPackageJSON(PACKAGES_DIR));
     const versions = packages.map((pkg) => readPackageVersion(pkg));
 
     if (versions.length === 0) {
@@ -67,6 +67,12 @@ function main(){
     ensureTelemetryVersionMatches(versions[0]);
 
     console.log('All good!')
+}
+
+// Temporary measure to unblock a release.
+// We haven't versioned storybook with each release yet. We should, but we can do that after this release.
+function removeBrokenPackages(packages) {
+    return packages.filter((pkg) => !pkg.includes('storybook'));
 }
 
 main()


### PR DESCRIPTION
# What

* Temporarily allow inconsisten package version for storybook while I figure out the actual fix.

# Why

* Unblock release. We haven't versioned storybook with the NPM package yet, so this will not be a regression.

# How Tested

* Locally ran all the scripts needed to create a release branch.
* Will validate by creating a new release branch.