### PR TITLE
Try fix localization test flakiness take 2

### DIFF
--- a/change/@internal-react-composites-ef42f82c-2653-4ca3-9b93-feef44c8914a.json
+++ b/change/@internal-react-composites-ef42f82c-2653-4ca3-9b93-feef44c8914a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Try fix test flakiness",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/tests/browser/call/Localization.test.ts
+++ b/packages/react-composites/tests/browser/call/Localization.test.ts
@@ -4,21 +4,22 @@
 import { test } from './fixture';
 import { loadPageWithPermissionsForCalls, waitForCallCompositeToLoad, loadCallScreen } from '../common/utils';
 import { expect } from '@playwright/test';
+import { v1 as generateGUID } from 'uuid';
 
 test.describe('Localization tests', async () => {
-  test.beforeEach(async ({ pages }) => {
-    for (const page of pages) {
-      // Ensure any previous call users from prior tests have left the call
-      await page.reload();
-    }
-  });
-
   test('Configuration page title and participant button in call should be localized', async ({
     serverUrl,
     users,
     testBrowser
   }) => {
-    const page = await loadPageWithPermissionsForCalls(testBrowser, serverUrl, users[0], { useFrlocale: 'true' });
+    // Run this test in an isolated thread to ensure the test is totally isolated.
+    const newCallId = generateGUID();
+    const page = await loadPageWithPermissionsForCalls(
+      testBrowser,
+      serverUrl,
+      { ...users[0], threadId: newCallId },
+      { useFrlocale: 'true' }
+    );
     await page.bringToFront();
     await waitForCallCompositeToLoad(page);
     expect(await page.screenshot()).toMatchSnapshot('localized-call-configuration-page.png', { threshold: 0.5 });


### PR DESCRIPTION
# What
#853 fixed that test, but is causing other tests to be more flakey: https://github.com/Azure/communication-ui-library/runs/3747592784
Try putting the call locale test in its own call instead to ensure its isolated.

My assumption here is that these tests aren't running deterministically sequentially.

# How Tested
Running stress test: https://github.com/Azure/communication-ui-library/actions/runs/1288002656