### PR TITLE
Prevent isSpeaking border on video tiles in UI tests

### DIFF
--- a/change/@internal-react-components-a488974b-c8a2-4b8d-8a72-4d67d02f6326.json
+++ b/change/@internal-react-components-a488974b-c8a2-4b8d-8a72-4d67d02f6326.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add data-ui-id for video tiles",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-react-composites-4a94d894-b9ca-494c-a98b-68c64d2a0adb.json
+++ b/change/@internal-react-composites-4a94d894-b9ca-494c-a98b-68c64d2a0adb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Prevent borders on the video tiles to prevent isSpeaking border flakiness",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -339,6 +339,7 @@ export interface Identifiers {
     sendboxTextfield: string;
     typingIndicator: string;
     videoGallery: string;
+    videoTile: string;
 }
 
 // @public (undocumented)

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -4,6 +4,7 @@
 import { DefaultPalette as palette, Icon, IStyle, mergeStyles, Persona, Stack, Text } from '@fluentui/react';
 import { Ref } from '@fluentui/react-northstar';
 import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useIdentifiers } from '../identifiers';
 import { useTheme } from '../theming';
 import { BaseCustomStylesProps, CustomAvatarOptions, OnRenderAvatarCallback } from '../types';
 import {
@@ -148,9 +149,12 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
     [nametagColorOverride]
   );
 
+  const ids = useIdentifiers();
+
   return (
     <Ref innerRef={videoTileRef}>
       <Stack
+        data-ui-id={ids.videoTile}
         className={mergeStyles(
           rootStyles,
           isSpeaking ? isSpeakingStyles : {},

--- a/packages/react-components/src/identifiers/IdentifierProvider.tsx
+++ b/packages/react-components/src/identifiers/IdentifierProvider.tsx
@@ -28,6 +28,8 @@ export interface Identifiers {
   typingIndicator: string;
   /** `data-ui-id` value for `VideoGallery` Component */
   videoGallery: string;
+  /** `data-ui-id` value for `VideoTile` Component */
+  videoTile: string;
 }
 
 const defaultIdentifiers: Identifiers = {
@@ -36,7 +38,8 @@ const defaultIdentifiers: Identifiers = {
   messageContent: 'message-content',
   messageTimestamp: 'message-timestamp',
   typingIndicator: 'typing-indicator',
-  videoGallery: 'video-gallery'
+  videoGallery: 'video-gallery',
+  videoTile: 'video-tile'
 };
 
 export const IdentifierContext = createContext<Identifiers>(defaultIdentifiers);

--- a/packages/react-composites/tests/browser/call/app/public/index.html
+++ b/packages/react-composites/tests/browser/call/app/public/index.html
@@ -8,6 +8,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Call Composite - Test App" />
     <title>Composite - Test App</title>
+    <style>
+      /*
+       * There is a flakiness bug in our UI tests where the isSpeaker border
+       * is sometimes showing on renders. This disables the video tiles having
+       * a border to prevent that.
+       * A work item for a real fix has been created: https://skype.visualstudio.com/SPOOL/_workitems/edit/2588337
+       */
+      div[data-ui-id='video-tile'] {
+        border: none !important;
+      }
+    </style>
   </head>
 
   <body>

--- a/packages/react-composites/tests/browser/config.ts
+++ b/packages/react-composites/tests/browser/config.ts
@@ -7,5 +7,6 @@ export const IDS = {
   messageContent: 'message-content',
   messageTimestamp: 'message-timestamp',
   typingIndicator: 'typing-indicator',
-  videoGallery: 'video-gallery'
+  videoGallery: 'video-gallery',
+  videoTile: 'video-tile'
 };


### PR DESCRIPTION
# What
Prevent video tile having borders in UI tests

# Why
We have a lot of test failures from the isSpeaking border. This is a workaround to prevent that.

A bug is filed to find a real fix: https://skype.visualstudio.com/SPOOL/_workitems/edit/2588337

# How Tested
Tested locally this disables borders.
