### PR TITLE
CI optimization: don't wait for packlets to be built in ui tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,6 @@ jobs:
         run: npm install -g @microsoft/rush@5.47.0
       - name: Install dependencies
         run: rush install
-      # Builds
-      - name: Build Packages
-        run: rush build -t @internal/react-composites
       # Tests
       - name: Build Test
         run: |

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -92,8 +92,6 @@ jobs:
         run: npm install -g @microsoft/rush@5.47.0
       - name: Install dependencies
         run: rush install
-      - name: Build Packages
-        run: rush build -t @internal/react-composites
       - name: Build Test
         run: |
           cd packages/react-composites

--- a/change/@internal-react-composites-a708dbdf-a283-42c5-9f51-d9b6cfc2d361.json
+++ b/change/@internal-react-composites-a708dbdf-a283-42c5-9f51-d9b6cfc2d361.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "ci optimization: don't wait for packlets to be built in CI UI tests",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/tests/browser/common/testapp.webpack.config.js
+++ b/packages/react-composites/tests/browser/common/testapp.webpack.config.js
@@ -12,8 +12,15 @@ module.exports = (appDir) => ({
   resolve: {
     extensions: ['.ts', '.tsx', '.js'],
     alias: {
-      // reference internal packlets src directly for hot reloading when developing
-      '@internal/react-components': path.resolve(appDir, '../../../../../react-components/src')
+      // Reference internal packlets' src directly for hot reloading when developing.
+      // This also removes the need for CI to wait for packlets to be built before building tests.
+      '@internal/react-components': path.resolve(appDir, '../../../../../react-components/src'),
+      '@internal/react-composites': path.resolve(appDir, '../../../../../react-composites/src'),
+      '@internal/chat-stateful-client': path.resolve(appDir, '../../../../../chat-stateful-client/src'),
+      '@internal/chat-component-bindings': path.resolve(appDir, '../../../../../chat-component-bindings/src'),
+      '@internal/calling-stateful-client': path.resolve(appDir, '../../../../../calling-stateful-client/src'),
+      '@internal/calling-component-bindings': path.resolve(appDir, '../../../../../calling-component-bindings/src'),
+      '@internal/acs-ui-common': path.resolve(appDir, '../../../../../acs-ui-common/src')
     }
   },
   output: {


### PR DESCRIPTION
# What
Don't wait for packlets to be built when building code for UI tests - instead link directly to src

# Why
Should reduce CI task by 1-2minutes. Shouldn't increase the build time of ui tests. Also extends hot reloading locally to all packlets.

# How Tested
PR tests pass