### PR TITLE
[DO NOT REVIEW] Move poll to video gallery

### DIFF
--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -766,6 +766,7 @@ export interface VideoGalleryProps {
     remoteParticipants?: VideoGalleryRemoteParticipant[];
     remoteVideoViewOption?: VideoStreamOptions;
     showMuteIndicator?: boolean;
+    spotFocusTile?: JSX.Element;
     strings?: Partial<VideoGalleryStrings>;
     styles?: BaseCustomStylesProps;
 }

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -34,6 +34,10 @@ export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcon
    * A callback function that can be used to provide custom data to an Avatar.
    */
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
+
+  /** If set, takes the center stage entirely. All other tiles are moved to horizontal gallery. */
+  spotFocusTile?: JSX.Element;
+
   /**
    * Flags to enable/disable or customize UI elements of the {@link CallComposite}.
    */
@@ -72,6 +76,8 @@ type MainScreenProps = {
   callInvitationUrl?: string;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
+  /** If set, takes the center stage entirely. All other tiles are moved to horizontal gallery. */
+  spotFocusTile?: JSX.Element;
   options?: CallCompositeOptions;
 };
 
@@ -147,6 +153,7 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
           callInvitationURL={callInvitationUrl}
           onFetchAvatarPersonaData={onFetchAvatarPersonaData}
           onFetchParticipantMenuItems={onFetchParticipantMenuItems}
+          spotFocusTile={props.spotFocusTile}
           options={props.options}
         />
       );
@@ -177,6 +184,7 @@ export const CallComposite = (props: CallCompositeProps): JSX.Element => {
           callInvitationUrl={callInvitationUrl}
           onFetchAvatarPersonaData={onFetchAvatarPersonaData}
           onFetchParticipantMenuItems={onFetchParticipantMenuItems}
+          spotFocusTile={props.spotFocusTile}
           options={options}
         />
       </CallAdapterProvider>

--- a/packages/react-composites/src/composites/CallComposite/components/MediaGallery.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/MediaGallery.tsx
@@ -33,6 +33,8 @@ const remoteVideoViewOption = {
 export interface MediaGalleryProps {
   isVideoStreamOn?: boolean;
   isMicrophoneChecked?: boolean;
+  /** If set, takes the center stage entirely. All other tiles are moved to horizontal gallery. */
+  spotFocusTile?: JSX.Element;
   onStartLocalVideo: () => Promise<void>;
   onRenderAvatar?: OnRenderAvatarCallback;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
@@ -65,6 +67,7 @@ export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
         remoteVideoViewOption={remoteVideoViewOption}
         styles={VideoGalleryStyles}
         layout="floatingLocalVideo"
+        spotFocusTile={props.spotFocusTile}
         onRenderAvatar={(userId, options) => (
           <Stack className={mergeStyles({ position: 'absolute', height: '100%', width: '100%' })}>
             <AvatarPersona userId={userId} {...options} dataProvider={props.onFetchAvatarPersonaData} />

--- a/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
@@ -36,6 +36,8 @@ export interface CallPageProps {
   onRenderAvatar?: OnRenderAvatarCallback;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
+  /** If set, takes the center stage entirely. All other tiles are moved to horizontal gallery. */
+  spotFocusTile?: JSX.Element;
   options?: CallCompositeOptions;
 }
 
@@ -98,6 +100,7 @@ export const CallPage = (props: CallPageProps): JSX.Element => {
                 {...mediaGalleryHandlers}
                 onRenderAvatar={onRenderAvatar}
                 onFetchAvatarPersonaData={onFetchAvatarPersonaData}
+                spotFocusTile={props.spotFocusTile}
               />
             </Stack>
           )}

--- a/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useState, useMemo } from 'react';
 import { PartialTheme, Stack, Theme } from '@fluentui/react';
 import { CallComposite } from '../CallComposite';
 import { CallAdapterProvider } from '../CallComposite/adapter/CallAdapterProvider';
-import { EmbeddedChatPane, EmbeddedPeoplePane, EmbeddedPollCreatorPane, EmbeddedTestPane } from './SidePane';
+import { EmbeddedChatPane, EmbeddedPeoplePane } from './SidePane';
 import { MeetingCallControlBar } from './MeetingCallControlBar';
 import { CallState } from '@azure/communication-calling';
 import { compositeOuterContainerStyles } from './styles/MeetingCompositeStyles';
@@ -16,6 +16,7 @@ import { MeetingBackedChatAdapter } from './adapter/MeetingBackedChatAdapter';
 import { MeetingCompositePage } from './state/MeetingCompositePage';
 import { CallAdapter } from '../CallComposite';
 import { ChatAdapter } from '../ChatComposite';
+import { PollCreator, PollQuestion } from './PollCreator';
 
 /**
  * Props required for the {@link MeetingComposite}
@@ -119,6 +120,7 @@ export const MeetingComposite = (props: MeetingCompositeProps): JSX.Element => {
               options={{ callControls: false, mobileView: props.options?.mobileView }}
               adapter={callAdapter}
               fluentTheme={fluentTheme}
+              spotFocusTile={showPollCreatorPane ? <PollCreatorTile /> : undefined}
             />
           </Stack.Item>
           {chatAdapter && hasJoinedCall && (
@@ -140,7 +142,6 @@ export const MeetingComposite = (props: MeetingCompositeProps): JSX.Element => {
               />
             </CallAdapterProvider>
           )}
-          {hasJoinedCall && <EmbeddedPollCreatorPane hidden={!showPollCreatorPane} onClose={closePane} />}
         </Stack>
         {hasJoinedCall && (
           <MeetingCallControlBar
@@ -157,5 +158,16 @@ export const MeetingComposite = (props: MeetingCompositeProps): JSX.Element => {
         )}
       </Stack>
     </FluentThemeProvider>
+  );
+};
+
+const PollCreatorTile = (): JSX.Element => {
+  return (
+    <PollCreator
+      onPresentPoll={(question: PollQuestion) => {
+        // TODO: Connect with fluid!
+        console.log('Egad! A new poll question is come!', question);
+      }}
+    />
   );
 };


### PR DESCRIPTION
Shows the poll creator as a focus tile in VideoGallery.

TODO
* The width calculation of the gallery is broken, it's too wide.
* Add a similar option for "overlayTile" -- that shows the grid as usual, but overlays a modal.  That's the one we actually want for the PollCreator. We want the `spotFocusTile` to show poll and results.