### PR TITLE
Add long press event to chat messages (part 1)

### DIFF
--- a/change/@internal-react-components-9892a792-896b-4149-9c60-b859916bce2e.json
+++ b/change/@internal-react-components-9892a792-896b-4149-9c60-b859916bce2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add support for opening chat message context menu with a long touch press",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ChatMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessageComponent.tsx
@@ -179,8 +179,8 @@ export const ChatMessageComponent = (props: ChatMessageProps): JSX.Element => {
   );
 
   if (messageRef.current) {
-    // Follow up PR will implement the callback for the long press
     attachLongTouchPressEvent(messageRef.current, () => {
+      // Follow up PR will implement the callback for the long press
       console.log('Long press event!');
     });
   }

--- a/packages/react-components/src/components/ChatMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessageComponent.tsx
@@ -180,7 +180,9 @@ export const ChatMessageComponent = (props: ChatMessageProps): JSX.Element => {
 
   if (messageRef.current) {
     // Follow up PR will implement the callback for the long press
-    attachLongTouchPressEvent(messageRef.current, () => alert('long press!'));
+    attachLongTouchPressEvent(messageRef.current, () => {
+      console.log('Long press event!');
+    });
   }
 
   return chatMessage;

--- a/packages/react-components/src/components/utils/longPress.ts
+++ b/packages/react-components/src/components/utils/longPress.ts
@@ -15,11 +15,20 @@ const CANCEL_ON_MOVEMENT = true;
 // Singleton that tracks whether there is an active touchstart event.
 let longPressTimerHandle: number | undefined = undefined;
 
+const clearLongPressTimeout = (): void => {
+  clearTimeout(longPressTimerHandle);
+  longPressTimerHandle = undefined;
+};
+
+const disableContextMenu = (e: MouseEvent): void => {
+  e.preventDefault();
+};
+
 /**
  * Attach a long press event on an element.
  *
  * @remarks
- * This disables the context menu that would usually show on long touch in a mobile browser.
+ * This disables the context menu for the target that would usually show on long touch in a mobile browser.
  * This is intentionally set to only work with touch events.
  * The long press is cancelled on movement.
  *
@@ -27,13 +36,13 @@ let longPressTimerHandle: number | undefined = undefined;
  *
  * @private
  */
-export function attachLongTouchPressEvent<T extends HTMLElement>(target: T, callback: () => void): void {
-  const clearLongPressTimeout = (): void => {
-    clearTimeout(longPressTimerHandle);
-  };
-
+export function attachLongTouchPressEvent(target: HTMLElement, callback: () => void): void {
   target.addEventListener('touchstart', (e) => {
+    // Disable context menu that would normally show on long press
+    target.addEventListener('contextmenu', disableContextMenu);
+
     clearLongPressTimeout();
+
     longPressTimerHandle = window.setTimeout(() => {
       e.stopPropagation();
       callback();
@@ -53,10 +62,5 @@ export function attachLongTouchPressEvent<T extends HTMLElement>(target: T, call
     if (CANCEL_ON_MOVEMENT) {
       clearLongPressTimeout();
     }
-  });
-
-  // Disable context menu that would normally show on long press
-  target.addEventListener('contextmenu', (e) => {
-    e.preventDefault();
   });
 }

--- a/packages/react-components/src/components/utils/longPress.ts
+++ b/packages/react-components/src/components/utils/longPress.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Number of milliseconds that indicates a press was a 'long press'.
+// 400ms is the current Android long press time: https://android.googlesource.com/platform/packages/apps/Settings.git/+/06dfd7566/res/values/arrays.xml#731
+// 500ms is the current iOS long press time: https://developer.apple.com/documentation/uikit/uilongpressgesturerecognizer/1616423-minimumpressduration
+// However both iOS and Android allow customization of this behavior.
+// We will default to 500ms and gather feedback on this value.
+const LONG_PRESS_TIMEOUT_MS = 500;
+
+// Cancel the long press on movement. If this is too aggressive this should be updated to detect
+// if movement goes out of bounds of the element instead of cancelling on any movement.
+const CANCEL_ON_MOVEMENT = true;
+
+// Singleton that tracks whether there is an active touchstart event.
+let longPressTimerHandle: number | undefined = undefined;
+
+/**
+ * Attach a long press event on an element.
+ *
+ * @remarks
+ * This disables the context menu that would usually show on long touch in a mobile browser.
+ * This is intentionally set to only work with touch events.
+ * The long press is cancelled on movement.
+ *
+ * @returns The passed in element with the long press event attached.
+ *
+ * @private
+ */
+export function attachLongTouchPressEvent<T extends HTMLElement>(target: T, callback: () => void): void {
+  const clearLongPressTimeout = (): void => {
+    clearTimeout(longPressTimerHandle);
+  };
+
+  target.addEventListener('touchstart', (e) => {
+    clearLongPressTimeout();
+    longPressTimerHandle = window.setTimeout(() => {
+      e.stopPropagation();
+      callback();
+    }, LONG_PRESS_TIMEOUT_MS);
+  });
+
+  // Do not trigger long press if touchend event ends before long press
+  // timeout has completed.
+  target.addEventListener('touchend', () => {
+    clearLongPressTimeout();
+  });
+
+  // Do not trigger long press if touchmove event occurs before long press
+  // timeout has completed. If this is too aggressive consider adding a
+  // movement threshold or allow movement within the bound of the element.
+  target.addEventListener('touchmove', () => {
+    if (CANCEL_ON_MOVEMENT) {
+      clearLongPressTimeout();
+    }
+  });
+
+  // Disable context menu that would normally show on long press
+  target.addEventListener('contextmenu', (e) => {
+    e.preventDefault();
+  });
+}


### PR DESCRIPTION
# What
Add long press event to chat messages triggered after `500ms`

# Why
(Next PR) we will open the chat message context menu on long press

# How Tested
In storybook:
* In dev mode set to mobile view (so its touch events), click and hold triggers console log.
* In non-touch mode - long press does nothing, context menus function as expected.