### PR TITLE
Re-enable `ae-incompatible-release-tags` - Mark StatefulCallClient `diagnostics` as public and `transfer` beta

### DIFF
--- a/change/@internal-calling-stateful-client-bc80be50-1716-4828-9324-104277dc5434.json
+++ b/change/@internal-calling-stateful-client-bc80be50-1716-4828-9324-104277dc5434.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Mark StatefulCallClient `diagnostics` and `transfer` properties as beta",
+  "packageName": "@internal/calling-stateful-client",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-calling-stateful-client-bc80be50-1716-4828-9324-104277dc5434.json
+++ b/change/@internal-calling-stateful-client-bc80be50-1716-4828-9324-104277dc5434.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Mark StatefulCallClient `diagnostics` and `transfer` properties as beta",
+  "comment": "Mark StatefulCallClient `diagnostics` property as public and `transfer` property as beta",
   "packageName": "@internal/calling-stateful-client",
   "email": "2684369+JamesBurnside@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/common/config/api-extractor/api-extractor.json
+++ b/common/config/api-extractor/api-extractor.json
@@ -18,6 +18,9 @@
         "logLevel": "error"
       },
       "ae-unresolved-link": {
+        // This must be set to none, as when our individual packlets reference exports
+        // from other packlets this throws an error. Ideally we should turn this on just
+        // for the communication-react api.md file.
         "logLevel": "none"
       },
       "ae-forgotten-export": {
@@ -25,7 +28,8 @@
         "addToApiReportFile": false
       },
       "ae-incompatible-release-tags": {
-        "logLevel": "none"
+        "logLevel": "error",
+        "addToApiReportFile": false
       }
     },
     "tsdocMessageReporting": {

--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -78,7 +78,7 @@ export type CallErrorTarget = 'Call.addParticipant' | 'Call.api' | 'Call.hangUp'
 export interface CallState {
     callEndReason?: CallEndReason;
     callerInfo: CallerInfo;
-    // Warning: (ae-incompatible-release-tags) The symbol "diagnostics" is marked as @public, but its signature references "DiagnosticsCallFeatureState" which is marked as @beta
+    // @beta
     diagnostics: DiagnosticsCallFeatureState;
     direction: CallDirection;
     dominantSpeakers?: DominantSpeakersInfo;
@@ -98,7 +98,7 @@ export interface CallState {
     startTime: Date;
     state: CallState_2;
     transcription: TranscriptionCallFeature;
-    // Warning: (ae-incompatible-release-tags) The symbol "transfer" is marked as @public, but its signature references "TransferCallFeatureState" which is marked as @beta
+    // @beta
     transfer: TransferCallFeatureState;
 }
 

--- a/packages/calling-stateful-client/review/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/calling-stateful-client.api.md
@@ -78,7 +78,6 @@ export type CallErrorTarget = 'Call.addParticipant' | 'Call.api' | 'Call.hangUp'
 export interface CallState {
     callEndReason?: CallEndReason;
     callerInfo: CallerInfo;
-    // @beta
     diagnostics: DiagnosticsCallFeatureState;
     direction: CallDirection;
     dominantSpeakers?: DominantSpeakersInfo;
@@ -118,7 +117,7 @@ export type DeviceManagerState = {
     unparentedViews: LocalVideoStreamState[];
 };
 
-// @beta
+// @public
 export interface DiagnosticsCallFeatureState {
     media: MediaDiagnosticsState;
     network: NetworkDiagnosticsState;
@@ -140,13 +139,13 @@ export interface LocalVideoStreamState {
     view?: VideoStreamRendererViewState;
 }
 
-// @beta
+// @public
 export interface MediaDiagnosticsState {
     // (undocumented)
     latest: LatestMediaDiagnostics;
 }
 
-// @beta
+// @public
 export interface NetworkDiagnosticsState {
     // (undocumented)
     latest: LatestNetworkDiagnostics;

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -311,6 +311,8 @@ export interface CallState {
   /**
    * Proxy of {@link @azure/communication-calling#TransferCallFeature} with some differences see
    * {@link TransferCallFeatureState} for details.
+   *
+   * @beta
    */
   transfer: TransferCallFeatureState;
   /**
@@ -336,6 +338,8 @@ export interface CallState {
 
   /**
    * Stores the latest call diagnostics.
+   *
+   * @beta
    */
   diagnostics: DiagnosticsCallFeatureState;
 }

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -338,8 +338,6 @@ export interface CallState {
 
   /**
    * Stores the latest call diagnostics.
-   *
-   * @beta
    */
   diagnostics: DiagnosticsCallFeatureState;
 }
@@ -575,7 +573,7 @@ export type CallErrorTarget =
 /**
  * State only proxy for {@link @azure/communication-calling#DiagnosticsCallFeature}.
  *
- * @beta
+ * @public
  */
 export interface DiagnosticsCallFeatureState {
   /**
@@ -592,7 +590,7 @@ export interface DiagnosticsCallFeatureState {
 /**
  * State only proxy for {@link @azure/communication-calling#NetworkDiagnostics}.
  *
- * @beta
+ * @public
  */
 export interface NetworkDiagnosticsState {
   latest: LatestNetworkDiagnostics;
@@ -601,7 +599,7 @@ export interface NetworkDiagnosticsState {
 /**
  * State only proxy for {@link @azure/communication-calling#MediaDiagnostics}.
  *
- * @beta
+ * @public
  */
 export interface MediaDiagnosticsState {
   latest: LatestMediaDiagnostics;

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -456,7 +456,7 @@ export interface CallProviderProps {
 export interface CallState {
     callEndReason?: CallEndReason;
     callerInfo: CallerInfo;
-    // Warning: (ae-incompatible-release-tags) The symbol "diagnostics" is marked as @public, but its signature references "DiagnosticsCallFeatureState" which is marked as @beta
+    // @beta
     diagnostics: DiagnosticsCallFeatureState;
     direction: CallDirection;
     dominantSpeakers?: DominantSpeakersInfo;
@@ -476,7 +476,7 @@ export interface CallState {
     startTime: Date;
     state: CallState_2;
     transcription: TranscriptionCallFeature;
-    // Warning: (ae-incompatible-release-tags) The symbol "transfer" is marked as @public, but its signature references "TransferCallFeatureState" which is marked as @beta
+    // @beta
     transfer: TransferCallFeatureState;
 }
 

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -456,7 +456,6 @@ export interface CallProviderProps {
 export interface CallState {
     callEndReason?: CallEndReason;
     callerInfo: CallerInfo;
-    // @beta
     diagnostics: DiagnosticsCallFeatureState;
     direction: CallDirection;
     dominantSpeakers?: DominantSpeakersInfo;
@@ -1074,7 +1073,7 @@ export type DeviceManagerState = {
 // @public
 export type DiagnosticChangedEventListner = (event: MediaDiagnosticChangedEvent | NetworkDiagnosticChangedEvent) => void;
 
-// @beta
+// @public
 export interface DiagnosticsCallFeatureState {
     media: MediaDiagnosticsState;
     network: NetworkDiagnosticsState;
@@ -1263,7 +1262,7 @@ export type MediaDiagnosticChangedEvent = MediaDiagnosticChangedEventArgs & {
     type: 'media';
 };
 
-// @beta
+// @public
 export interface MediaDiagnosticsState {
     // (undocumented)
     latest: LatestMediaDiagnostics;
@@ -1552,7 +1551,7 @@ export type NetworkDiagnosticChangedEvent = NetworkDiagnosticChangedEventArgs & 
     type: 'network';
 };
 
-// @beta
+// @public
 export interface NetworkDiagnosticsState {
     // (undocumented)
     latest: LatestNetworkDiagnostics;


### PR DESCRIPTION
# What
* Re-enable failing compilation for incomaptible release tags
* Mark StatefulCallClient `diagnostics` and `transfer` as beta to fix errors

# Why
We want this to error