### PR TITLE
Remove `@public` from storybook component docs

### DIFF
--- a/change/@internal-react-components-cbe01186-9d40-416f-8399-622b6a3efc2e.json
+++ b/change/@internal-react-components-cbe01186-9d40-416f-8399-622b6a3efc2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update doc comment",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-storybook-713b031e-24e4-451b-b86f-124ed3692ba9.json
+++ b/change/@internal-storybook-713b031e-24e4-451b-b86f-124ed3692ba9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Cleanup component descriptions",
+  "packageName": "@internal/storybook",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -116,8 +116,8 @@ const DRAG_OPTIONS: IDragOptions = {
 };
 
 /**
- * VideoGallery represents a {@link GridLayout} of video tiles for a specific call.
- * It displays a {@link VideoTile} for the local user as well as for each remote participants who joined the call.
+ * VideoGallery represents a layout of video tiles for a specific call.
+ * It displays a {@link VideoTile} for the local user as well as for each remote participant who has joined the call.
  *
  * @public
  */

--- a/packages/storybook/.eslintrc.js
+++ b/packages/storybook/.eslintrc.js
@@ -60,7 +60,10 @@ module.exports = {
         message: 'Please use @azure/communication-react instead.'
       }
     ],
-    'react/display-name': 'off'
+    'react/display-name': 'off',
+
+    // This rule directly conflicts with allowed characters in Storybook's markdown
+    'react/no-unescaped-entities': 'off'
   },
   root: true,
   settings: {

--- a/packages/storybook/stories/ControlBar/Buttons/Camera/Camera.stories.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/Camera/Camera.stories.tsx
@@ -24,10 +24,9 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>CameraButton</Title>
-      <Description of={CameraButton} />
       <Description>
-        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, don not forget to add a unique key
-        to each element to avoid warning for children in a list.
+        A button to toggle the user's camera on and off. For use with the [Control
+        Bar](./?path=/docs/ui-components-controlbar--control-bar).
       </Description>
 
       <Heading>Importing</Heading>
@@ -54,6 +53,10 @@ const getDocs: () => JSX.Element = () => {
       <Description>
         You can change the styles of the `CameraButton` as you would customized any Button (styles, primary,
         onRenderIcon, onRenderText, etc... ).
+      </Description>
+      <Description>
+        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, do not forget to add a unique key
+        to each element to avoid warning for children in a list.
       </Description>
       <Canvas mdxSource={CustomButtonExampleText}>
         <CustomCameraButtonExample />

--- a/packages/storybook/stories/ControlBar/Buttons/ControlBarButton/ControlBarButton.stories.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/ControlBarButton/ControlBarButton.stories.tsx
@@ -25,10 +25,8 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>ControlBarButton</Title>
-      <Description of={ControlBarButton} />
       <Description>
-        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, do not forget to add a unique key
-        to each element to avoid warning for children in a list.
+        Default button styled for use with the [Control Bar](./?path=/docs/ui-components-controlbar--control-bar).
       </Description>
 
       <Heading>Importing</Heading>
@@ -50,6 +48,10 @@ const getDocs: () => JSX.Element = () => {
       <Description>
         You can override the styles of the `ControlBarButton` as you would customized any Button (styles, primary,
         onRenderIcon, onRenderText, etc... ).
+      </Description>
+      <Description>
+        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, do not forget to add a unique key
+        to each element to avoid warning for children in a list.
       </Description>
       <Canvas mdxSource={CustomControlBarButtonExampleText}>
         <CustomControlBarButtonExample />

--- a/packages/storybook/stories/ControlBar/Buttons/EndCall/EndCall.stories.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/EndCall/EndCall.stories.tsx
@@ -24,10 +24,9 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>EndCallButton</Title>
-      <Description of={EndCallButton} />
       <Description>
-        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, don not forget to add a unique key
-        to each element to avoid warning for children in a list.
+        A button to end an ongoing call. For use with the [Control
+        Bar](./?path=/docs/ui-components-controlbar--control-bar).
       </Description>
 
       <Heading>Importing</Heading>
@@ -53,6 +52,10 @@ const getDocs: () => JSX.Element = () => {
       <Description>
         You can change the styles of the `EndCallButton` as you would customized any Button (styles, primary,
         onRenderIcon, onRenderText, etc... ).
+      </Description>
+      <Description>
+        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, do not forget to add a unique key
+        to each element to avoid warning for children in a list.
       </Description>
       <Canvas mdxSource={EndCallButtonCustomExampleText}>
         <EndCallButtonCustomExample />

--- a/packages/storybook/stories/ControlBar/Buttons/Microphone/Microphone.stories.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/Microphone/Microphone.stories.tsx
@@ -24,10 +24,9 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>MicrophoneButton</Title>
-      <Description of={MicrophoneButton} />
       <Description>
-        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, don not forget to add a unique key
-        to each element to avoid warning for children in a list.
+        A button to toggle the user's microphone on and off. For use with the [Control
+        Bar](./?path=/docs/ui-components-controlbar--control-bar).
       </Description>
 
       <Heading>Importing</Heading>
@@ -54,6 +53,10 @@ const getDocs: () => JSX.Element = () => {
       <Description>
         You can change the styles of the `MicrophoneButton` as you would customized any Button (styles, primary,
         onRenderIcon, onRenderText, etc... ).
+      </Description>
+      <Description>
+        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, do not forget to add a unique key
+        to each element to avoid warning for children in a list.
       </Description>
       <Canvas mdxSource={CustomMicrophoneButtonExampleText}>
         <CustomMicrophoneButtonExample />

--- a/packages/storybook/stories/ControlBar/Buttons/Options/Options.stories.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/Options/Options.stories.tsx
@@ -25,10 +25,9 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>OptionsButton</Title>
-      <Description of={OptionsButton} />
       <Description>
-        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, don not forget to add a unique key
-        to each element to avoid warning for children in a list.
+        A button to open a menu that allows for device selection. For use with the [Control
+        Bar](./?path=/docs/ui-components-controlbar--control-bar).
       </Description>
 
       <Heading>Importing</Heading>
@@ -54,6 +53,10 @@ const getDocs: () => JSX.Element = () => {
       <Description>
         You can change the styles of the `OptionsButton` as you would customized any Button (styles, primary,
         onRenderIcon, onRenderText, etc... ).
+      </Description>
+      <Description>
+        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, do not forget to add a unique key
+        to each element to avoid warning for children in a list.
       </Description>
       <Canvas mdxSource={OptionsButtonCustomExampleText}>
         <OptionsButtonCustomExample />

--- a/packages/storybook/stories/ControlBar/Buttons/Participants/Participants.stories.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/Participants/Participants.stories.tsx
@@ -36,10 +36,9 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>ParticipantsButton</Title>
-      <Description of={ParticipantsButton} />
       <Description>
-        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, do not forget to add a unique key
-        to each element to avoid warning for children in a list.
+        A button to show a menu containing the call or chat participants. For use with the [Control
+        Bar](./?path=/docs/ui-components-controlbar--control-bar).
       </Description>
 
       <Heading>Importing</Heading>
@@ -95,6 +94,10 @@ const getDocs: () => JSX.Element = () => {
         You can change the styles of `ParticipantsButton` through its `styles` props as you would customize any Button
         styles (root, label, etc..) with the addition of customizing the participant list container like shown in the
         example below.
+      </Description>
+      <Description>
+        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, do not forget to add a unique key
+        to each element to avoid warning for children in a list.
       </Description>
       <Canvas mdxSource={ParticipantsButtonWithCustomStylesExampleText}>
         <ParticipantsButtonWithCustomStylesExample />

--- a/packages/storybook/stories/ControlBar/Buttons/ScreenShare/ScreenShare.stories.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/ScreenShare/ScreenShare.stories.tsx
@@ -24,10 +24,9 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>ScreenShareButton</Title>
-      <Description of={ScreenShareButton} />
       <Description>
-        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, don not forget to add a unique key
-        to each element to avoid warning for children in a list.
+        A button to toggle the user's screen sharing on and off. For use with the [Control
+        Bar](./?path=/docs/ui-components-controlbar--control-bar).
       </Description>
 
       <Heading>Importing</Heading>
@@ -54,6 +53,10 @@ const getDocs: () => JSX.Element = () => {
       <Description>
         You can change the styles of the `ScreenShareButton` as you would customized any Button (styles, primary,
         onRenderIcon, onRenderText, etc... ).
+      </Description>
+      <Description>
+        Note: When overriding a render, like using `onRenderIcon` or `onRenderText`, do not forget to add a unique key
+        to each element to avoid warning for children in a list.
       </Description>
       <Canvas mdxSource={CustomButtonExampleText}>
         <CustomScreenShareButtonExample />

--- a/packages/storybook/stories/ControlBar/ControlBar.stories.tsx
+++ b/packages/storybook/stories/ControlBar/ControlBar.stories.tsx
@@ -73,7 +73,9 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>ControlBar</Title>
-      <Description of={ControlBarComponent} />
+      <Description>
+        A container for call control buttons. See [layouts](#layouts) for the different formats this control provides.
+      </Description>
 
       <Heading>Importing</Heading>
       <Source code={importStatement} />

--- a/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
+++ b/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
@@ -63,7 +63,15 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>MessageThread</Title>
-      <Description of={MessageThreadComponent} />
+      <Description>
+        MessageThread allows you to easily create a component for rendering chat messages, handling scrolling behavior
+        of new/old messages and customizing icons &amp; controls inside the chat thread.
+      </Description>
+      <Description>
+        MessageThread internally uses the `Chat` &amp; `Chat.Message` component from `@fluentui/react-northstar`. You
+        can checkout the details about these [two
+        components](https://fluentsite.z22.web.core.windows.net/0.53.0/components/chat/props).
+      </Description>
 
       <Heading>Importing</Heading>
       <Source code={importStatement} />

--- a/packages/storybook/stories/ParticipantItem/ParticipantItem.stories.tsx
+++ b/packages/storybook/stories/ParticipantItem/ParticipantItem.stories.tsx
@@ -27,7 +27,10 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>ParticipantItem</Title>
-      <Description of={ParticipantItemComponent} />
+      <Description>
+        Component to render a calling or chat participant. This component can display the participant's avatar,
+        displayName, online presence as well as optional icons and context menu.
+      </Description>
 
       <Heading>Importing</Heading>
       <Source code={importStatement} />
@@ -110,9 +113,9 @@ export default {
   title: `${COMPONENT_FOLDER_PREFIX}/Participant Item`,
   component: ParticipantItemComponent,
   argTypes: {
-    displayName: controlsToAdd.displayName,
-    isScreenSharing: controlsToAdd.isScreenSharing,
-    isMuted: controlsToAdd.isMuted,
+    displayName: { ...controlsToAdd.displayName, defaultValue: 'August (CEO)' },
+    isScreenSharing: { ...controlsToAdd.isScreenSharing, defaultValue: true },
+    isMuted: { ...controlsToAdd.isMuted, defaultValue: true },
     me: controlsToAdd.isMe,
     menuItemsStr: controlsToAdd.participantItemMenuItemsStr,
     // Hiding auto-generated controls

--- a/packages/storybook/stories/ParticipantItem/ParticipantItem.stories.tsx
+++ b/packages/storybook/stories/ParticipantItem/ParticipantItem.stories.tsx
@@ -113,7 +113,7 @@ export default {
   title: `${COMPONENT_FOLDER_PREFIX}/Participant Item`,
   component: ParticipantItemComponent,
   argTypes: {
-    displayName: { ...controlsToAdd.displayName, defaultValue: 'August (CEO)' },
+    displayName: { ...controlsToAdd.displayName, defaultValue: 'August Manning' },
     isScreenSharing: { ...controlsToAdd.isScreenSharing, defaultValue: true },
     isMuted: { ...controlsToAdd.isMuted, defaultValue: true },
     me: controlsToAdd.isMe,

--- a/packages/storybook/stories/ParticipantItem/__snapshots__/ParticipantItem.stories.storyshot
+++ b/packages/storybook/stories/ParticipantItem/__snapshots__/ParticipantItem.stories.storyshot
@@ -53,13 +53,9 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                     aria-hidden="true"
                     className="ms-Persona-initials initials-20"
                   >
-                    <i
-                      aria-hidden={true}
-                      className="root-37 root-22"
-                      data-icon-name="Contact"
-                    >
-                      
-                    </i>
+                    <span>
+                      AM
+                    </span>
                   </div>
                 </div>
               </div>
@@ -69,7 +65,18 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                 <div
                   className="ms-Persona-primaryText primaryText-10"
                   dir="auto"
-                />
+                >
+                  <div
+                    className="ms-TooltipHost root-23"
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    August Manning
+                  </div>
+                </div>
                 <div
                   className="ms-Persona-secondaryText secondaryText-11"
                   dir="auto"
@@ -85,15 +92,56 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
               </div>
             </div>
             <div
-              className="ms-Stack css-25"
+              className="ms-Stack css-24"
             >
               <div
-                className="ms-Stack css-26"
-              />
+                className="ms-Stack css-25"
+              >
+                <span
+                  aria-hidden={true}
+                  className="root-span css-1"
+                >
+                  <svg
+                    className="svg"
+                    fill="currentColor"
+                    height={20}
+                    viewBox="0 0 20 20"
+                    width={20}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M4 4a2 2 0 00-2 2v8c0 1.1.9 2 2 2h12a2 2 0 002-2V6a2 2 0 00-2-2H4zm6 10a.5.5 0 01-.5-.5V7.7L7.85 9.36a.5.5 0 11-.7-.7l2.5-2.5c.2-.2.5-.2.7 0l2.5 2.5a.5.5 0 01-.7.7L10.5 7.71v5.79a.5.5 0 01-.5.5z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  aria-hidden={true}
+                  className="root-span css-1"
+                >
+                  <svg
+                    className="svg"
+                    fill="currentColor"
+                    height={16}
+                    viewBox="0 0 16 16"
+                    width={16}
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10.8 11.52l3.35 3.33a.5.5 0 00.7-.7l-13-13a.5.5 0 10-.7.7L5.5 6.21V8a2.5 2.5 0 003.88 2.09l.72.71A3.5 3.5 0 014.5 8a.5.5 0 10-1 0 4.5 4.5 0 004 4.47v1.03a.5.5 0 101 0v-1.03c.87-.1 1.66-.44 2.3-.95zM8.66 9.35A1.5 1.5 0 016.5 8v-.8l2.15 2.15z"
+                    />
+                    <path
+                      d="M9.5 7.38V4.5a1.5 1.5 0 00-3-.12l-.82-.82a2.5 2.5 0 014.82.94V8c0 .12 0 .24-.02.35l-.98-.97z"
+                    />
+                    <path
+                      d="M12.06 9.94l-.76-.76c.13-.37.2-.77.2-1.18a.5.5 0 011 0c0 .7-.16 1.35-.44 1.94z"
+                    />
+                  </svg>
+                </span>
+              </div>
             </div>
           </div>
           <div
-            className="ms-Stack css-27"
+            className="ms-Stack css-26"
             data-ui-id="participant-item-menu-button"
             title="More Options"
           >
@@ -131,7 +179,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
             className="ms-layer"
           >
             <div
-              className="ms-Fabric ms-Layer-content content-51"
+              className="ms-Fabric ms-Layer-content content-50"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
@@ -164,7 +212,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
               onTouchStart={[Function]}
             >
               <div
-                className="ms-Callout-container container-53"
+                className="ms-Callout-container container-52"
                 style={
                   Object {
                     "visibility": "hidden",
@@ -172,7 +220,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                 }
               >
                 <div
-                  className="ms-Callout ms-ContextualMenu-Callout root-54"
+                  className="ms-Callout ms-ContextualMenu-Callout root-53"
                   hidden={true}
                   onScroll={[Function]}
                   style={
@@ -185,7 +233,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                   tabIndex={-1}
                 >
                   <div
-                    className="ms-Callout-main calloutMain-57"
+                    className="ms-Callout-main calloutMain-56"
                     onKeyDown={[Function]}
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
@@ -199,7 +247,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                     }
                   >
                     <div
-                      className="ms-ContextualMenu-container container-29"
+                      className="ms-ContextualMenu-container container-28"
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
                       onKeyUp={[Function]}
@@ -207,27 +255,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                       tabIndex={-1}
                     >
                       <div
-                        className="ms-FocusZone css-58 ms-ContextualMenu is-open root-28"
-                        data-focuszone-id="FocusZone3"
+                        className="ms-FocusZone css-57 ms-ContextualMenu is-open root-27"
+                        data-focuszone-id="FocusZone4"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
                       >
                         <ul
-                          className="ms-ContextualMenu-list is-open list-30"
+                          className="ms-ContextualMenu-list is-open list-29"
                           onKeyDown={[Function]}
                           onKeyUp={[Function]}
                           role="presentation"
                         >
                           <li
-                            className="ms-ContextualMenu-item item-33"
+                            className="ms-ContextualMenu-item item-32"
                             role="presentation"
                           >
                             <button
                               aria-disabled={false}
                               aria-posinset={1}
                               aria-setsize={2}
-                              className="ms-ContextualMenu-link root-35"
+                              className="ms-ContextualMenu-link root-34"
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseEnter={[Function]}
@@ -236,10 +284,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                               role="menuitem"
                             >
                               <div
-                                className="ms-ContextualMenu-linkContent linkContent-39"
+                                className="ms-ContextualMenu-linkContent linkContent-38"
                               >
                                 <span
-                                  className="ms-ContextualMenu-itemText label-45"
+                                  className="ms-ContextualMenu-itemText label-44"
                                 >
                                   Mute
                                 </span>
@@ -247,14 +295,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                             </button>
                           </li>
                           <li
-                            className="ms-ContextualMenu-item item-33"
+                            className="ms-ContextualMenu-item item-32"
                             role="presentation"
                           >
                             <button
                               aria-disabled={false}
                               aria-posinset={2}
                               aria-setsize={2}
-                              className="ms-ContextualMenu-link root-35"
+                              className="ms-ContextualMenu-link root-34"
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseEnter={[Function]}
@@ -263,10 +311,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                               role="menuitem"
                             >
                               <div
-                                className="ms-ContextualMenu-linkContent linkContent-39"
+                                className="ms-ContextualMenu-linkContent linkContent-38"
                               >
                                 <span
-                                  className="ms-ContextualMenu-itemText label-45"
+                                  className="ms-ContextualMenu-itemText label-44"
                                 >
                                   Remove
                                 </span>

--- a/packages/storybook/stories/ParticipantList/ParticipantList.stories.tsx
+++ b/packages/storybook/stories/ParticipantList/ParticipantList.stories.tsx
@@ -25,7 +25,7 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>Participant List</Title>
-      <Description of={ParticipantListComponent} />
+      <Description>Component that renders a list of all calling or chat participants.</Description>
 
       <Heading>Default example for Chat</Heading>
       <Description>

--- a/packages/storybook/stories/ParticipantList/ParticipantList.stories.tsx
+++ b/packages/storybook/stories/ParticipantList/ParticipantList.stories.tsx
@@ -24,7 +24,7 @@ const ParticipantListWithExcludedUserExampleText =
 const getDocs: () => JSX.Element = () => {
   return (
     <>
-      <Title>Participant List</Title>
+      <Title>ParticipantList</Title>
       <Description>Component that renders a list of all calling or chat participants.</Description>
 
       <Heading>Default example for Chat</Heading>

--- a/packages/storybook/stories/ParticipantList/__snapshots__/ParticipantList.stories.storyshot
+++ b/packages/storybook/stories/ParticipantList/__snapshots__/ParticipantList.stories.storyshot
@@ -210,7 +210,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                         tabIndex={-1}
                       >
                         <div
-                          className="ms-FocusZone css-58 ms-ContextualMenu is-open root-27"
+                          className="ms-FocusZone css-57 ms-ContextualMenu is-open root-27"
                           data-focuszone-id="FocusZone11"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
@@ -442,7 +442,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                         tabIndex={-1}
                       >
                         <div
-                          className="ms-FocusZone css-58 ms-ContextualMenu is-open root-27"
+                          className="ms-FocusZone css-57 ms-ContextualMenu is-open root-27"
                           data-focuszone-id="FocusZone12"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
@@ -678,7 +678,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                         tabIndex={-1}
                       >
                         <div
-                          className="ms-FocusZone css-58 ms-ContextualMenu is-open root-27"
+                          className="ms-FocusZone css-57 ms-ContextualMenu is-open root-27"
                           data-focuszone-id="FocusZone13"
                           onFocus={[Function]}
                           onKeyDown={[Function]}

--- a/packages/storybook/stories/SendBox/SendBox.stories.tsx
+++ b/packages/storybook/stories/SendBox/SendBox.stories.tsx
@@ -25,7 +25,10 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>SendBox</Title>
-      <Description of={SendBoxComponent} />
+      <Description>
+        Component for typing and sending messages. SendBox has a callback for sending typing notification when user
+        starts entering text. It also supports an optional message below the text input field.
+      </Description>
 
       <Heading>Importing</Heading>
       <Source code={importStatement} />

--- a/packages/storybook/stories/TypingIndicator/TypingIndicator.stories.tsx
+++ b/packages/storybook/stories/TypingIndicator/TypingIndicator.stories.tsx
@@ -22,7 +22,9 @@ const getDocs: () => JSX.Element = () => {
   return (
     <>
       <Title>TypingIndicator</Title>
-      <Description of={TypingIndicatorComponent} />
+      <Description>
+        Component to notify the local user when one or more participants in the chat thread are typing.
+      </Description>
 
       <Heading>Importing</Heading>
       <Source code={importStatement} />

--- a/packages/storybook/stories/VideoGallery/VideoGallery.stories.tsx
+++ b/packages/storybook/stories/VideoGallery/VideoGallery.stories.tsx
@@ -21,8 +21,12 @@ const importStatement = `import { VideoGallery } from '@azure/communication-reac
 const getDocs: () => JSX.Element = () => {
   return (
     <>
-      <Title>Video Gallery</Title>
-      <Description of={VideoGalleryComponent} />
+      <Title>VideoGallery</Title>
+      <Description>
+        VideoGallery represents a layout of video tiles for a specific call. It displays a
+        [VideoTile](./?path=/docs/ui-components-videotile--video-tile) for the local user as well as for each remote
+        participant who has joined the call.
+      </Description>
 
       <Heading>Importing</Heading>
       <Source code={importStatement} />


### PR DESCRIPTION
# What
* Have descriptions set manually instead of using `<Description of=Component />`
* Quickly update participant item canvas defaults to make it nicer when landing on that component:
  * |before | after |
    | -- | -- |
    | ![image](https://user-images.githubusercontent.com/2684369/141157530-d91937f6-4b69-43bc-88fa-c02c9fb7e6bc.png) | ![image](https://user-images.githubusercontent.com/2684369/141157538-0c03cce5-4a74-4109-abd2-613e1565ec1f.png) |

# Why
Before `@public` and `@link` would show which isn't ideal. Can't find a way for the docs addon to handle these
![image](https://user-images.githubusercontent.com/2684369/141156958-152dc067-a435-4b59-9680-4ee41cb52708.png)

# How Tested
Please see storybook link created by PR and check out the changes.