### PR TITLE
Try fix subsequent flaky test issue

### DIFF
--- a/change/@internal-react-composites-c3bcd936-934a-4e83-9e39-8b4f885e0e9e.json
+++ b/change/@internal-react-composites-c3bcd936-934a-4e83-9e39-8b4f885e0e9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix flakey ui tests",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/tests/browser/utils.ts
+++ b/packages/react-composites/tests/browser/utils.ts
@@ -36,6 +36,7 @@ export const waitForCompositeToLoad = async (page: Page): Promise<void> => {
  * Wait for the CallComposite on a page to fully load.
  */
 export const waitForCallCompositeToLoad = async (page: Page): Promise<void> => {
+  await page.bringToFront();
   await page.waitForLoadState('load');
 
   await page.waitForFunction(() => {


### PR DESCRIPTION
# What
Try fix more flakiness

# Why
Flakiness still exists (timeouts happening - cannot repro locally):
https://github.com/Azure/communication-ui-library/pull/818/checks?check_run_id=3691615600
![image](https://user-images.githubusercontent.com/2684369/134569965-3446d564-65b9-481d-ba86-9bd128416ff7.png)

# How Tested
Cannot repro issue locally and test output has no information why this happened.
This flakiness looks newly introduced from #819 - only immediate difference if the removal of a `page.bringToFront()`
