### PR TITLE
[🚧 DO NOT REVIEW ... YET] Add typedoc config to npm package

### DIFF
--- a/packages/communication-react/.npmignore
+++ b/packages/communication-react/.npmignore
@@ -1,7 +1,7 @@
 # Disallow everything by default so new files aren't accidently included:
 *
 
-# include the typedoc config file that is used to generate the docs.microsoft.com API surface
+# Allow the typedoc config file that is used to generate the docs.microsoft.com API surface
 !typedoc.js
 
 # Allow dist folder, this is the folder that should be packed and published:

--- a/packages/communication-react/.npmignore
+++ b/packages/communication-react/.npmignore
@@ -1,6 +1,9 @@
 # Disallow everything by default so new files aren't accidently included:
 *
 
+# include the typedoc config file that is used to generate the docs.microsoft.com API surface
+!typedoc.js
+
 # Allow dist folder, this is the folder that should be packed and published:
 !dist/**/*
 

--- a/packages/communication-react/typedoc.js
+++ b/packages/communication-react/typedoc.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+module.exports = {
+  exclude: ['dist/dist-esm', 'dist/dist-cjs', 'node_modules']
+};

--- a/packages/communication-react/typedoc.js
+++ b/packages/communication-react/typedoc.js
@@ -10,5 +10,5 @@ module.exports = {
   /**
    * Exclude files and folders that should not be part of the API surface.
    */
-  exclude: ['dist-esm', 'dist/dist-cjs', 'node_modules']
+  exclude: ['dist/dist-esm', 'dist/dist-cjs', 'node_modules']
 };

--- a/packages/communication-react/typedoc.js
+++ b/packages/communication-react/typedoc.js
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * Typedoc is used by docs.microsoft.com to generate the API surface.
+ * This API surface can be seen here: https://docs.microsoft.com/en-us/javascript/api/@azure/communication-react
+ */
+
 module.exports = {
-  exclude: ['dist/dist-esm', 'dist/dist-cjs', 'node_modules']
+  /**
+   * Exclude files and folders that should not be part of the API surface.
+   */
+  exclude: ['dist-esm', 'dist/dist-cjs', 'node_modules']
 };


### PR DESCRIPTION
# What
Add a config for typedoc

Once this update is pushed to a new beta release, then the DCOM tool can be updated to target the root folder of the package

# Why
[Typedoc](https://typedoc.org/) is used to generate our [docs.microsoft.com/../communication-react](https://docs.microsoft.com/en-us/javascript/api/@azure/communication-react) API surface.

However currently it is picking up *every* .d.ts file in our package, which is incorrect. For more information see #763.

The fix here is to exclude folders in the npm package that shouldn't contribute to the API surface on DCOM.

# How Tested
* Locally running it generates an API surface with only traits that appear in the rolled up `communication-react.d.ts`.
* Checked in npm pack the package includes the typedoc.js file:
  ![image](https://user-images.githubusercontent.com/2684369/134984789-49b79006-3062-4e81-b7a0-aec9ad2253ea.png)
