### PR TITLE
Add storybook doc note to highlight that landscape is unsupported when formfactor is mobile

### DIFF
--- a/change/@internal-storybook-9814385c-5de0-4f94-91c8-5cdd586ac211.json
+++ b/change/@internal-storybook-9814385c-5de0-4f94-91c8-5cdd586ac211.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding info message to storybook about unsupported landscape mode",
+  "packageName": "@internal/storybook",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/CallComposite/CallCompositeDocs.tsx
+++ b/packages/storybook/stories/CallComposite/CallCompositeDocs.tsx
@@ -2,7 +2,8 @@
 // Licensed under the MIT license.
 
 import { CallComposite } from '@azure/communication-react';
-import { Description, Heading, Props, Source, Title } from '@storybook/addon-docs';
+import { MessageBar } from '@fluentui/react';
+import { Description, Heading, Props, Source, Title, Canvas } from '@storybook/addon-docs';
 import React from 'react';
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 
@@ -68,6 +69,9 @@ export const getDocs: () => JSX.Element = () => {
         can be set at any time and immediately updates the composite UI to be optimized for a mobile device.
       </Description>
       <Source code={formFactorSnippet} />
+      <MessageBar>
+        Note: Only Protrait mode is supported when the `formFactor` is set to "mobile". Landscape mode is not supported.
+      </MessageBar>
       <Description>
         You can try out the form factor property in the [CallComposite Basic
         Example](./?path=/story/composites-call-basicexample--basic-example).

--- a/packages/storybook/stories/CallComposite/CallCompositeDocs.tsx
+++ b/packages/storybook/stories/CallComposite/CallCompositeDocs.tsx
@@ -63,10 +63,10 @@ export const getDocs: () => JSX.Element = () => {
       <Heading>Running in a Mobile browser</Heading>
       <Description>
         CallComposite by default is optimized for desktop views. To provide an optimized mobile experience, you may set
-        the `formFactor` property to `"mobile"`. Currently the mobile form factor only supports Portrait orientation and
-        not Landscape. The CallComposite does not detect if it is running on mobile device vs desktop, instead you must
-        identify if your clients device is a mobile device and set the `formFactor` property to `"mobile"`. This prop
-        can be set at any time and immediately updates the composite UI to be optimized for a mobile device.
+        the `formFactor` property to `"mobile"`. The CallComposite does not detect if it is running on mobile device vs
+        desktop, instead you must identify if your clients device is a mobile device and set the `formFactor` property
+        to `"mobile"`. This prop can be set at any time and immediately updates the composite UI to be optimized for a
+        mobile device.
       </Description>
       <Source code={formFactorSnippet} />
       <MessageBar>

--- a/packages/storybook/stories/MeetingComposite/MeetingCompositeDocs.tsx
+++ b/packages/storybook/stories/MeetingComposite/MeetingCompositeDocs.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { MessageBar } from '@fluentui/react';
 import { Title, Description, Heading, Source } from '@storybook/addon-docs';
 import React from 'react';
 
@@ -40,12 +41,15 @@ export const getDocs: () => JSX.Element = () => {
       <Heading>Running in a Mobile browser</Heading>
       <Description>
         MeetingComposite by default is optimized for desktop views. To provide an optimized mobile experience, you may
-        set the `formFactor` property to `"mobile"`. Currently the mobile form factor only supports Portrait orientation
-        and not Landscape. The MeetingComposite does not detect if it is running on mobile device vs desktop, instead
-        you must identify if your clients device is a mobile device and set the `formFactor` property to `"mobile"`.
-        This prop can be set at any time and immediately updates the composite UI to be optimized for a mobile device.
+        set the `formFactor` property to `"mobile"`. The MeetingComposite does not detect if it is running on mobile
+        device vs desktop, instead you must identify if your clients device is a mobile device and set the `formFactor`
+        property to `"mobile"`. This prop can be set at any time and immediately updates the composite UI to be
+        optimized for a mobile device.
       </Description>
       <Source code={formFactorSnippet} />
+      <MessageBar>
+        Note: Only Protrait mode is supported when the `formFactor` is set to "mobile". Landscape mode is not supported.
+      </MessageBar>
       <Description>
         You can try out the form factor property in the [MeetingComposite Basic
         Example](./?path=/story/composites-meeting-basicexample--basic-example).


### PR DESCRIPTION
# What
Add storybook doc note to highlight that landscape is unsupported when formfactor is mobile

![image](https://user-images.githubusercontent.com/9782747/142293287-4287e92d-0c87-440c-a8d0-f0f8d0cdf307.png)


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->