### PR TITLE
updated deployment to be once a day and added Chat

### DIFF
--- a/.github/workflows/deploy-azure-webapps.yml
+++ b/.github/workflows/deploy-azure-webapps.yml
@@ -5,7 +5,7 @@ on:
     # minute 0, hour 0 UTC (which is 6pm PST/5pm PDT), any day of month, any month, any day of the week
     # if we want to support only Mon - Fri we need to change the check how we look for new changes. Currently we
     # check for any new changes in the last 24 hours regardless of day)
-    - cron: '0 0 * * *'
+    - cron: '0 21 * * *'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
# What
Added Chat deployment to our deployment pipeline.
Made our deployment to be only once a day instead of for every push to main. You still can deploy manually if absolutely needed though

# Why
Chat was not deployed automatically and needed to be done manually.
As we are fixing bugs, especially a11y ones, we need an automatic update so testing teams can verify our changes and close resolved bugs

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->