### PR TITLE
Bugfix camera permanently disabled

### DIFF
--- a/change/@internal-react-components-4527ddaa-b6a6-420b-b4de-2b7d7d8da6a8.json
+++ b/change/@internal-react-components-4527ddaa-b6a6-420b-b4de-2b7d7d8da6a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bugfix for permanent camera disable when it is being used elsewhere",
+  "packageName": "@internal/react-components",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/CameraButton.tsx
+++ b/packages/react-components/src/components/CameraButton.tsx
@@ -68,8 +68,11 @@ export function CameraButton(props: CameraButtonProps): JSX.Element {
     // Throttle click on camera, need to await onToggleCamera then allow another click
     if (onToggleCamera) {
       setWaitForCamera(true);
-      await onToggleCamera(localVideoViewOption ?? defaultLocalVideoViewOption);
-      setWaitForCamera(false);
+      try {
+        await onToggleCamera(localVideoViewOption ?? defaultLocalVideoViewOption);
+      } finally {
+        setWaitForCamera(false);
+      }
     }
   }, [localVideoViewOption, onToggleCamera]);
 


### PR DESCRIPTION
# What
Fixes the bug where camera button gets permanently disabled when clicking on it causes an error.
More info here:
https://skype.visualstudio.com/SPOOL/_workitems/edit/2622518

# Why
Users were not able to click toggle camera even if the camera device became available.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->