### PR TITLE
Genearlize `*state.userId` type to be `CommunicationIdentifierKind`

### DIFF
--- a/change/@internal-calling-stateful-client-f840350e-3bbc-4bef-8146-cf3ea8c07c22.json
+++ b/change/@internal-calling-stateful-client-f840350e-3bbc-4bef-8146-cf3ea8c07c22.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generalize state.userId type",
+  "packageName": "@internal/calling-stateful-client",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-react-composites-4538a96e-03cb-464b-9cc3-e13ac6c5264c.json
+++ b/change/@internal-react-composites-4538a96e-03cb-464b-9cc3-e13ac6c5264c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generalize adapterState.userId type",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -11,6 +11,7 @@ import { CallEndReason } from '@azure/communication-calling';
 import { CallerInfo } from '@azure/communication-calling';
 import { CallState as CallState_2 } from '@azure/communication-calling';
 import { CommunicationIdentifier } from '@azure/communication-common';
+import { CommunicationIdentifierKind } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { CommunicationUserKind } from '@azure/communication-common';
 import { CreateViewOptions } from '@azure/communication-calling';
@@ -54,7 +55,7 @@ export interface CallClientState {
         [key: string]: IncomingCallState;
     };
     latestErrors: CallErrors;
-    userId: CommunicationUserKind;
+    userId: CommunicationIdentifierKind;
 }
 
 // @public

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -26,7 +26,8 @@ import {
   PhoneNumberKind,
   UnknownIdentifierKind,
   MicrosoftTeamsUserIdentifier,
-  UnknownIdentifier
+  UnknownIdentifier,
+  CommunicationIdentifierKind
 } from '@azure/communication-common';
 
 /**
@@ -474,7 +475,7 @@ export interface CallClientState {
    * developer for easier access to userId. Must be passed in at initialization of the {@link StatefulCallClient}.
    * Completely controlled by the developer.
    */
-  userId: CommunicationUserKind;
+  userId: CommunicationIdentifierKind;
   /**
    * Stores the latest error for each API method.
    *

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CommunicationUserKind } from '@azure/communication-common';
+import { CommunicationIdentifierKind } from '@azure/communication-common';
 import {
   AudioDeviceInfo,
   DeviceAccess,
@@ -56,7 +56,7 @@ export class CallContext {
   private _atomicId: number;
   private _batchMode: boolean;
 
-  constructor(userId: CommunicationUserKind, maxListeners = 50) {
+  constructor(userId: CommunicationIdentifierKind, maxListeners = 50) {
     this._state = {
       calls: {},
       callsEnded: {},

--- a/packages/calling-stateful-client/src/StatefulCallClient.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.ts
@@ -8,12 +8,7 @@ import { CallContext } from './CallContext';
 import { callAgentDeclaratify } from './CallAgentDeclarative';
 import { InternalCallContext } from './InternalCallContext';
 import { createView, disposeView } from './StreamUtils';
-import {
-  CommunicationIdentifier,
-  CommunicationUserIdentifier,
-  CommunicationUserKind,
-  getIdentifierKind
-} from '@azure/communication-common';
+import { CommunicationIdentifier, CommunicationUserIdentifier, getIdentifierKind } from '@azure/communication-common';
 
 /**
  * Defines the methods that allow CallClient {@link @azure/communication-calling#CallClient} to be used statefully.
@@ -250,7 +245,7 @@ export const createStatefulCallClient = (
 ): StatefulCallClient => {
   return createStatefulCallClientWithDeps(
     new CallClient(),
-    new CallContext(getIdentifierKind(args.userId) as CommunicationUserKind, options?.maxStateChangeListeners),
+    new CallContext(getIdentifierKind(args.userId), options?.maxStateChangeListeners),
     new InternalCallContext()
   );
 };

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -22,7 +22,6 @@ import { ChatParticipant } from '@azure/communication-chat';
 import { ChatThreadClient } from '@azure/communication-chat';
 import { CommunicationIdentifier } from '@azure/communication-common';
 import { CommunicationIdentifierKind } from '@azure/communication-common';
-import { CommunicationIdentifierKind as CommunicationIdentifierKind_2 } from '@azure/communication-signaling';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { CommunicationUserKind } from '@azure/communication-common';
@@ -1267,7 +1266,7 @@ export interface MeetingAdapter extends MeetingAdapterMeetingManagement, Adapter
 export interface MeetingAdapterClientState extends Pick<CallAdapterClientState, 'devices' | 'isTeamsCall'> {
     displayName: string | undefined;
     meeting: MeetingState | undefined;
-    userId: CommunicationIdentifierKind_2;
+    userId: CommunicationIdentifierKind;
 }
 
 // @alpha

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -572,7 +572,7 @@ export const ChatComposite: (props: ChatCompositeProps) => JSX.Element;
 
 // @public
 export type ChatCompositeClientState = {
-    userId: string;
+    userId: CommunicationIdentifierKind;
     displayName: string;
     thread: ChatThreadClientState;
     latestErrors: AdapterErrors;

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -278,7 +278,7 @@ export interface CallClientState {
         [key: string]: IncomingCallState;
     };
     latestErrors: CallErrors;
-    userId: CommunicationUserKind;
+    userId: CommunicationIdentifierKind;
 }
 
 // @public

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -181,7 +181,7 @@ export interface CallAdapterCallManagement {
 
 // @public
 export type CallAdapterClientState = {
-    userId: CommunicationUserKind;
+    userId: CommunicationIdentifierKind;
     displayName?: string;
     call?: CallState;
     devices: DeviceManagerState;

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -22,6 +22,7 @@ import { ChatParticipant } from '@azure/communication-chat';
 import { ChatThreadClient } from '@azure/communication-chat';
 import { CommunicationIdentifier } from '@azure/communication-common';
 import { CommunicationIdentifierKind } from '@azure/communication-common';
+import { CommunicationIdentifierKind as CommunicationIdentifierKind_2 } from '@azure/communication-signaling';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { CommunicationUserKind } from '@azure/communication-common';
@@ -1266,7 +1267,7 @@ export interface MeetingAdapter extends MeetingAdapterMeetingManagement, Adapter
 export interface MeetingAdapterClientState extends Pick<CallAdapterClientState, 'devices' | 'isTeamsCall'> {
     displayName: string | undefined;
     meeting: MeetingState | undefined;
-    userId: CommunicationUserIdentifier;
+    userId: CommunicationIdentifierKind_2;
 }
 
 // @alpha

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -135,7 +135,7 @@ export interface CallAdapterCallManagement {
 
 // @public
 export type CallAdapterClientState = {
-    userId: CommunicationUserKind;
+    userId: CommunicationIdentifierKind;
     displayName?: string;
     call?: CallState;
     devices: DeviceManagerState;

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -326,7 +326,7 @@ export const ChatComposite: (props: ChatCompositeProps) => JSX.Element;
 
 // @public
 export type ChatCompositeClientState = {
-    userId: string;
+    userId: CommunicationIdentifierKind;
     displayName: string;
     thread: ChatThreadClientState;
     latestErrors: AdapterErrors;

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -15,8 +15,7 @@ import type { ChatMessage } from '@azure/communication-chat';
 import type { ChatParticipant } from '@azure/communication-chat';
 import { ChatThreadClient } from '@azure/communication-chat';
 import { ChatThreadClientState } from '@internal/chat-stateful-client';
-import type { CommunicationIdentifierKind } from '@azure/communication-common';
-import { CommunicationIdentifierKind as CommunicationIdentifierKind_2 } from '@azure/communication-signaling';
+import { CommunicationIdentifierKind } from '@azure/communication-common';
 import { CommunicationParticipant } from '@internal/react-components';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
@@ -534,7 +533,7 @@ export interface MeetingAdapter extends MeetingAdapterMeetingManagement, Adapter
 export interface MeetingAdapterClientState extends Pick<CallAdapterClientState, 'devices' | 'isTeamsCall'> {
     displayName: string | undefined;
     meeting: MeetingState | undefined;
-    userId: CommunicationIdentifierKind_2;
+    userId: CommunicationIdentifierKind;
 }
 
 // @alpha

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -16,6 +16,7 @@ import type { ChatParticipant } from '@azure/communication-chat';
 import { ChatThreadClient } from '@azure/communication-chat';
 import { ChatThreadClientState } from '@internal/chat-stateful-client';
 import type { CommunicationIdentifierKind } from '@azure/communication-common';
+import { CommunicationIdentifierKind as CommunicationIdentifierKind_2 } from '@azure/communication-signaling';
 import { CommunicationParticipant } from '@internal/react-components';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
@@ -533,7 +534,7 @@ export interface MeetingAdapter extends MeetingAdapterMeetingManagement, Adapter
 export interface MeetingAdapterClientState extends Pick<CallAdapterClientState, 'devices' | 'isTeamsCall'> {
     displayName: string | undefined;
     meeting: MeetingState | undefined;
-    userId: CommunicationUserIdentifier;
+    userId: CommunicationIdentifierKind_2;
 }
 
 // @alpha

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -13,7 +13,7 @@ import type {
 } from '@azure/communication-calling';
 
 import { VideoStreamOptions } from '@internal/react-components';
-import type { CommunicationUserKind, CommunicationIdentifierKind } from '@azure/communication-common';
+import type { CommunicationIdentifierKind } from '@azure/communication-common';
 import type { AdapterState, Disposable, AdapterError, AdapterErrors } from '../../common/adapters';
 
 /**
@@ -45,7 +45,7 @@ export type CallAdapterUiState = {
  * @public
  */
 export type CallAdapterClientState = {
-  userId: CommunicationUserKind;
+  userId: CommunicationIdentifierKind;
   displayName?: string;
   call?: CallState;
   devices: DeviceManagerState;

--- a/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
@@ -9,8 +9,7 @@ import memoizeOne from 'memoize-one';
 import { useAdapter } from '../adapter/CallAdapterProvider';
 import { CallAdapterState } from '../adapter/CallAdapter';
 import { CallErrors, CallState, CallClientState, DeviceManagerState } from '@internal/calling-stateful-client';
-import { CommunicationUserKind } from '@azure/communication-common';
-
+import { CommunicationIdentifierKind } from '@azure/communication-common';
 /**
  * @private
  */
@@ -77,7 +76,7 @@ export const useSelectorWithAdaptation = <
 
 const memoizeState = memoizeOne(
   (
-    userId: CommunicationUserKind,
+    userId: CommunicationIdentifierKind,
     deviceManager: DeviceManagerState,
     calls: { [key: string]: CallState },
     latestErrors: CallErrors,
@@ -98,8 +97,7 @@ const memoizeCalls = memoizeOne((call?: CallState): { [key: string]: CallState }
 
 const adaptCompositeState = (compositeState: CallAdapterState): CallClientState => {
   return memoizeState(
-    // xkcd: FIXME
-    compositeState.userId as CommunicationUserKind,
+    compositeState.userId,
     compositeState.devices,
     memoizeCalls(compositeState.call),
     // This is an unsafe type expansion.

--- a/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
+++ b/packages/react-composites/src/composites/CallComposite/hooks/useAdaptedSelector.ts
@@ -98,7 +98,8 @@ const memoizeCalls = memoizeOne((call?: CallState): { [key: string]: CallState }
 
 const adaptCompositeState = (compositeState: CallAdapterState): CallClientState => {
   return memoizeState(
-    compositeState.userId,
+    // xkcd: FIXME
+    compositeState.userId as CommunicationUserKind,
     compositeState.devices,
     memoizeCalls(compositeState.call),
     // This is an unsafe type expansion.

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -41,7 +41,7 @@ class ChatContext {
     this.threadId = threadId;
     if (!thread) throw 'Cannot find threadId, please initialize thread before use!';
     this.state = {
-      userId: toFlatCommunicationIdentifier(clientState.userId),
+      userId: clientState.userId,
       displayName: clientState.displayName,
       thread,
       latestErrors: clientState.latestErrors
@@ -73,7 +73,7 @@ class ChatContext {
     const thread = clientState.threads[this.threadId];
     if (!thread) throw 'Cannot find threadId, please make sure thread state is still in Stateful ChatClient.';
     this.setState({
-      userId: toFlatCommunicationIdentifier(clientState.userId),
+      userId: clientState.userId,
       displayName: clientState.displayName,
       thread,
       latestErrors: clientState.latestErrors

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
@@ -3,7 +3,7 @@
 
 import { ChatThreadClientState } from '@internal/chat-stateful-client';
 import type { ChatMessage, ChatParticipant } from '@azure/communication-chat';
-import type { CommunicationUserKind } from '@azure/communication-common';
+import type { CommunicationIdentifierKind, CommunicationUserKind } from '@azure/communication-common';
 import type { AdapterState, Disposable, AdapterErrors, AdapterError } from '../../common/adapters';
 
 /**
@@ -23,8 +23,7 @@ export type ChatAdapterUiState = {
  * @public
  */
 export type ChatCompositeClientState = {
-  // Properties from backend services
-  userId: string;
+  userId: CommunicationIdentifierKind;
   displayName: string;
   thread: ChatThreadClientState;
   /**

--- a/packages/react-composites/src/composites/ChatComposite/hooks/useAdaptedSelector.ts
+++ b/packages/react-composites/src/composites/ChatComposite/hooks/useAdaptedSelector.ts
@@ -3,13 +3,12 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { fromFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 import { ChatClientState, ChatErrors, ChatThreadClientState } from '@internal/chat-stateful-client';
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { ChatAdapterState } from '../adapter/ChatAdapter';
 import { useAdapter } from '../adapter/ChatAdapterProvider';
 import memoizeOne from 'memoize-one';
-import { CommunicationIdentifierKind, getIdentifierKind } from '@azure/communication-common';
+import { CommunicationIdentifierKind } from '@azure/communication-common';
 
 /**
  * @private
@@ -93,7 +92,7 @@ const memoizeThreads = memoizeOne((thread: ChatThreadClientState) => ({ [thread.
 
 const adaptCompositeState = (compositeState: ChatAdapterState): ChatClientState => {
   return memoizeState(
-    getIdentifierKind(fromFlatCommunicationIdentifier(compositeState.userId)),
+    compositeState.userId,
     compositeState.displayName,
     memoizeThreads(compositeState.thread),
     // This is an unsafe type expansion.

--- a/packages/react-composites/src/composites/MeetingComposite/adapter/AzureCommunicationMeetingAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/AzureCommunicationMeetingAdapter.ts
@@ -37,6 +37,7 @@ import {
 import { createAzureCommunicationChatAdapter } from '../../ChatComposite/adapter/AzureCommunicationChatAdapter';
 import { EventEmitter } from 'events';
 import { CommunicationTokenCredential, CommunicationUserIdentifier } from '@azure/communication-common';
+import { toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 
 type MeetingAdapterStateChangedHandler = (newState: MeetingAdapterState) => void;
 
@@ -150,7 +151,7 @@ export class AzureCommunicationMeetingAdapter implements MeetingAdapter {
   }
   /** Leave current Meeting. */
   public async leaveMeeting(): Promise<void> {
-    await this.chatAdapter.removeParticipant(this.chatAdapter.getState().userId);
+    await this.chatAdapter.removeParticipant(toFlatCommunicationIdentifier(this.chatAdapter.getState().userId));
     await this.callAdapter.leaveCall();
   }
   /** Start a new Meeting. */

--- a/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedCallAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedCallAdapter.ts
@@ -41,8 +41,7 @@ function callAdapterStateFromMeetingAdapterState(meetingState: MeetingAdapterSta
   return {
     isLocalPreviewMicrophoneEnabled: meetingState.isLocalPreviewMicrophoneEnabled,
     page: meetingPageToCallPage(meetingState.page),
-    // xkcd: FIXME
-    userId: meetingState.userId as CommunicationUserKind,
+    userId: meetingState.userId,
     displayName: meetingState.displayName,
     call: meetingState.meeting ? callStateFromMeetingState(meetingState.meeting) : undefined,
     devices: meetingState.devices,

--- a/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedCallAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedCallAdapter.ts
@@ -9,7 +9,6 @@ import { AudioDeviceInfo, VideoDeviceInfo, Call, PermissionConstraints } from '@
 import { MeetingAdapterState, MeetingState } from '..';
 import { CallState } from '@internal/calling-stateful-client';
 import { callParticipantsFromMeetingParticipants } from '../state/MeetingParticipants';
-import { CommunicationUserKind } from '@azure/communication-signaling';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */

--- a/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedCallAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedCallAdapter.ts
@@ -9,7 +9,6 @@ import { AudioDeviceInfo, VideoDeviceInfo, Call, PermissionConstraints } from '@
 import { MeetingAdapterState, MeetingState } from '..';
 import { CallState } from '@internal/calling-stateful-client';
 import { callParticipantsFromMeetingParticipants } from '../state/MeetingParticipants';
-import { getIdentifierKind } from '@azure/communication-common';
 import { CommunicationUserKind } from '@azure/communication-signaling';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -42,7 +41,8 @@ function callAdapterStateFromMeetingAdapterState(meetingState: MeetingAdapterSta
   return {
     isLocalPreviewMicrophoneEnabled: meetingState.isLocalPreviewMicrophoneEnabled,
     page: meetingPageToCallPage(meetingState.page),
-    userId: getIdentifierKind(meetingState.userId) as CommunicationUserKind,
+    // xkcd: FIXME
+    userId: meetingState.userId as CommunicationUserKind,
     displayName: meetingState.displayName,
     call: meetingState.meeting ? callStateFromMeetingState(meetingState.meeting) : undefined,
     devices: meetingState.devices,

--- a/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedChatAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedChatAdapter.ts
@@ -3,7 +3,6 @@
 
 import { MeetingAdapter } from './MeetingAdapter';
 import { ChatAdapter, ChatAdapterState } from '../../ChatComposite';
-import { toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 import { ErrorBarStrings } from '@internal/react-components';
 import { ChatThreadClientState } from '@internal/chat-stateful-client';
 import { MeetingAdapterState, MeetingState } from '..';
@@ -27,7 +26,7 @@ function ChatAdapterStateFromMeetingAdapterState(meetingState: MeetingAdapterSta
   if (!meetingState.meeting) throw 'Cannot get chat adapter state. Meeting state is undefined.';
 
   return {
-    userId: toFlatCommunicationIdentifier(meetingState.userId),
+    userId: meetingState.userId,
     displayName: meetingState.displayName || '',
     thread: chatThreadStateFromMeetingState(meetingState.meeting),
     latestErrors: {} //@TODO: latest errors not supported in meeting composite yet.

--- a/packages/react-composites/src/composites/MeetingComposite/state/MeetingAdapterState.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/state/MeetingAdapterState.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CommunicationUserIdentifier } from '@azure/communication-common';
+import { CommunicationIdentifierKind } from '@azure/communication-signaling';
 import { CallAdapter, CallAdapterClientState, CallAdapterState, CallAdapterUiState } from '../../CallComposite';
 import { ChatAdapter, ChatAdapterState } from '../../ChatComposite';
 import { callPageToMeetingPage, MeetingCompositePage } from './MeetingCompositePage';
@@ -29,7 +29,7 @@ export interface MeetingAdapterUiState extends Pick<CallAdapterUiState, 'isLocal
  */
 export interface MeetingAdapterClientState extends Pick<CallAdapterClientState, 'devices' | 'isTeamsCall'> {
   /** ID of the meeting participant using this Meeting Adapter. */
-  userId: CommunicationUserIdentifier;
+  userId: CommunicationIdentifierKind;
   /** Display name of the meeting participant using this Meeting Adapter. */
   displayName: string | undefined;
   /** State of the current Meeting. */

--- a/packages/react-composites/src/composites/MeetingComposite/state/MeetingAdapterState.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/state/MeetingAdapterState.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { CommunicationIdentifierKind } from '@azure/communication-signaling';
+import { CommunicationIdentifierKind } from '@azure/communication-common';
 import { CallAdapter, CallAdapterClientState, CallAdapterState, CallAdapterUiState } from '../../CallComposite';
 import { ChatAdapter, ChatAdapterState } from '../../ChatComposite';
 import { callPageToMeetingPage, MeetingCompositePage } from './MeetingCompositePage';

--- a/packages/react-composites/tests/browser/call/app/index.tsx
+++ b/packages/react-composites/tests/browser/call/app/index.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AzureCommunicationTokenCredential } from '@azure/communication-common';
+import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from '@azure/communication-common';
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -20,7 +20,6 @@ import { isMobile, verifyParamExists } from '../../common/testAppUtils';
 import memoizeOne from 'memoize-one';
 import { IContextualMenuItem, mergeStyles } from '@fluentui/react';
 import { fromFlatCommunicationIdentifier } from '@internal/acs-ui-common';
-import { CommunicationUserIdentifier } from '@azure/communication-signaling';
 
 const urlSearchParams = new URLSearchParams(window.location.search);
 const params = Object.fromEntries(urlSearchParams.entries());


### PR DESCRIPTION
# Why
* Consistency in our API -- all constructors / factory functions expect `CommunictionUserIdentifier` and all state fields are `CommunicationIdentifierKind`.
* Make our API future proof. Although currently we only ever work with a CommunicationUserIdentifier for the local participant, we might accept other identifiers in the future (especially Teams). While it is backward compatible to accept a broader type of participant in the constructor, changing the state.userId field later would be a backwards incompatible change.
* Reduces the need to convert the identifier between different types in our implementation because of the increased consistency across our interfaces.

# How Tested
* Chat sample
* Calling sample
* `rush test`