### PR TITLE
Cherry pick: Document error handling setup (#778)

### DIFF
--- a/change/@internal-storybook-fc4b2436-5929-4a2a-95ee-37d87395cf23.json
+++ b/change/@internal-storybook-fc4b2436-5929-4a2a-95ee-37d87395cf23.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add error handling story",
+  "packageName": "@internal/storybook",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/ErrorBar/ErrorBar.stories.tsx
+++ b/packages/storybook/stories/ErrorBar/ErrorBar.stories.tsx
@@ -31,6 +31,17 @@ const getDocs: () => JSX.Element = () => {
         Similar to other UI components in this library, `ErrorBarProps` accepts all strings shown on the UI as a
         `strings` field. The `activeErrors` field selects from these strings to show in the `ErrorBar` UI.
       </Description>
+      <Subheading>Dismissed messages</Subheading>
+      <Description>
+        User can dismiss the errors shown via `ErrorBar`. The `ErrorBar` component internally tracks dismissed errors
+        and only shows a `MessageBar` for errors that have not been dismissed. When `activeErrors` include a timestamp,
+        errors that occur after the latest dismissal are shown on the UI. When `activeErrors` do not include a timestamp
+        a dismissed error is only shown on the UI if it is removed from the active errors and then occurs again.
+      </Description>
+      <Description>
+        This way, `ErrorBar` separates the tracking of active errors from the purely UI related state of `ErrorBar`
+        dismissals.
+      </Description>
       <Subheading>Multiple errors</Subheading>
       <Description>
         More than one error can occur at the same time. The `ErrorBar` component can show multiple active errors. To

--- a/packages/storybook/stories/ErrorHandling.stories.mdx
+++ b/packages/storybook/stories/ErrorHandling.stories.mdx
@@ -1,0 +1,53 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta id="errorhandling" title="Error Handling" />
+
+# Error handling
+
+An application must properly respond to unexpected conditions for a delightful end-user experience.
+The Azure Communication Services UI library contains multiple mechanisms that an application can use for this purpose.
+Choose the error handling mechanisms that best balances your need for ease-of-use and flexibility.
+
+## Error conditions
+
+Unexpected operational conditions that may occur in an application include:
+
+- Network drop or quality issues
+- Inability to contact Azure Communication Services backends or quality of service degradation
+- Inability to use or control local devices like microphone, camera etc
+- Removal of the local participant from a call, chat or meeting
+
+The Azure Communication Services client side SDKs surface these error conditions in a variety of ways, including:
+
+- Failure of API method invocations
+- Diagnostic events (e.g. call quality diagnostics)
+
+The UI library plumbs through these error conditions to its own API surfaces.
+In addition, it provides a UI component to directly surface these conditions to end-users in your application.
+
+Error conditions handled in this way exclude programming errors in your application,
+UI library or its dependencies. These errors are best caught upstream through robust Continuous Integration practices.
+
+Error conditions also exclude operational errors unrelated to Azure Communication Services
+(e.g., errors caused in your application logic due to network issues). [React error boundaries] is a popular mechanism for handling
+those errors.
+
+[react error boundaries]: https://reactjs.org/docs/error-boundaries.html
+
+## `ErrorBar` component
+
+The [`ErrorBar` component](./?path=/docs/ui-components-error-bar--error-bar) provides an out of the box solution to surface error
+conditions in your application's UI. This component translates errors returned from client SDKs and diagnostic events into
+localizable error notifications to the user.
+
+The UI Composites in this library use `ErrorBar` to show errors. This feature can be enabled when constructing the Composite.
+
+## Advanced error handling
+
+Applications that need more flexibility than what `ErrorBar` provides can leverage the error information directly.
+
+Diagnostic events update corresponding parts of the state maintained by the stateful clients (used with UI Components) and adapters
+(used with UI Composites). e.g., Call diagnostics information is stored in the `diagnostics` field of the stateful calling client state.
+
+Similarly, the latest error returned from Azure Communication Services API methods is stored in the `latestErrors` field of the state.
+In addition, adapters also generate an `'error'` event for each error encountered in an underlying API method invocation.


### PR DESCRIPTION
# What

Cherry-pick https://github.com/Azure/communication-ui-library/pull/778 to release.

# Why

Document the error related functionality going out this release.

# How Tested

storybook via chromatic