### PR TITLE
Fix "New Messages" button not disappearing when scrolling to the bottom of the message thread

### DIFF
--- a/change/@internal-react-components-c81978de-a215-42da-93ca-6f19ccb76f86.json
+++ b/change/@internal-react-components-c81978de-a215-42da-93ca-6f19ccb76f86.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix 'New Messages' not clearing when the user scrolls to the bottom of the message thread'",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -720,7 +720,6 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
         scrollToBottom();
       }
     }
-
     setIsAtBottomOfScrollRef(atBottom);
   }, [scrollToBottom, sendMessageStatusIfAtBottom]);
 

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -712,7 +712,7 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
     }
 
     const atBottom =
-      Math.floor(chatScrollDivRef.current.scrollTop) >=
+      Math.ceil(chatScrollDivRef.current.scrollTop) >=
       chatScrollDivRef.current.scrollHeight - chatScrollDivRef.current.clientHeight;
     if (atBottom) {
       sendMessageStatusIfAtBottom();
@@ -720,6 +720,7 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
         scrollToBottom();
       }
     }
+
     setIsAtBottomOfScrollRef(atBottom);
   }, [scrollToBottom, sendMessageStatusIfAtBottom]);
 


### PR DESCRIPTION
# What
Fix the math, if this repros for someone again we can add a tolerance here also.
Example of when this failed:
![image](https://user-images.githubusercontent.com/2684369/142495447-2c3c9f53-6294-4f8a-b7fe-545871ec80a9.png)

# Why
Scrolling to the bottom didn't always dismiss the New messages button:
![image](https://user-images.githubusercontent.com/2684369/142495482-ad959988-85fa-4f4c-bdc2-390491495191.png)

# How Tested
Storybook on web only - can no longer repro bug