### PR TITLE
Move mobileView prop to top level

### DIFF
--- a/change/@internal-react-composites-83011ace-47f1-4d6b-882c-838ded213672.json
+++ b/change/@internal-react-composites-83011ace-47f1-4d6b-882c-838ded213672.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make mobileView prop a top level property on the composite",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-storybook-1ee464fd-124d-463c-8fcd-d80f6e7aa87d.json
+++ b/change/@internal-storybook-1ee464fd-124d-463c-8fcd-d80f6e7aa87d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update docs to reflect prop change",
+  "packageName": "@internal/storybook",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -288,7 +288,6 @@ export type CallCompositeIcons = Partial<Pick<CompositeIcons, 'ControlButtonCame
 
 // @public
 export type CallCompositeOptions = {
-    mobileView?: boolean;
     errorBar?: boolean;
     callControls?: boolean | CallControlOptions;
 };
@@ -299,8 +298,8 @@ export type CallCompositePage = 'accessDeniedTeamsMeeting' | 'call' | 'configura
 // @public
 export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcons> {
     adapter: CallAdapter;
-    // (undocumented)
     callInvitationUrl?: string;
+    mobileView?: boolean;
     options?: CallCompositeOptions;
 }
 
@@ -1359,19 +1358,14 @@ export interface MeetingAdapterUiState extends Pick<CallAdapterUiState, 'isLocal
 export const MeetingComposite: (props: MeetingCompositeProps) => JSX.Element;
 
 // @beta
-export type MeetingCompositeOptions = {
-    mobileView?: boolean;
-};
-
-// @beta
 export type MeetingCompositePage = 'accessDeniedTeamsMeeting' | 'configuration' | 'joinMeetingFailedDueToNoNetwork' | 'leftMeeting' | 'lobby' | 'meeting' | 'removedFromMeeting';
 
 // @beta
 export type MeetingCompositeProps = {
     meetingAdapter: MeetingAdapter;
     fluentTheme?: PartialTheme | Theme;
+    mobileView?: boolean;
     meetingInvitationURL?: string;
-    options?: MeetingCompositeOptions;
 };
 
 // @beta

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -195,7 +195,6 @@ export type CallCompositeIcons = Partial<Pick<CompositeIcons, 'ControlButtonCame
 
 // @public
 export type CallCompositeOptions = {
-    mobileView?: boolean;
     errorBar?: boolean;
     callControls?: boolean | CallControlOptions;
 };
@@ -206,8 +205,8 @@ export type CallCompositePage = 'accessDeniedTeamsMeeting' | 'call' | 'configura
 // @public
 export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcons> {
     adapter: CallAdapter;
-    // (undocumented)
     callInvitationUrl?: string;
+    mobileView?: boolean;
     options?: CallCompositeOptions;
 }
 
@@ -620,19 +619,14 @@ export interface MeetingAdapterUiState extends Pick<CallAdapterUiState, 'isLocal
 export const MeetingComposite: (props: MeetingCompositeProps) => JSX.Element;
 
 // @beta
-export type MeetingCompositeOptions = {
-    mobileView?: boolean;
-};
-
-// @beta
 export type MeetingCompositePage = 'accessDeniedTeamsMeeting' | 'configuration' | 'joinMeetingFailedDueToNoNetwork' | 'leftMeeting' | 'lobby' | 'meeting' | 'removedFromMeeting';
 
 // @beta
 export type MeetingCompositeProps = {
     meetingAdapter: MeetingAdapter;
     fluentTheme?: PartialTheme | Theme;
+    mobileView?: boolean;
     meetingInvitationURL?: string;
-    options?: MeetingCompositeOptions;
 };
 
 // @beta

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -130,7 +130,7 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
         />
       );
     case 'lobby':
-      return <LobbyPage options={props.options} />;
+      return <LobbyPage mobileView={props.mobileView} options={props.options} />;
     case 'call':
       return (
         <CallPage

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -30,6 +30,16 @@ export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcon
    * Composite can also be controlled using the adapter.
    */
   adapter: CallAdapter;
+  /**
+   * Optimizes the composite UI for use on a mobile device.
+   * @remarks This is currently only optimized for Portrait mode on mobile devices and does not support landscape.
+   * @defaultValue false
+   */
+  mobileView?: boolean;
+  /**
+   * URL to invite new participants to the current call. If this is supplied, a button appears in the Participants
+   * Button flyout menu.
+   */
   callInvitationUrl?: string;
   /**
    * Flags to enable/disable or customize UI elements of the {@link CallComposite}.
@@ -43,12 +53,6 @@ export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcon
  * @public
  */
 export type CallCompositeOptions = {
-  /**
-   * Optimizes the composite UI for use on a mobile device.
-   * @remarks This is currently only optimized for Portrait mode on mobile devices and does not support landscape.
-   * @defaultValue false
-   */
-  mobileView?: boolean;
   /**
    * Surface Azure Communication Services backend errors in the UI with {@link @azure/communication-react#ErrorBar}.
    * Hide or show the error bar.
@@ -64,6 +68,7 @@ export type CallCompositeOptions = {
 };
 
 type MainScreenProps = {
+  mobileView: boolean;
   onRenderAvatar?: OnRenderAvatarCallback;
   callInvitationUrl?: string;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
@@ -82,7 +87,7 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
     case 'configuration':
       return (
         <ConfigurationPage
-          mobileView={props.options?.mobileView ?? false}
+          mobileView={props.mobileView}
           startCallHandler={(): void => {
             adapter.joinCall();
           }}
@@ -133,6 +138,7 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
           callInvitationURL={callInvitationUrl}
           onFetchAvatarPersonaData={onFetchAvatarPersonaData}
           onFetchParticipantMenuItems={onFetchParticipantMenuItems}
+          mobileView={props.mobileView}
           options={props.options}
         />
       );
@@ -151,7 +157,14 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
  * @public
  */
 export const CallComposite = (props: CallCompositeProps): JSX.Element => {
-  const { adapter, callInvitationUrl, onFetchAvatarPersonaData, onFetchParticipantMenuItems, options } = props;
+  const {
+    adapter,
+    callInvitationUrl,
+    onFetchAvatarPersonaData,
+    onFetchParticipantMenuItems,
+    options,
+    mobileView = false
+  } = props;
   useEffect(() => {
     (async () => {
       await adapter.askDevicePermission({ video: true, audio: true });
@@ -162,8 +175,8 @@ export const CallComposite = (props: CallCompositeProps): JSX.Element => {
   }, [adapter]);
 
   const mainScreenContainerClassName = useMemo(() => {
-    return options?.mobileView ? mainScreenContainerStyleMobile : mainScreenContainerStyleDesktop;
-  }, [options?.mobileView]);
+    return mobileView ? mainScreenContainerStyleMobile : mainScreenContainerStyleDesktop;
+  }, [mobileView]);
 
   return (
     <div className={mainScreenContainerClassName}>
@@ -173,6 +186,7 @@ export const CallComposite = (props: CallCompositeProps): JSX.Element => {
             callInvitationUrl={callInvitationUrl}
             onFetchAvatarPersonaData={onFetchAvatarPersonaData}
             onFetchParticipantMenuItems={onFetchParticipantMenuItems}
+            mobileView={mobileView}
             options={options}
           />
         </CallAdapterProvider>

--- a/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
@@ -23,6 +23,7 @@ import { NetworkReconnectTile } from '../components/NetworkReconnectTile';
  * @private
  */
 export interface CallPageProps {
+  mobileView: boolean;
   callInvitationURL?: string;
   onRenderAvatar?: OnRenderAvatarCallback;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
@@ -34,7 +35,14 @@ export interface CallPageProps {
  * @private
  */
 export const CallPage = (props: CallPageProps): JSX.Element => {
-  const { callInvitationURL, onRenderAvatar, onFetchAvatarPersonaData, onFetchParticipantMenuItems, options } = props;
+  const {
+    callInvitationURL,
+    onRenderAvatar,
+    onFetchAvatarPersonaData,
+    onFetchParticipantMenuItems,
+    options,
+    mobileView
+  } = props;
 
   // To use useProps to get these states, we need to create another file wrapping Call,
   // It seems unnecessary in this case, so we get the updated states using this approach.
@@ -47,9 +55,7 @@ export const CallPage = (props: CallPageProps): JSX.Element => {
   const networkReconnectTileProps = useSelector(networkReconnectTileSelector);
 
   // Reduce the controls shown when mobile view is enabled.
-  const callControlOptions = options?.mobileView
-    ? reduceCallControlsForMobile(options?.callControls)
-    : options?.callControls;
+  const callControlOptions = mobileView ? reduceCallControlsForMobile(options?.callControls) : options?.callControls;
 
   return (
     <CallArrangement
@@ -61,10 +67,10 @@ export const CallPage = (props: CallPageProps): JSX.Element => {
           callInvitationURL: callInvitationURL,
           onFetchParticipantMenuItems: onFetchParticipantMenuItems,
           options: callControlOptions,
-          increaseFlyoutItemSize: props.options?.mobileView
+          increaseFlyoutItemSize: mobileView
         }
       }
-      mobileView={options?.mobileView ?? false}
+      mobileView={mobileView}
       onRenderGalleryContent={() =>
         callStatus === 'Connected' ? (
           isNetworkHealthy(networkReconnectTileProps.networkReconnectValue) ? (

--- a/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
@@ -20,6 +20,7 @@ import { useLocalVideoStartTrigger } from '../components/MediaGallery';
  * @private
  */
 export interface LobbyPageProps {
+  mobileView: boolean;
   options?: CallCompositeOptions;
 }
 
@@ -37,7 +38,7 @@ export const LobbyPage = (props: LobbyPageProps): JSX.Element => {
   useLocalVideoStartTrigger(lobbyProps.localParticipantVideoStream.isAvailable, inLobby);
 
   // Reduce the controls shown when mobile view is enabled.
-  let callControlOptions = props.options?.mobileView
+  let callControlOptions = props.mobileView
     ? reduceCallControlsForMobile(props.options?.callControls)
     : props.options?.callControls;
 
@@ -50,10 +51,10 @@ export const LobbyPage = (props: LobbyPageProps): JSX.Element => {
       callControlProps={
         callControlOptions !== false && {
           options: callControlOptions,
-          increaseFlyoutItemSize: props.options?.mobileView
+          increaseFlyoutItemSize: props.mobileView
         }
       }
-      mobileView={props.options?.mobileView ?? false}
+      mobileView={props.mobileView}
       onRenderGalleryContent={() => <LobbyTile {...lobbyProps} overlayProps={overlayProps(strings, inLobby)} />}
       dataUiId={'lobby-page'}
     />

--- a/packages/react-composites/src/composites/MeetingComposite/MeetingCallControlBar.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/MeetingCallControlBar.tsx
@@ -21,7 +21,7 @@ export interface MeetingCallControlBarProps {
   peopleButtonChecked: boolean;
   onChatButtonClicked: () => void;
   onPeopleButtonClicked: () => void;
-  mobileView?: boolean;
+  mobileView: boolean;
   disableButtonsForLobbyPage: boolean;
 }
 

--- a/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
@@ -31,28 +31,16 @@ export type MeetingCompositeProps = {
    */
   fluentTheme?: PartialTheme | Theme;
   /**
-   * URL that can be used to copy a meeting invite to the Users clipboard.
-   */
-  meetingInvitationURL?: string;
-  /**
-   * Flags to enable/disable or customize UI elements of the {@link CallComposite}.
-   */
-  options?: MeetingCompositeOptions;
-};
-
-/**
- * Optional features of the {@link MeetingComposite}
- *
- * @beta
- */
-export type MeetingCompositeOptions = {
-  /**
    * Optimizes the composite UI for use on a mobile device.
    * @remarks This is currently only optimized for Portrait mode on mobile devices and does not support landscape.
    * @defaultValue false
    * @alpha
    */
   mobileView?: boolean;
+  /**
+   * URL that can be used to copy a meeting invite to the Users clipboard.
+   */
+  meetingInvitationURL?: string;
 };
 
 /**
@@ -103,7 +91,8 @@ export const MeetingComposite = (props: MeetingCompositeProps): JSX.Element => {
         <Stack horizontal grow>
           <Stack.Item grow>
             <CallComposite
-              options={{ callControls: false, mobileView: props.options?.mobileView }}
+              mobileView={props.mobileView}
+              options={{ callControls: false }}
               adapter={callAdapter}
               fluentTheme={fluentTheme}
             />
@@ -135,7 +124,7 @@ export const MeetingComposite = (props: MeetingCompositeProps): JSX.Element => {
             onChatButtonClicked={toggleChat}
             peopleButtonChecked={showPeople}
             onPeopleButtonClicked={togglePeople}
-            mobileView={props.options?.mobileView}
+            mobileView={props.mobileView ?? false}
             disableButtonsForLobbyPage={isInLobbyOrConnecting}
           />
         )}

--- a/packages/react-composites/tests/browser/call/app/index.tsx
+++ b/packages/react-composites/tests/browser/call/app/index.tsx
@@ -68,7 +68,7 @@ function App(): JSX.Element {
           <CallComposite
             adapter={callAdapter}
             locale={locale}
-            options={{ mobileView: isMobile() }}
+            mobileView={isMobile()}
             onFetchParticipantMenuItems={injectParticipantMenuItems ? onFetchParticipantMenuItems : undefined}
           />
         )}

--- a/packages/react-composites/tests/browser/meeting/app/index.tsx
+++ b/packages/react-composites/tests/browser/meeting/app/index.tsx
@@ -64,7 +64,7 @@ function App(): JSX.Element {
   return (
     <div style={{ position: 'fixed', width: '100%', height: '100%' }}>
       <_IdentifierProvider identifiers={IDS}>
-        {meetingAdapter && <MeetingComposite meetingAdapter={meetingAdapter} options={{ mobileView: isMobile() }} />}
+        {meetingAdapter && <MeetingComposite meetingAdapter={meetingAdapter} mobileView={isMobile()} />}
       </_IdentifierProvider>
     </div>
   );

--- a/packages/storybook/stories/CallComposite/BasicExample.stories.tsx
+++ b/packages/storybook/stories/CallComposite/BasicExample.stories.tsx
@@ -39,7 +39,8 @@ const BasicStory = (args, context): JSX.Element => {
           {...containerProps}
           callInvitationURL={args.callInvitationURL}
           locale={compositeLocale(locale)}
-          options={{ mobileView: args.mobileView, errorBar: args.errorBar }}
+          mobileView={args.mobileView}
+          options={{ errorBar: args.errorBar }}
         />
       ) : (
         <ConfigHintBanner />

--- a/packages/storybook/stories/CallComposite/CallCompositeDocs.tsx
+++ b/packages/storybook/stories/CallComposite/CallCompositeDocs.tsx
@@ -11,7 +11,7 @@ const customDataModelExampleContainerText =
   require('!!raw-loader!./snippets/CustomDataModelExampleContainer.snippet.tsx').default;
 
 const mobileViewSnippet = `
-<CallComposite options={{ mobileView: true }} />
+<CallComposite mobileView={true} />
 `;
 
 const cssSnippet = `

--- a/packages/storybook/stories/CallComposite/CustomDataModelExample.stories.tsx
+++ b/packages/storybook/stories/CallComposite/CustomDataModelExample.stories.tsx
@@ -40,7 +40,7 @@ const CustomDataModelStory = (args, context): JSX.Element => {
           {...containerProps}
           callInvitationURL={args.callInvitationURL}
           locale={compositeLocale(locale)}
-          options={{ mobileView: args.mobileView }}
+          mobileView={args.mobileView}
         />
       ) : (
         <ConfigHintBanner />

--- a/packages/storybook/stories/CallComposite/JoinExistingCall.stories.tsx
+++ b/packages/storybook/stories/CallComposite/JoinExistingCall.stories.tsx
@@ -29,7 +29,7 @@ const JoinExistingCallStory = (args, context): JSX.Element => {
           displayName={args.displayName}
           callInvitationURL={args.callInvitationURL}
           locale={compositeLocale(locale)}
-          options={{ mobileView: args.mobileView }}
+          mobileView={args.mobileView}
         />
       ) : (
         <ConfigJoinCallHintBanner />

--- a/packages/storybook/stories/CallComposite/ThemeExample.stories.tsx
+++ b/packages/storybook/stories/CallComposite/ThemeExample.stories.tsx
@@ -47,7 +47,7 @@ const ThemeExampleStory = (args, context): JSX.Element => {
           {...containerProps}
           callInvitationURL={args.callInvitationURL}
           locale={compositeLocale(locale)}
-          options={{ mobileView: args.mobileView }}
+          mobileView={args.mobileView}
         />
       ) : (
         <ConfigHintBanner />

--- a/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
@@ -14,6 +14,7 @@ export type ContainerProps = {
   token: string;
   locator: string;
   displayName: string;
+  mobileView?: boolean;
   fluentTheme?: PartialTheme | Theme;
   callInvitationURL?: string;
   locale?: CompositeLocale;
@@ -74,6 +75,7 @@ export const ContosoCallContainer = (props: ContainerProps): JSX.Element => {
       <div style={{ height: '90vh', width: '90vw' }}>
         <CallComposite
           adapter={adapter}
+          mobileView={props.mobileView}
           fluentTheme={props.fluentTheme}
           callInvitationUrl={props?.callInvitationURL}
           locale={props?.locale}

--- a/packages/storybook/stories/MeetingComposite/MeetingCompositeDocs.tsx
+++ b/packages/storybook/stories/MeetingComposite/MeetingCompositeDocs.tsx
@@ -8,7 +8,7 @@ const containerText = require('!!raw-loader!./snippets/Meeting.snippet.tsx').def
 const serverText = require('!!raw-loader!./snippets/Server.snippet.tsx').default;
 
 const mobileViewSnippet = `
-<MeetingComposite options={{ mobileView: true }} />
+<MeetingComposite mobileView={true} />
 `;
 
 export const getDocs: () => JSX.Element = () => {

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -16,7 +16,7 @@ import { useSwitchableFluentTheme } from '../theming/SwitchableFluentThemeProvid
 import { createAutoRefreshingCredential } from '../utils/credential';
 import MobileDetect from 'mobile-detect';
 
-const isMobileSession = !!new MobileDetect(window.navigator.userAgent).mobile();
+const detectMobileSession = (): boolean => !!new MobileDetect(window.navigator.userAgent).mobile();
 
 export interface CallScreenProps {
   token: string;
@@ -33,6 +33,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
   const callIdRef = useRef<string>();
   const adapterRef = useRef<CallAdapter>();
   const { currentTheme, currentRtl } = useSwitchableFluentTheme();
+  const [isMobileSession, setIsMobileSession] = useState<boolean>(detectMobileSession());
 
   useEffect(() => {
     if (!callIdRef.current) {
@@ -40,6 +41,13 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     }
     console.log(`Call Id: ${callIdRef.current}`);
   }, [callIdRef.current]);
+
+  // Whenever the sample is changed from desktop -> mobile using the emulator, make sure we update mobileView.
+  useEffect(() => {
+    const updateIsMobile = (): void => setIsMobileSession(detectMobileSession());
+    window.addEventListener('resize', updateIsMobile);
+    return window.removeEventListener('resize', updateIsMobile);
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -82,7 +90,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
       fluentTheme={currentTheme.theme}
       rtl={currentRtl}
       callInvitationUrl={window.location.href}
-      options={{ mobileView: isMobileSession }}
+      mobileView={isMobileSession}
     />
   );
 };

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -46,7 +46,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
   useEffect(() => {
     const updateIsMobile = (): void => setIsMobileSession(detectMobileSession());
     window.addEventListener('resize', updateIsMobile);
-    return window.removeEventListener('resize', updateIsMobile);
+    return () => window.removeEventListener('resize', updateIsMobile);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
# What
Move mobileView prop to top level (i.e. not a sub-prop inside options)

# Why
The likes of theme and locale are top level - so I think mobileView makes more sense here

# How Tested
Verified running sample locally