### PR TITLE
Allow developers to set messages count per load

### DIFF
--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -562,6 +562,7 @@ export type ChatCompositeOptions = {
     errorBar?: boolean;
     participantPane?: boolean;
     topic?: boolean;
+    messagesPerFetch?: number;
 };
 
 // @public

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -585,7 +585,7 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
     disableJumpToNewMessageButton = false,
     showMessageDate = false,
     showMessageStatus = false,
-    numberOfChatMessagesToReload = 0,
+    numberOfChatMessagesToReload = 10,
     onMessageSeen,
     onRenderMessageStatus,
     onRenderAvatar,

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -318,6 +318,7 @@ export type ChatCompositeOptions = {
     errorBar?: boolean;
     participantPane?: boolean;
     topic?: boolean;
+    messagesPerFetch?: number;
 };
 
 // @public

--- a/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
@@ -58,6 +58,13 @@ export type ChatCompositeOptions = {
    * @defaultValue true
    */
   topic?: boolean;
+  /**
+   * Message count to fetch when chat composite tries to load more messages from history.
+   * @remark Message load usually triggers when initializing or when users scroll to the top.
+   * Smaller number for smoother experience, larger number for better rendering perf
+   * @defaultValue 10
+   */
+  messagesPerFetch?: number;
 };
 
 /**

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -48,6 +48,7 @@ export type ChatScreenProps = {
   onRenderTypingIndicator?: (typingUsers: CommunicationParticipant[]) => JSX.Element;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
   styles?: ChatScreenStyles;
+  messageSizePerFetch?: number;
 };
 
 /**
@@ -72,7 +73,6 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
     styles
   } = props;
 
-  const defaultNumberOfChatMessagesToReload = 5;
   const sendBoxParentStyle = mergeStyles({ width: '100%' });
 
   const adapter = useAdapter();
@@ -112,8 +112,8 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
             {...messageThreadProps}
             onRenderAvatar={onRenderAvatarCallback}
             onRenderMessage={onRenderMessage}
-            numberOfChatMessagesToReload={defaultNumberOfChatMessagesToReload}
             styles={messageThreadStyles}
+            numberOfChatMessagesToReload={options?.messagesPerFetch}
           />
           <Stack.Item align="center" className={sendBoxParentStyle}>
             <div style={{ paddingLeft: '0.5rem', paddingRight: '0.5rem' }}>


### PR DESCRIPTION
- Allow users to set how many number to fetch
- Set default number to 10(match sdk -request size)
# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->