### PR TITLE
samples: Don't exit call on all errors

### DIFF
--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -19,7 +19,7 @@ export interface CallScreenProps {
 }
 
 export const CallScreen = (props: CallScreenProps): JSX.Element => {
-  const { token, userId, callLocator, displayName, onCallEnded, onCallError } = props;
+  const { token, userId, callLocator, displayName, onCallEnded } = props;
   const [adapter, setAdapter] = useState<CallAdapter>();
   const adapterRef = useRef<CallAdapter>();
   const { currentTheme, currentRtl } = useSwitchableFluentTheme();
@@ -36,13 +36,9 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
         onCallEnded();
       });
       adapter.on('error', (e) => {
-        // Do not call error handler when error target is starting screen sharing
-        if (e.target === 'Call.startScreenSharing') {
-          console.log('Error squelched. ' + e);
-          return;
-        }
-        console.error(e);
-        onCallError(e);
+        // Error is already acted upon by the Call composite, but the surrounding application could
+        // add top-level error handling logic here (e.g. reporting telemetry).
+        console.log('Adapter error event:', e);
       });
       setAdapter(adapter);
       adapterRef.current = adapter;
@@ -51,7 +47,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     return () => {
       adapterRef?.current?.dispose();
     };
-  }, [callLocator, displayName, token, userId, onCallEnded, onCallError]);
+  }, [callLocator, displayName, token, userId, onCallEnded]);
 
   if (!adapter) {
     return <Spinner label={'Creating adapter'} ariaLive="assertive" labelPosition="top" />;


### PR DESCRIPTION
# What

Stop exiting call on all errors from adapters.

# Why

The CallComposite already acts on errors. The `error` event handler is intended for top-level error handling (e.g., showing the error in another place in the app). If the error is critical enough that the call should be dropped, the underlying SDK should do so (we haven't seen errors of that sort in practice).

Fixes the problem where starting video fails due to device permission issues. The right response is to show an error bar UI, which is the responsibility of the CallComposite, not the sample app.

# How Tested

Join a call with video off from Edge and Chrome, then turn on video on both. The second attempt will fail, but we will stay in the call (with video disabled).