### PR TITLE
Document public API for @internal/react-composites

### DIFF
--- a/change/@internal-react-composites-7a74ad3d-723a-4526-9868-4237330fe8a0.json
+++ b/change/@internal-react-composites-7a74ad3d-723a-4526-9868-4237330fe8a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add release tags to API and add jsdoc exceptions for internal types",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/api-extractor/api-extractor.json
+++ b/common/config/api-extractor/api-extractor.json
@@ -15,7 +15,7 @@
   "messages": {
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
-        "logLevel": "none"
+        "logLevel": "error"
       },
       "ae-unresolved-link": {
         "logLevel": "none"

--- a/common/config/api-extractor/api-extractor.json
+++ b/common/config/api-extractor/api-extractor.json
@@ -15,7 +15,7 @@
   "messages": {
     "extractorMessageReporting": {
       "ae-missing-release-tag": {
-        "logLevel": "error"
+        "logLevel": "none"
       },
       "ae-unresolved-link": {
         "logLevel": "none"

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -26,7 +26,7 @@ packages:
       integrity: sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==
   /@azure/communication-calling/1.2.1-beta.1:
     dependencies:
-      '@azure/communication-common': 1.0.0
+      '@azure/communication-common': 1.1.0
       '@azure/logger': 1.0.2
     dev: false
     resolution:
@@ -81,7 +81,7 @@ packages:
   /@azure/communication-identity/1.0.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
-      '@azure/communication-common': 1.0.0
+      '@azure/communication-common': 1.1.0
       '@azure/core-auth': 1.3.2
       '@azure/core-http': 1.2.4
       '@azure/core-lro': 1.0.5
@@ -19641,6 +19641,7 @@ packages:
       eslint-config-prettier: 6.15.0_eslint@7.32.0
       eslint-plugin-header: 3.1.1_eslint@7.32.0
       eslint-plugin-import: 2.22.1_eslint@7.32.0
+      eslint-plugin-jsdoc: 36.1.0_eslint@7.32.0
       eslint-plugin-jsx-a11y: 6.4.1_eslint@7.32.0
       eslint-plugin-prettier: 3.4.0_8142a4287e8e8e0691574dfac8adcedb
       eslint-plugin-react: 7.24.0_eslint@7.32.0
@@ -19685,7 +19686,7 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-TOGPg+z0nS9tSj6J1sOUqyVBpc4AU/d+ziILNI73iEBFD2YSUB52IWnFA6JO/Xe7DBuTuROb+gqLFA4+KFVUuA==
+      integrity: sha512-UnTbvuErLodVzrzB+qZMuhNOe0Bo5+Y3wHE78vsV3IBj7uc70qf7WLiLpNlUXYWtok2nnuEYF7my30eS/TG+3Q==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -129,7 +129,7 @@ export type AvatarPersonaData = {
 // @public
 export type AvatarPersonaDataCallback = (userId: string) => Promise<AvatarPersonaData>;
 
-// @public (undocumented)
+// @public
 export type AzureCommunicationCallAdapterArgs = {
     userId: CommunicationUserKind;
     displayName: string;
@@ -137,7 +137,7 @@ export type AzureCommunicationCallAdapterArgs = {
     locator: TeamsMeetingLinkLocator | GroupCallLocator;
 };
 
-// @public (undocumented)
+// @public
 export type AzureCommunicationChatAdapterArgs = {
     endpointUrl: string;
     userId: CommunicationIdentifierKind;
@@ -156,7 +156,7 @@ export type AzureCommunicationMeetingAdapterArgs = {
     callLocator: TeamsMeetingLinkLocator | GroupCallLocator;
 };
 
-// @public (undocumented)
+// @public
 export interface BaseCompositeProps<TIcons extends Record<string, JSX.Element>> {
     fluentTheme?: PartialTheme | Theme;
     icons?: TIcons;
@@ -234,21 +234,21 @@ export interface CallAdapterDeviceManagement {
     setSpeaker(sourceId: AudioDeviceInfo): Promise<void>;
 }
 
-// @public (undocumented)
+// @public
 export type CallAdapterState = CallAdapterUiState & CallAdapterClientState;
 
 // @public
 export interface CallAdapterSubscribers {
     // (undocumented)
-    off(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
+    off(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
     // (undocumented)
-    off(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+    off(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
     // (undocumented)
-    off(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+    off(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
     // (undocumented)
     off(event: 'callIdChanged', listener: CallIdChangedListener): void;
     // (undocumented)
-    off(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+    off(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
     // (undocumented)
     off(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
     // (undocumented)
@@ -258,15 +258,15 @@ export interface CallAdapterSubscribers {
     // (undocumented)
     off(event: 'error', listener: (e: AdapterError) => void): void;
     // (undocumented)
-    on(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
+    on(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
     // (undocumented)
-    on(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+    on(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
     // (undocumented)
-    on(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+    on(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
     // (undocumented)
     on(event: 'callIdChanged', listener: CallIdChangedListener): void;
     // (undocumented)
-    on(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+    on(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
     // (undocumented)
     on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
     // (undocumented)
@@ -326,10 +326,10 @@ export interface CallClientState {
     userId: CommunicationUserKind;
 }
 
-// @public (undocumented)
+// @public
 export const CallComposite: (props: CallCompositeProps) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export type CallCompositeIcons = Partial<Pick<CompositeIcons, 'ControlButtonCameraOff' | 'ControlButtonCameraOn' | 'ControlButtonEndCall' | 'ControlButtonMicOff' | 'ControlButtonMicOn' | 'ControlButtonOptions' | 'ControlButtonParticipants' | 'ControlButtonScreenShareStart' | 'ControlButtonScreenShareStop' | 'OptionsCamera' | 'OptionsMic' | 'OptionsSpeaker' | 'ParticipantItemScreenShareStart' | 'ParticipantItemMicOff' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'VideoTileMicOff'>>;
 
 // @public
@@ -339,10 +339,10 @@ export type CallCompositeOptions = {
     callControls?: boolean | CallControlOptions;
 };
 
-// @public (undocumented)
+// @public
 export type CallCompositePage = 'configuration' | 'call' | 'error' | 'errorJoiningTeamsMeeting' | 'removed';
 
-// @public (undocumented)
+// @public
 export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcons> {
     adapter: CallAdapter;
     // (undocumented)
@@ -366,7 +366,7 @@ export interface CallCompositeStrings {
     teamsMeetingFailToJoin: string;
 }
 
-// @public (undocumented)
+// @public
 export type CallControlOptions = {
     compressedMode?: boolean;
     cameraButton?: boolean;
@@ -377,7 +377,7 @@ export type CallControlOptions = {
     screenShareButton?: boolean;
 };
 
-// @public (undocumented)
+// @public
 export type CallEndedListener = (event: {
     callId: string;
 }) => void;
@@ -405,7 +405,7 @@ export type CallErrors = {
 // @public
 export type CallErrorTarget = 'Call.addParticipant' | 'Call.api' | 'Call.hangUp' | 'Call.hold' | 'Call.mute' | 'Call.off' | 'Call.on' | 'Call.removeParticipant' | 'Call.resume' | 'Call.sendDtmf' | 'Call.startScreenSharing' | 'Call.startVideo' | 'Call.stopScreenSharing' | 'Call.stopVideo' | 'Call.unmute' | 'CallAgent.dispose' | 'CallAgent.join' | 'CallAgent.off' | 'CallAgent.on' | 'CallAgent.startCall' | 'CallClient.createCallAgent' | 'CallClient.getDeviceManager' | 'DeviceManager.askDevicePermission' | 'DeviceManager.getCameras' | 'DeviceManager.getMicrophones' | 'DeviceManager.getSpeakers' | 'DeviceManager.off' | 'DeviceManager.on' | 'DeviceManager.selectMicrophone' | 'DeviceManager.selectSpeaker';
 
-// @public (undocumented)
+// @public
 export type CallIdChangedListener = (event: {
     callId: string;
 }) => void;
@@ -522,7 +522,7 @@ export interface CameraButtonStrings {
 export interface ChatAdapter extends ChatAdapterThreadManagement, AdapterState<ChatAdapterState>, AdapterDisposal, ChatAdapterSubscribers {
 }
 
-// @public (undocumented)
+// @public
 export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
 
 // @public
@@ -579,7 +579,7 @@ export interface ChatAdapterThreadManagement {
     updateMessage(messageId: string, content: string): Promise<void>;
 }
 
-// @public (undocumented)
+// @public
 export type ChatAdapterUiState = {
     error?: Error;
 };
@@ -608,10 +608,10 @@ export type ChatClientState = {
     latestErrors: ChatErrors;
 };
 
-// @public (undocumented)
+// @public
 export const ChatComposite: (props: ChatCompositeProps) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export type ChatCompositeClientState = {
     userId: string;
     displayName: string;
@@ -619,7 +619,7 @@ export type ChatCompositeClientState = {
     latestErrors: AdapterErrors;
 };
 
-// @public (undocumented)
+// @public
 export type ChatCompositeIcons = Partial<Pick<CompositeIcons, 'MessageDelivered' | 'MessageFailed' | 'MessageSeen' | 'MessageSending' | 'MessageEdit' | 'MessageRemove' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'SendBoxSend' | 'SendBoxSendHovered' | 'EditBoxCancel' | 'EditBoxSubmit'>>;
 
 // @public
@@ -629,7 +629,7 @@ export type ChatCompositeOptions = {
     topic?: boolean;
 };
 
-// @public (undocumented)
+// @public
 export interface ChatCompositeProps extends BaseCompositeProps<ChatCompositeIcons> {
     adapter: ChatAdapter;
     onRenderMessage?: (messageProps: MessageProps, defaultOnRender?: MessageRenderer) => JSX.Element;
@@ -883,7 +883,7 @@ export const COMPOSITE_ONLY_ICONS: {
     ScreenSharePopupStopPresenting: JSX.Element;
 };
 
-// @public (undocumented)
+// @public
 export type CompositeIcons = ComponentIcons & Record<keyof typeof COMPOSITE_ONLY_ICONS, JSX.Element>;
 
 // @public
@@ -934,16 +934,16 @@ export interface ControlBarProps {
     styles?: BaseCustomStylesProps;
 }
 
-// @public (undocumented)
+// @public
 export const createAzureCommunicationCallAdapter: ({ userId, displayName, credential, locator }: AzureCommunicationCallAdapterArgs) => Promise<CallAdapter>;
 
-// @public (undocumented)
+// @public
 export const createAzureCommunicationCallAdapterFromClient: (callClient: StatefulCallClient, callAgent: CallAgent, locator: TeamsMeetingLinkLocator | GroupCallLocator) => Promise<CallAdapter>;
 
-// @public (undocumented)
+// @public
 export const createAzureCommunicationChatAdapter: ({ endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;
 
-// @public (undocumented)
+// @public
 export const createAzureCommunicationChatAdapterFromClient: (chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient) => Promise<ChatAdapter>;
 
 // @alpha
@@ -1073,7 +1073,7 @@ export interface DiagnosticsCallFeatureState {
     network: NetworkDiagnosticsState;
 }
 
-// @public (undocumented)
+// @public
 export type DisplayNameChangedListener = (event: {
     participantId: CommunicationIdentifierKind;
     displayName: string;
@@ -1186,15 +1186,6 @@ export interface _Identifiers {
     videoTile: string;
 }
 
-// @public (undocumented)
-export type IncomingCallListener = (event: {
-    callId: string;
-    callerId: string;
-    callerDisplayName?: string;
-    accept: () => Promise<void>;
-    reject: () => Promise<void>;
-}) => Promise<void>;
-
 // @public
 export interface IncomingCallState {
     callEndReason?: CallEndReason;
@@ -1212,18 +1203,18 @@ export type InputBoxButtonProps = {
     id?: string;
 };
 
-// @public (undocumented)
-export type IsMuteChangedListener = (event: {
+// @public
+export type IsLocalScreenSharingActiveChangedListener = (event: {
+    isScreenSharingOn: boolean;
+}) => void;
+
+// @public
+export type IsMutedChangedListener = (event: {
     identifier: CommunicationIdentifierKind;
     isMuted: boolean;
 }) => void;
 
-// @public (undocumented)
-export type IsScreenSharingOnChangedListener = (event: {
-    isScreenSharingOn: boolean;
-}) => void;
-
-// @public (undocumented)
+// @public
 export type IsSpeakingChangedListener = (event: {
     identifier: CommunicationIdentifierKind;
     isSpeaking: boolean;
@@ -1286,19 +1277,19 @@ export interface MeetingAdapterState extends MeetingAdapterUiState, MeetingAdapt
 // @alpha
 export interface MeetingAdapterSubscriptions {
     // (undocumented)
-    off(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
+    off(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
     // (undocumented)
-    off(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+    off(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
     // (undocumented)
     off(event: 'meetingEnded', listener: CallEndedListener): void;
     // (undocumented)
     off(event: 'error', listener: (e: Error) => void): void;
     // (undocumented)
-    off(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+    off(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
     // (undocumented)
     off(event: 'callIdChanged', listener: CallIdChangedListener): void;
     // (undocumented)
-    off(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+    off(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
     // (undocumented)
     off(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
     // (undocumented)
@@ -1310,19 +1301,19 @@ export interface MeetingAdapterSubscriptions {
     // (undocumented)
     off(event: 'messageRead', listener: MessageReadListener): void;
     // (undocumented)
-    on(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
+    on(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
     // (undocumented)
-    on(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+    on(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
     // (undocumented)
     on(event: 'meetingEnded', listener: CallEndedListener): void;
     // (undocumented)
     on(event: 'error', listener: (e: Error) => void): void;
     // (undocumented)
-    on(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+    on(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
     // (undocumented)
     on(event: 'callIdChanged', listener: CallIdChangedListener): void;
     // (undocumented)
-    on(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+    on(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
     // (undocumented)
     on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
     // (undocumented)
@@ -1343,7 +1334,7 @@ export interface MeetingAdapterUiState extends Pick<CallAdapterUiState, 'isLocal
 // @alpha
 export const MeetingComposite: (props: MeetingCompositeProps) => JSX.Element;
 
-// @public
+// @alpha
 export type MeetingCompositeOptions = {
     mobileView?: boolean;
 };
@@ -1406,13 +1397,13 @@ export type MessageProps = {
     onDeleteMessage?: (messageId: string) => Promise<void>;
 };
 
-// @public (undocumented)
+// @public
 export type MessageReadListener = (event: {
     message: ChatMessage_2;
     readBy: CommunicationUserKind;
 }) => void;
 
-// @public (undocumented)
+// @public
 export type MessageReceivedListener = (event: {
     message: ChatMessage_2;
 }) => void;
@@ -1420,7 +1411,7 @@ export type MessageReceivedListener = (event: {
 // @public
 export type MessageRenderer = (props: MessageProps) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export type MessageSentListener = MessageReceivedListener;
 
 // @public
@@ -1631,16 +1622,6 @@ export interface ParticipantItemStylesProps extends BaseCustomStylesProps {
     menu?: IStyle;
 }
 
-// @public (undocumented)
-export type ParticipantJoinedListener = (event: {
-    joined: RemoteParticipant[];
-}) => void;
-
-// @public (undocumented)
-export type ParticipantLeftListener = (event: {
-    removed: RemoteParticipant[];
-}) => void;
-
 // @public
 export const ParticipantList: (props: ParticipantListProps) => JSX.Element;
 
@@ -1669,7 +1650,7 @@ export const participantListSelector: reselect.OutputParametricSelector<CallClie
 // @public
 export type ParticipantMenuItemsCallback = (participantUserId: string, userId?: string, defaultMenuItems?: IContextualMenuItem[]) => IContextualMenuItem[];
 
-// @public (undocumented)
+// @public
 export type ParticipantsAddedListener = (event: {
     participantsAdded: ChatParticipant[];
     addedBy: ChatParticipant;
@@ -1713,7 +1694,17 @@ export interface ParticipantsButtonStyles extends ControlBarButtonStyles {
     participantListContainerStyle?: IStyle;
 }
 
-// @public (undocumented)
+// @public
+export type ParticipantsJoinedListener = (event: {
+    joined: RemoteParticipant[];
+}) => void;
+
+// @public
+export type ParticipantsLeftListener = (event: {
+    removed: RemoteParticipant[];
+}) => void;
+
+// @public
 export type ParticipantsRemovedListener = (event: {
     participantsRemoved: ChatParticipant[];
     removedBy: ChatParticipant;
@@ -1890,7 +1881,7 @@ export type SystemMessageType = 'topicUpdated' | 'participantAdded' | 'participa
 // @public
 export const toFlatCommunicationIdentifier: (id: CommunicationIdentifier) => string;
 
-// @public (undocumented)
+// @public
 export type TopicChangedListener = (event: {
     topic: string;
 }) => void;

--- a/packages/react-composites/.eslintrc.js
+++ b/packages/react-composites/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     'plugin:react-hooks/recommended'
   ],
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'header'],
+  plugins: ['@typescript-eslint', 'header', 'jsdoc'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true
@@ -34,10 +34,48 @@ module.exports = {
     'header/header': ['error', 'line', ' Copyright (c) Microsoft Corporation.\n Licensed under the MIT license.'],
     'react/display-name': 'off',
     '@typescript-eslint/no-explicit-any': 'error',
-    '@typescript-eslint/no-unused-vars': ['warn', { varsIgnorePattern: '^_' }]
+    '@typescript-eslint/no-unused-vars': ['warn', { varsIgnorePattern: '^_' }],
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          // Do not allow references that are outside the src folder. These will break the npm package created as no src dir exists in output dir.
+          '**/../**/src/*',
+          // Do not allow references to node_modules' /es/ folder. These will break jest tests and the npm package as those imports won't be transpiled.
+          '**/dist/**/es/*',
+          '**/lib/**/es/*'
+        ]
+      }
+    ],
+    'jsdoc/require-jsdoc': [
+      'error',
+      {
+        checkConstructors: false,
+        enableFixer: false,
+        publicOnly: true,
+        require: {
+          ArrowFunctionExpression: true,
+          ClassDeclaration: true,
+          FunctionDeclaration: true
+        },
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+          'TSDeclareFunction',
+          'TSEnumDeclaration',
+          'TSInterfaceDeclaration',
+          'TSTypeAliasDeclaration',
+          'VariableDeclaration'
+        ]
+      }
+    ]
   },
   root: true,
   settings: {
+    jsdoc: {
+      ignorePrivate: true
+    },
     react: {
       version: 'detect'
     }
@@ -50,13 +88,6 @@ module.exports = {
       },
       env: {
         jest: true
-      }
-    },
-    {
-      // remove the ban on certain types due to the complexity of this file
-      files: ['ConnectContext.tsx'],
-      rules: {
-        '@typescript-eslint/ban-types': 'off'
       }
     }
   ]

--- a/packages/react-composites/.eslintrc.js
+++ b/packages/react-composites/.eslintrc.js
@@ -89,6 +89,12 @@ module.exports = {
       env: {
         jest: true
       }
+    },
+    {
+      files: ['tests/**/*.ts'],
+      rules: {
+        'jsdoc/require-jsdoc': 'off'
+      }
     }
   ]
 };

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -96,6 +96,7 @@
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-header": "^3.1.0",
     "eslint-plugin-import": "~2.22.1",
+    "eslint-plugin-jsdoc": "~36.1.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react-hooks": "^4.1.2",

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -83,7 +83,7 @@ export type AvatarPersonaData = {
 // @public
 export type AvatarPersonaDataCallback = (userId: string) => Promise<AvatarPersonaData>;
 
-// @public (undocumented)
+// @public
 export type AzureCommunicationCallAdapterArgs = {
     userId: CommunicationUserKind;
     displayName: string;
@@ -91,7 +91,7 @@ export type AzureCommunicationCallAdapterArgs = {
     locator: TeamsMeetingLinkLocator | GroupCallLocator;
 };
 
-// @public (undocumented)
+// @public
 export type AzureCommunicationChatAdapterArgs = {
     endpointUrl: string;
     userId: CommunicationIdentifierKind;
@@ -110,7 +110,7 @@ export type AzureCommunicationMeetingAdapterArgs = {
     callLocator: TeamsMeetingLinkLocator | GroupCallLocator;
 };
 
-// @public (undocumented)
+// @public
 export interface BaseCompositeProps<TIcons extends Record<string, JSX.Element>> {
     fluentTheme?: PartialTheme | Theme;
     icons?: TIcons;
@@ -183,21 +183,21 @@ export interface CallAdapterDeviceManagement {
     setSpeaker(sourceId: AudioDeviceInfo): Promise<void>;
 }
 
-// @public (undocumented)
+// @public
 export type CallAdapterState = CallAdapterUiState & CallAdapterClientState;
 
 // @public
 export interface CallAdapterSubscribers {
     // (undocumented)
-    off(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
+    off(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
     // (undocumented)
-    off(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+    off(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
     // (undocumented)
-    off(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+    off(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
     // (undocumented)
     off(event: 'callIdChanged', listener: CallIdChangedListener): void;
     // (undocumented)
-    off(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+    off(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
     // (undocumented)
     off(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
     // (undocumented)
@@ -207,15 +207,15 @@ export interface CallAdapterSubscribers {
     // (undocumented)
     off(event: 'error', listener: (e: AdapterError) => void): void;
     // (undocumented)
-    on(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
+    on(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
     // (undocumented)
-    on(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+    on(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
     // (undocumented)
-    on(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+    on(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
     // (undocumented)
     on(event: 'callIdChanged', listener: CallIdChangedListener): void;
     // (undocumented)
-    on(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+    on(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
     // (undocumented)
     on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
     // (undocumented)
@@ -232,10 +232,10 @@ export type CallAdapterUiState = {
     page: CallCompositePage;
 };
 
-// @public (undocumented)
+// @public
 export const CallComposite: (props: CallCompositeProps) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export type CallCompositeIcons = Partial<Pick<CompositeIcons, 'ControlButtonCameraOff' | 'ControlButtonCameraOn' | 'ControlButtonEndCall' | 'ControlButtonMicOff' | 'ControlButtonMicOn' | 'ControlButtonOptions' | 'ControlButtonParticipants' | 'ControlButtonScreenShareStart' | 'ControlButtonScreenShareStop' | 'OptionsCamera' | 'OptionsMic' | 'OptionsSpeaker' | 'ParticipantItemScreenShareStart' | 'ParticipantItemMicOff' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'VideoTileMicOff'>>;
 
 // @public
@@ -245,10 +245,10 @@ export type CallCompositeOptions = {
     callControls?: boolean | CallControlOptions;
 };
 
-// @public (undocumented)
+// @public
 export type CallCompositePage = 'configuration' | 'call' | 'error' | 'errorJoiningTeamsMeeting' | 'removed';
 
-// @public (undocumented)
+// @public
 export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcons> {
     adapter: CallAdapter;
     // (undocumented)
@@ -272,7 +272,7 @@ export interface CallCompositeStrings {
     teamsMeetingFailToJoin: string;
 }
 
-// @public (undocumented)
+// @public
 export type CallControlOptions = {
     compressedMode?: boolean;
     cameraButton?: boolean;
@@ -283,12 +283,12 @@ export type CallControlOptions = {
     screenShareButton?: boolean;
 };
 
-// @public (undocumented)
+// @public
 export type CallEndedListener = (event: {
     callId: string;
 }) => void;
 
-// @public (undocumented)
+// @public
 export type CallIdChangedListener = (event: {
     callId: string;
 }) => void;
@@ -297,7 +297,7 @@ export type CallIdChangedListener = (event: {
 export interface ChatAdapter extends ChatAdapterThreadManagement, AdapterState<ChatAdapterState>, AdapterDisposal, ChatAdapterSubscribers {
 }
 
-// @public (undocumented)
+// @public
 export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
 
 // @public
@@ -354,15 +354,15 @@ export interface ChatAdapterThreadManagement {
     updateMessage(messageId: string, content: string): Promise<void>;
 }
 
-// @public (undocumented)
+// @public
 export type ChatAdapterUiState = {
     error?: Error;
 };
 
-// @public (undocumented)
+// @public
 export const ChatComposite: (props: ChatCompositeProps) => JSX.Element;
 
-// @public (undocumented)
+// @public
 export type ChatCompositeClientState = {
     userId: string;
     displayName: string;
@@ -370,7 +370,7 @@ export type ChatCompositeClientState = {
     latestErrors: AdapterErrors;
 };
 
-// @public (undocumented)
+// @public
 export type ChatCompositeIcons = Partial<Pick<CompositeIcons, 'MessageDelivered' | 'MessageFailed' | 'MessageSeen' | 'MessageSending' | 'MessageEdit' | 'MessageRemove' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'SendBoxSend' | 'SendBoxSendHovered' | 'EditBoxCancel' | 'EditBoxSubmit'>>;
 
 // @public
@@ -380,7 +380,7 @@ export type ChatCompositeOptions = {
     topic?: boolean;
 };
 
-// @public (undocumented)
+// @public
 export interface ChatCompositeProps extends BaseCompositeProps<ChatCompositeIcons> {
     adapter: ChatAdapter;
     onRenderMessage?: (messageProps: MessageProps, defaultOnRender?: MessageRenderer) => JSX.Element;
@@ -445,7 +445,7 @@ export const COMPOSITE_ONLY_ICONS: {
     ScreenSharePopupStopPresenting: JSX.Element;
 };
 
-// @public (undocumented)
+// @public
 export type CompositeIcons = ComponentIcons & Record<keyof typeof COMPOSITE_ONLY_ICONS, JSX.Element>;
 
 // @public
@@ -460,16 +460,16 @@ export interface CompositeStrings {
     chat: ChatCompositeStrings;
 }
 
-// @public (undocumented)
+// @public
 export const createAzureCommunicationCallAdapter: ({ userId, displayName, credential, locator }: AzureCommunicationCallAdapterArgs) => Promise<CallAdapter>;
 
-// @public (undocumented)
+// @public
 export const createAzureCommunicationCallAdapterFromClient: (callClient: StatefulCallClient, callAgent: CallAgent, locator: TeamsMeetingLinkLocator | GroupCallLocator) => Promise<CallAdapter>;
 
-// @public (undocumented)
+// @public
 export const createAzureCommunicationChatAdapter: ({ endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;
 
-// @public (undocumented)
+// @public
 export const createAzureCommunicationChatAdapterFromClient: (chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient) => Promise<ChatAdapter>;
 
 // @alpha
@@ -512,33 +512,24 @@ export const DEFAULT_COMPOSITE_ICONS: {
     MessageRemove: JSX.Element;
 };
 
-// @public (undocumented)
+// @public
 export type DisplayNameChangedListener = (event: {
     participantId: CommunicationIdentifierKind;
     displayName: string;
 }) => void;
 
-// @public (undocumented)
-export type IncomingCallListener = (event: {
-    callId: string;
-    callerId: string;
-    callerDisplayName?: string;
-    accept: () => Promise<void>;
-    reject: () => Promise<void>;
-}) => Promise<void>;
+// @public
+export type IsLocalScreenSharingActiveChangedListener = (event: {
+    isScreenSharingOn: boolean;
+}) => void;
 
-// @public (undocumented)
-export type IsMuteChangedListener = (event: {
+// @public
+export type IsMutedChangedListener = (event: {
     identifier: CommunicationIdentifierKind;
     isMuted: boolean;
 }) => void;
 
-// @public (undocumented)
-export type IsScreenSharingOnChangedListener = (event: {
-    isScreenSharingOn: boolean;
-}) => void;
-
-// @public (undocumented)
+// @public
 export type IsSpeakingChangedListener = (event: {
     identifier: CommunicationIdentifierKind;
     isSpeaking: boolean;
@@ -570,19 +561,19 @@ export interface MeetingAdapterState extends MeetingAdapterUiState, MeetingAdapt
 // @alpha
 export interface MeetingAdapterSubscriptions {
     // (undocumented)
-    off(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
+    off(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
     // (undocumented)
-    off(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+    off(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
     // (undocumented)
     off(event: 'meetingEnded', listener: CallEndedListener): void;
     // (undocumented)
     off(event: 'error', listener: (e: Error) => void): void;
     // (undocumented)
-    off(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+    off(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
     // (undocumented)
     off(event: 'callIdChanged', listener: CallIdChangedListener): void;
     // (undocumented)
-    off(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+    off(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
     // (undocumented)
     off(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
     // (undocumented)
@@ -594,19 +585,19 @@ export interface MeetingAdapterSubscriptions {
     // (undocumented)
     off(event: 'messageRead', listener: MessageReadListener): void;
     // (undocumented)
-    on(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
+    on(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
     // (undocumented)
-    on(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+    on(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
     // (undocumented)
     on(event: 'meetingEnded', listener: CallEndedListener): void;
     // (undocumented)
     on(event: 'error', listener: (e: Error) => void): void;
     // (undocumented)
-    on(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+    on(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
     // (undocumented)
     on(event: 'callIdChanged', listener: CallIdChangedListener): void;
     // (undocumented)
-    on(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+    on(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
     // (undocumented)
     on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
     // (undocumented)
@@ -627,7 +618,7 @@ export interface MeetingAdapterUiState extends Pick<CallAdapterUiState, 'isLocal
 // @alpha
 export const MeetingComposite: (props: MeetingCompositeProps) => JSX.Element;
 
-// @public
+// @alpha
 export type MeetingCompositeOptions = {
     mobileView?: boolean;
 };
@@ -667,43 +658,43 @@ export interface MeetingState extends Pick<CallState, 'callerInfo' | 'state' | '
     };
 }
 
-// @public (undocumented)
+// @public
 export type MessageReadListener = (event: {
     message: ChatMessage;
     readBy: CommunicationUserKind;
 }) => void;
 
-// @public (undocumented)
+// @public
 export type MessageReceivedListener = (event: {
     message: ChatMessage;
 }) => void;
 
-// @public (undocumented)
+// @public
 export type MessageSentListener = MessageReceivedListener;
 
-// @public (undocumented)
-export type ParticipantJoinedListener = (event: {
-    joined: RemoteParticipant[];
-}) => void;
-
-// @public (undocumented)
-export type ParticipantLeftListener = (event: {
-    removed: RemoteParticipant[];
-}) => void;
-
-// @public (undocumented)
+// @public
 export type ParticipantsAddedListener = (event: {
     participantsAdded: ChatParticipant[];
     addedBy: ChatParticipant;
 }) => void;
 
-// @public (undocumented)
+// @public
+export type ParticipantsJoinedListener = (event: {
+    joined: RemoteParticipant[];
+}) => void;
+
+// @public
+export type ParticipantsLeftListener = (event: {
+    removed: RemoteParticipant[];
+}) => void;
+
+// @public
 export type ParticipantsRemovedListener = (event: {
     participantsRemoved: ChatParticipant[];
     removedBy: ChatParticipant;
 }) => void;
 
-// @public (undocumented)
+// @public
 export type TopicChangedListener = (event: {
     topic: string;
 }) => void;

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -16,6 +16,11 @@ import { Error } from './Error';
 import { useSelector } from './hooks/useSelector';
 import { getPage } from './selectors/baseSelectors';
 
+/**
+ * Props for {@link CallComposite}.
+ *
+ * @public
+ */
 export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcons> {
   /**
    * An adapter provides logic and data to the composite.
@@ -34,7 +39,9 @@ export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcon
 }
 
 /**
- * Optional features of the {@link CallComposite}
+ * Optional features of the {@link CallComposite}.
+ *
+ * @public
  */
 export type CallCompositeOptions = {
   /**
@@ -111,6 +118,11 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
   }
 };
 
+/**
+ * A customizable UI composite for calling experience.
+ *
+ * @public
+ */
 export const CallComposite = (props: CallCompositeProps): JSX.Element => {
   const { adapter, callInvitationURL, onFetchAvatarPersonaData, onFetchParticipantMenuItems, options } = props;
   useEffect(() => {

--- a/packages/react-composites/src/composites/CallComposite/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallControls.tsx
@@ -15,6 +15,9 @@ import React, { useCallback } from 'react';
 import { usePropsFor } from './hooks/usePropsFor';
 import { groupCallLeaveButtonCompressedStyle, groupCallLeaveButtonStyle } from './styles/CallControls.styles';
 
+/**
+ * @private
+ */
 export type CallControlsProps = {
   onEndCallClick(): void;
   callInvitationURL?: string;
@@ -22,6 +25,11 @@ export type CallControlsProps = {
   options?: boolean | CallControlOptions;
 };
 
+/**
+ * Customization options for the control bar in calling experience.
+ *
+ * @public
+ */
 export type CallControlOptions = {
   /**
    * Compressed mode decreases the size of buttons in control bar and hides label
@@ -60,6 +68,9 @@ export type CallControlOptions = {
   screenShareButton?: boolean;
 };
 
+/**
+ * @private
+ */
 export const CallControls = (props: CallControlsProps): JSX.Element => {
   const { callInvitationURL, onEndCallClick, onFetchParticipantMenuItems } = props;
   const options = typeof props.options === 'boolean' ? {} : props.options;

--- a/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallScreen.tsx
@@ -38,6 +38,9 @@ import {
   subContainerStyles
 } from './styles/CallScreen.styles';
 
+/**
+ * @private
+ */
 export interface CallScreenProps {
   callInvitationURL?: string;
   endCallHandler(): void;
@@ -49,7 +52,9 @@ export interface CallScreenProps {
 }
 
 const spinnerLabel = 'Initializing call client...';
-
+/**
+ * @private
+ */
 export const CallScreen = (props: CallScreenProps): JSX.Element => {
   const {
     callInvitationURL,

--- a/packages/react-composites/src/composites/CallComposite/ComplianceBanner.tsx
+++ b/packages/react-composites/src/composites/CallComposite/ComplianceBanner.tsx
@@ -3,10 +3,17 @@
 import React, { useEffect, useState } from 'react';
 import { Link, MessageBar } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export type ComplianceBannerProps = {
   callTranscribeState?: boolean;
   callRecordState?: boolean;
 };
+
+/**
+ * @private
+ */
 export const ComplianceBanner = (props: ComplianceBannerProps): JSX.Element => {
   const [previousCallTranscribeState, setPreviousCallTranscribeState] = useState<boolean | undefined>(false);
   const [previousCallRecordState, setPreviousCallRecordState] = useState<boolean | undefined>(false);

--- a/packages/react-composites/src/composites/CallComposite/ConfigurationScreen.tsx
+++ b/packages/react-composites/src/composites/CallComposite/ConfigurationScreen.tsx
@@ -3,8 +3,6 @@
 
 import React from 'react';
 import { useAdaptedSelector } from './hooks/useAdaptedSelector';
-// TODO: Next PR should move move provider & hooks into the selector package
-// and we want to make samples and composite both use from selector package.
 import { useHandlers } from './hooks/useHandlers';
 import { LocalDeviceSettings } from './LocalDeviceSettings';
 import { StartCallButton } from './StartCallButton';
@@ -22,10 +20,16 @@ import {
 } from './styles/CallConfiguration.styles';
 import { useLocale } from '../localization';
 
+/**
+ * @private
+ */
 export interface ConfigurationScreenProps {
   startCallHandler(): void;
 }
 
+/**
+ * @private
+ */
 export const ConfigurationScreen = (props: ConfigurationScreenProps): JSX.Element => {
   const { startCallHandler } = props;
 

--- a/packages/react-composites/src/composites/CallComposite/Error.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Error.tsx
@@ -15,12 +15,18 @@ import {
   bottomStackFooterStyle
 } from './styles/Error.styles';
 
+/**
+ * @private
+ */
 export interface ErrorProps {
   rejoinHandler(): void;
   title?: string;
   reason?: string;
 }
 
+/**
+ * @private
+ */
 export function Error(props: ErrorProps): JSX.Element {
   const title = props.title ?? 'Error joining the Call';
   const rejoinCall = 'Retry Call';

--- a/packages/react-composites/src/composites/CallComposite/Lobby.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Lobby.tsx
@@ -6,6 +6,9 @@ import { LobbyCallControlBar } from './LobbyControlBar';
 import { useSelector } from './hooks/useSelector';
 import { getIsPreviewCameraOn } from './selectors/baseSelectors';
 
+/**
+ * @private
+ */
 export interface LobbyProps {
   callState: string;
   localParticipantVideoStream: VideoGalleryStream;
@@ -19,6 +22,9 @@ export interface LobbyProps {
 
 const onRenderEmptyPlaceholder = (): JSX.Element => <></>;
 
+/**
+ * @private
+ */
 export const Lobby = (props: LobbyProps): JSX.Element => {
   const theme = useTheme();
   const palette = theme.palette;

--- a/packages/react-composites/src/composites/CallComposite/LobbyControlBar.tsx
+++ b/packages/react-composites/src/composites/CallComposite/LobbyControlBar.tsx
@@ -11,11 +11,17 @@ import {
 } from '@internal/react-components';
 import { usePropsFor } from './hooks/usePropsFor';
 
+/**
+ * @private
+ */
 export interface LobbyCallControlBarProps {
   isMicrophoneChecked?: boolean;
   onEndCallClick(): void;
 }
 
+/**
+ * @private
+ */
 export const LobbyCallControlBar = (props: LobbyCallControlBarProps): JSX.Element => {
   const theme = useTheme();
 

--- a/packages/react-composites/src/composites/CallComposite/LocalDeviceSettings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/LocalDeviceSettings.tsx
@@ -61,6 +61,9 @@ const localVideoViewOption = {
   isMirrored: true
 } as VideoStreamOptions;
 
+/**
+ * @private
+ */
 export interface LocalDeviceSettingsType {
   cameras: VideoDeviceInfo[];
   microphones: AudioDeviceInfo[];
@@ -75,6 +78,9 @@ export interface LocalDeviceSettingsType {
   onSelectSpeaker: (device: AudioDeviceInfo) => Promise<void>;
 }
 
+/**
+ * @private
+ */
 export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element => {
   const theme = useTheme();
   const locale = useLocale();

--- a/packages/react-composites/src/composites/CallComposite/LocalPreview.tsx
+++ b/packages/react-composites/src/composites/CallComposite/LocalPreview.tsx
@@ -20,6 +20,9 @@ import { devicePermissionSelector } from './selectors/devicePermissionSelector';
 import { localPreviewSelector } from './selectors/localPreviewSelector';
 import { cameraOffLabelStyle, localPreviewContainerStyle, localPreviewTileStyle } from './styles/LocalPreview.styles';
 
+/**
+ * @private
+ */
 export const LocalPreview = (): JSX.Element => {
   const locale = useLocale();
   const cameraButtonProps = usePropsFor(CameraButton);

--- a/packages/react-composites/src/composites/CallComposite/MediaGallery.tsx
+++ b/packages/react-composites/src/composites/CallComposite/MediaGallery.tsx
@@ -27,6 +27,9 @@ const remoteVideoViewOption = {
   scalingMode: 'Crop'
 } as VideoStreamOptions;
 
+/**
+ * @private
+ */
 export interface MediaGalleryProps {
   isVideoStreamOn?: boolean;
   isMicrophoneChecked?: boolean;
@@ -35,6 +38,9 @@ export interface MediaGalleryProps {
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
 }
 
+/**
+ * @private
+ */
 export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
   const videoGalleryProps = usePropsFor(VideoGallery);
   const [isButtonStatusSynced, setIsButtonStatusSynced] = useState(false);

--- a/packages/react-composites/src/composites/CallComposite/ScreenShare.tsx
+++ b/packages/react-composites/src/composites/CallComposite/ScreenShare.tsx
@@ -21,6 +21,9 @@ import {
 } from './styles/MediaGallery.styles';
 import { loadingStyle, videoStreamStyle } from './styles/ScreenShare.styles';
 
+/**
+ * @private
+ */
 export type ScreenShareProps = {
   screenShareParticipant: VideoGalleryRemoteParticipant | undefined;
   localParticipant?: VideoGalleryLocalParticipant;
@@ -61,6 +64,9 @@ const onRenderPlaceholder: OnRenderAvatarCallback = (userId, options): JSX.Eleme
   </div>
 );
 
+/**
+ * @private
+ */
 export const ScreenShare = (props: ScreenShareProps): JSX.Element => {
   const {
     screenShareParticipant,

--- a/packages/react-composites/src/composites/CallComposite/ScreenSharePopup.tsx
+++ b/packages/react-composites/src/composites/CallComposite/ScreenSharePopup.tsx
@@ -33,6 +33,9 @@ const DRAG_OPTIONS: IDragOptions = {
   keepInBounds: true
 };
 
+/**
+ * @private
+ */
 export interface ScreenSharePopupProps {
   onStopScreenShare: () => Promise<void>;
 
@@ -46,6 +49,9 @@ export interface ScreenSharePopupProps {
   hostId?: string;
 }
 
+/**
+ * @private
+ */
 export const ScreenSharePopup = (props: ScreenSharePopupProps): JSX.Element => {
   const { hostId, onStopScreenShare } = props;
   const [stoppingInProgress, setStoppingInProgress] = useState(false);

--- a/packages/react-composites/src/composites/CallComposite/StartCallButton.tsx
+++ b/packages/react-composites/src/composites/CallComposite/StartCallButton.tsx
@@ -7,11 +7,17 @@ import { buttonStyle, videoCameraIconStyle } from './styles/StartCallButton.styl
 import { Video20Filled } from '@fluentui/react-icons';
 import { useLocale } from '../localization';
 
+/**
+ * @private
+ */
 export interface StartCallButtonProps {
   onClickHandler: () => void;
   isDisabled: boolean;
 }
 
+/**
+ * @private
+ */
 export const StartCallButton = (props: StartCallButtonProps): JSX.Element => {
   const { isDisabled, onClickHandler } = props;
   const locale = useLocale();

--- a/packages/react-composites/src/composites/CallComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Strings.tsx
@@ -5,6 +5,8 @@
  * Strings used by the {@link CallComposite} directly.
  *
  * This strings are in addition to those used by the components from the component library.
+ *
+ * @public
  */
 export interface CallCompositeStrings {
   /**
@@ -51,16 +53,4 @@ export interface CallCompositeStrings {
    * Error shown when Teams meeting connection is dropped for some reason.
    */
   teamsMeetingFailToJoin: string;
-}
-
-/**
- * Strings used by the {@link ChatComposite} directly.
- *
- * This strings are in addition to those used by the components from the component library.
- */
-export interface ChatCompositeStrings {
-  /**
-   * Chat list header text
-   */
-  chatListHeader: string;
 }

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -27,15 +27,14 @@ import {
   CallAdapter,
   CallCompositePage,
   CallEndedListener,
-  CallEvent,
   CallIdChangedListener,
   CallAdapterState,
   DisplayNameChangedListener,
-  IsMuteChangedListener,
-  IsScreenSharingOnChangedListener,
+  IsMutedChangedListener,
+  IsLocalScreenSharingActiveChangedListener,
   IsSpeakingChangedListener,
-  ParticipantJoinedListener,
-  ParticipantLeftListener
+  ParticipantsJoinedListener,
+  ParticipantsLeftListener
 } from './CallAdapter';
 import { isInCall } from '../../../utils';
 import { VideoStreamOptions } from '@internal/react-components';
@@ -114,6 +113,9 @@ class CallContext {
   }
 }
 
+/**
+ * @private
+ */
 export class AzureCommunicationCallAdapter implements CallAdapter {
   private callClient: StatefulCallClient;
   private callAgent: CallAgent;
@@ -384,18 +386,18 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
     this.context.offStateChange(handler);
   }
 
-  on(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
-  on(event: 'participantsLeft', listener: ParticipantLeftListener): void;
-  on(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+  on(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
+  on(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
+  on(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
   on(event: 'callIdChanged', listener: CallIdChangedListener): void;
-  on(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+  on(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
   on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   on(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   on(event: 'callEnded', listener: CallEndedListener): void;
   on(event: 'error', errorHandler: (e: AdapterError) => void): void;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public on(event: CallEvent, listener: (e: any) => void): void {
+  public on(event: string, listener: (e: any) => void): void {
     this.emitter.on(event, listener);
   }
 
@@ -467,18 +469,18 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
     this.emitter.emit('callIdChanged', { callId: this.callIdChanged.bind(this) });
   }
 
-  off(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
-  off(event: 'participantsLeft', listener: ParticipantLeftListener): void;
-  off(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+  off(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
+  off(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
+  off(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
   off(event: 'callIdChanged', listener: CallIdChangedListener): void;
-  off(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+  off(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
   off(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   off(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   off(event: 'callEnded', listener: CallEndedListener): void;
   off(event: 'error', errorHandler: (e: AdapterError) => void): void;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public off(event: CallEvent, listener: (e: any) => void): void {
+  public off(event: string, listener: (e: any) => void): void {
     this.emitter.off(event, listener);
   }
 
@@ -500,6 +502,11 @@ const isPreviewOn = (deviceManager: DeviceManagerState): boolean => {
   return deviceManager.unparentedViews.length > 0 && deviceManager.unparentedViews[0].view !== undefined;
 };
 
+/**
+ * Arguments for creating the Azure Communication Services implementation of {@link CallAdapter}.
+ *
+ * @public
+ */
 export type AzureCommunicationCallAdapterArgs = {
   userId: CommunicationUserKind;
   displayName: string;
@@ -507,6 +514,13 @@ export type AzureCommunicationCallAdapterArgs = {
   locator: TeamsMeetingLinkLocator | GroupCallLocator;
 };
 
+/**
+ * Create a {@link CallAdapter} backed by Azure Communication Services.
+ *
+ * This is the default implementation of {@link CallAdapter} provided by this library.
+ *
+ * @public
+ */
 export const createAzureCommunicationCallAdapter = async ({
   userId,
   displayName,
@@ -519,6 +533,14 @@ export const createAzureCommunicationCallAdapter = async ({
   return adapter;
 };
 
+/**
+ * Create a {@link CallAdapter} using the provided {@link StatefulCallClient}.
+ *
+ * Useful if you want to keep a reference to {@link StatefulCallClient}.
+ * Consider using {@link createAzureCommunicationCallAdapter} for a simpler API.
+ *
+ * @public
+ */
 export const createAzureCommunicationCallAdapterFromClient = async (
   callClient: StatefulCallClient,
   callAgent: CallAgent,

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -14,10 +14,17 @@ import { VideoStreamOptions } from '@internal/react-components';
 import type { CommunicationUserKind, CommunicationIdentifierKind } from '@azure/communication-common';
 import type { AdapterState, AdapterDisposal, AdapterPages, AdapterError, AdapterErrors } from '../../common/adapters';
 
+/**
+ * Major UI screens shown in the {@link CallComposite}.
+ *
+ * @public
+ */
 export type CallCompositePage = 'configuration' | 'call' | 'error' | 'errorJoiningTeamsMeeting' | 'removed';
 
 /**
- * Purely UI related adapter state.
+ * {@link CallAdapter} state for pure UI purposes.
+ *
+ * @public
  */
 export type CallAdapterUiState = {
   isLocalPreviewMicrophoneEnabled: boolean;
@@ -25,7 +32,9 @@ export type CallAdapterUiState = {
 };
 
 /**
- * State from the backend ACS services.
+ * {@link CallAdapter} state inferred from Azure Communication Services backend.
+ *
+ * @public
  */
 export type CallAdapterClientState = {
   userId: CommunicationUserKind;
@@ -40,46 +49,79 @@ export type CallAdapterClientState = {
   latestErrors: AdapterErrors;
 };
 
+/**
+ * {@link CallAdapter} state.
+ *
+ * @public
+ */
 export type CallAdapterState = CallAdapterUiState & CallAdapterClientState;
 
-export type IncomingCallListener = (event: {
-  callId: string;
-  callerId: string;
-  callerDisplayName?: string;
-  /**
-   * Invoke to accept the call.
-   */
-  accept: () => Promise<void>;
-  /**
-   * Invoke to reject the call.
-   */
-  reject: () => Promise<void>;
-}) => Promise<void>;
+/**
+ * Callback for {@link CallAdapterSubscribers} 'participantsJoined' event.
+ *
+ * @public
+ */
+export type ParticipantsJoinedListener = (event: { joined: RemoteParticipant[] }) => void;
 
-export type ParticipantJoinedListener = (event: { joined: RemoteParticipant[] }) => void;
+/**
+ * Callback for {@link CallAdapterSubscribers} 'participantsLeft' event.
+ *
+ * @public
+ */
+export type ParticipantsLeftListener = (event: { removed: RemoteParticipant[] }) => void;
 
-export type ParticipantLeftListener = (event: { removed: RemoteParticipant[] }) => void;
+/**
+ * Callback for {@link CallAdapterSubscribers} 'isMuted' event.
+ *
+ * @public
+ */
+export type IsMutedChangedListener = (event: { identifier: CommunicationIdentifierKind; isMuted: boolean }) => void;
 
-export type IsMuteChangedListener = (event: { identifier: CommunicationIdentifierKind; isMuted: boolean }) => void;
-
+/**
+ * Callback for {@link CallAdapterSubscribers} 'callIdChanged' event.
+ *
+ * @public
+ */
 export type CallIdChangedListener = (event: { callId: string }) => void;
 
-export type IsScreenSharingOnChangedListener = (event: { isScreenSharingOn: boolean }) => void;
+/**
+ * Callback for {@link CallAdapterSubscribers} 'isLocalScreenSharingActiveChanged' event.
+ *
+ * @public
+ */
+export type IsLocalScreenSharingActiveChangedListener = (event: { isScreenSharingOn: boolean }) => void;
 
+/**
+ * Callback for {@link CallAdapterSubscribers} 'isSpeakingChanged' event.
+ *
+ * @public
+ */
 export type IsSpeakingChangedListener = (event: {
   identifier: CommunicationIdentifierKind;
   isSpeaking: boolean;
 }) => void;
 
+/**
+ * Callback for {@link CallAdapterSubscribers} 'displayNameChanged' event.
+ *
+ * @public
+ */
 export type DisplayNameChangedListener = (event: {
   participantId: CommunicationIdentifierKind;
   displayName: string;
 }) => void;
 
+/**
+ * Callback for {@link CallAdapterSubscribers} 'callEnded' event.
+ *
+ * @public
+ */
 export type CallEndedListener = (event: { callId: string }) => void;
 
 /**
  * Functionality for managing the current call.
+ *
+ * @public
  */
 export interface CallAdapterCallManagement {
   joinCall(microphoneOn?: boolean): Call | undefined;
@@ -99,6 +141,8 @@ export interface CallAdapterCallManagement {
 
 /**
  * Functionality for managing devices within a call.
+ *
+ * @public
  */
 export interface CallAdapterDeviceManagement {
   askDevicePermission(constrain: PermissionConstraints): Promise<void>;
@@ -112,23 +156,25 @@ export interface CallAdapterDeviceManagement {
 
 /**
  * Call composite events that can be subscribed to.
+ *
+ * @public
  */
 export interface CallAdapterSubscribers {
-  on(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
-  on(event: 'participantsLeft', listener: ParticipantLeftListener): void;
-  on(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+  on(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
+  on(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
+  on(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
   on(event: 'callIdChanged', listener: CallIdChangedListener): void;
-  on(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+  on(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
   on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   on(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   on(event: 'callEnded', listener: CallEndedListener): void;
   on(event: 'error', listener: (e: AdapterError) => void): void;
 
-  off(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
-  off(event: 'participantsLeft', listener: ParticipantLeftListener): void;
-  off(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+  off(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
+  off(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
+  off(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
   off(event: 'callIdChanged', listener: CallIdChangedListener): void;
-  off(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+  off(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
   off(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   off(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   off(event: 'callEnded', listener: CallEndedListener): void;
@@ -136,7 +182,9 @@ export interface CallAdapterSubscribers {
 }
 
 /**
- * Call Composite Adapter interface.
+ * {@link CallComposite} Adapter interface.
+ *
+ * @public
  */
 export interface CallAdapter
   extends AdapterState<CallAdapterState>,
@@ -145,14 +193,3 @@ export interface CallAdapter
     CallAdapterCallManagement,
     CallAdapterDeviceManagement,
     CallAdapterSubscribers {}
-
-export type CallEvent =
-  | 'participantsJoined'
-  | 'participantsLeft'
-  | 'isMutedChanged'
-  | 'callIdChanged'
-  | 'isLocalScreenSharingActiveChanged'
-  | 'displayNameChanged'
-  | 'isSpeakingChanged'
-  | 'callEnded'
-  | 'error';

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapterProvider.tsx
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapterProvider.tsx
@@ -11,11 +11,17 @@ type CallProviderProps = {
 
 const CallAdapterContext = createContext<CallAdapter | undefined>(undefined);
 
+/**
+ * @private
+ */
 export const CallAdapterProvider = (props: CallProviderProps): JSX.Element => {
   const { adapter } = props;
   return <CallAdapterContext.Provider value={adapter}>{props.children}</CallAdapterContext.Provider>;
 };
 
+/**
+ * @private
+ */
 export const useAdapter = (): CallAdapter => {
   const adapter = useContext(CallAdapterContext);
   if (!adapter) throw 'Cannot find adapter please initialize before usage.';

--- a/packages/react-composites/src/composites/CallComposite/adapter/ParticipantSubcriber.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/ParticipantSubcriber.ts
@@ -3,6 +3,9 @@
 import { RemoteParticipant, RemoteVideoStream } from '@azure/communication-calling';
 import EventEmitter from 'events';
 
+/**
+ * @private
+ */
 export class ParticipantSubscriber {
   private participant: RemoteParticipant;
   private emitter: EventEmitter;
@@ -53,4 +56,7 @@ export class ParticipantSubscriber {
   }
 }
 
+/**
+ * @private
+ */
 export type ParticipantEvent = 'isMutedChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'videoStreamsUpdated';

--- a/packages/react-composites/src/composites/CallComposite/adapter/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/index.ts
@@ -19,10 +19,9 @@ export type {
   CallEndedListener,
   CallIdChangedListener,
   DisplayNameChangedListener,
-  IncomingCallListener,
-  IsMuteChangedListener,
-  IsScreenSharingOnChangedListener,
+  IsMutedChangedListener,
+  IsLocalScreenSharingActiveChangedListener,
   IsSpeakingChangedListener,
-  ParticipantJoinedListener,
-  ParticipantLeftListener
+  ParticipantsJoinedListener,
+  ParticipantsLeftListener
 } from './CallAdapter';

--- a/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
@@ -11,8 +11,9 @@ import { CallAdapterState } from '../adapter/CallAdapter';
 import { CallErrors, CallState, CallClientState, DeviceManagerState } from '@internal/calling-stateful-client';
 import { CommunicationUserKind } from '@azure/communication-common';
 
-// This function highly depends on chatClient.onChange event
-// It will be moved into selector folder when the ChatClientProvide when refactor finished
+/**
+ * @private
+ */
 export const useAdaptedSelector = <SelectorT extends (state: CallClientState, props: any) => any>(
   selector: SelectorT,
   selectorProps?: Parameters<SelectorT>[1]
@@ -20,6 +21,9 @@ export const useAdaptedSelector = <SelectorT extends (state: CallClientState, pr
   return useSelectorWithAdaptation(selector, adaptCompositeState, selectorProps);
 };
 
+/**
+ * @private
+ */
 export const useSelectorWithAdaptation = <
   SelectorT extends (state: ReturnType<AdaptFuncT>, props: any) => any,
   AdaptFuncT extends (state: CallAdapterState) => any

--- a/packages/react-composites/src/composites/CallComposite/hooks/useHandlers.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/useHandlers.ts
@@ -8,6 +8,9 @@ import memoizeOne from 'memoize-one';
 import { CallAdapter } from '..';
 import { useAdapter } from '../adapter/CallAdapterProvider';
 
+/**
+ * @private
+ */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
 export const useHandlers = <PropsT>(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/react-composites/src/composites/CallComposite/hooks/usePropsFor.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/usePropsFor.ts
@@ -10,6 +10,9 @@ import { useHandlers } from './useHandlers';
 
 type Selector = (state: any, props: any) => any;
 
+/**
+ * @private
+ */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
 export const usePropsFor = <Component extends (props: any) => JSX.Element>(
   component: Component

--- a/packages/react-composites/src/composites/CallComposite/hooks/useSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/useSelector.ts
@@ -6,7 +6,9 @@
 import { CallAdapterState } from '../adapter/CallAdapter';
 import { useSelectorWithAdaptation } from './useAdaptedSelector';
 
-// This function highly depends on callClient.onChange event
+/**
+ * @private
+ */
 export const useSelector = <SelectorT extends (state: CallAdapterState, props: any) => any>(
   selector: SelectorT,
   selectorProps?: Parameters<SelectorT>[1]

--- a/packages/react-composites/src/composites/CallComposite/selectors/baseSelectors.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/baseSelectors.ts
@@ -2,24 +2,64 @@
 // Licensed under the MIT license.
 
 import { CallState as SDKCallStatus } from '@azure/communication-calling';
-import { toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 import { CallState, DeviceManagerState, LocalVideoStreamState } from '@internal/calling-stateful-client';
 import { CallAdapterState, CallCompositePage } from '../adapter/CallAdapter';
 
+/**
+ * @private
+ */
 export const getCallId = (state: CallAdapterState): string | undefined => state.call?.id;
+
+/**
+ * @private
+ */
 export const getEndedCall = (state: CallAdapterState): CallState | undefined => state.endedCall;
+
+/**
+ * @private
+ */
 export const getCallStatus = (state: CallAdapterState): SDKCallStatus => state.call?.state ?? 'None';
+
+/**
+ * @private
+ */
 export const getDeviceManager = (state: CallAdapterState): DeviceManagerState => state.devices;
+
+/**
+ * @private
+ */
 export const getIsScreenShareOn = (state: CallAdapterState): boolean => state.call?.isScreenSharingOn ?? false;
+
+/**
+ * @private
+ */
 export const getIsPreviewCameraOn = (state: CallAdapterState): boolean => isPreviewOn(state.devices);
+
+/**
+ * @private
+ */
 export const getPage = (state: CallAdapterState): CallCompositePage => state.page;
+
+/**
+ * @private
+ */
 export const getLocalMicrophoneEnabled = (state: CallAdapterState): boolean => state.isLocalPreviewMicrophoneEnabled;
-export const getDisplayName = (state: CallAdapterState): string | undefined => state.displayName;
-export const getIdentifier = (state: CallAdapterState): string => toFlatCommunicationIdentifier(state.userId);
+
+/**
+ * @private
+ */
 export const getLocalVideoStreams = (state: CallAdapterState): LocalVideoStreamState[] | undefined =>
   state.call?.localVideoStreams;
+
+/**
+ * @private
+ */
 export const getIsTranscriptionActive = (state: CallAdapterState): boolean =>
   !!state.call?.transcription.isTranscriptionActive;
+
+/**
+ * @private
+ */
 export const getIsRecordingActive = (state: CallAdapterState): boolean => !!state.call?.recording.isRecordingActive;
 
 const isPreviewOn = (deviceManager: DeviceManagerState): boolean => {

--- a/packages/react-composites/src/composites/CallComposite/selectors/callStatusSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/callStatusSelector.ts
@@ -4,6 +4,9 @@ import { getCallStatus, getIsScreenShareOn } from './baseSelectors';
 import { createSelector } from 'reselect';
 import { CallState as SDKCallStatus } from '@azure/communication-calling';
 
+/**
+ * @private
+ */
 export const callStatusSelector = createSelector(
   [getCallStatus, getIsScreenShareOn],
   (callStatus: SDKCallStatus, isScreenShareOn) => {

--- a/packages/react-composites/src/composites/CallComposite/selectors/complianceBannerSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/complianceBannerSelector.ts
@@ -4,6 +4,9 @@
 import * as reselect from 'reselect';
 import { getIsRecordingActive, getIsTranscriptionActive } from './baseSelectors';
 
+/**
+ * @private
+ */
 export const complianceBannerSelector = reselect.createSelector(
   [getIsTranscriptionActive, getIsRecordingActive],
   (isTranscriptionActive, isRecordingActive) => {

--- a/packages/react-composites/src/composites/CallComposite/selectors/devicePermissionSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/devicePermissionSelector.ts
@@ -4,6 +4,9 @@
 import * as reselect from 'reselect';
 import { getDeviceManager } from './baseSelectors';
 
+/**
+ * @private
+ */
 export const devicePermissionSelector = reselect.createSelector([getDeviceManager], (deviceManager) => {
   return {
     video: deviceManager.deviceAccess ? deviceManager.deviceAccess.video : undefined,

--- a/packages/react-composites/src/composites/CallComposite/selectors/lobbySelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/lobbySelector.ts
@@ -4,6 +4,9 @@
 import * as reselect from 'reselect';
 import { getLocalVideoStreams } from './baseSelectors';
 
+/**
+ * @private
+ */
 export const lobbySelector = reselect.createSelector([getLocalVideoStreams], (localVideoStreams) => {
   const localVideoStream = localVideoStreams?.find((i) => i.mediaStreamType === 'Video');
   return {

--- a/packages/react-composites/src/composites/CallComposite/selectors/localPreviewSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/localPreviewSelector.ts
@@ -4,6 +4,9 @@
 import * as reselect from 'reselect';
 import { getDeviceManager } from './baseSelectors';
 
+/**
+ * @private
+ */
 export const localPreviewSelector = reselect.createSelector([getDeviceManager], (deviceManager) => {
   // TODO: we should take in a LocalVideoStream that developer wants to use as their 'Preview' view. We should also
   // handle cases where 'Preview' view is in progress and not necessary completed.

--- a/packages/react-composites/src/composites/CallComposite/selectors/mediaGallerySelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/mediaGallerySelector.ts
@@ -4,6 +4,9 @@
 import * as reselect from 'reselect';
 import { getLocalVideoStreams } from './baseSelectors';
 
+/**
+ * @private
+ */
 export const mediaGallerySelector = reselect.createSelector([getLocalVideoStreams], (localVideoStreams) => {
   return {
     isVideoStreamOn: !!localVideoStreams?.find((stream) => stream.mediaStreamType === 'Video')?.view?.target

--- a/packages/react-composites/src/composites/CallComposite/styles/CallConfiguration.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/CallConfiguration.styles.ts
@@ -4,10 +4,16 @@
 import { IStackTokens } from '@fluentui/react';
 import { mergeStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const configurationStackTokens: IStackTokens = {
   childrenGap: '2rem'
 };
 
+/**
+ * @private
+ */
 export const configurationContainer = mergeStyles({
   height: '100%',
   width: '100% ',
@@ -16,11 +22,17 @@ export const configurationContainer = mergeStyles({
   minHeight: 'auto'
 });
 
+/**
+ * @private
+ */
 export const selectionContainerStyle = mergeStyles({
   minWidth: '12.5rem',
   padding: '0.5rem'
 });
 
+/**
+ * @private
+ */
 export const titleContainerStyle = mergeStyles({
   fontSize: '1.25rem',
   lineHeight: '1.75rem',

--- a/packages/react-composites/src/composites/CallComposite/styles/CallControls.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/CallControls.styles.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * @private
+ */
 export const groupCallLeaveButtonStyle = {
   root: {
     border: '0.125rem',
@@ -14,6 +17,9 @@ export const groupCallLeaveButtonStyle = {
   }
 };
 
+/**
+ * @private
+ */
 export const groupCallLeaveButtonCompressedStyle = {
   root: {
     width: '2rem',

--- a/packages/react-composites/src/composites/CallComposite/styles/CallScreen.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/CallScreen.styles.ts
@@ -3,12 +3,18 @@
 
 import { IStackItemStyles, IStackStyles, mergeStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const callControlsStyles: IStackItemStyles = {
   root: {
     width: '100%'
   }
 };
 
+/**
+ * @private
+ */
 export const callControlsContainer = mergeStyles({
   width: '100%',
   height: '3.875rem',
@@ -26,6 +32,9 @@ export const callControlsContainer = mergeStyles({
   }
 });
 
+/**
+ * @private
+ */
 export const containerStyles: IStackStyles = {
   root: {
     height: '100%',
@@ -35,6 +44,9 @@ export const containerStyles: IStackStyles = {
   }
 };
 
+/**
+ * @private
+ */
 export const subContainerStyles: IStackStyles = {
   root: {
     width: '100%',
@@ -42,12 +54,18 @@ export const subContainerStyles: IStackStyles = {
   }
 };
 
+/**
+ * @private
+ */
 export const mediaGalleryContainerStyles: IStackItemStyles = {
   root: {
     height: '100%'
   }
 };
 
+/**
+ * @private
+ */
 export const bannersContainerStyles: IStackStyles = {
   root: {
     width: '100%',

--- a/packages/react-composites/src/composites/CallComposite/styles/ConfigurationScreen.styles.tsx
+++ b/packages/react-composites/src/composites/CallComposite/styles/ConfigurationScreen.styles.tsx
@@ -3,6 +3,9 @@
 
 import { mergeStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const titleContainerStyle = mergeStyles({
   fontSize: '1.25rem',
   lineHeight: '1.75rem',

--- a/packages/react-composites/src/composites/CallComposite/styles/DisplayNameField.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/DisplayNameField.styles.ts
@@ -3,6 +3,9 @@
 
 import { mergeStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const TextFieldStyleProps = {
   wrapper: {
     height: '2.3rem'
@@ -12,6 +15,9 @@ export const TextFieldStyleProps = {
   }
 };
 
+/**
+ * @private
+ */
 export const inputBoxStyle = mergeStyles({
   boxSizing: 'border-box',
   height: '2.5rem',
@@ -19,6 +25,9 @@ export const inputBoxStyle = mergeStyles({
   borderRadius: '0.125rem'
 });
 
+/**
+ * @private
+ */
 export const inputBoxTextStyle = mergeStyles({
   fontSize: '0.875rem',
   fontWeight: 600,
@@ -37,6 +46,9 @@ export const inputBoxTextStyle = mergeStyles({
   }
 });
 
+/**
+ * @private
+ */
 export const inputBoxWarningStyle = mergeStyles({
   boxSizing: 'border-box',
   height: '2.5rem',
@@ -45,6 +57,9 @@ export const inputBoxWarningStyle = mergeStyles({
   fontSize: '0.875rem'
 });
 
+/**
+ * @private
+ */
 export const labelFontStyle = mergeStyles({
   fontSize: '0.875rem',
   fontWeight: 600,
@@ -56,6 +71,9 @@ export const labelFontStyle = mergeStyles({
   overflowWrap: 'break-word'
 });
 
+/**
+ * @private
+ */
 export const warningStyle = mergeStyles({
   width: '18.75rem',
   marginTop: '0.188rem',

--- a/packages/react-composites/src/composites/CallComposite/styles/Error.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/Error.styles.ts
@@ -3,18 +3,37 @@
 
 import { IStackTokens, mergeStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const mainStackTokens: IStackTokens = {
   childrenGap: '0.25rem'
 };
+
+/**
+ * @private
+ */
 export const buttonsStackTokens: IStackTokens = {
   childrenGap: '0.75rem'
 };
+
+/**
+ * @private
+ */
 export const upperStackTokens: IStackTokens = {
   childrenGap: '1.5rem'
 };
+
+/**
+ * @private
+ */
 export const bottomStackTokens: IStackTokens = {
   childrenGap: '1.4375rem'
 };
+
+/**
+ * @private
+ */
 export const endCallContainerStyle = mergeStyles({
   width: '20.625rem',
   position: 'absolute',
@@ -24,10 +43,18 @@ export const endCallContainerStyle = mergeStyles({
   right: '0',
   margin: 'auto'
 });
+
+/**
+ * @private
+ */
 export const endCallTitleStyle = mergeStyles({
   fontSize: '1.375rem',
   fontWeight: 600
 });
+
+/**
+ * @private
+ */
 export const buttonStyle = mergeStyles({
   fontWeight: 600,
   height: '2.5rem',
@@ -35,10 +62,18 @@ export const buttonStyle = mergeStyles({
   fontSize: '0.875rem', // 14px
   padding: 0
 });
+
+/**
+ * @private
+ */
 export const videoCameraIconStyle = mergeStyles({
   marginRight: '0.375rem',
   fontSize: '1.375rem'
 });
+
+/**
+ * @private
+ */
 export const bottomStackFooterStyle = mergeStyles({
   fontSize: '0.875 rem'
 });

--- a/packages/react-composites/src/composites/CallComposite/styles/LocalDeviceSettings.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/LocalDeviceSettings.styles.ts
@@ -3,14 +3,23 @@
 
 import { IDropdownStyles, IStackTokens, Theme, mergeStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const mainStackTokens: IStackTokens = {
   childrenGap: '1rem'
 };
 
+/**
+ * @private
+ */
 export const micStackTokens: IStackTokens = {
   childrenGap: '1rem'
 };
 
+/**
+ * @private
+ */
 export const dropDownStyles = (theme: Theme): Partial<IDropdownStyles> => ({
   caretDownWrapper: {
     height: '2.5rem',
@@ -42,11 +51,17 @@ export const dropDownStyles = (theme: Theme): Partial<IDropdownStyles> => ({
   }
 });
 
+/**
+ * @private
+ */
 export const localSettingsContainer = mergeStyles({
   minWidth: '12.5rem',
   maxWidth: '18.75rem'
 });
 
+/**
+ * @private
+ */
 export const dropDownTitleIconStyles = mergeStyles({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
@@ -56,6 +71,9 @@ export const dropDownTitleIconStyles = mergeStyles({
   margin: '.063rem'
 });
 
+/**
+ * @private
+ */
 export const optionIconStyles = mergeStyles({
   marginRight: '8px',
   verticalAlign: 'text-top'

--- a/packages/react-composites/src/composites/CallComposite/styles/LocalPreview.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/LocalPreview.styles.ts
@@ -3,6 +3,9 @@
 
 import { mergeStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const localPreviewContainerStyle = mergeStyles({
   borderRadius: '.25rem',
   width: '25rem',
@@ -11,11 +14,17 @@ export const localPreviewContainerStyle = mergeStyles({
   padding: '0.5rem'
 });
 
+/**
+ * @private
+ */
 export const cameraOffLabelStyle = mergeStyles({
   fontFamily: 'Segoe UI Regular',
   fontSize: '0.625rem' // 10px
 });
 
+/**
+ * @private
+ */
 export const localPreviewTileStyle = {
   root: {
     borderRadius: '.25rem'

--- a/packages/react-composites/src/composites/CallComposite/styles/MediaGallery.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/MediaGallery.styles.ts
@@ -7,11 +7,17 @@ const videoBaseStyle = mergeStyles({
   border: 0
 });
 
+/**
+ * @private
+ */
 export const gridStyle = mergeStyles(videoBaseStyle, {
   width: '100%',
   height: '100%'
 });
 
+/**
+ * @private
+ */
 export const aspectRatioBoxStyle = mergeStyles(videoBaseStyle, {
   width: '100%',
   height: 0,
@@ -19,6 +25,9 @@ export const aspectRatioBoxStyle = mergeStyles(videoBaseStyle, {
   paddingTop: '56.25%' /* default to 16:9 Aspect Ratio for now*/
 });
 
+/**
+ * @private
+ */
 export const aspectRatioBoxContentStyle = mergeStyles({
   position: 'absolute',
   top: 0,
@@ -27,17 +36,26 @@ export const aspectRatioBoxContentStyle = mergeStyles({
   height: '100%'
 });
 
+/**
+ * @private
+ */
 export const stackContainerStyle = mergeStyles({
   height: '100%',
   width: '15%'
 });
 
+/**
+ * @private
+ */
 export const screenShareContainerStyle = mergeStyles({
   height: '100%',
   width: '85%',
   position: 'relative'
 });
 
+/**
+ * @private
+ */
 export const stackContainerParticipantVideoStyles = {
   root: { borderRadius: 0 },
   videoContainer: { borderRadius: 0, '& video': { borderRadius: 0 } }

--- a/packages/react-composites/src/composites/CallComposite/styles/ScreenShare.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/ScreenShare.styles.ts
@@ -3,6 +3,9 @@
 
 import { mergeStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const videoStreamStyle = mergeStyles({
   position: 'absolute',
   bottom: '.25rem',
@@ -11,6 +14,9 @@ export const videoStreamStyle = mergeStyles({
   width: '25%'
 });
 
+/**
+ * @private
+ */
 export const loadingStyle = mergeStyles({
   height: '100%',
   width: '100%',

--- a/packages/react-composites/src/composites/CallComposite/styles/ScreenSharePopup.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/ScreenSharePopup.styles.ts
@@ -4,6 +4,9 @@
 import { IButtonStyles, IModalStyleProps, IModalStyles, IStyleFunctionOrObject, Theme } from '@fluentui/react';
 import { CSSProperties } from 'react';
 
+/**
+ * @private
+ */
 export const getScreenSharePopupModalStyles = (
   theme: Theme
 ): IStyleFunctionOrObject<IModalStyleProps, IModalStyles> => {
@@ -17,18 +20,27 @@ export const getScreenSharePopupModalStyles = (
   };
 };
 
+/**
+ * @private
+ */
 export const screenSharePopupModalStackStyles: CSSProperties = {
   width: '18rem',
   height: '11.4375rem',
   paddingBottom: '0.5rem'
 };
 
+/**
+ * @private
+ */
 export const screenSharePopupModalLabelStyles: CSSProperties = {
   lineHeight: '1rem',
   fontSize: '0.75rem',
   fontWeight: 'normal'
 };
 
+/**
+ * @private
+ */
 export const getScreenSharePopupModalButtonStyles = (theme: Theme): IButtonStyles => {
   return {
     root: {

--- a/packages/react-composites/src/composites/CallComposite/styles/StartCallButton.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/StartCallButton.styles.ts
@@ -3,11 +3,17 @@
 
 import { mergeStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const videoCameraIconStyle = mergeStyles({
   marginRight: '0.375rem',
   fontSize: '1.375rem'
 });
 
+/**
+ * @private
+ */
 export const buttonStyle = mergeStyles({
   fontWeight: 600,
   fontSize: '0.875rem', // 14px

--- a/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
@@ -9,6 +9,11 @@ import { ChatAdapter } from './adapter/ChatAdapter';
 import { ChatAdapterProvider } from './adapter/ChatAdapterProvider';
 import { ChatScreen } from './ChatScreen';
 
+/**
+ * Props for {@link ChatComposite}.
+ *
+ * @public
+ */
 export interface ChatCompositeProps extends BaseCompositeProps<ChatCompositeIcons> {
   /**
    * An adapter provides logic and data to the composite.
@@ -33,7 +38,9 @@ export interface ChatCompositeProps extends BaseCompositeProps<ChatCompositeIcon
 }
 
 /**
- * Optional features of the {@link ChatComposite}
+ * Optional features of the {@link ChatComposite}.
+ *
+ * @public
  */
 export type ChatCompositeOptions = {
   /**
@@ -54,6 +61,11 @@ export type ChatCompositeOptions = {
   topic?: boolean;
 };
 
+/**
+ * A customizable UI composite for the chat experience.
+ *
+ * @public
+ */
 export const ChatComposite = (props: ChatCompositeProps): JSX.Element => {
   const {
     adapter,

--- a/packages/react-composites/src/composites/ChatComposite/ChatHeader.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatHeader.tsx
@@ -8,10 +8,16 @@ import { ChatClientState } from '@internal/chat-stateful-client';
 import { ChatBaseSelectorProps } from '@internal/chat-component-bindings';
 import { chatHeaderContainerStyle, topicNameLabelStyle } from './styles/Chat.styles';
 
+/**
+ * @private
+ */
 export type HeaderProps = {
   topic: string;
 };
 
+/**
+ * @private
+ */
 export const ChatHeader = (props: HeaderProps): JSX.Element => {
   return (
     <Stack className={chatHeaderContainerStyle} horizontal>
@@ -22,12 +28,13 @@ export const ChatHeader = (props: HeaderProps): JSX.Element => {
   );
 };
 
-// TODO: Consider exporting building-block selectors internally to composites.
-// This will avoid code duplication but still keep the public API clean.
-export const getTopicName = (state: ChatClientState, props: ChatBaseSelectorProps): string => {
+const getTopicName = (state: ChatClientState, props: ChatBaseSelectorProps): string => {
   return state.threads[props.threadId]?.properties?.topic || '';
 };
 
+/**
+ * @private
+ */
 export const getHeaderProps = reselect.createSelector([getTopicName], (topic): HeaderProps => {
   return { topic: topic };
 });

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -32,6 +32,9 @@ import {
   participantListWrapper
 } from './styles/Chat.styles';
 
+/**
+ * @private
+ */
 export type ChatScreenProps = {
   options?: ChatCompositeOptions;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
@@ -40,6 +43,9 @@ export type ChatScreenProps = {
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
 };
 
+/**
+ * @private
+ */
 export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
   const { onFetchAvatarPersonaData, onRenderMessage, onRenderTypingIndicator, onFetchParticipantMenuItems, options } =
     props;

--- a/packages/react-composites/src/composites/ChatComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/Strings.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Strings used by the {@link ChatComposite} directly.
+ *
+ * This strings are in addition to those used by the components from the component library.
+ *
+ * @public
+ */
+export interface ChatCompositeStrings {
+  /**
+   * Chat list header text
+   */
+  chatListHeader: string;
+}

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.test.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.test.ts
@@ -113,7 +113,7 @@ describe('Error is reflected in state and events', () => {
   });
 });
 
-export const createChatAdapterWithStubs = async (chatClient: StubChatClient): Promise<ChatAdapter> => {
+const createChatAdapterWithStubs = async (chatClient: StubChatClient): Promise<ChatAdapter> => {
   // ChatClient constructor must return a ChatClient. StubChatClient only implements the
   // public interface of ChatClient. So we are forced to lose some type information here.
   ChatClientMock.mockImplementation((): ChatClient => {

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -21,7 +21,6 @@ import { toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 import EventEmitter from 'events';
 import {
   ChatAdapter,
-  ChatEvent,
   ChatAdapterState,
   MessageReadListener,
   MessageReceivedListener,
@@ -82,6 +81,9 @@ class ChatContext {
   }
 }
 
+/**
+ * @private
+ */
 export class AzureCommunicationChatAdapter implements ChatAdapter {
   private chatClient: StatefulChatClient;
   private chatThreadClient: ChatThreadClient;
@@ -263,7 +265,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   on(event: 'error', listener: (e: AdapterError) => void): void;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  on(event: ChatEvent, listener: (e: any) => void): void {
+  on(event: string, listener: (e: any) => void): void {
     this.emitter.on(event, listener);
   }
 
@@ -276,7 +278,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   off(event: 'error', listener: (e: AdapterError) => void): void;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  off(event: ChatEvent, listener: (e: any) => void): void {
+  off(event: string, listener: (e: any) => void): void {
     this.emitter.off(event, listener);
   }
 
@@ -312,6 +314,11 @@ const convertEventType = (type: string): ChatMessageType => {
   else return 'text';
 };
 
+/**
+ * Arguments for creating the Azure Communication Services implementation of {@link ChatAdapter}.
+ *
+ * @public
+ */
 export type AzureCommunicationChatAdapterArgs = {
   endpointUrl: string;
   userId: CommunicationIdentifierKind;
@@ -320,6 +327,13 @@ export type AzureCommunicationChatAdapterArgs = {
   threadId: string;
 };
 
+/**
+ * Create a {@link ChatAdapter} backed by Azure Communication Services.
+ *
+ * This is the default implementation of {@link ChatAdapter} provided by this library.
+ *
+ * @public
+ */
 export const createAzureCommunicationChatAdapter = async ({
   endpointUrl,
   userId,
@@ -341,6 +355,14 @@ export const createAzureCommunicationChatAdapter = async ({
   return adapter;
 };
 
+/**
+ * Create a {@link ChatAdapter} using the provided {@link StatefulChatClient}.
+ *
+ * Useful if you want to keep a reference to {@link StatefulChatClient}.
+ * Consider using {@link createAzureCommunicationChatAdapter} for a simpler API.
+ *
+ * @public
+ */
 export const createAzureCommunicationChatAdapterFromClient = async (
   chatClient: StatefulChatClient,
   chatThreadClient: ChatThreadClient

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
@@ -6,12 +6,22 @@ import type { ChatMessage, ChatParticipant } from '@azure/communication-chat';
 import type { CommunicationUserKind } from '@azure/communication-common';
 import type { AdapterState, AdapterDisposal, AdapterErrors, AdapterError } from '../../common/adapters';
 
+/**
+ * {@link ChatAdapter} state for pure UI purposes.
+ *
+ * @public
+ */
 export type ChatAdapterUiState = {
   // FIXME(Delete?)
   // Self-contained state for composite
   error?: Error;
 };
 
+/**
+ * {@link ChatAdapter} state inferred from Azure Communication Services backend.
+ *
+ * @public
+ */
 export type ChatCompositeClientState = {
   // Properties from backend services
   userId: string;
@@ -23,10 +33,17 @@ export type ChatCompositeClientState = {
   latestErrors: AdapterErrors;
 };
 
+/**
+ * {@link ChatAdapter} state.
+ *
+ * @public
+ */
 export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
 
 /**
  * Functionality for managing the current chat thread.
+ *
+ * @public
  */
 export interface ChatAdapterThreadManagement {
   /*
@@ -47,6 +64,8 @@ export interface ChatAdapterThreadManagement {
 
 /**
  * Chat composite events that can be subscribed to.
+ *
+ * @public
  */
 export interface ChatAdapterSubscribers {
   on(event: 'messageReceived', listener: MessageReceivedListener): void;
@@ -67,7 +86,9 @@ export interface ChatAdapterSubscribers {
 }
 
 /**
- * Chat Composite Adapter interface.
+ * {@link ChatComposite} Adapter interface.
+ *
+ * @public
  */
 export interface ChatAdapter
   extends ChatAdapterThreadManagement,
@@ -75,23 +96,50 @@ export interface ChatAdapter
     AdapterDisposal,
     ChatAdapterSubscribers {}
 
+/**
+ * Callback for {@link ChatAdapterSubscribers} 'messageReceived' event.
+ *
+ * @public
+ */
 export type MessageReceivedListener = (event: { message: ChatMessage }) => void;
+
+/**
+ * Callback for {@link ChatAdapterSubscribers} 'messageSent' event.
+ *
+ * @public
+ */
 export type MessageSentListener = MessageReceivedListener;
+
+/**
+ * Callback for {@link ChatAdapterSubscribers} 'messageRead' event.
+ *
+ * @public
+ */
 export type MessageReadListener = (event: { message: ChatMessage; readBy: CommunicationUserKind }) => void;
+
+/**
+ * Callback for {@link ChatAdapterSubscribers} 'participantsAdded' event.
+ *
+ * @public
+ */
 export type ParticipantsAddedListener = (event: {
   participantsAdded: ChatParticipant[];
   addedBy: ChatParticipant;
 }) => void;
+
+/**
+ * Callback for {@link ChatAdapterSubscribers} 'participantsRemoved' event.
+ *
+ * @public
+ */
 export type ParticipantsRemovedListener = (event: {
   participantsRemoved: ChatParticipant[];
   removedBy: ChatParticipant;
 }) => void;
+
+/**
+ * Callback for {@link ChatAdapterSubscribers} 'topicChanged' event.
+ *
+ * @public
+ */
 export type TopicChangedListener = (event: { topic: string }) => void;
-export type ChatEvent =
-  | 'messageReceived'
-  | 'messageSent'
-  | 'messageRead'
-  | 'participantsAdded'
-  | 'participantsRemoved'
-  | 'topicChanged'
-  | 'error';

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapterProvider.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapterProvider.tsx
@@ -4,6 +4,9 @@
 import React, { createContext, useContext } from 'react';
 import { ChatAdapter } from './ChatAdapter';
 
+/**
+ * @private
+ */
 type ChatProviderProps = {
   children: React.ReactNode;
   adapter: ChatAdapter;
@@ -11,11 +14,17 @@ type ChatProviderProps = {
 
 const ChatAdapterContext = createContext<ChatAdapter | undefined>(undefined);
 
+/**
+ * @private
+ */
 export const ChatAdapterProvider = (props: ChatProviderProps): JSX.Element => {
   const { adapter } = props;
   return <ChatAdapterContext.Provider value={adapter}>{props.children}</ChatAdapterContext.Provider>;
 };
 
+/**
+ * @private
+ */
 export const useAdapter = (): ChatAdapter => {
   const adapter = useContext(ChatAdapterContext);
   if (!adapter) throw 'Cannot find adapter please initialize before usage.';

--- a/packages/react-composites/src/composites/ChatComposite/adapter/StubChatClient.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/StubChatClient.ts
@@ -17,7 +17,9 @@ import { PagedAsyncIterableIterator } from '@azure/core-paging';
 
 type PublicInterface<T> = { [K in keyof T]: T[K] };
 
-// A public interface compatible stub for ChatClient.
+/**
+ * A public interface compatible stub for ChatClient.
+ */
 export class StubChatClient implements PublicInterface<ChatClient> {
   private threadClient;
 
@@ -58,7 +60,9 @@ export class StubChatClient implements PublicInterface<ChatClient> {
   }
 }
 
-// A public interface compatible stub for ChatThreadClient.
+/**
+ * A public interface compatible stub for ChatThreadClient.
+ */
 export class StubChatThreadClient implements PublicInterface<ChatThreadClient> {
   readonly threadId: string;
 
@@ -106,8 +110,10 @@ export class StubChatThreadClient implements PublicInterface<ChatThreadClient> {
   }
 }
 
-// A paged async operator that asynchronously iterates over values in an array.
-// In paging mode, the whole array is returned as a single page, ignoring all page size options.
+/**
+ * A paged async operator that asynchronously iterates over values in an array.
+ * In paging mode, the whole array is returned as a single page, ignoring all page size options.
+ */
 export const pagedAsyncIterator = <T>(values: T[]): PagedAsyncIterableIterator<T, T[]> => {
   async function* listAll(values: T[]): AsyncIterableIterator<T> {
     yield* values;
@@ -132,7 +138,9 @@ export const pagedAsyncIterator = <T>(values: T[]): PagedAsyncIterableIterator<T
   };
 };
 
-// An iterator that throws the given error when asynchronously iterating over items, directly or byPage.
+/**
+ * An iterator that throws the given error when asynchronously iterating over items, directly or byPage.
+ */
 export const failingPagedAsyncIterator = <T>(error: Error): PagedAsyncIterableIterator<T, T[]> => {
   return {
     async next() {

--- a/packages/react-composites/src/composites/ChatComposite/hooks/useAdaptedSelector.ts
+++ b/packages/react-composites/src/composites/ChatComposite/hooks/useAdaptedSelector.ts
@@ -10,8 +10,9 @@ import { useAdapter } from '../adapter/ChatAdapterProvider';
 import memoizeOne from 'memoize-one';
 import { CommunicationIdentifierKind } from '@azure/communication-common';
 
-// This function highly depends on chatClient.onChange event
-// It will be moved into selector folder when the ChatClientProvide when refactor finished
+/**
+ * @private
+ */
 export const useAdaptedSelector = <SelectorT extends (state: ChatClientState, props: any) => any>(
   selector: SelectorT,
   selectorProps?: Parameters<SelectorT>[1]
@@ -19,6 +20,9 @@ export const useAdaptedSelector = <SelectorT extends (state: ChatClientState, pr
   return useSelectorWithAdaptation(selector, adaptCompositeState, selectorProps);
 };
 
+/**
+ * @private
+ */
 export const useSelectorWithAdaptation = <
   SelectorT extends (state: ReturnType<AdaptFuncT>, props: any) => any,
   AdaptFuncT extends (state: ChatAdapterState) => any

--- a/packages/react-composites/src/composites/ChatComposite/hooks/useHandlers.ts
+++ b/packages/react-composites/src/composites/ChatComposite/hooks/useHandlers.ts
@@ -9,7 +9,9 @@ import memoizeOne from 'memoize-one';
 import { ChatAdapter } from '../adapter/ChatAdapter';
 import { useAdapter } from '../adapter/ChatAdapterProvider';
 
-// This will be moved into selector folder when ChatClientProvide when refactor finished
+/**
+ * @private
+ */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/explicit-function-return-type
 export const useHandlers = <PropsT>(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/react-composites/src/composites/ChatComposite/hooks/usePropsFor.ts
+++ b/packages/react-composites/src/composites/ChatComposite/hooks/usePropsFor.ts
@@ -11,6 +11,9 @@ import { Common } from '@internal/acs-ui-common';
 
 type Selector = (state: any, props: any) => any;
 
+/**
+ * @private
+ */
 export const usePropsFor = <Component extends (props: any) => JSX.Element>(
   component: Component
 ): GetChatSelector<Component> extends Selector

--- a/packages/react-composites/src/composites/ChatComposite/hooks/useSelector.ts
+++ b/packages/react-composites/src/composites/ChatComposite/hooks/useSelector.ts
@@ -6,8 +6,9 @@
 import { ChatAdapterState } from '../adapter/ChatAdapter';
 import { useSelectorWithAdaptation } from './useAdaptedSelector';
 
-// This function highly depends on chatClient.onChange event
-// It will be moved into selector folder when the ChatClientProvide when refactor finished
+/**
+ * @private
+ */
 export const useSelector = <SelectorT extends (state: ChatAdapterState, props: any) => any>(
   selector: SelectorT,
   selectorProps: Parameters<SelectorT>[1]

--- a/packages/react-composites/src/composites/ChatComposite/index.ts
+++ b/packages/react-composites/src/composites/ChatComposite/index.ts
@@ -24,3 +24,5 @@ export type {
   ParticipantsRemovedListener,
   TopicChangedListener
 } from './adapter/ChatAdapter';
+
+export * from './Strings';

--- a/packages/react-composites/src/composites/ChatComposite/styles/Chat.styles.ts
+++ b/packages/react-composites/src/composites/ChatComposite/styles/Chat.styles.ts
@@ -3,6 +3,9 @@
 
 import { mergeStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const chatContainer = mergeStyles({
   height: '100%',
   width: '100%',
@@ -22,18 +25,27 @@ export const chatContainer = mergeStyles({
   }
 });
 
+/**
+ * @private
+ */
 export const chatArea = mergeStyles({
   height: '100%',
   width: '100%',
   overflow: 'hidden'
 });
 
+/**
+ * @private
+ */
 export const chatWrapper = mergeStyles({
   height: '100%',
   width: '100%',
   overflow: 'auto'
 });
 
+/**
+ * @private
+ */
 export const chatHeaderContainerStyle = mergeStyles({
   width: '100%',
   paddingLeft: '1.5rem',
@@ -45,6 +57,9 @@ export const chatHeaderContainerStyle = mergeStyles({
   borderBottom: '0.063rem solid #DDDDDD'
 });
 
+/**
+ * @private
+ */
 export const topicNameLabelStyle = mergeStyles({
   fontSize: '1.1rem',
   lineHeight: '2.5rem',
@@ -54,24 +69,39 @@ export const topicNameLabelStyle = mergeStyles({
   overflowY: 'hidden'
 });
 
+/**
+ * @private
+ */
 export const participantListWrapper = mergeStyles({
   boxShadow: '0px 0.3px 0.9px rgba(0, 0, 0, 0.1), 0px 1.6px 3.6px rgba(0, 0, 0, 0.13)',
   width: '15rem',
   height: '100%'
 });
 
+/**
+ * @private
+ */
 export const participantListContainerPadding = { childrenGap: '0.5rem' };
 
+/**
+ * @private
+ */
 export const listHeader = mergeStyles({
   fontSize: '1rem',
   margin: '1rem'
 });
 
+/**
+ * @private
+ */
 export const participantListStack = mergeStyles({
   width: '15rem',
   height: '100%'
 });
 
+/**
+ * @private
+ */
 export const participantListStyle = mergeStyles({
   overflowY: 'hidden'
 });

--- a/packages/react-composites/src/composites/MeetingComposite/ChatButton.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/ChatButton.tsx
@@ -8,6 +8,9 @@ import { Chat20Filled, Chat20Regular } from '@fluentui/react-icons';
 const onRenderOnIcon = (): JSX.Element => <Chat20Filled key={'chatOnIconKey'} primaryFill="currentColor" />;
 const onRenderOffIcon = (): JSX.Element => <Chat20Regular key={'chatOffIconKey'} primaryFill="currentColor" />;
 
+/**
+ * @private
+ */
 export const ChatButton = (props: ControlBarButtonProps): JSX.Element => {
   const strings = { label: 'Chat', ...props.strings };
 

--- a/packages/react-composites/src/composites/MeetingComposite/MeetingCallControlBar.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/MeetingCallControlBar.tsx
@@ -9,6 +9,9 @@ import { ChatButton } from './ChatButton';
 import { PeopleButton } from './PeopleButton';
 import { Stack } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export interface MeetingCallControlBarProps {
   callAdapter: CallAdapter;
   onEndCallClick: () => void;
@@ -18,6 +21,9 @@ export interface MeetingCallControlBarProps {
   onPeopleButtonClicked: () => void;
 }
 
+/**
+ * @private
+ */
 export const MeetingCallControlBar = (props: MeetingCallControlBarProps): JSX.Element => {
   return (
     <Stack horizontal>

--- a/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
@@ -19,6 +19,7 @@ import { ChatAdapter } from '../ChatComposite';
 
 /**
  * Props required for the {@link MeetingComposite}
+ *
  * @alpha
  */
 export type MeetingCompositeProps = {
@@ -41,6 +42,8 @@ export type MeetingCompositeProps = {
 
 /**
  * Optional features of the {@link MeetingComposite}
+ *
+ * @alpha
  */
 export type MeetingCompositeOptions = {
   /**
@@ -54,6 +57,7 @@ export type MeetingCompositeOptions = {
 
 /**
  * Meeting Composite brings together key components to provide a full meeting experience out of the box.
+ *
  * @alpha
  */
 export const MeetingComposite = (props: MeetingCompositeProps): JSX.Element => {

--- a/packages/react-composites/src/composites/MeetingComposite/PeopleButton.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/PeopleButton.tsx
@@ -8,6 +8,9 @@ import { People20Filled, People20Regular } from '@fluentui/react-icons';
 const onRenderOnIcon = (): JSX.Element => <People20Filled key={'peopleOnIconKey'} primaryFill="currentColor" />;
 const onRenderOffIcon = (): JSX.Element => <People20Regular key={'peopleOffIconKey'} primaryFill="currentColor" />;
 
+/**
+ * @private
+ */
 export const PeopleButton = (props: ControlBarButtonProps): JSX.Element => {
   const strings = { label: 'People', ...props.strings };
 

--- a/packages/react-composites/src/composites/MeetingComposite/SidePane.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/SidePane.tsx
@@ -67,6 +67,9 @@ const removeParticipantFromMeeting = async (
   await chatAdapter.removeParticipant(participantId);
 };
 
+/**
+ * @private
+ */
 export const EmbeddedPeoplePane = (props: {
   inviteLink?: string;
   onClose: () => void;
@@ -104,6 +107,9 @@ export const EmbeddedPeoplePane = (props: {
   );
 };
 
+/**
+ * @private
+ */
 export const EmbeddedChatPane = (props: {
   chatAdapter: ChatAdapter;
   fluentTheme?: PartialTheme | Theme;

--- a/packages/react-composites/src/composites/MeetingComposite/adapter/AzureCommunicationMeetingAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/AzureCommunicationMeetingAdapter.ts
@@ -14,11 +14,11 @@ import {
 } from '@azure/communication-calling';
 import { VideoStreamOptions } from '@internal/react-components';
 import {
-  ParticipantJoinedListener,
-  ParticipantLeftListener,
-  IsMuteChangedListener,
+  ParticipantsJoinedListener,
+  ParticipantsLeftListener,
+  IsMutedChangedListener,
   CallIdChangedListener,
-  IsScreenSharingOnChangedListener,
+  IsLocalScreenSharingActiveChangedListener,
   DisplayNameChangedListener,
   IsSpeakingChangedListener,
   CallAdapter,
@@ -285,13 +285,13 @@ export class AzureCommunicationMeetingAdapter implements MeetingAdapter {
   public async deleteMessage(messageId: string): Promise<void> {
     return await this.chatAdapter.deleteMessage(messageId);
   }
-  on(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
-  on(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+  on(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
+  on(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
   on(event: 'meetingEnded', listener: CallEndedListener): void;
   on(event: 'error', listener: (e: Error) => void): void;
-  on(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+  on(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
   on(event: 'callIdChanged', listener: CallIdChangedListener): void;
-  on(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+  on(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
   on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   on(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   on(event: 'messageReceived', listener: MessageReceivedListener): void;
@@ -341,13 +341,13 @@ export class AzureCommunicationMeetingAdapter implements MeetingAdapter {
     }
   }
 
-  off(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
-  off(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+  off(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
+  off(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
   off(event: 'meetingEnded', listener: CallEndedListener): void;
   off(event: 'error', listener: (e: Error) => void): void;
-  off(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+  off(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
   off(event: 'callIdChanged', listener: CallIdChangedListener): void;
-  off(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+  off(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
   off(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   off(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   off(event: 'messageReceived', listener: MessageReceivedListener): void;

--- a/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingAdapter.ts
@@ -9,11 +9,11 @@ import {
   CallAdapterDeviceManagement,
   CallIdChangedListener,
   DisplayNameChangedListener,
-  IsMuteChangedListener,
-  IsScreenSharingOnChangedListener,
+  IsMutedChangedListener,
+  IsLocalScreenSharingActiveChangedListener,
   IsSpeakingChangedListener,
-  ParticipantJoinedListener,
-  ParticipantLeftListener,
+  ParticipantsJoinedListener,
+  ParticipantsLeftListener,
   CallEndedListener
 } from '../../CallComposite';
 import {
@@ -96,26 +96,26 @@ export interface MeetingAdapterMeetingManagement
  */
 export interface MeetingAdapterSubscriptions {
   // Meeting specific subscriptions
-  on(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
-  on(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+  on(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
+  on(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
   on(event: 'meetingEnded', listener: CallEndedListener): void;
   on(event: 'error', listener: (e: Error) => void): void;
 
-  off(event: 'participantsJoined', listener: ParticipantJoinedListener): void;
-  off(event: 'participantsLeft', listener: ParticipantLeftListener): void;
+  off(event: 'participantsJoined', listener: ParticipantsJoinedListener): void;
+  off(event: 'participantsLeft', listener: ParticipantsLeftListener): void;
   off(event: 'meetingEnded', listener: CallEndedListener): void;
   off(event: 'error', listener: (e: Error) => void): void;
 
   // Call subscriptions
-  on(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+  on(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
   on(event: 'callIdChanged', listener: CallIdChangedListener): void;
-  on(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+  on(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
   on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   on(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
 
-  off(event: 'isMutedChanged', listener: IsMuteChangedListener): void;
+  off(event: 'isMutedChanged', listener: IsMutedChangedListener): void;
   off(event: 'callIdChanged', listener: CallIdChangedListener): void;
-  off(event: 'isLocalScreenSharingActiveChanged', listener: IsScreenSharingOnChangedListener): void;
+  off(event: 'isLocalScreenSharingActiveChanged', listener: IsLocalScreenSharingActiveChangedListener): void;
   off(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   off(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
 

--- a/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedCallAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedCallAdapter.ts
@@ -36,7 +36,7 @@ function callStateFromMeetingState(meetingState: MeetingState): CallState {
   };
 }
 
-export function callAdapterStateFromMeetingAdapterState(meetingState: MeetingAdapterState): CallAdapterState {
+function callAdapterStateFromMeetingAdapterState(meetingState: MeetingAdapterState): CallAdapterState {
   return {
     isLocalPreviewMicrophoneEnabled: meetingState.isLocalPreviewMicrophoneEnabled,
     page: meetingPageToCallPage(meetingState.page),
@@ -51,6 +51,8 @@ export function callAdapterStateFromMeetingAdapterState(meetingState: MeetingAda
 
 /**
  * Facade around the MeetingAdapter to satisfy the call adapter interface.
+ *
+ * @private
  */
 export class MeetingBackedCallAdapter implements CallAdapter {
   private meetingAdapter: MeetingAdapter;

--- a/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedChatAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedChatAdapter.ts
@@ -35,6 +35,8 @@ function ChatAdapterStateFromMeetingAdapterState(meetingState: MeetingAdapterSta
 
 /**
  * Facade around the MeetingAdapter to satisfy the chat adapter interface.
+ *
+ * @private
  */
 export class MeetingBackedChatAdapter implements ChatAdapter {
   private meetingAdapter: MeetingAdapter;

--- a/packages/react-composites/src/composites/MeetingComposite/state/MeetingAdapterState.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/state/MeetingAdapterState.ts
@@ -14,6 +14,7 @@ import {
 
 /**
  * UI state pertaining to the Meeting Composite.
+ *
  * @alpha
  */
 export interface MeetingAdapterUiState extends Pick<CallAdapterUiState, 'isLocalPreviewMicrophoneEnabled'> {
@@ -23,6 +24,7 @@ export interface MeetingAdapterUiState extends Pick<CallAdapterUiState, 'isLocal
 
 /**
  * State from the backend services that drives Meeting Composite.
+ *
  * @alpha
  */
 export interface MeetingAdapterClientState extends Pick<CallAdapterClientState, 'devices' | 'isTeamsCall'> {
@@ -44,6 +46,9 @@ export interface MeetingAdapterClientState extends Pick<CallAdapterClientState, 
  */
 export interface MeetingAdapterState extends MeetingAdapterUiState, MeetingAdapterClientState {}
 
+/**
+ * @private
+ */
 export function meetingAdapterStateFromBackingStates(
   callAdapter: CallAdapter,
   chatAdapter: ChatAdapter
@@ -66,6 +71,9 @@ export function meetingAdapterStateFromBackingStates(
   };
 }
 
+/**
+ * @private
+ */
 export function mergeChatAdapterStateIntoMeetingAdapterState(
   meetingAdapterState: MeetingAdapterState,
   chatAdapterState: ChatAdapterState
@@ -80,6 +88,9 @@ export function mergeChatAdapterStateIntoMeetingAdapterState(
   };
 }
 
+/**
+ * @private
+ */
 export function mergeCallAdapterStateIntoMeetingAdapterState(
   meetingAdapterState: MeetingAdapterState,
   callAdapterState: CallAdapterState

--- a/packages/react-composites/src/composites/MeetingComposite/state/MeetingCompositePage.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/state/MeetingCompositePage.ts
@@ -5,14 +5,21 @@ import { CallCompositePage } from '../../CallComposite';
 
 /**
  * Page state the Meeting composite could be in.
+ *
  * @alpha
  */
 export type MeetingCompositePage = 'configuration' | 'meeting' | 'error' | 'errorJoiningTeamsMeeting' | 'removed';
 
+/**
+ * @private
+ */
 export function callPageToMeetingPage(page: CallCompositePage): MeetingCompositePage {
   return page === 'call' ? 'meeting' : page;
 }
 
+/**
+ * @private
+ */
 export function meetingPageToCallPage(page: MeetingCompositePage): CallCompositePage {
   return page === 'meeting' ? 'call' : page;
 }

--- a/packages/react-composites/src/composites/MeetingComposite/state/MeetingEndReason.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/state/MeetingEndReason.ts
@@ -5,6 +5,7 @@ import { CallEndReason } from '@azure/communication-calling';
 
 /**
  * Describes the reason the meeting ended.
+ *
  * @alpha
  */
 export type MeetingEndReason = CallEndReason;

--- a/packages/react-composites/src/composites/MeetingComposite/state/MeetingParticipants.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/state/MeetingParticipants.ts
@@ -12,6 +12,7 @@ import { MeetingEndReason } from './MeetingEndReason';
 
 /**
  * Participants of a Meeting.
+ *
  * @alpha
  */
 export interface MeetingParticipant
@@ -23,8 +24,16 @@ export interface MeetingParticipant
   meetingEndReason?: MeetingEndReason;
 }
 
+/**
+ * Participants of a Meeting, keyed by userId.
+ *
+ * @alpha
+ */
 export type MeetingParticipants = { [keys: string]: MeetingParticipant };
 
+/**
+ * @private
+ */
 function meetingParticipantFromCallParticipant(callParticipant: RemoteParticipantState): MeetingParticipant {
   return {
     id: callParticipant.identifier,
@@ -37,6 +46,9 @@ function meetingParticipantFromCallParticipant(callParticipant: RemoteParticipan
   };
 }
 
+/**
+ * @private
+ */
 function callParticipantFromMeetingParticipant(meetingParticipant: MeetingParticipant): RemoteParticipantState {
   return {
     identifier: meetingParticipant.id,
@@ -53,6 +65,9 @@ type RemoteCallParticipants = {
   [keys: string]: RemoteParticipantState;
 };
 
+/**
+ * @private
+ */
 export function meetingParticipantsFromCallParticipants(callParticipants: RemoteCallParticipants): MeetingParticipants {
   const meetingParticipants: MeetingParticipants = {};
   for (const [key, value] of Object.entries(callParticipants)) {
@@ -61,6 +76,9 @@ export function meetingParticipantsFromCallParticipants(callParticipants: Remote
   return meetingParticipants;
 }
 
+/**
+ * @private
+ */
 export function callParticipantsFromMeetingParticipants(
   meetingParticipants: MeetingParticipants
 ): RemoteCallParticipants {

--- a/packages/react-composites/src/composites/MeetingComposite/state/MeetingState.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/state/MeetingState.ts
@@ -9,6 +9,7 @@ import { meetingParticipantsFromCallParticipants } from '../state/MeetingPartici
 
 /**
  * State of a single Meeting.
+ *
  * @alpha
  */
 export interface MeetingState
@@ -44,6 +45,8 @@ export interface MeetingState
 
 /**
  * Return properties from call state that are used in meeting state.
+ *
+ * @private
  */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const meetingPropsFromCallState = (callState: CallState) => ({
@@ -69,6 +72,8 @@ const meetingPropsFromCallState = (callState: CallState) => ({
 
 /**
  * Return properties from chat state that are used in meeting state.
+ *
+ * @private
  */
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const meetingPropsFromChatState = (chatState: ChatThreadClientState) => ({
@@ -82,6 +87,8 @@ const meetingPropsFromChatState = (chatState: ChatThreadClientState) => ({
 
 /**
  * Helper function to return meeting state created from call and chat states
+ *
+ * @private
  */
 export function meetingStateFromBackingStates(callState: CallState, chatState: ChatThreadClientState): MeetingState {
   return {
@@ -92,6 +99,8 @@ export function meetingStateFromBackingStates(callState: CallState, chatState: C
 
 /**
  * Helper function to return an updated meeting state with new chat state applied
+ *
+ * @private
  */
 export function mergeChatStateIntoMeetingState(
   meetingState: MeetingState,
@@ -105,6 +114,8 @@ export function mergeChatStateIntoMeetingState(
 
 /**
  * Helper function to return an updated meeting state with new call state applied
+ *
+ * @private
  */
 export function mergeCallStateIntoMeetingState(
   meetingState: MeetingState | undefined,

--- a/packages/react-composites/src/composites/MeetingComposite/styles/MeetingCompositeStyles.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/styles/MeetingCompositeStyles.ts
@@ -3,4 +3,7 @@
 
 import { IStackStyles } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const compositeOuterContainerStyles: IStackStyles = { root: { width: '100%' } };

--- a/packages/react-composites/src/composites/MeetingComposite/styles/SidePane.styles.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/styles/SidePane.styles.ts
@@ -6,6 +6,9 @@ import { IContextualMenuItemStyles, IStackStyles, IStackItemStyles, IStackTokens
 const theme = getTheme();
 const palette = theme.palette;
 
+/**
+ * @private
+ */
 export const sidePaneContainerStyles: IStackItemStyles = {
   root: {
     height: '100%',
@@ -15,6 +18,9 @@ export const sidePaneContainerStyles: IStackItemStyles = {
   }
 };
 
+/**
+ * @private
+ */
 export const sidePaneContainerHiddenStyles: IStackItemStyles = {
   root: {
     ...sidePaneContainerStyles,
@@ -22,10 +28,16 @@ export const sidePaneContainerHiddenStyles: IStackItemStyles = {
   }
 };
 
+/**
+ * @private
+ */
 export const sidePaneContainerTokens: IStackTokens = {
   childrenGap: '0.5rem'
 };
 
+/**
+ * @private
+ */
 export const sidePaneHeaderStyles: IStackItemStyles = {
   root: {
     fontSize: '0.825rem',
@@ -35,16 +47,33 @@ export const sidePaneHeaderStyles: IStackItemStyles = {
   }
 };
 
+/**
+ * @private
+ */
 export const sidePaneCloseButtonStyles: Partial<IContextualMenuItemStyles> = {
   icon: { color: palette.neutralSecondary },
   iconHovered: { color: palette.neutralSecondary },
   iconPressed: { color: palette.neutralSecondary }
 };
 
+/**
+ * @private
+ */
 export const paneBodyContainer: IStackStyles = { root: { flexDirection: 'column', display: 'flex' } };
+
+/**
+ * @private
+ */
 export const scrollableContainer: IStackStyles = { root: { flexBasis: '0', flexGrow: '1', overflowY: 'auto' } };
+
+/**
+ * @private
+ */
 export const scrollableContainerContents: IStackItemStyles = { root: { flexGrow: '1', flexBasis: '0' } };
 
+/**
+ * @private
+ */
 export const peopleSubheadingStyle: IStackItemStyles = {
   root: {
     fontSize: '0.75rem',
@@ -52,6 +81,9 @@ export const peopleSubheadingStyle: IStackItemStyles = {
   }
 };
 
+/**
+ * @private
+ */
 export const peoplePaneContainerTokens: IStackTokens = {
   childrenGap: '0.5rem'
 };

--- a/packages/react-composites/src/composites/common/AvatarPersona.tsx
+++ b/packages/react-composites/src/composites/common/AvatarPersona.tsx
@@ -5,7 +5,9 @@ import { IPersonaProps, Persona, PersonaInitialsColor } from '@fluentui/react';
 import React, { useEffect } from 'react';
 
 /**
- * Custom data attributes for the AvatarPersona component.
+ * Custom data attributes for displaying avatar for a user.
+ *
+ * @public
  */
 export type AvatarPersonaData = {
   /**
@@ -34,10 +36,15 @@ export type AvatarPersonaData = {
 };
 
 /**
- * Callback function used to provide custom data to the AvatarPersona component.
+ * Callback function used to provide custom data to build an avatar for a user.
+ *
+ * @public
  */
 export type AvatarPersonaDataCallback = (userId: string) => Promise<AvatarPersonaData>;
 
+/**
+ * @private
+ */
 export interface AvatarPersonaProps extends IPersonaProps {
   /**
    * Azure Communicator user ID.
@@ -53,6 +60,8 @@ export interface AvatarPersonaProps extends IPersonaProps {
  * An Avatar component made using the `Persona` component.
  * It allows you to specify a `userId` and a `dataProvider` to retrieve the `AvatarPersonaData`.
  * Read more about `Persona` component at https://developer.microsoft.com/fluentui#/controls/web/persona
+ *
+ * @private
  */
 export const AvatarPersona = (props: AvatarPersonaProps): JSX.Element => {
   const { userId, dataProvider } = props;

--- a/packages/react-composites/src/composites/common/BaseComposite.tsx
+++ b/packages/react-composites/src/composites/common/BaseComposite.tsx
@@ -9,6 +9,11 @@ import { CompositeLocale, LocalizationProvider } from '../localization';
 import { AvatarPersonaDataCallback } from './AvatarPersona';
 import { CallCompositeIcons, DEFAULT_COMPOSITE_ICONS } from './icons';
 
+/**
+ * Properties common to all composites exported from this library.
+ *
+ * @public
+ */
 export interface BaseCompositeProps<TIcons extends Record<string, JSX.Element>> {
   /**
    * Fluent theme for the composite.
@@ -49,6 +54,8 @@ export interface BaseCompositeProps<TIcons extends Record<string, JSX.Element>> 
 /**
  * A base class for composites.
  * Provides common wrappers such as FluentThemeProvider and LocalizationProvider.
+ *
+ * @private
  */
 export const BaseComposite = (
   props: BaseCompositeProps<CallCompositeIcons | ChatCompositeIcons> & { children: React.ReactNode }

--- a/packages/react-composites/src/composites/common/PermissionsBanner.tsx
+++ b/packages/react-composites/src/composites/common/PermissionsBanner.tsx
@@ -5,9 +5,30 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { MessageBar, MessageBarButton, MessageBarType } from '@fluentui/react';
 import { permissionsBannerMessageBarStyle } from '../common/styles/PermissionsBanner.styles';
 
+/**
+ * @private
+ *
+ * TODO: Localize
+ */
 export const CAMERA_PERMISSION_DENIED = 'Camera use is blocked by your browser.';
+
+/**
+ * @private
+ *
+ * TODO: Localize
+ */
 export const MICROPHONE_PERMISSION_DENIED = 'Microphone use is blocked by your browser.';
+
+/**
+ * @private
+ *
+ * TODO: Localize
+ */
 export const CAMERA_AND_MICROPHONE_PERMISSION_DENIED = 'Camera and microphone use is blocked by your browser.';
+
+/**
+ * TODO: Localize
+ */
 const ALLOW_PERMISSIONS_INSTRUCTIONS =
   "Grant permission by clicking the lock in the address bar and selecting 'Allow'.";
 

--- a/packages/react-composites/src/composites/common/PermissionsBanner.tsx
+++ b/packages/react-composites/src/composites/common/PermissionsBanner.tsx
@@ -11,6 +11,9 @@ export const CAMERA_AND_MICROPHONE_PERMISSION_DENIED = 'Camera and microphone us
 const ALLOW_PERMISSIONS_INSTRUCTIONS =
   "Grant permission by clicking the lock in the address bar and selecting 'Allow'.";
 
+/**
+ * @private
+ */
 export interface PermissionsBannerProps {
   /**
    * If cameraPermission is true or undefined, no banner is shown for camera.
@@ -32,6 +35,7 @@ export interface PermissionsBannerProps {
  * @param dismissedCameraBanner - If camera banner was already dismissed
  * @param dismissedMicrophoneBanner - If microphone banner was already dismissed
  * @returns
+ *
  */
 export const getPermissionsBannerMessage = (
   cameraPermissionGranted: boolean | undefined,
@@ -62,6 +66,7 @@ export const getPermissionsBannerMessage = (
  * the props and stay dismissed even if permission change after dismissal.
  *
  * @param props {@link PermissionsBannerProps}
+ *
  */
 export const PermissionsBanner = (props: PermissionsBannerProps): JSX.Element => {
   const { cameraPermissionGranted, microphonePermissionGranted } = props;

--- a/packages/react-composites/src/composites/common/adapters.ts
+++ b/packages/react-composites/src/composites/common/adapters.ts
@@ -3,6 +3,8 @@
 
 /**
  * Functionality for interfacing with Composite adapter state.
+ *
+ * @public
  */
 export interface AdapterState<TState> {
   /** Subscribes the handler to stateChanged events. */
@@ -15,6 +17,8 @@ export interface AdapterState<TState> {
 
 /**
  * Functionality for interfacing with Composite adapter pages.
+ *
+ * @public
  */
 export interface AdapterPages<TPage> {
   /** Set the current page of the Composite */
@@ -23,6 +27,8 @@ export interface AdapterPages<TPage> {
 
 /**
  * Functionality for correctly disposing a Composite.
+ *
+ * @public
  */
 export interface AdapterDisposal {
   /** Dispose of the Composite */
@@ -31,6 +37,8 @@ export interface AdapterDisposal {
 
 /**
  * Error reported via error events and stored in adapter state.
+ *
+ * @public
  */
 export interface AdapterError extends Error {
   /**
@@ -51,5 +59,7 @@ export interface AdapterError extends Error {
  * Adapters stores the latest error for each operation in the state.
  *
  * `target` is an adapter defined string for each unique operation performed by the adapter.
+ *
+ * @public
  */
 export type AdapterErrors = { [target: string]: AdapterError };

--- a/packages/react-composites/src/composites/common/icons.tsx
+++ b/packages/react-composites/src/composites/common/icons.tsx
@@ -13,7 +13,9 @@ import { ComponentIcons, DEFAULT_COMPONENT_ICONS } from '@internal/react-compone
 import React from 'react';
 
 /**
- * These icons are composite specific and not being used inside components.
+ * The default set of icons used by the composites directly (i.e. not via the components defined in this library).
+ *
+ * @public
  */
 export const COMPOSITE_ONLY_ICONS = {
   LocalDeviceSettingsCamera: <Video20Filled />,
@@ -26,14 +28,28 @@ export const COMPOSITE_ONLY_ICONS = {
 
 /**
  * The default set of icons that are available to used in the Composites.
+ *
+ * @public
  */
 export const DEFAULT_COMPOSITE_ICONS = {
   ...DEFAULT_COMPONENT_ICONS,
   ...COMPOSITE_ONLY_ICONS
 };
 
+/**
+ * Icons that can be overridden in one of the composites exported by this library.
+ *
+ * See {@link ChatCompositeIcons} and {@link CallCompositeIcons} for more targeted types.
+ *
+ * @public
+ */
 export type CompositeIcons = ComponentIcons & Record<keyof typeof COMPOSITE_ONLY_ICONS, JSX.Element>;
 
+/**
+ * Icons that can be overridden for {@link ChatComposite}.
+ *
+ * @public
+ */
 export type ChatCompositeIcons = Partial<
   Pick<
     CompositeIcons,
@@ -51,7 +67,11 @@ export type ChatCompositeIcons = Partial<
     | 'EditBoxSubmit'
   >
 >;
-
+/**
+ * Icons that can be overridden for {@link CallComposite}.
+ *
+ * @public
+ */
 export type CallCompositeIcons = Partial<
   Pick<
     CompositeIcons,

--- a/packages/react-composites/src/composites/common/styles/PermissionsBanner.styles.ts
+++ b/packages/react-composites/src/composites/common/styles/PermissionsBanner.styles.ts
@@ -3,10 +3,16 @@
 
 import { IMessageBarStyleProps, IMessageBarStyles, IStyleFunctionOrObject } from '@fluentui/react';
 
+/**
+ * @private
+ */
 export const permissionsBannerContainerStyle = {
   width: '100%'
 };
 
+/**
+ * @private
+ */
 export const permissionsBannerMessageBarStyle: IStyleFunctionOrObject<IMessageBarStyleProps, IMessageBarStyles> = {
   root: {
     // Constrain permission banner height if there is a long error message in a narrow space.

--- a/packages/react-composites/src/composites/localization/LocalizationProvider.tsx
+++ b/packages/react-composites/src/composites/localization/LocalizationProvider.tsx
@@ -6,10 +6,13 @@ import React, { createContext, useContext } from 'react';
 import { ComponentLocale, LocalizationProvider as ComponentLocalizationProvider } from '@internal/react-components';
 
 import { COMPOSITE_LOCALE_EN_US } from './locales';
-import { CallCompositeStrings, ChatCompositeStrings } from '../CallComposite';
+import { CallCompositeStrings } from '../CallComposite';
+import { ChatCompositeStrings } from '../ChatComposite';
 
 /**
- * Data structure for localization
+ * Locale information for all composites exported from this library.
+ *
+ * @public
  */
 export interface CompositeLocale {
   /** Strings used in composites directly
@@ -26,6 +29,8 @@ export interface CompositeLocale {
  * Strings used in the composites directly.
  *
  * These strings are used by the composites directly, instead of by the contained components.
+ *
+ * @public
  */
 export interface CompositeStrings {
   /**
@@ -40,11 +45,15 @@ export interface CompositeStrings {
 
 /**
  * Context for providing localized strings to components
+ *
+ * @private
  */
 export const LocaleContext = createContext<CompositeLocale>(COMPOSITE_LOCALE_EN_US);
 
 /**
  * Props to LocalizationProvider
+ *
+ * @private
  */
 export type LocalizationProviderProps = {
   /** Locale context to provide components */
@@ -56,7 +65,7 @@ export type LocalizationProviderProps = {
 /**
  * Provider to provide localized strings for this library's composites.
  *
- * This provider is internal. Do not export in public API.
+ * @private
  */
 export const LocalizationProvider = (props: LocalizationProviderProps): JSX.Element => {
   const { locale, children } = props;
@@ -67,5 +76,7 @@ export const LocalizationProvider = (props: LocalizationProviderProps): JSX.Elem
   );
 };
 
-/** React hook to access locale */
+/**
+ * @private
+ */
 export const useLocale = (): CompositeLocale => useContext(LocaleContext);

--- a/packages/react-composites/src/composites/localization/locales/index.ts
+++ b/packages/react-composites/src/composites/localization/locales/index.ts
@@ -42,72 +42,128 @@ const createCompositeStrings = (localizedStrings: PartialDeep<CompositeStrings>)
   return strings;
 };
 
-/** Locale for English (US) */
+/**
+ * Locale for English (US)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_EN_US: CompositeLocale = {
   component: COMPONENT_LOCALE_EN_US,
   strings: en_US
 };
-/** Locale for English (British) */
+/**
+ * Locale for English (British)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_EN_GB: CompositeLocale = {
   component: COMPONENT_LOCALE_EN_GB,
   strings: createCompositeStrings(en_GB)
 };
-/** Locale for German (Germany) */
+/**
+ * Locale for German (Germany)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_DE_DE: CompositeLocale = {
   component: COMPONENT_LOCALE_DE_DE,
   strings: createCompositeStrings(de_DE)
 };
-/** Locale for Spanish (Spain) */
+/**
+ * Locale for Spanish (Spain)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_ES_ES: CompositeLocale = {
   component: COMPONENT_LOCALE_ES_ES,
   strings: createCompositeStrings(es_ES)
 };
-/** Locale for French (France) */
+/**
+ * Locale for French (France)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_FR_FR: CompositeLocale = {
   component: COMPONENT_LOCALE_FR_FR,
   strings: createCompositeStrings(fr_FR)
 };
-/** Locale for Italian (Italy) */
+/**
+ * Locale for Italian (Italy)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_IT_IT: CompositeLocale = {
   component: COMPONENT_LOCALE_IT_IT,
   strings: createCompositeStrings(it_IT)
 };
-/** Locale for Japanese (Japan) */
+/**
+ * Locale for Japanese (Japan)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_JA_JP: CompositeLocale = {
   component: COMPONENT_LOCALE_JA_JP,
   strings: createCompositeStrings(ja_JP)
 };
-/** Locale for Korean (South Korea) */
+/**
+ * Locale for Korean (South Korea)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_KO_KR: CompositeLocale = {
   component: COMPONENT_LOCALE_KO_KR,
   strings: createCompositeStrings(ko_KR)
 };
-/** Locale for Dutch (Netherlands) */
+/**
+ * Locale for Dutch (Netherlands)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_NL_NL: CompositeLocale = {
   component: COMPONENT_LOCALE_NL_NL,
   strings: createCompositeStrings(nl_NL)
 };
-/** Locale for Portuguese (Brazil) */
+/**
+ * Locale for Portuguese (Brazil)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_PT_BR: CompositeLocale = {
   component: COMPONENT_LOCALE_PT_BR,
   strings: createCompositeStrings(pt_BR)
 };
-/** Locale for Russian (Russia) */
+/**
+ * Locale for Russian (Russia)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_RU_RU: CompositeLocale = {
   component: COMPONENT_LOCALE_RU_RU,
   strings: createCompositeStrings(ru_RU)
 };
-/** Locale for Turkish (Turkey) */
+/**
+ * Locale for Turkish (Turkey)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_TR_TR: CompositeLocale = {
   component: COMPONENT_LOCALE_TR_TR,
   strings: createCompositeStrings(tr_TR)
 };
-/** Locale for Chinese (Mainland China) */
+/**
+ * Locale for Chinese (Mainland China)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_ZH_CN: CompositeLocale = {
   component: COMPONENT_LOCALE_ZH_CN,
   strings: createCompositeStrings(zh_CN)
 };
-/** Locale for Chinese (Taiwan) */
+/**
+ * Locale for Chinese (Taiwan)
+ *
+ * @public
+ */
 export const COMPOSITE_LOCALE_ZH_TW: CompositeLocale = {
   component: COMPONENT_LOCALE_ZH_TW,
   strings: createCompositeStrings(zh_TW)

--- a/packages/react-composites/src/mocks/CallingMocks.ts
+++ b/packages/react-composites/src/mocks/CallingMocks.ts
@@ -28,6 +28,9 @@ type MockCallProps = {
   isIncoming: boolean;
 };
 
+/**
+ * @private
+ */
 export const defaultMockCallProps = {
   muteExecutedCallback: jest.fn(),
   unmuteExecutedCallback: jest.fn(),

--- a/packages/react-composites/src/mocks/CallingMocks.ts
+++ b/packages/react-composites/src/mocks/CallingMocks.ts
@@ -46,6 +46,9 @@ export const defaultMockCallProps = {
   isIncoming: false
 };
 
+/**
+ * @private
+ */
 export function mockCall(mockProps?: MockCallProps): MockCall {
   const props = { ...defaultMockCallProps, ...mockProps };
 
@@ -137,6 +140,9 @@ export function mockCall(mockProps?: MockCallProps): MockCall {
   };
 }
 
+/**
+ * @private
+ */
 export function mockCallAgent(props?: MockCallProps): MockCallAgent {
   const call = mockCall(props);
   return {
@@ -161,6 +167,9 @@ export function mockCallAgent(props?: MockCallProps): MockCallAgent {
   };
 }
 
+/**
+ * @private
+ */
 export function mockRemoteParticipant(
   videoStreams?: MockRemoteVideoStream[],
   displayName?: string,
@@ -183,6 +192,9 @@ export function mockRemoteParticipant(
   };
 }
 
+/**
+ * @private
+ */
 export function mockRemoteVideoStream(type?: MediaStreamType, isAvailable?: boolean): MockRemoteVideoStream {
   return {
     id: 1,

--- a/packages/react-composites/src/mocks/CallingTypeMocks.ts
+++ b/packages/react-composites/src/mocks/CallingTypeMocks.ts
@@ -220,8 +220,9 @@ export declare interface MockCall {
 }
 
 /**
- * Represents a mock remote participants video or screen-sharing stream
- * @public
+ * Represents a mock remote participants video or screen-sharing stream.
+ *
+ * @private
  */
 export declare interface MockRemoteVideoStream {
   /**
@@ -258,7 +259,8 @@ export declare interface MockRemoteVideoStream {
 
 /**
  * The Mock CallAgent is used to handle calls.
- * @public
+ *
+ * @private
  */
 export declare interface MockCallAgent {
   /**

--- a/packages/react-composites/src/mocks/CallingTypeMocks.ts
+++ b/packages/react-composites/src/mocks/CallingTypeMocks.ts
@@ -33,7 +33,8 @@ import {
 
 /**
  * Represents a MockCall
- * @public
+ *
+ * @private
  */
 export declare interface MockCall {
   /**

--- a/packages/react-composites/src/mocks/MockUtils.ts
+++ b/packages/react-composites/src/mocks/MockUtils.ts
@@ -15,6 +15,8 @@ function waitMilliseconds(duration: number): Promise<void> {
  * fail some expects check before the 5 seconds otherwise you'll just get a cryptic 'jest timeout error'.
  *
  * @param breakCondition
+ *
+ * @private
  */
 export async function waitWithBreakCondition(breakCondition: () => boolean): Promise<void> {
   for (let i = 0; i < 40; i++) {

--- a/packages/react-composites/src/utils/SDKUtils.ts
+++ b/packages/react-composites/src/utils/SDKUtils.ts
@@ -4,10 +4,17 @@
 import { AzureCommunicationTokenCredential, CommunicationTokenRefreshOptions } from '@azure/communication-common';
 import { CallState as CallStatus } from '@azure/communication-calling';
 
+/**
+ * @private
+ */
 export const isInCall = (callStatus: CallStatus): boolean => !!(callStatus !== 'None' && callStatus !== 'Disconnected');
 
-// Create AzureCommunicationUserCredential using optional refreshTokenCallback if provided. If callback is provided then
-// identity must also be provided for callback to be used.
+/**
+ * Create AzureCommunicationUserCredential using optional refreshTokenCallback if provided.
+ * If callback is provided then identity must also be provided for callback to be used.
+ *
+ * @private
+ */
 export const createAzureCommunicationUserCredential = (
   token: string,
   refreshTokenCallback?: (() => Promise<string>) | undefined

--- a/packages/react-composites/tests/browser/chat/app/index.tsx
+++ b/packages/react-composites/tests/browser/chat/app/index.tsx
@@ -71,7 +71,7 @@ function App(): JSX.Element {
           }
           onFetchAvatarPersonaData={
             customDataModel
-              ? (userId) =>
+              ? () =>
                   new Promise((resolve) =>
                     resolve({
                       imageInitials: 'CI',

--- a/packages/react-composites/tests/server/server.ts
+++ b/packages/react-composites/tests/server/server.ts
@@ -10,7 +10,7 @@ const app = express();
 export const startServer = (appDir: string): Promise<void> => {
   app.use(express.static(path.resolve(appDir, 'dist')));
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     server = app.listen(3000, () => {
       resolve();
     });


### PR DESCRIPTION
For the calling-stateful-client and calling-component-bindings packlets,

* All API exported from modules must now have docstrings.
  * This is annoying and not as useful for API exported from internal modules, but not exported from packages, so allow marking such API with @private
* All API exported from the packages must now have release tags @public, @beta etc: https://api-extractor.com/pages/tsdoc/doc_comment_syntax/#release-tags

Release tags are a good idea anyway -- they make sure that all our package exported API is intentional, no leakages.
Coupled with the @private, it serves another purpose -- if we mark something @private to satisfy eslint, but then mark it @public to satisfy api extractor, we know something's gone wrong ;)

This PR does not yet enable the enforcement of release tags from api extractor. That can only be done once all packlets are clean.