### PR TITLE
[POC] API exploration for CallControls button injection

### DIFF
--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -27,6 +27,7 @@ import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { CommunicationUserKind } from '@azure/communication-common';
 import { ComponentSlotStyle } from '@fluentui/react-northstar';
 import { CreateViewOptions } from '@azure/communication-calling';
+import { DefaultButton } from '@fluentui/react';
 import { DeviceAccess } from '@azure/communication-calling';
 import { DeviceManager } from '@azure/communication-calling';
 import { DominantSpeakersInfo } from '@azure/communication-calling';
@@ -335,6 +336,7 @@ export type CallControlOptions = {
     optionsButton?: boolean;
     participantsButton?: boolean;
     screenShareButton?: boolean;
+    customButtons?: CustomCallControlsButton[];
 };
 
 // @public
@@ -860,6 +862,9 @@ export const ControlBar: (props: ControlBarProps) => JSX.Element;
 // @public
 export const ControlBarButton: (props: ControlBarButtonProps) => JSX.Element;
 
+// @alpha
+export type ControlBarButtonPlacement = 'first' | 'afterCameraButton' | 'afterEndCallButton' | 'afterMicrophoneButton' | 'afterOptionsButton' | 'afterParticipantsButton' | 'afterScreenShareButton';
+
 // @public
 export interface ControlBarButtonProps extends IButtonProps {
     labelKey?: string;
@@ -928,6 +933,14 @@ export type CustomAvatarOptions = {
     styles?: IStyleFunctionOrObject<IPersonaStyleProps, IPersonaStyles>;
     text?: string;
 };
+
+// @alpha
+export interface CustomCallControlsButton {
+    // (undocumented)
+    button: DefaultButton;
+    // (undocumented)
+    placement: ControlBarButtonPlacement;
+}
 
 // @public
 export interface CustomMessage extends MessageCommon {
@@ -2062,5 +2075,9 @@ export interface VideoTileStylesProps extends BaseCustomStylesProps {
     overlayContainer?: IStyle;
     videoContainer?: IStyle;
 }
+
+// Warnings were encountered during analysis:
+//
+// /workspaces/communication-ui-library/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx:75:3 - (ae-incompatible-release-tags) The symbol "customButtons" is marked as @public, but its signature references "CustomCallControlsButton" which is marked as @alpha
 
 ```

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -27,7 +27,6 @@ import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { CommunicationUserKind } from '@azure/communication-common';
 import { ComponentSlotStyle } from '@fluentui/react-northstar';
 import { CreateViewOptions } from '@azure/communication-calling';
-import { DefaultButton } from '@fluentui/react';
 import { DeviceAccess } from '@azure/communication-calling';
 import { DeviceManager } from '@azure/communication-calling';
 import { DominantSpeakersInfo } from '@azure/communication-calling';
@@ -936,10 +935,14 @@ export type CustomAvatarOptions = {
 
 // @alpha
 export interface CustomCallControlsButton {
-    // (undocumented)
-    button: DefaultButton;
+    getProps: (args: CustomCallControlsButtonArgs) => ControlBarButtonProps;
     // (undocumented)
     placement: ControlBarButtonPlacement;
+}
+
+// @alpha (undocumented)
+export interface CustomCallControlsButtonArgs {
+    compressedMode?: boolean;
 }
 
 // @public
@@ -2078,6 +2081,6 @@ export interface VideoTileStylesProps extends BaseCustomStylesProps {
 
 // Warnings were encountered during analysis:
 //
-// /workspaces/communication-ui-library/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx:75:3 - (ae-incompatible-release-tags) The symbol "customButtons" is marked as @public, but its signature references "CustomCallControlsButton" which is marked as @alpha
+// /workspaces/communication-ui-library/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx:77:3 - (ae-incompatible-release-tags) The symbol "customButtons" is marked as @public, but its signature references "CustomCallControlsButton" which is marked as @alpha
 
 ```

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -862,7 +862,7 @@ export const ControlBar: (props: ControlBarProps) => JSX.Element;
 export const ControlBarButton: (props: ControlBarButtonProps) => JSX.Element;
 
 // @alpha
-export type ControlBarButtonPlacement = 'first' | 'afterCameraButton' | 'afterEndCallButton' | 'afterMicrophoneButton' | 'afterOptionsButton' | 'afterParticipantsButton' | 'afterScreenShareButton';
+export type ControlBarButtonPlacement = 'first' | 'last' | 'afterCameraButton' | 'afterEndCallButton' | 'afterMicrophoneButton' | 'afterOptionsButton' | 'afterParticipantsButton' | 'afterScreenShareButton';
 
 // @public
 export interface ControlBarButtonProps extends IButtonProps {

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -22,7 +22,7 @@ import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { CommunicationUserKind } from '@azure/communication-common';
 import { ComponentIcons } from '@internal/react-components';
 import { ComponentLocale } from '@internal/react-components';
-import { DefaultButton } from '@fluentui/react';
+import { ControlBarButtonProps } from '@internal/react-components';
 import { DeviceManagerState } from '@internal/calling-stateful-client';
 import { GroupCallLocator } from '@azure/communication-calling';
 import { MessageProps } from '@internal/react-components';
@@ -418,10 +418,14 @@ export const createAzureCommunicationMeetingAdapter: ({ userId, displayName, cre
 
 // @alpha
 export interface CustomCallControlsButton {
-    // (undocumented)
-    button: DefaultButton;
+    getProps: (args: CustomCallControlsButtonArgs) => ControlBarButtonProps;
     // (undocumented)
     placement: ControlBarButtonPlacement;
+}
+
+// @alpha (undocumented)
+export interface CustomCallControlsButtonArgs {
+    compressedMode?: boolean;
 }
 
 // @public
@@ -653,7 +657,7 @@ export type TopicChangedListener = (event: {
 
 // Warnings were encountered during analysis:
 //
-// src/composites/CallComposite/components/CallControls.tsx:75:3 - (ae-incompatible-release-tags) The symbol "customButtons" is marked as @public, but its signature references "CustomCallControlsButton" which is marked as @alpha
+// src/composites/CallComposite/components/CallControls.tsx:77:3 - (ae-incompatible-release-tags) The symbol "customButtons" is marked as @public, but its signature references "CustomCallControlsButton" which is marked as @alpha
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -22,6 +22,7 @@ import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { CommunicationUserKind } from '@azure/communication-common';
 import { ComponentIcons } from '@internal/react-components';
 import { ComponentLocale } from '@internal/react-components';
+import { DefaultButton } from '@fluentui/react';
 import { DeviceManagerState } from '@internal/calling-stateful-client';
 import { GroupCallLocator } from '@azure/communication-calling';
 import { MessageProps } from '@internal/react-components';
@@ -242,6 +243,7 @@ export type CallControlOptions = {
     optionsButton?: boolean;
     participantsButton?: boolean;
     screenShareButton?: boolean;
+    customButtons?: CustomCallControlsButton[];
 };
 
 // @public
@@ -396,6 +398,9 @@ export interface CompositeStrings {
     chat: ChatCompositeStrings;
 }
 
+// @alpha
+export type ControlBarButtonPlacement = 'first' | 'afterCameraButton' | 'afterEndCallButton' | 'afterMicrophoneButton' | 'afterOptionsButton' | 'afterParticipantsButton' | 'afterScreenShareButton';
+
 // @public
 export const createAzureCommunicationCallAdapter: ({ userId, displayName, credential, locator }: AzureCommunicationCallAdapterArgs) => Promise<CallAdapter>;
 
@@ -410,6 +415,14 @@ export const createAzureCommunicationChatAdapterFromClient: (chatClient: Statefu
 
 // @alpha
 export const createAzureCommunicationMeetingAdapter: ({ userId, displayName, credential, endpointUrl, chatThreadId, callLocator }: AzureCommunicationMeetingAdapterArgs) => Promise<MeetingAdapter>;
+
+// @alpha
+export interface CustomCallControlsButton {
+    // (undocumented)
+    button: DefaultButton;
+    // (undocumented)
+    placement: ControlBarButtonPlacement;
+}
 
 // @public
 export const DEFAULT_COMPOSITE_ICONS: {
@@ -637,6 +650,10 @@ export type ParticipantsRemovedListener = (event: {
 export type TopicChangedListener = (event: {
     topic: string;
 }) => void;
+
+// Warnings were encountered during analysis:
+//
+// src/composites/CallComposite/components/CallControls.tsx:75:3 - (ae-incompatible-release-tags) The symbol "customButtons" is marked as @public, but its signature references "CustomCallControlsButton" which is marked as @alpha
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -399,7 +399,7 @@ export interface CompositeStrings {
 }
 
 // @alpha
-export type ControlBarButtonPlacement = 'first' | 'afterCameraButton' | 'afterEndCallButton' | 'afterMicrophoneButton' | 'afterOptionsButton' | 'afterParticipantsButton' | 'afterScreenShareButton';
+export type ControlBarButtonPlacement = 'first' | 'last' | 'afterCameraButton' | 'afterEndCallButton' | 'afterMicrophoneButton' | 'afterOptionsButton' | 'afterParticipantsButton' | 'afterScreenShareButton';
 
 // @public
 export const createAzureCommunicationCallAdapter: ({ userId, displayName, credential, locator }: AzureCommunicationCallAdapterArgs) => Promise<CallAdapter>;

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -83,7 +83,7 @@ export type CallControlOptions = {
  * ... and so on.
  *
  * It is an error to place the button in reference to another button that has
- * been disabled via {@link CallControlOptions}.
+ * been hidden via an {@link CallControlOptions} field.
  *
  * Multiple buttons placed in the same position are appeneded in order.
  * E.g., if two buttons are placed 'first', they'll both appear on the left end (right end in rtl mode)
@@ -192,12 +192,31 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
 
   return (
     <ControlBar layout="dockedBottom">
+      <FilteredCustomButtons options={options} placement={'first'} />
       {microphoneButton}
+      <FilteredCustomButtons options={options} placement={'afterMicrophoneButton'} />
       {cameraButton}
+      <FilteredCustomButtons options={options} placement={'afterCameraButton'} />
       {screenShareButton}
+      <FilteredCustomButtons options={options} placement={'afterScreenShareButton'} />
       {participantButton}
+      <FilteredCustomButtons options={options} placement={'afterParticipantsButton'} />
       {optionsButton}
+      <FilteredCustomButtons options={options} placement={'afterOptionsButton'} />
       {endCallButton}
+      <FilteredCustomButtons options={options} placement={'afterEndCallButton'} />
     </ControlBar>
   );
+};
+
+const FilteredCustomButtons = (props: {
+  options?: CallControlOptions;
+  placement: ControlBarButtonPlacement;
+}): JSX.Element => {
+  const { options, placement } = props;
+  if (!options || !options.customButtons) {
+    return <></>;
+  }
+  const buttons = options.customButtons.filter((button) => button.placement === placement);
+  return <>{buttons}</>;
 };

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -95,6 +95,7 @@ export type CallControlOptions = {
  */
 export type ControlBarButtonPlacement =
   | 'first'
+  | 'last'
   | 'afterCameraButton'
   | 'afterEndCallButton'
   | 'afterMicrophoneButton'
@@ -226,6 +227,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
       <FilteredCustomButtons options={options} placement={'afterOptionsButton'} />
       {endCallButton}
       <FilteredCustomButtons options={options} placement={'afterEndCallButton'} />
+      <FilteredCustomButtons options={options} placement={'last'} />
     </ControlBar>
   );
 };

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { DefaultButton, DefaultPalette as palette } from '@fluentui/react';
+import { DefaultPalette as palette } from '@fluentui/react';
 import {
   CameraButton,
   ControlBar,
+  ControlBarButton,
+  ControlBarButtonProps,
   EndCallButton,
   MicrophoneButton,
   OptionsButton,
@@ -106,8 +108,16 @@ export type ControlBarButtonPlacement =
  * @alpha
  */
 export interface CustomCallControlsButton {
-  button: DefaultButton;
+  getProps: (args: CustomCallControlsButtonArgs) => ControlBarButtonProps;
   placement: ControlBarButtonPlacement;
+}
+
+export interface CustomCallControlsButtonArgs {
+  /**
+   * Compressed mode should decrease the size of button and hide the label
+   * @defaultValue false
+   */
+  compressedMode?: boolean;
 }
 
 /**
@@ -218,5 +228,11 @@ const FilteredCustomButtons = (props: {
     return <></>;
   }
   const buttons = options.customButtons.filter((button) => button.placement === placement);
-  return <>{buttons}</>;
+  return (
+    <>
+      {buttons.map((b) => (
+        <ControlBarButton {...b.getProps({ compressedMode: options.compressedMode })} />
+      ))}
+    </>
+  );
 };

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { DefaultPalette as palette } from '@fluentui/react';
+import { DefaultButton, DefaultPalette as palette } from '@fluentui/react';
 import {
   CameraButton,
   ControlBar,
@@ -68,7 +68,47 @@ export type CallControlOptions = {
    * @defaultValue true
    */
   screenShareButton?: boolean;
+
+  /**
+   * Inject custom buttons in the call controls.
+   */
+  customButtons?: CustomCallControlsButton[];
 };
+
+/**
+ * Placement for a custom button injected in the {@link CallControls}.
+ *
+ * 'first': Place the button on the left end (right end in rtl mode).
+ * 'afterCameraButton': Place the button on the right (left in rtl mode) of the camera button.
+ * ... and so on.
+ *
+ * It is an error to place the button in reference to another button that has
+ * been disabled via {@link CallControlOptions}.
+ *
+ * Multiple buttons placed in the same position are appeneded in order.
+ * E.g., if two buttons are placed 'first', they'll both appear on the left end (right end in rtl mode)
+ * in the order provided.
+ *
+ * @alpha
+ */
+export type ControlBarButtonPlacement =
+  | 'first'
+  | 'afterCameraButton'
+  | 'afterEndCallButton'
+  | 'afterMicrophoneButton'
+  | 'afterOptionsButton'
+  | 'afterParticipantsButton'
+  | 'afterScreenShareButton';
+
+/**
+ * A custom button to inject in the {@link CallControls}.
+ *
+ * @alpha
+ */
+export interface CustomCallControlsButton {
+  button: DefaultButton;
+  placement: ControlBarButtonPlacement;
+}
 
 /**
  * @private

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -108,10 +108,21 @@ export type ControlBarButtonPlacement =
  * @alpha
  */
 export interface CustomCallControlsButton {
+  /**
+   * Callback to provide props for the injected button.
+   *
+   * A {@link ControlBarButton} with the provided props will be injected.
+   *
+   * Performance tip: `getProps` will be called each time {@link CallControls} is rendered.
+   * Consider memoizing for optimal performance.
+   */
   getProps: (args: CustomCallControlsButtonArgs) => ControlBarButtonProps;
   placement: ControlBarButtonPlacement;
 }
 
+/**
+ * @alpha
+ */
 export interface CustomCallControlsButtonArgs {
   /**
    * Compressed mode should decrease the size of button and hide the label

--- a/packages/react-composites/src/composites/CallComposite/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/index.ts
@@ -5,8 +5,9 @@ export { CallComposite } from './CallComposite';
 export type { CallCompositeOptions, CallCompositeProps } from './CallComposite';
 export type {
   CallControlOptions,
+  ControlBarButtonPlacement,
   CustomCallControlsButton,
-  ControlBarButtonPlacement
+  CustomCallControlsButtonArgs
 } from './components/CallControls';
 
 export * from './adapter';

--- a/packages/react-composites/src/composites/CallComposite/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/index.ts
@@ -3,7 +3,11 @@
 
 export { CallComposite } from './CallComposite';
 export type { CallCompositeOptions, CallCompositeProps } from './CallComposite';
-export type { CallControlOptions } from './components/CallControls';
+export type {
+  CallControlOptions,
+  CustomCallControlsButton,
+  ControlBarButtonPlacement
+} from './components/CallControls';
 
 export * from './adapter';
 export * from './Strings';

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -7,9 +7,10 @@ import {
   CallAdapter,
   CallAdapterState,
   CallComposite,
+  ControlBarButtonProps,
   createAzureCommunicationCallAdapter
 } from '@azure/communication-react';
-import { Spinner } from '@fluentui/react';
+import { Icon, Spinner } from '@fluentui/react';
 import React, { useEffect, useRef, useState } from 'react';
 import { useSwitchableFluentTheme } from '../theming/SwitchableFluentThemeProvider';
 import { createAutoRefreshingCredential } from '../utils/credential';
@@ -76,7 +77,21 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
       fluentTheme={currentTheme.theme}
       rtl={currentRtl}
       callInvitationUrl={window.location.href}
-      options={{ mobileView: isMobileSession }}
+      options={{
+        mobileView: isMobileSession,
+        callControls: { customButtons: [{ getProps: getCustomButtonProps, placement: 'first' }] }
+      }}
     />
   );
 };
+
+const getCustomButtonProps = (): ControlBarButtonProps => ({
+  onClick: () => window.alert('You clicked a custom button'),
+  onRenderOnIcon: onRenderMicOnIcon,
+  onRenderOffIcon: onRenderMicOffIcon,
+  strings: { label: 'customButton', offLabel: 'customOff', onLabel: 'customOn' },
+  labelKey: 'customButton'
+});
+
+const onRenderMicOnIcon = (): JSX.Element => <Icon iconName="ControlButtonMicOn" />;
+const onRenderMicOffIcon = (): JSX.Element => <Icon iconName="ControlButtonMicOff" />;

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -8,7 +8,8 @@ import {
   CallAdapterState,
   CallComposite,
   ControlBarButtonProps,
-  createAzureCommunicationCallAdapter
+  createAzureCommunicationCallAdapter,
+  CustomCallControlsButtonArgs
 } from '@azure/communication-react';
 import { Icon, Spinner } from '@fluentui/react';
 import React, { useEffect, useRef, useState } from 'react';
@@ -85,12 +86,13 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
   );
 };
 
-const getCustomButtonProps = (): ControlBarButtonProps => ({
+const getCustomButtonProps = ({ compressedMode }: CustomCallControlsButtonArgs): ControlBarButtonProps => ({
   onClick: () => window.alert('You clicked a custom button'),
   onRenderOnIcon: onRenderMicOnIcon,
   onRenderOffIcon: onRenderMicOffIcon,
   strings: { label: 'customButton', offLabel: 'customOff', onLabel: 'customOn' },
-  labelKey: 'customButton'
+  labelKey: 'customButton',
+  showLabel: !compressedMode
 });
 
 const onRenderMicOnIcon = (): JSX.Element => <Icon iconName="ControlButtonMicOn" />;


### PR DESCRIPTION
A possible API for injecting buttons in the CallControls.

Note that:
* This is a backwards compatible extension of the stable API, so safe to do post GA.
* It preserves the simple way we've added to customize individual buttons (e.g., the `microphneButton` might become a 'boolean | MicrophoneButtonOptions` in the future to allow customization of that button).

Let's take a quick look, but we shouldn't land this right now.