### PR TITLE
Try fix flakey video rendering results - wait for video ready state

### DIFF
--- a/change/@internal-react-composites-6626f18d-d45f-4bd7-9a8c-7d643c52e120.json
+++ b/change/@internal-react-composites-6626f18d-d45f-4bd7-9a8c-7d643c52e120.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Try fix flakey tests by waiting for video.isReady",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -17,7 +17,7 @@
     "build:e2e:chat": "webpack-cli build --config ./tests/browser/chat/app/webpack.config.js --mode=production --env production",
     "test": "jest",
     "test:coverage": "npm run test -- --coverage",
-    "test:e2e:call": "playwright test --workers=1 --retries=2 tests.browser.call",
+    "test:e2e:call": "playwright test --workers=1 tests.browser.call",
     "test:e2e:chat": "playwright test --workers=1 --retries=2 tests.browser.chat",
     "test:e2e:chat:update": "playwright test --workers=1 tests.browser.chat --update-snapshots",
     "test:e2e:call:update": "playwright test --workers=1 tests.browser.call --update-snapshots",

--- a/packages/react-composites/tests/browser/call/CallComposite.test.ts
+++ b/packages/react-composites/tests/browser/call/CallComposite.test.ts
@@ -54,7 +54,7 @@ test.describe('Call Composite E2E CallScreen Tests', () => {
     // In case it is retry logic
     for (const page of pages) {
       page.reload();
-      page.bringToFront();
+      await page.bringToFront();
       await waitForCallCompositeToLoad(page);
 
       await page.waitForSelector(dataUiId('call-composite-start-call-button'));
@@ -62,9 +62,14 @@ test.describe('Call Composite E2E CallScreen Tests', () => {
       await page.click(dataUiId('call-composite-start-call-button'));
     }
 
+    // Wait for all video feeds to have loaded for all participants (local and remote)
     for (const page of pages) {
+      await page.bringToFront();
       await page.waitForFunction(() => {
-        return document.querySelectorAll('video').length === 2;
+        const videoNodes = document.querySelectorAll('video');
+        const correctNoOfVideos = document.querySelectorAll('video').length === 2;
+        const allVideosLoaded = Array.from(videoNodes).every((videoNode) => videoNode.readyState === 4);
+        return correctNoOfVideos && allVideosLoaded;
       });
     }
   });
@@ -72,7 +77,7 @@ test.describe('Call Composite E2E CallScreen Tests', () => {
   test('video gallery renders for all pages', async ({ pages }) => {
     for (const idx in pages) {
       const page = pages[idx];
-      page.bringToFront();
+      await page.bringToFront();
 
       expect(await page.screenshot()).toMatchSnapshot(`page-${idx}-video-gallery.png`);
     }
@@ -85,7 +90,7 @@ test.describe('Call Composite E2E CallScreen Tests', () => {
 
     for (const idx in pages) {
       const page = pages[idx];
-      page.bringToFront();
+      await page.bringToFront();
 
       // waitForElementState('stable') is not working for opacity animation https://github.com/microsoft/playwright/issues/4055#issuecomment-777697079
       // this is for disable transition/animation of participant list
@@ -103,7 +108,7 @@ test.describe('Call Composite E2E CallScreen Tests', () => {
   test('can turn off local video', async ({ pages }) => {
     const page = pages[0];
 
-    page.bringToFront();
+    await page.bringToFront();
     await page.click(dataUiId('call-composite-camera-button'));
     await page.waitForFunction(() => {
       return document.querySelectorAll('video').length === 1;
@@ -114,10 +119,10 @@ test.describe('Call Composite E2E CallScreen Tests', () => {
 
 const turnOffAllVideos = async (pages: Page[]): Promise<void> => {
   for (const page of pages) {
-    page.click(dataUiId('call-composite-camera-button'));
+    await page.click(dataUiId('call-composite-camera-button'));
   }
   for (const page of pages) {
-    page.bringToFront();
+    await page.bringToFront();
     await page.waitForFunction(() => {
       return document.querySelectorAll('video').length === 0;
     });

--- a/packages/react-composites/tests/browser/utils.ts
+++ b/packages/react-composites/tests/browser/utils.ts
@@ -38,12 +38,6 @@ export const waitForCompositeToLoad = async (page: Page): Promise<void> => {
 export const waitForCallCompositeToLoad = async (page: Page): Promise<void> => {
   await page.waitForLoadState('load');
 
-  // @TODO
-  // We wait 3 sec here to work around flakiness due to timing.
-  // It sometimes take a while for the local video / audio streams to load in CI environments.
-  // We don't have a good way to know when the composite is fully loaded.
-  await page.waitForTimeout(3000);
-
   // @TODO Add more checks to make sure the composite is fully loaded.
 };
 


### PR DESCRIPTION
# What
Wait for video ready state when testing if videos have loaded

Also:
* Add awaits to all page.bringtofront and page clicks that were missing them
* Remove retries to highlight these issues quicker

# Why
We have incredibly flakey ui tests currently

**Note**: There is still flakiness where isSpeaking border still appears - despite our tests not sending any sound. This could be a logic or SDK bug 

# How Tested
Ran many times locally - before ~40% would fail. Now 100% pass locally (from ~10-20 local runs)