### PR TITLE
Use objects for `callsEnded` and `incomingCallsEnded`

### DIFF
--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -48,7 +48,9 @@ export interface CallClientState {
     incomingCalls: {
         [key: string]: IncomingCallState;
     };
-    incomingCallsEnded: IncomingCallState[];
+    incomingCallsEnded: {
+        [key: string]: IncomingCallState;
+    };
     latestErrors: CallErrors;
     userId: CommunicationUserKind;
 }

--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -41,7 +41,9 @@ export interface CallClientState {
     calls: {
         [key: string]: CallState;
     };
-    callsEnded: CallState[];
+    callsEnded: {
+        [key: string]: CallState;
+    };
     deviceManager: DeviceManagerState;
     incomingCalls: {
         [key: string]: IncomingCallState;

--- a/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
@@ -274,12 +274,12 @@ describe('declarative call agent', () => {
 
     mockIncomingCall.emit('callEnded', { callEndReason: { code: 1 } });
 
-    await waitWithBreakCondition(() => context.getState().incomingCallsEnded.length !== 0);
+    await waitWithBreakCondition(() => Object.keys(context.getState().incomingCallsEnded).length !== 0);
 
     expect(Object.keys(context.getState().incomingCalls).length).toBe(0);
-    expect(context.getState().incomingCallsEnded.length).toBe(1);
-    expect(context.getState().incomingCallsEnded[0].callEndReason?.code).toBe(1);
-    expect(context.getState().incomingCallsEnded[0].endTime).toBeTruthy();
+    expect(Object.keys(context.getState().incomingCallsEnded).length).toBe(1);
+    expect(context.getState().incomingCallsEnded[mockCallId].callEndReason?.code).toBe(1);
+    expect(context.getState().incomingCallsEnded[mockCallId].endTime).toBeTruthy();
   });
 
   test('should make sure that callsEnded not exceed max length', async () => {
@@ -328,7 +328,7 @@ describe('declarative call agent', () => {
 
     await waitWithBreakCondition(() => Object.keys(context.getState().incomingCalls).length === 0);
 
-    expect(context.getState().incomingCallsEnded.length).toBe(MAX_CALL_HISTORY_LENGTH);
+    expect(Object.keys(context.getState().incomingCallsEnded).length).toBe(MAX_CALL_HISTORY_LENGTH);
   });
 
   test('should wrap the calls property and the onCallsUpdated and return DeclarativeCall when accessed', async () => {

--- a/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
@@ -250,12 +250,12 @@ describe('declarative call agent', () => {
     mockCallAgent.calls = [];
     mockCallAgent.emit('callsUpdated', { added: [], removed: [mockCall] });
 
-    await waitWithBreakCondition(() => context.getState().callsEnded.length !== 0);
+    await waitWithBreakCondition(() => Object.keys(context.getState().callsEnded).length !== 0);
 
     expect(Object.keys(context.getState().calls).length).toBe(0);
-    expect(context.getState().callsEnded.length).toBe(1);
-    expect(context.getState().callsEnded[0].callEndReason?.code).toBe(1);
-    expect(context.getState().callsEnded[0].endTime).toBeTruthy();
+    expect(Object.keys(context.getState().callsEnded).length).toBe(1);
+    expect(context.getState().callsEnded[mockCallId].callEndReason?.code).toBe(1);
+    expect(context.getState().callsEnded[mockCallId].endTime).toBeTruthy();
   });
 
   test('should move incoming call to incomingCallEnded when incoming call is ended and add endTime', async () => {
@@ -303,7 +303,7 @@ describe('declarative call agent', () => {
 
     await waitWithBreakCondition(() => Object.keys(context.getState().calls).length === 0);
 
-    expect(context.getState().callsEnded.length).toBe(MAX_CALL_HISTORY_LENGTH);
+    expect(Object.keys(context.getState().callsEnded).length).toBe(MAX_CALL_HISTORY_LENGTH);
   });
 
   test('should make sure that incomingCallsEnded not exceed max length', async () => {

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -444,18 +444,17 @@ export interface CallClientState {
    */
   callsEnded: { [key: string]: CallState };
   /**
-   * Proxy of {@link @azure/communication-calling#IncomingCall} as an object with IncomingCall {@link IncomingCall} fields.
+   * Proxy of {@link @azure/communication-calling#IncomingCall} as an object with {@link IncomingCall} fields.
    * It is keyed by {@link @azure/communication-calling#IncomingCall.id}.
    */
   incomingCalls: { [key: string]: IncomingCallState };
   /**
-   * Incoming Calls that have ended are stored here so the callEndReason could be checked. It is a array of IncomingCall
-   * {@link IncomingCall} received in the event 'incomingCall' emitted by
-   * {@link @azure/communication-calling#CallAgent}. IncomingCalls are pushed on to the array as they end, meaning this
-   * is sorted by endTime ascending. Only MAX_CALL_HISTORY_LENGTH number of IncomingCalls are kept in this array with
-   * the older ones being replaced by newer ones.
+   * Incoming Calls that have ended are stored here so the callEndReason could be checked.
+   * It is an as an object with {@link @azure/communication-calling#Call.id} keys and {@link IncomingCall} values.
+   *
+   * Only {@link MAX_CALL_HISTORY_LENGTH} Calls are kept in the history. Oldest calls are evicted if required.
    */
-  incomingCallsEnded: IncomingCallState[];
+  incomingCallsEnded: { [key: string]: IncomingCallState };
   /**
    * Proxy of {@link @azure/communication-calling#DeviceManager}. Please review {@link DeviceManagerState}.
    */

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -437,12 +437,12 @@ export interface CallClientState {
    */
   calls: { [key: string]: CallState };
   /**
-   * Calls that have ended are stored here so the callEndReason could be checked. It is an array of CallState
-   * {@link CallState}. Calls are pushed on to the array as they end, meaning this is sorted by endTime ascending. Only
-   * {@link MAX_CALL_HISTORY_LENGTH} number of Calls are kept in this array with the older ones being replaced by newer
-   * ones.
+   * Calls that have ended are stored here so the callEndReason could be checked.
+   * It is an as an object with {@link @azure/communication-calling#Call.id} keys and {@link CallState} values.
+   *
+   * Only {@link MAX_CALL_HISTORY_LENGTH} Calls are kept in the history. Oldest calls are evicted if required.
    */
-  callsEnded: CallState[];
+  callsEnded: { [key: string]: CallState };
   /**
    * Proxy of {@link @azure/communication-calling#IncomingCall} as an object with IncomingCall {@link IncomingCall} fields.
    * It is keyed by {@link @azure/communication-calling#IncomingCall.id}.

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -61,7 +61,7 @@ export class CallContext {
       calls: {},
       callsEnded: {},
       incomingCalls: {},
-      incomingCallsEnded: [],
+      incomingCallsEnded: {},
       deviceManager: {
         isSpeakerSelectionAvailable: false,
         cameras: [],
@@ -147,7 +147,7 @@ export class CallContext {
         draft.calls = {};
         draft.incomingCalls = {};
         draft.callsEnded = {};
-        draft.incomingCallsEnded.splice(0, draft.incomingCallsEnded.length);
+        draft.incomingCallsEnded = {};
       })
     );
   }
@@ -597,10 +597,12 @@ export class CallContext {
           call.endTime = new Date();
           call.callEndReason = callEndReason;
           delete draft.incomingCalls[callId];
-          if (draft.incomingCallsEnded.length >= MAX_CALL_HISTORY_LENGTH) {
-            draft.incomingCallsEnded.shift();
+          // Performance note: This loop should run only once because the number of entries
+          // is never allowed to exceed MAX_CALL_HISTORY_LENGTH. A loop is used for correctness.
+          while (Object.keys(draft.incomingCallsEnded).length >= MAX_CALL_HISTORY_LENGTH) {
+            delete draft.incomingCallsEnded[findOldestCallEnded(draft.incomingCallsEnded)];
           }
-          draft.incomingCallsEnded.push(call);
+          draft.incomingCallsEnded[callId] = call;
         }
       })
     );
@@ -776,7 +778,7 @@ const toCallError = (target: CallErrorTarget, error: unknown): CallError => {
   return new CallError(target, new Error(error as string));
 };
 
-const findOldestCallEnded = (calls: { [key: string]: CallState }): string => {
+const findOldestCallEnded = (calls: { [key: string]: { endTime?: Date } }): string => {
   const callEntries = Object.entries(calls);
   let [oldestCallId, oldestCall] = callEntries[0];
   if (oldestCall.endTime === undefined) {

--- a/packages/calling-stateful-client/src/StatefulCallClient.test.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.test.ts
@@ -102,14 +102,14 @@ describe('Stateful call client', () => {
       const listener = new StateChangeListener(client);
       agent.testHelperPushCall(createMockCall());
       expect(await waitWithBreakCondition(() => Object.keys(client.getState().calls).length === 1)).toBe(true);
-      expect(await waitWithBreakCondition(() => client.getState().callsEnded.length === 0)).toBe(true);
+      expect(await waitWithBreakCondition(() => Object.keys(client.getState().callsEnded).length === 0)).toBe(true);
       expect(listener.onChangeCalledCount).toBe(1);
     }
     {
       const listener = new StateChangeListener(client);
       agent.testHelperPopCall();
       expect(await waitWithBreakCondition(() => Object.keys(client.getState().calls).length === 0)).toBe(true);
-      expect(await waitWithBreakCondition(() => client.getState().callsEnded.length === 1)).toBe(true);
+      expect(await waitWithBreakCondition(() => Object.keys(client.getState().callsEnded).length === 1)).toBe(true);
       expect(listener.onChangeCalledCount).toBe(1);
     }
   });
@@ -557,8 +557,8 @@ describe('Stateful call client', () => {
     expect(client.getState().calls[callId]?.transfer.receivedTransferRequests.length).toBe(0);
 
     agent.testHelperPopCall();
-    expect(await waitWithBreakCondition(() => client.getState().callsEnded.length === 1)).toBe(true);
-    const callEnded = client.getState().callsEnded[0];
+    expect(await waitWithBreakCondition(() => Object.keys(client.getState().callsEnded).length === 1)).toBe(true);
+    const callEnded = client.getState().callsEnded[callId];
 
     // Once the call ends, expect that call state is no longer updated.
     recording.isRecordingActive = false;

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -268,12 +268,16 @@ export interface CallClientState {
     calls: {
         [key: string]: CallState;
     };
-    callsEnded: CallState[];
+    callsEnded: {
+        [key: string]: CallState;
+    };
     deviceManager: DeviceManagerState;
     incomingCalls: {
         [key: string]: IncomingCallState;
     };
-    incomingCallsEnded: IncomingCallState[];
+    incomingCallsEnded: {
+        [key: string]: IncomingCallState;
+    };
     latestErrors: CallErrors;
     userId: CommunicationUserKind;
 }

--- a/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
@@ -85,7 +85,7 @@ const memoizeState = memoizeOne(
   ): CallClientState => ({
     userId,
     incomingCalls: {},
-    incomingCallsEnded: [],
+    incomingCallsEnded: {},
     callsEnded: {},
     deviceManager,
     callAgent: { displayName },

--- a/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
@@ -86,7 +86,7 @@ const memoizeState = memoizeOne(
     userId,
     incomingCalls: {},
     incomingCallsEnded: [],
-    callsEnded: [],
+    callsEnded: {},
     deviceManager,
     callAgent: { displayName },
     calls,


### PR DESCRIPTION
# Why
ARB feedback: For consistency with `calls` and `incomingCalls`.

# How Tested
`rush build`

# Process & policy checklist
**Is this a breaking change?**

- [x] This change causes current functionality to break.
  Changes field type of a public interface