### PR TITLE
Add package documentation

### DIFF
--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -2069,6 +2069,4 @@ export interface VideoTileStylesProps extends BaseCustomStylesProps {
     videoContainer?: IStyle;
 }
 
-// (No @packageDocumentation comment for this package)
-
 ```

--- a/packages/communication-react/src/index.ts
+++ b/packages/communication-react/src/index.ts
@@ -10,7 +10,7 @@
  *
  * These UI client libraries all use Microsoft's Fluent design language and assets. Fluent UI provides a foundational layer for the UI Library and is actively used across Microsoft products.
  *
- * In conjunction to the UI components, the UI Library exposes a stateful client library for calling and chat. This client is agnostic to any specific state management framework and can be integrated with common state managers like Redux or React Context.
+ * In conjunction with the UI components, the UI Library exposes a stateful client library for calling and chat. This client is agnostic to any specific state management framework and can be integrated with common state managers like Redux or React Context.
  * This stateful client library can be used with the UI Components to pass props and methods for the UI Components to render data. For more information, see Stateful Client Overview.
  *
  * For more information visit: https://aka.ms/acsstorybook

--- a/packages/communication-react/src/index.ts
+++ b/packages/communication-react/src/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 /**
- * @azure/communication-react is the npm package that exports functionality for the Azure Communication Services - UI Library.
+ * `@azure/communication-react` is an npm package that exports the functionality of the Azure Communication Services - UI Library.
  *
  * This package makes it easy for you to build modern communications user experiences using Azure Communication Services. It gives you a library of production-ready UI components that you can drop into your applications:
  *   - Composites: These components are turn-key solutions that implement common communication scenarios. You can quickly add video calling or chat experiences to your applications. Composites are open-source higher order components built using UI components.

--- a/packages/communication-react/src/index.ts
+++ b/packages/communication-react/src/index.ts
@@ -1,6 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * Azure Communication Services - UI Library makes it easy for you to build modern communications user experiences using Azure Communication Services. It gives you a library of production-ready UI components that you can drop into your applications:
+ *   - Composites: These components are turn-key solutions that implement common communication scenarios. You can quickly add video calling or chat experiences to your applications. Composites are open-source higher order components built using UI components.
+ *   - UI Components - These components are open-source building blocks that let you build custom communications experience. Components are offered for both calling and chat capabilities that can be combined to build experiences.
+ *
+ * These UI client libraries all use Microsoft's Fluent design language and assets. Fluent UI provides a foundational layer for the UI Library and is actively used across Microsoft products.
+ *
+ * In conjunction to the UI components, the UI Library exposes a stateful client library for calling and chat. This client is agnostic to any specific state management framework and can be integrated with common state managers like Redux or React Context.
+ * This stateful client library can be used with the UI Components to pass props and methods for the UI Components to render data. For more information, see Stateful Client Overview.
+ *
+ * For more documentation visit: https://aka.ms/acsstorybook
+ *
+ * @packageDocumentation
+ */
+
 export { fromFlatCommunicationIdentifier, toFlatCommunicationIdentifier } from '../../acs-ui-common/src';
 export type {
   AreEqual,

--- a/packages/communication-react/src/index.ts
+++ b/packages/communication-react/src/index.ts
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 
 /**
- * Azure Communication Services - UI Library makes it easy for you to build modern communications user experiences using Azure Communication Services. It gives you a library of production-ready UI components that you can drop into your applications:
+ * @azure/communication-react is the npm package that exports functionality for the Azure Communication Services - UI Library.
+ *
+ * This package makes it easy for you to build modern communications user experiences using Azure Communication Services. It gives you a library of production-ready UI components that you can drop into your applications:
  *   - Composites: These components are turn-key solutions that implement common communication scenarios. You can quickly add video calling or chat experiences to your applications. Composites are open-source higher order components built using UI components.
  *   - UI Components - These components are open-source building blocks that let you build custom communications experience. Components are offered for both calling and chat capabilities that can be combined to build experiences.
  *
@@ -11,7 +13,7 @@
  * In conjunction to the UI components, the UI Library exposes a stateful client library for calling and chat. This client is agnostic to any specific state management framework and can be integrated with common state managers like Redux or React Context.
  * This stateful client library can be used with the UI Components to pass props and methods for the UI Components to render data. For more information, see Stateful Client Overview.
  *
- * For more documentation visit: https://aka.ms/acsstorybook
+ * For more information visit: https://aka.ms/acsstorybook
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
# What
Quickly add package documentation for tsdoc/api-extractor documentation.

Text copied from aka.ms/acsstorybook intro paragraph

# Why
API extractor complains we don't have package documentation:
![image](https://user-images.githubusercontent.com/2684369/133649348-086dcb6b-00b7-4769-b7a7-232b92a38bf7.png)


https://skype.visualstudio.com/SPOOL/_workitems/edit/2581874

