### PR TITLE
notification banner should not float on top of video gallery

### DIFF
--- a/change/@internal-react-composites-12562ee3-6774-4a9b-8683-06213c37bc4b.json
+++ b/change/@internal-react-composites-12562ee3-6774-4a9b-8683-06213c37bc4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "updating notifications to be relative instead of absolute",
+  "packageName": "@internal/react-composites",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -37,7 +37,7 @@ export interface CallArrangementProps {
 export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
   return (
     <Stack horizontalAlign="center" verticalAlign="center" styles={containerStyles} grow data-ui-id={props.dataUiId}>
-      <Stack.Item styles={notificationsContainerStyles(NOTIFICATIONS_CONTAINER_ZINDEX)}>
+      <Stack.Item styles={notificationsContainerStyles}>
         <Stack>
           <ComplianceBanner {...props.complianceBannerProps} />
         </Stack>

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -16,9 +16,6 @@ import {
   subContainerStyles
 } from '../styles/CallPage.styles';
 
-// High enough to be above `onRenderGalleryContent()`.
-const NOTIFICATIONS_CONTAINER_ZINDEX = 9;
-
 /**
  * @private
  */

--- a/packages/react-composites/src/composites/CallComposite/styles/CallPage.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/CallPage.styles.ts
@@ -66,13 +66,8 @@ export const mediaGalleryContainerStyles: IStackItemStyles = {
 /**
  * @private
  */
-export const notificationsContainerStyles = (zIndex: number): IStackStyles => ({
+export const notificationsContainerStyles: IStackStyles = {
   root: {
-    width: '100%',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    padding: '1rem',
-    zIndex
+    width: '100%'
   }
-});
+};


### PR DESCRIPTION
# What
We are going to have the compliance banner and any messages take up space and not hover over the video gallery

# Why
The messages would hover and partially cover the video tiles on the top of the gallery

# How Tested
Ran it locally.
Join from a Teams client first with your video on
Joined a teams interop call and started recording so I could see a recording banner.
*Should be getting a number of warnings that camera cannot be activated which also reduces the space of the screen below it instead of floating on top.