### PR TITLE
Mark IdentifierProvider and friends internal

### DIFF
--- a/change/@internal-react-composites-95954aec-78d8-4793-bc19-f0454f6ab813.json
+++ b/change/@internal-react-composites-95954aec-78d8-4793-bc19-f0454f6ab813.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make IdentifierProvider @internal",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -1163,10 +1163,12 @@ export interface GridLayoutProps {
 // @public
 export type GridLayoutType = 'standard';
 
-// @beta
-export const IdentifierProvider: (props: IdentifierProviderProps) => JSX.Element;
+// @internal
+export const _IdentifierProvider: (props: IdentifierProviderProps) => JSX.Element;
 
-// @beta
+// Warning: (ae-internal-missing-underscore) The name "IdentifierProviderProps" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export interface IdentifierProviderProps {
     // (undocumented)
     children: React_2.ReactNode;
@@ -1174,7 +1176,9 @@ export interface IdentifierProviderProps {
     identifiers?: Identifiers;
 }
 
-// @public
+// Warning: (ae-internal-missing-underscore) The name "Identifiers" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export interface Identifiers {
     messageContent: string;
     messageTimestamp: string;

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -1164,22 +1164,18 @@ export interface GridLayoutProps {
 export type GridLayoutType = 'standard';
 
 // @internal
-export const _IdentifierProvider: (props: IdentifierProviderProps) => JSX.Element;
+export const _IdentifierProvider: (props: _IdentifierProviderProps) => JSX.Element;
 
-// Warning: (ae-internal-missing-underscore) The name "IdentifierProviderProps" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal
-export interface IdentifierProviderProps {
+export interface _IdentifierProviderProps {
     // (undocumented)
     children: React_2.ReactNode;
     // (undocumented)
-    identifiers?: Identifiers;
+    identifiers?: _Identifiers;
 }
 
-// Warning: (ae-internal-missing-underscore) The name "Identifiers" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal
-export interface Identifiers {
+export interface _Identifiers {
     messageContent: string;
     messageTimestamp: string;
     participantList: string;

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -323,22 +323,18 @@ export interface GridLayoutProps {
 export type GridLayoutType = 'standard';
 
 // @internal
-export const _IdentifierProvider: (props: IdentifierProviderProps) => JSX.Element;
+export const _IdentifierProvider: (props: _IdentifierProviderProps) => JSX.Element;
 
-// Warning: (ae-internal-missing-underscore) The name "IdentifierProviderProps" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal
-export interface IdentifierProviderProps {
+export interface _IdentifierProviderProps {
     // (undocumented)
     children: React_2.ReactNode;
     // (undocumented)
-    identifiers?: Identifiers;
+    identifiers?: _Identifiers;
 }
 
-// Warning: (ae-internal-missing-underscore) The name "Identifiers" should be prefixed with an underscore because the declaration is marked as @internal
-//
 // @internal
-export interface Identifiers {
+export interface _Identifiers {
     messageContent: string;
     messageTimestamp: string;
     participantList: string;

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -322,10 +322,12 @@ export interface GridLayoutProps {
 // @public
 export type GridLayoutType = 'standard';
 
-// @beta
-export const IdentifierProvider: (props: IdentifierProviderProps) => JSX.Element;
+// @internal
+export const _IdentifierProvider: (props: IdentifierProviderProps) => JSX.Element;
 
-// @beta
+// Warning: (ae-internal-missing-underscore) The name "IdentifierProviderProps" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export interface IdentifierProviderProps {
     // (undocumented)
     children: React_2.ReactNode;
@@ -333,7 +335,9 @@ export interface IdentifierProviderProps {
     identifiers?: Identifiers;
 }
 
-// @public
+// Warning: (ae-internal-missing-underscore) The name "Identifiers" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
 export interface Identifiers {
     messageContent: string;
     messageTimestamp: string;

--- a/packages/react-components/src/identifiers/IdentifierProvider.tsx
+++ b/packages/react-components/src/identifiers/IdentifierProvider.tsx
@@ -14,9 +14,9 @@ import React, { createContext, useContext } from 'react';
  * guarantee of the public API. This will remain perenially experimental and compatibility breaking changes
  * may be made at any point.
  *
- * @public
+ * @internal
  */
-export interface Identifiers {
+export interface _Identifiers {
   /** `data-ui-id` value for `SendBox` Component */
   sendboxTextfield: string;
   /** `data-ui-id` value for `ParticipantList` Component */
@@ -33,7 +33,7 @@ export interface Identifiers {
   videoTile: string;
 }
 
-const defaultIdentifiers: Identifiers = {
+const defaultIdentifiers: _Identifiers = {
   sendboxTextfield: 'sendbox-textfield',
   participantList: 'participant-list',
   messageContent: 'message-content',
@@ -46,32 +46,32 @@ const defaultIdentifiers: Identifiers = {
 /**
  * @private
  */
-export const IdentifierContext = createContext<Identifiers>(defaultIdentifiers);
+export const IdentifierContext = createContext<_Identifiers>(defaultIdentifiers);
 
 /**
- * Arguments to Context Provider for {@link Identifiers}.
+ * Arguments to Context Provider for {@link _Identifiers}.
  *
  * @experimental
  *
- * See documentation for {@link Identifiers}.
+ * See documentation for {@link _Identifiers}.
  *
- * @beta
+ * @internal
  */
 export interface IdentifierProviderProps {
-  identifiers?: Identifiers;
+  identifiers?: _Identifiers;
   children: React.ReactNode;
 }
 
 /**
- * React Context provider for {@link Identifiers}.
+ * React Context provider for {@link _Identifiers}.
  *
  * @experimental
  *
- * See documentation for {@link Identifiers}.
+ * See documentation for {@link _Identifiers}.
  *
- * @beta
+ * @internal
  */
-export const IdentifierProvider = (props: IdentifierProviderProps): JSX.Element => {
+export const _IdentifierProvider = (props: IdentifierProviderProps): JSX.Element => {
   const { identifiers, children } = props;
   return <IdentifierContext.Provider value={identifiers ?? defaultIdentifiers}>{children}</IdentifierContext.Provider>;
 };
@@ -79,4 +79,4 @@ export const IdentifierProvider = (props: IdentifierProviderProps): JSX.Element 
 /**
  * @private
  */
-export const useIdentifiers = (): Identifiers => useContext(IdentifierContext);
+export const useIdentifiers = (): _Identifiers => useContext(IdentifierContext);

--- a/packages/react-components/src/identifiers/IdentifierProvider.tsx
+++ b/packages/react-components/src/identifiers/IdentifierProvider.tsx
@@ -57,7 +57,7 @@ export const IdentifierContext = createContext<_Identifiers>(defaultIdentifiers)
  *
  * @internal
  */
-export interface IdentifierProviderProps {
+export interface _IdentifierProviderProps {
   identifiers?: _Identifiers;
   children: React.ReactNode;
 }
@@ -71,7 +71,7 @@ export interface IdentifierProviderProps {
  *
  * @internal
  */
-export const _IdentifierProvider = (props: IdentifierProviderProps): JSX.Element => {
+export const _IdentifierProvider = (props: _IdentifierProviderProps): JSX.Element => {
   const { identifiers, children } = props;
   return <IdentifierContext.Provider value={identifiers ?? defaultIdentifiers}>{children}</IdentifierContext.Provider>;
 };

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -3,7 +3,7 @@
 
 export * from './components';
 export { _IdentifierProvider } from './identifiers';
-export type { _Identifiers as Identifiers, IdentifierProviderProps } from './identifiers';
+export type { _Identifiers, _IdentifierProviderProps } from './identifiers';
 export * from './localization/locales';
 export { LocalizationProvider } from './localization';
 export type { ComponentStrings, ComponentLocale, LocalizationProviderProps } from './localization';

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 
 export * from './components';
-export { IdentifierProvider } from './identifiers';
-export type { Identifiers, IdentifierProviderProps } from './identifiers';
+export { _IdentifierProvider } from './identifiers';
+export type { _Identifiers as Identifiers, IdentifierProviderProps } from './identifiers';
 export * from './localization/locales';
 export { LocalizationProvider } from './localization';
 export type { ComponentStrings, ComponentLocale, LocalizationProviderProps } from './localization';

--- a/packages/react-composites/src/composites/common/BaseComposite.tsx
+++ b/packages/react-composites/src/composites/common/BaseComposite.tsx
@@ -48,7 +48,7 @@ export interface BaseCompositeProps<TIcons extends Record<string, JSX.Element>> 
 
 /**
  * A base class for composites.
- * Provides common wrappers such as FluentThemeProvider, IdentifierProvider and LocalizationProvider.
+ * Provides common wrappers such as FluentThemeProvider and LocalizationProvider.
  */
 export const BaseComposite = (
   props: BaseCompositeProps<CallCompositeIcons | ChatCompositeIcons> & { children: React.ReactNode }

--- a/packages/react-composites/tests/browser/call/app/index.tsx
+++ b/packages/react-composites/tests/browser/call/app/index.tsx
@@ -5,7 +5,7 @@ import { AzureCommunicationTokenCredential } from '@azure/communication-common';
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
-import { IdentifierProvider } from '@internal/react-components';
+import { _IdentifierProvider } from '@internal/react-components';
 import {
   CallAdapter,
   createAzureCommunicationCallAdapter,
@@ -47,11 +47,11 @@ function App(): JSX.Element {
 
   return (
     <div style={{ position: 'fixed', width: '100%', height: '100%' }}>
-      <IdentifierProvider identifiers={IDS}>
+      <_IdentifierProvider identifiers={IDS}>
         {callAdapter && (
           <CallComposite adapter={callAdapter} locale={useFrLocale ? COMPOSITE_LOCALE_FR_FR : undefined} />
         )}
-      </IdentifierProvider>
+      </_IdentifierProvider>
     </div>
   );
 }

--- a/packages/react-composites/tests/browser/chat/app/index.tsx
+++ b/packages/react-composites/tests/browser/chat/app/index.tsx
@@ -5,7 +5,7 @@ import { AzureCommunicationTokenCredential } from '@azure/communication-common';
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
-import { IdentifierProvider } from '@internal/react-components';
+import { _IdentifierProvider } from '@internal/react-components';
 import {
   ChatAdapter,
   createAzureCommunicationChatAdapter,
@@ -48,7 +48,7 @@ function App(): JSX.Element {
   }, []);
 
   return (
-    <IdentifierProvider identifiers={IDS}>
+    <_IdentifierProvider identifiers={IDS}>
       {chatAdapter && (
         <ChatComposite
           adapter={chatAdapter}
@@ -83,7 +83,7 @@ function App(): JSX.Element {
           locale={useFrlocale ? COMPOSITE_LOCALE_FR_FR : undefined}
         />
       )}
-    </IdentifierProvider>
+    </_IdentifierProvider>
   );
 }
 

--- a/packages/react-composites/tests/browser/meeting/app/index.tsx
+++ b/packages/react-composites/tests/browser/meeting/app/index.tsx
@@ -5,7 +5,7 @@ import { AzureCommunicationTokenCredential } from '@azure/communication-common';
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
-import { IdentifierProvider } from '@internal/react-components';
+import { _IdentifierProvider } from '@internal/react-components';
 import { MeetingAdapter, createAzureCommunicationMeetingAdapter, MeetingComposite } from '../../../../src';
 import { IDS } from '../../common/config';
 
@@ -56,9 +56,9 @@ function App(): JSX.Element {
 
   return (
     <div style={{ position: 'fixed', width: '100%', height: '100%' }}>
-      <IdentifierProvider identifiers={IDS}>
+      <_IdentifierProvider identifiers={IDS}>
         {meetingAdapter && <MeetingComposite meetingAdapter={meetingAdapter} />}
-      </IdentifierProvider>
+      </_IdentifierProvider>
     </div>
   );
 }


### PR DESCRIPTION
# What

`IdentifierProvider` is intended for e2e testing needs. It's not part of the stable public API. So mark it @internal and rename as indicated by api-extrator.

**Is this a breaking change?**

No, 'cause @internal ;)