### PR TITLE
Alcail/removing chat/call samples display name length check

### DIFF
--- a/samples/Calling/src/app/views/DisplayNameField.tsx
+++ b/samples/Calling/src/app/views/DisplayNameField.tsx
@@ -5,29 +5,18 @@ import React from 'react';
 import { TextFieldStyleProps, inputBoxStyle, inputBoxTextStyle } from '../styles/DisplayNameField.styles';
 import { TextField } from '@fluentui/react';
 
-export const MAXIMUM_LENGTH_OF_NAME = 10;
 export const ENTER_KEY = 13;
 
 interface DisplayNameFieldProps {
   setName(displayName: string): void;
   setEmptyWarning?(isEmpty: boolean): void;
-  setNameLengthExceedLimit?(isNameLengthExceedLimit: boolean): void;
   isEmpty?: boolean;
-  isNameLengthExceedLimit?: boolean;
   defaultName?: string;
   validateName?(): void;
 }
 
 export const DisplayNameField = (props: DisplayNameFieldProps): JSX.Element => {
-  const {
-    setName,
-    setEmptyWarning,
-    setNameLengthExceedLimit,
-    isEmpty,
-    isNameLengthExceedLimit,
-    defaultName,
-    validateName
-  } = props;
+  const { setName, setEmptyWarning, isEmpty, defaultName, validateName } = props;
 
   const onNameTextChange = (
     event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -38,11 +27,8 @@ export const DisplayNameField = (props: DisplayNameFieldProps): JSX.Element => {
     setName(newValue);
     if (setEmptyWarning && !newValue) {
       setEmptyWarning(true);
-    } else if (setNameLengthExceedLimit && newValue.length > MAXIMUM_LENGTH_OF_NAME) {
-      setNameLengthExceedLimit(true);
     } else {
       setEmptyWarning && setEmptyWarning(false);
-      setNameLengthExceedLimit && setNameLengthExceedLimit(false);
     }
   };
 
@@ -62,9 +48,7 @@ export const DisplayNameField = (props: DisplayNameFieldProps): JSX.Element => {
         }
       }}
       styles={TextFieldStyleProps}
-      errorMessage={
-        isEmpty ? 'Name cannot be empty' : isNameLengthExceedLimit ? 'Name cannot be over 10 characters' : undefined
-      }
+      errorMessage={isEmpty ? 'Name cannot be empty' : undefined}
     />
   );
 };

--- a/samples/Calling/src/app/views/HomeScreen.tsx
+++ b/samples/Calling/src/app/views/HomeScreen.tsx
@@ -39,13 +39,12 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
   // Get display name from local storage if available
   const defaultDisplayName = localStorageAvailable ? getDisplayNameFromLocalStorage() : null;
   const [displayName, setDisplayName] = useState<string | undefined>(defaultDisplayName ?? undefined);
-  const [nameTooLongWarning, setNameTooLongWarning] = useState(false);
 
   const [chosenCallOption, setChosenCallOption] = useState<IChoiceGroupOption>(callOptions[0]);
   const [teamsLink, setTeamsLink] = useState<TeamsMeetingLinkLocator>();
 
   const teamsCallChosen: boolean = chosenCallOption.key === 'TeamsMeeting';
-  const buttonEnabled = displayName && !nameTooLongWarning && (!teamsCallChosen || teamsLink);
+  const buttonEnabled = displayName && (!teamsCallChosen || teamsLink);
 
   return (
     <Stack
@@ -80,12 +79,7 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
               />
             )}
           </Stack>
-          <DisplayNameField
-            defaultName={displayName}
-            setName={setDisplayName}
-            isNameLengthExceedLimit={nameTooLongWarning}
-            setNameLengthExceedLimit={setNameTooLongWarning}
-          />
+          <DisplayNameField defaultName={displayName} setName={setDisplayName} />
           <PrimaryButton
             disabled={!buttonEnabled}
             className={buttonStyle}

--- a/samples/Chat/src/app/ConfigurationScreen.tsx
+++ b/samples/Chat/src/app/ConfigurationScreen.tsx
@@ -36,8 +36,6 @@ import { joinThread } from './utils/joinThread';
 import { getEndpointUrl } from './utils/getEndpointUrl';
 import { checkThreadValid } from './utils/checkThreadValid';
 
-export const MAXIMUM_LENGTH_OF_NAME = 10;
-
 // These props are set by the caller of ConfigurationScreen in the JSX and not found in context
 export interface ConfigurationScreenProps {
   joinChatHandler(): void;
@@ -69,7 +67,6 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
   const initializeChatSpinnerLabel = 'Initializing chat client...';
   const [name, setName] = useState('');
   const [emptyWarning, setEmptyWarning] = useState(false);
-  const [isNameLengthExceedLimit, setNameLengthExceedLimit] = useState(false);
   const [selectedAvatar, setSelectedAvatar] = useState(CAT);
   const [configurationScreenState, setConfigurationScreenState] = useState<number>(
     CONFIGURATIONSCREEN_SHOWING_SPINNER_LOADING
@@ -130,13 +127,8 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
   const validateName = (): void => {
     if (!name) {
       setEmptyWarning(true);
-      setNameLengthExceedLimit(false);
-    } else if (name.length > MAXIMUM_LENGTH_OF_NAME) {
-      setEmptyWarning(false);
-      setNameLengthExceedLimit(true);
     } else {
       setEmptyWarning(false);
-      setNameLengthExceedLimit(false);
       setDisableJoinChatButton(true);
       setConfigurationScreenState(CONFIGURATIONSCREEN_SHOWING_SPINNER_INITIALIZE_CHAT);
       setupAndJoinChatThreadWithNewUser();
@@ -189,10 +181,8 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
           <DisplayNameField
             setName={setName}
             setEmptyWarning={setEmptyWarning}
-            setNameLengthExceedLimit={setNameLengthExceedLimit}
             validateName={validateName}
             isEmpty={emptyWarning}
-            isNameLengthExceedLimit={isNameLengthExceedLimit}
           />
           <PrimaryButton
             disabled={disableJoinChatButton}

--- a/samples/Chat/src/app/DisplayNameField.tsx
+++ b/samples/Chat/src/app/DisplayNameField.tsx
@@ -9,7 +9,7 @@ import {
   labelFontStyle,
   warningStyle
 } from './styles/DisplayNameField.styles';
-import { ENTER_KEY, MAXIMUM_LENGTH_OF_NAME } from './utils/constants';
+import { ENTER_KEY } from './utils/constants';
 
 import React from 'react';
 import { TextField } from '@fluentui/react';
@@ -17,23 +17,13 @@ import { TextField } from '@fluentui/react';
 interface DisplayNameFieldProps {
   setName(displayName: string): void;
   setEmptyWarning(isEmpty: boolean): void;
-  setNameLengthExceedLimit(isNameLengthExceedLimit: boolean): void;
   isEmpty: boolean;
-  isNameLengthExceedLimit: boolean;
   defaultName?: string;
   validateName?(): void;
 }
 
 const DisplayNameFieldComponent = (props: DisplayNameFieldProps): JSX.Element => {
-  const {
-    setName,
-    setEmptyWarning,
-    setNameLengthExceedLimit,
-    isEmpty,
-    isNameLengthExceedLimit,
-    defaultName,
-    validateName
-  } = props;
+  const { setName, setEmptyWarning, isEmpty, defaultName, validateName } = props;
 
   const onNameTextChange = (
     event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -44,11 +34,8 @@ const DisplayNameFieldComponent = (props: DisplayNameFieldProps): JSX.Element =>
     setName(newValue);
     if (!newValue) {
       setEmptyWarning(true);
-    } else if (newValue.length > MAXIMUM_LENGTH_OF_NAME) {
-      setNameLengthExceedLimit(true);
     } else {
       setEmptyWarning(false);
-      setNameLengthExceedLimit(false);
     }
   };
 
@@ -60,7 +47,7 @@ const DisplayNameFieldComponent = (props: DisplayNameFieldProps): JSX.Element =>
         defaultValue={defaultName}
         inputClassName={inputBoxTextStyle}
         ariaLabel="Choose your name"
-        className={isEmpty || isNameLengthExceedLimit ? inputBoxWarningStyle : inputBoxStyle}
+        className={isEmpty ? inputBoxWarningStyle : inputBoxStyle}
         onChange={onNameTextChange}
         id="displayName"
         placeholder="Enter your name"
@@ -75,11 +62,6 @@ const DisplayNameFieldComponent = (props: DisplayNameFieldProps): JSX.Element =>
             <div role="alert" className={warningStyle}>
               {' '}
               Name cannot be empty{' '}
-            </div>
-          ) : isNameLengthExceedLimit ? (
-            <div role="alert" className={warningStyle}>
-              {' '}
-              Name cannot be over 10 characters{' '}
             </div>
           ) : undefined
         }

--- a/samples/Chat/src/app/utils/constants.ts
+++ b/samples/Chat/src/app/utils/constants.ts
@@ -7,5 +7,4 @@ export enum StatusCode {
 }
 
 export const ENTER_KEY = 13;
-export const MAXIMUM_LENGTH_OF_NAME = 10;
 export const GUID_FOR_INITIAL_TOPIC_NAME = 'c774da81-94d5-4652-85c7-6ed0e8dc67e6';


### PR DESCRIPTION
# What
Removed the display name length check from our chat and call samples

# Why
bug https://skype.visualstudio.com/SPOOL/_workitems/edit/2641755
extended to Call sample

# How Tested
ran call and chat sample locally.
* Chat:
  ![image](https://user-images.githubusercontent.com/82416644/141863281-f9031c09-f476-4f6a-9b7f-cb541156e3bf.png)
* Call:
  ![image](https://user-images.githubusercontent.com/82416644/141863371-6c97d96d-d828-46af-8951-e396c7a758e0.png)
  ![image](https://user-images.githubusercontent.com/82416644/141863391-83e3176d-1992-4502-9be0-0f40bb1a1500.png)
  ![image](https://user-images.githubusercontent.com/82416644/141863429-b3e385f8-1a03-4fb3-aa8a-16ae6829426e.png)
  mobile view: 
    ![image](https://user-images.githubusercontent.com/82416644/141863841-9b87c874-69e5-4dc8-ae52-e4f30f93967f.png)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->