### PR TITLE
Update type trimming in GitHub actions for different releases

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -34,6 +34,15 @@ jobs:
       - name: Install dependencies
         run: rush install
 
+      # Update the types field in the package.json to use the untrimmed types file
+      - name: Update package.json types field is set to alpha
+        run: npm run update-types-field -- --rc alpha
+        working-directory: ./packages/communication-react
+      # Verify the types field in the package.json was updated successfully
+      - name: Verify package.json types field is set to alpha
+        run: npm run check-types-field -- --rc alpha
+        working-directory: ./packages/communication-react
+
       # Get datetime
       - name: Get datetime for alpha release name
         id: datetime

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -9,6 +9,9 @@ on:
         description: 'Branch or tag to create release from'
         required: true
         default: 'main'
+      release-type:
+        description: 'Release type. This must be public, beta, alpha'
+        required: true
 
 jobs:
   release:
@@ -25,6 +28,13 @@ jobs:
           # This machine account is only for this PAT, pwd was created and thrown away
           # If any update needed, create a new account, add access to the repo and generate a new PAT
           token: ${{ secrets.MACHINE_ACCOUNT_PAT }}
+
+      # Verify the github action workflow inputs are expected values
+      - name: Check release-type input
+        if: ${{ github.event.inputs.release-type != public && github.event.inputs.release-type != beta && github.event.inputs.release-type != alpha }}
+        run: |
+          echo 'Release type incorrect! It should be public, beta or alpha.'
+          exit(1)
 
       # Setup bot information for creating pull request
       # Here we use the id from the github actions bot: https://api.github.com/users/better-informatics%5Bbot%5D
@@ -66,6 +76,20 @@ jobs:
       # Important to check version consistency again after bumping versions.
       - name: Ensure all package versions are consistent
         run: rush ensure-consistent-versions
+
+      # Update the types field in the package.json
+      - name: Update package.json types field is set to public
+        if: ${{ github.event.inputs.release-type == public }}
+        run: npm run update-types-field -- --rc public
+        working-directory: ./packages/communication-react
+      - name: Update package.json types field is set to beta
+        if: ${{ github.event.inputs.release-type == beta }}
+        run: npm run update-types-field -- --rc beta
+        working-directory: ./packages/communication-react
+      - name: Update package.json types field is set to alpha
+        if: ${{ github.event.inputs.release-type == alpha }}
+        run: npm run update-types-field -- --rc alpha
+        working-directory: ./packages/communication-react
 
       # Retrieve new version to create branch with
       - name: Retrieve new version from package.json

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -79,6 +79,15 @@ jobs:
       - name: Install dependencies
         run: rush install
 
+      # Update the types field in the package.json to use the untrimmed types file
+      - name: Update package.json types field is set to alpha
+        run: npm run update-types-field -- --rc alpha
+        working-directory: ./packages/communication-react
+      # Verify the types field in the package.json was updated successfully
+      - name: Verify package.json types field is set to alpha
+        run: npm run check-types-field -- --rc alpha
+        working-directory: ./packages/communication-react
+
       # Get datetime
       - name: Get datetime for alpha release name
         id: datetime

--- a/.github/workflows/npm-release-publish.yml
+++ b/.github/workflows/npm-release-publish.yml
@@ -3,9 +3,12 @@ name: Release branch - Publish npm package
 on:
   workflow_dispatch:
     inputs:
+      release-type:
+        description: 'Release type. This must be public, beta, alpha'
+        required: true
       npm-tag:
         description: 'Npm tag for the release, e.g. latest, next, dev'
-        required: true
+        required: false
 
 jobs:
   publish:
@@ -26,11 +29,32 @@ jobs:
         with:
           node-version: '14.x'
 
+      # Verify the github action workflow inputs are expected values
+      - name: Check release-type input
+        if: ${{ github.event.inputs.release-type != public && github.event.inputs.release-type != beta && github.event.inputs.release-type != alpha }}
+        run: |
+          echo 'Release type incorrect! It should be public, beta or alpha.'
+          exit(1)
+
       # Install dependencies
       - name: Install rush
         run: npm install -g @microsoft/rush@5.47.0
       - name: Install dependencies
         run: rush install
+
+      # Verify the types field in the package.json is correct
+      - name: Verify package.json types field is set to public
+        if: ${{ github.event.inputs.release-type == public }}
+        run: npm run check-types-field -- --rc public
+        working-directory: ./packages/communication-react
+      - name: Verify package.json types field is set to beta
+        if: ${{ github.event.inputs.release-type == beta }}
+        run: npm run check-types-field -- --rc beta
+        working-directory: ./packages/communication-react
+      - name: Verify package.json types field is set to alpha
+        if: ${{ github.event.inputs.release-type == alpha }}
+        run: npm run check-types-field -- --rc alpha
+        working-directory: ./packages/communication-react
 
       # Builds
       - name: Build Packages and Samples

--- a/docs/references/release-checklist.md
+++ b/docs/references/release-checklist.md
@@ -6,6 +6,8 @@ Before we release a new version or beta version the following checklist should b
 
 * ✅ Package version updates
   * Ensure packages to be released have the correct version number
+* ✅ Package "types" field
+  * Ensure packages to be released have the correct "types" field in their respective package.json based on whether the release is public vs beta vs alpha
 * ✅ Release documentation
   * Ensure changelogs have been generated for the released packages
 * ✅ Manual and automated tests pass


### PR DESCRIPTION
# What
* Set the types field in the package.json based on the release type

# Why
Our releases releases a different subset of our untrimmed api based

# How Tested
TODO: will get feedback on actions first (testing CI actions takes a **long** time)