### PR TITLE
removed tabindex on non-interactive elements in Chat sample Home screen

### DIFF
--- a/samples/Chat/src/app/HomeScreen.tsx
+++ b/samples/Chat/src/app/HomeScreen.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IImageStyles, Icon, Image, PrimaryButton, Spinner, Stack, Link } from '@fluentui/react';
+import { IImageStyles, Icon, Image, Link, List, PrimaryButton, Spinner, Stack, Text } from '@fluentui/react';
 import React, { useState } from 'react';
 import {
   buttonStyle,
@@ -10,7 +10,9 @@ import {
   containerTokens,
   containerStyle,
   headerStyle,
-  iconStyle,
+  listIconStyle,
+  listItemStackTokens,
+  listItemStyle,
   imgStyle,
   listStyle,
   nestedStackTokens,
@@ -80,6 +82,26 @@ export default (): JSX.Element => {
     return <Spinner label={spinnerLabel} ariaLive="assertive" labelPosition="top" />;
   };
 
+  const onRenderListItem = (item?: string, index?: number) => {
+    const listText =
+      index !== 3 ? (
+        <Text>{item}</Text>
+      ) : (
+        <Text>
+          {item}{' '}
+          <Link href="https://docs.microsoft.com/azure/communication-services/overview" aria-label={`${item} sample`}>
+            {'sample'}
+          </Link>
+        </Text>
+      );
+    return (
+      <Stack horizontal tokens={listItemStackTokens} className={listItemStyle}>
+        <Icon className={listIconStyle} iconName={iconName} />
+        {listText}
+      </Stack>
+    );
+  };
+
   const displayHomeScreen = (): JSX.Element => {
     return (
       <Stack
@@ -91,26 +113,10 @@ export default (): JSX.Element => {
         className={containerStyle}
       >
         <Stack className={infoContainerStyle} tokens={infoContainerStackTokens}>
-          <div tabIndex={0} className={headerStyle}>
-            {headerTitle}
-          </div>
+          <Text className={headerStyle}>{headerTitle}</Text>
           <Stack className={configContainerStyle} tokens={configContainerStackTokens}>
             <Stack tokens={nestedStackTokens}>
-              <ul className={listStyle}>
-                <li tabIndex={0}>
-                  <Icon className={iconStyle} iconName={iconName} /> {listItems[0]}
-                </li>
-                <li tabIndex={0}>
-                  <Icon className={iconStyle} iconName={iconName} /> {listItems[1]}
-                </li>
-                <li tabIndex={0}>
-                  <Icon className={iconStyle} iconName={iconName} /> {listItems[2]}
-                </li>
-                <li tabIndex={0}>
-                  <Icon className={iconStyle} iconName={iconName} /> {listItems[3]}{' '}
-                  <Link href="https://docs.microsoft.com/azure/communication-services/overview">sample</Link>
-                </li>
-              </ul>
+              <List className={listStyle} items={listItems} onRenderCell={onRenderListItem} />
             </Stack>
             <PrimaryButton
               id="startChat"

--- a/samples/Chat/src/app/styles/HomeScreen.styles.ts
+++ b/samples/Chat/src/app/styles/HomeScreen.styles.ts
@@ -43,7 +43,15 @@ export const listStyle = mergeStyles({
   fontSize: '0.875rem' // 14px
 });
 
-export const iconStyle = mergeStyles({
+export const listItemStackTokens = {
+  childrenGap: '0.4375rem' // 7px
+};
+
+export const listItemStyle = mergeStyles({
+  paddingBottom: '0.1rem'
+});
+
+export const listIconStyle = mergeStyles({
   marginRight: 7,
   color: palette.themePrimary
 });


### PR DESCRIPTION
# What
Removed the 'tabindex' property defined on non-interactive elements to keep only interactive elements (link, buttons) focusable.
And also used FluentUI component List to defined the list of explanation instead of creating our own list structure.

# Why
a11y bug https://skype.visualstudio.com/SPOOL/_workitems/edit/2582668
Navigation keyboard (Tab key) was landing first on 'Exceptionally simple chat app' then going through the list of explanation, which all are non-interactive elements, before going to the sample doc link (first interactive element).

# How Tested
Ran Chat sample locally and verified that focus is on interactive elements only (link then buttons)
![image](https://user-images.githubusercontent.com/82416644/135549163-a111084f-e291-4dd5-8987-0b00b3d73c3c.png)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->