### PR TITLE
Update create release branch to using machine account

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -19,6 +19,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          # Use a machine account when checking out. This is to workaround the issue were GitHub
+          # actions, when using the default account, cannot trigger other actions. And we want this
+          # action to trigger the regulaar CI pipeline on the created branch.
+          # This machine account is only for this PAT, pwd was created and thrown away
+          # If any update needed, create a new account, add access to the repo and generate a new PAT
+          token: ${{ secrets.MACHINE_ACCOUNT_PAT }}
 
       # Setup bot information for creating pull request
       # Here we use the id from the github actions bot: https://api.github.com/users/better-informatics%5Bbot%5D

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
           # Use a machine account when checking out. This is to workaround the issue were GitHub
           # actions, when using the default account, cannot trigger other actions. And we want this
-          # action to trigger the regulaar CI pipeline on the created branch.
+          # action to trigger the regular CI pipeline on the created branch.
           # This machine account is only for this PAT, pwd was created and thrown away
           # If any update needed, create a new account, add access to the repo and generate a new PAT
           token: ${{ secrets.MACHINE_ACCOUNT_PAT }}


### PR DESCRIPTION
# What
Use machine account that nan had created for the update-snapshots. Use it for the create release branch action so when the branch is created a CI action will be subsequently triggered

# Why
Actions by default cannot trigger other actions to prevent infinite loops.