### PR TITLE
Feedback request - Composite isMobile flag

### DIFF
--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -38,6 +38,13 @@ export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcon
  */
 export type CallCompositeOptions = {
   /**
+   * Choose to use the composite form optimized for use on a mobile device.
+   * @remarks This is currently only optimized for portrait mode on mobile devices.
+   * @defaultValue false
+   * @alpha
+   */
+  mobileView: boolean;
+  /**
    * Surface Azure Communication Services backend errors in the UI with {@link @azure/communication-react#ErrorBar}.
    * Hide or show the error bar.
    * @defaultValue true


### PR DESCRIPTION
# What
We're looking to add a flag for isMobile in the composites. Looking for feedback on what that API should look like

# Why
We are going to give composites a mobile-first view. For desktop we will be setting and documenting a min-height and width that gives an optimal experience (through customer asks we can then put in work to make this smaller and smaller). But mobile will have things like touch targets and UI elements that are optimized for mobile.

# Questions
* Is this the right place to put this flag?
* Is it OK that it defaults to false (opt-in when everything else is opt-out)