### PR TITLE
removed button role re-definition to keep default

### DIFF
--- a/samples/Chat/src/app/HomeScreen.tsx
+++ b/samples/Chat/src/app/HomeScreen.tsx
@@ -114,7 +114,6 @@ export default (): JSX.Element => {
             </Stack>
             <PrimaryButton
               id="startChat"
-              role="main"
               aria-label="Start chat"
               className={buttonStyle}
               onClick={() => {


### PR DESCRIPTION
# What
Start button in Chat sample Home page had its role defined as "main" so screen reader was announcing 'Start chat Main Landmark' instead of 'Start chat Button'.
Just removed this definition to keep the default one ("button")

# Why
bug https://skype.visualstudio.com/SPOOL/_workitems/edit/2582638

# How Tested
ran Chat sample locally, opened Narrator , navigated to "Start chat" button and listen to screen reader

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->