### PR TITLE
Remove press hold gesture message thread

### DIFF
--- a/change/@internal-react-components-d0f8a112-6819-410e-a2fb-2455f3f3894d.json
+++ b/change/@internal-react-components-d0f8a112-6819-410e-a2fb-2455f3f3894d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove long press gesture on MessageThread messages",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -42,7 +42,6 @@
     "react-aria-live": "^2.0.5",
     "react-linkify": "^1.0.0-alpha",
     "reselect": "~4.0.0",
-    "use-long-press": "~1.1.1",
     "uuid": "^8.1.0"
   },
   "peerDependencies": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -34,8 +34,7 @@
     "@internal/acs-ui-common": "1.0.0-beta.8",
     "react-aria-live": "^2.0.5",
     "react-linkify": "^1.0.0-alpha",
-    "html-to-react": "~1.4.5",
-    "use-long-press": "~1.1.1"
+    "html-to-react": "~1.4.5"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <18.0.0",

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
@@ -33,63 +33,73 @@ export const ChatMessageComponentAsMessageBubble = (props: ChatMessageComponentA
   const { message, onRemoveClick, disableEditing, showDate, messageContainerStyle, strings, onEditClick } = props;
 
   // Track if the action menu was opened by touch - if so we increase the touch targets for the items
-  const wasInteractionByTouch = useRef(false);
+  const [wasInteractionByTouch, setWasInteractionByTouch] = useState(false);
 
-  // Track a reference to the action button as this is what the flyout targets
+  // The chat message action flyout should target the Chat.Message action menu if clicked,
+  // or target the chat message if opened via touch press.
+  // Undefined indicates the flyout menu should not be being shown.
+  const messageRef = useRef<HTMLDivElement | null>(null);
   const messageActionButtonRef = useRef<HTMLElement | null>(null);
+  const [chatMessageActionFlyoutTarget, setChatMessageActionFlyoutTarget] = useState<
+    React.MutableRefObject<HTMLElement | null> | undefined
+  >(undefined);
 
   const chatActionsEnabled = !disableEditing && message.status !== 'sending' && !!message.mine;
-  const [showActionFlyout, setShowActionFlyout] = useState(false);
 
-  const actionMenuProps = chatMessageActionMenuProps({
-    enabled: chatActionsEnabled,
-    menuButtonRef: messageActionButtonRef,
-    // Force show the action button while the flyout is open (otherwise this will dismiss when the pointer is hovered over the flyout)
-    forceShow: showActionFlyout,
-    onActionButtonClick: () => {
-      setShowActionFlyout(true);
-    },
-    theme
-  });
+  const actionMenuProps = wasInteractionByTouch
+    ? undefined
+    : chatMessageActionMenuProps({
+        enabled: chatActionsEnabled,
+        menuButtonRef: messageActionButtonRef,
+        // Force show the action button while the flyout is open (otherwise this will dismiss when the pointer is hovered over the flyout)
+        forceShow: chatMessageActionFlyoutTarget === messageActionButtonRef,
+        onActionButtonClick: () => {
+          // Open chat action flyout, and set the context menu to target the chat message action button
+          setChatMessageActionFlyoutTarget(messageActionButtonRef);
+        },
+        theme
+      });
 
   const onActionFlyoutDismiss = useCallback((): void => {
     // When the flyout dismiss is called, since we control if the action flyout is visible
     // or not we need to set the target to undefined here to actually hide the action flyout
-    setShowActionFlyout(false);
-  }, [setShowActionFlyout]);
+    setChatMessageActionFlyoutTarget(undefined);
+  }, [setChatMessageActionFlyoutTarget]);
 
   const chatMessage = (
     <>
-      <Chat.Message
-        className={mergeStyles(messageContainerStyle as IStyle)}
-        styles={messageContainerStyle}
-        content={<ChatMessageContent message={message} liveAuthorIntro={strings.liveAuthorIntro} />}
-        author={<Text className={chatMessageDateStyle}>{message.senderDisplayName}</Text>}
-        mine={message.mine}
-        timestamp={
-          <Text data-ui-id={ids.messageTimestamp}>
-            {message.createdOn
-              ? showDate
-                ? formatTimestampForChatMessage(message.createdOn, new Date(), strings)
-                : formatTimeForChatMessage(message.createdOn)
-              : undefined}
-          </Text>
-        }
-        details={
-          message.editedOn ? <div className={chatMessageEditedTagStyle(theme)}>{strings.editedTag}</div> : undefined
-        }
-        positionActionMenu={false}
-        actionMenu={actionMenuProps}
-        onTouchStart={() => (wasInteractionByTouch.current = true)}
-        onPointerDown={() => (wasInteractionByTouch.current = false)}
-        onKeyDown={() => (wasInteractionByTouch.current = false)}
-      />
-
+      <div ref={messageRef}>
+        <Chat.Message
+          className={mergeStyles(messageContainerStyle as IStyle)}
+          styles={messageContainerStyle}
+          content={<ChatMessageContent message={message} liveAuthorIntro={strings.liveAuthorIntro} />}
+          author={<Text className={chatMessageDateStyle}>{message.senderDisplayName}</Text>}
+          mine={message.mine}
+          timestamp={
+            <Text data-ui-id={ids.messageTimestamp}>
+              {message.createdOn
+                ? showDate
+                  ? formatTimestampForChatMessage(message.createdOn, new Date(), strings)
+                  : formatTimeForChatMessage(message.createdOn)
+                : undefined}
+            </Text>
+          }
+          details={
+            message.editedOn ? <div className={chatMessageEditedTagStyle(theme)}>{strings.editedTag}</div> : undefined
+          }
+          positionActionMenu={false}
+          actionMenu={actionMenuProps}
+          onTouchStart={() => setWasInteractionByTouch(true)}
+          onPointerDown={() => setWasInteractionByTouch(false)}
+          onKeyDown={() => setWasInteractionByTouch(false)}
+          onClick={() => wasInteractionByTouch && setChatMessageActionFlyoutTarget(messageRef)}
+        />
+      </div>
       {chatActionsEnabled && (
         <ChatMessageActionFlyout
-          hidden={!showActionFlyout}
-          target={messageActionButtonRef}
-          increaseFlyoutItemSize={wasInteractionByTouch.current}
+          hidden={!chatMessageActionFlyoutTarget}
+          target={chatMessageActionFlyoutTarget}
+          increaseFlyoutItemSize={wasInteractionByTouch}
           onDismiss={onActionFlyoutDismiss}
           onEditClick={onEditClick}
           onRemoveClick={onRemoveClick}

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
@@ -9,7 +9,6 @@ import { chatMessageEditedTagStyle, chatMessageDateStyle } from '../styles/ChatM
 import { formatTimeForChatMessage, formatTimestampForChatMessage } from '../utils/Datetime';
 import { useIdentifiers } from '../../identifiers/IdentifierProvider';
 import { useTheme } from '../../theming';
-import { useLongPress, LongPressDetectEvents } from 'use-long-press';
 import { ChatMessageActionFlyout } from './ChatMessageActionsFlyout';
 import { ChatMessageContent } from './ChatMessageContent';
 import { ChatMessage } from '../../types/ChatMessage';
@@ -33,95 +32,64 @@ export const ChatMessageComponentAsMessageBubble = (props: ChatMessageComponentA
 
   const { message, onRemoveClick, disableEditing, showDate, messageContainerStyle, strings, onEditClick } = props;
 
-  // Control when the chat message action button is allowed to show. It should show when hovered over, or when the
-  // chat message is navigated to via keyboard, but not on touch events.
-  const [allowChatActionButtonShow, setAllowChatActionButtonShow] = useState(true);
-
-  // The chat message action flyout should target the Chat.Message action menu if clicked,
-  // or target the chat message if opened via long touch press.
-  // Undefined indicates the action menu should not be being shown.
-  const messageRef = useRef<HTMLDivElement | null>(null);
-  const messageActionButtonRef = useRef<HTMLElement | null>(null);
-  const [chatMessageActionFlyoutTarget, setChatMessageActionFlyoutTarget] = useState<
-    React.MutableRefObject<HTMLElement | null> | undefined
-  >(undefined);
-
   // Track if the action menu was opened by touch - if so we increase the touch targets for the items
-  const actionFlyoutLastOpenedByTouch = useRef(false);
+  const wasInteractionByTouch = useRef(false);
+
+  // Track a reference to the action button as this is what the flyout targets
+  const messageActionButtonRef = useRef<HTMLElement | null>(null);
 
   const chatActionsEnabled = !disableEditing && message.status !== 'sending' && !!message.mine;
-  const actionMenuProps = chatMessageActionMenuProps({
-    enabled: chatActionsEnabled && allowChatActionButtonShow,
-    // Force show the action button while the flyout is open and targeting the action menu button
-    forceShow: chatMessageActionFlyoutTarget === messageActionButtonRef,
-    menuButtonRef: messageActionButtonRef,
-    onActionButtonClick: () => {
-      actionFlyoutLastOpenedByTouch.current = false;
+  const [showActionFlyout, setShowActionFlyout] = useState(false);
 
-      // Open chat action flyout, and set the context menu to target the chat message action button
-      setChatMessageActionFlyoutTarget(messageActionButtonRef);
+  const actionMenuProps = chatMessageActionMenuProps({
+    enabled: chatActionsEnabled,
+    menuButtonRef: messageActionButtonRef,
+    // Force show the action button while the flyout is open (otherwise this will dismiss when the pointer is hovered over the flyout)
+    forceShow: showActionFlyout,
+    onActionButtonClick: () => {
+      setShowActionFlyout(true);
     },
     theme
   });
 
-  const longTouchPressProps = useLongPress(
-    () => {
-      actionFlyoutLastOpenedByTouch.current = true;
-
-      // Open chat action flyout, and set the context menu to target the chat message
-      setChatMessageActionFlyoutTarget(messageRef);
-    },
-    {
-      // Don't show the action button when clicked via touch events
-      onStart: () => setAllowChatActionButtonShow(false),
-      // If the touch press didn't complete, allow the action menu to be shown on hover/focus again
-      onCancel: () => setAllowChatActionButtonShow(true),
-      captureEvent: true,
-      cancelOnMovement: true,
-      detect: LongPressDetectEvents.TOUCH
-    }
-  );
-
   const onActionFlyoutDismiss = useCallback((): void => {
     // When the flyout dismiss is called, since we control if the action flyout is visible
     // or not we need to set the target to undefined here to actually hide the action flyout
-    setChatMessageActionFlyoutTarget(undefined);
-    // Now the flyout has been dismissed, ensure that the action menu button is allowed to be shown.
-    // This was previously set to false when the flyout is opened via a touch event.
-    setAllowChatActionButtonShow(true);
-  }, [setAllowChatActionButtonShow, setChatMessageActionFlyoutTarget]);
+    setShowActionFlyout(false);
+  }, [setShowActionFlyout]);
 
   const chatMessage = (
     <>
-      <div ref={messageRef} {...longTouchPressProps}>
-        <Chat.Message
-          className={mergeStyles(messageContainerStyle as IStyle)}
-          styles={messageContainerStyle}
-          content={<ChatMessageContent message={message} liveAuthorIntro={strings.liveAuthorIntro} />}
-          author={<Text className={chatMessageDateStyle}>{message.senderDisplayName}</Text>}
-          mine={message.mine}
-          timestamp={
-            <Text data-ui-id={ids.messageTimestamp}>
-              {message.createdOn
-                ? showDate
-                  ? formatTimestampForChatMessage(message.createdOn, new Date(), strings)
-                  : formatTimeForChatMessage(message.createdOn)
-                : undefined}
-            </Text>
-          }
-          details={
-            message.editedOn ? <div className={chatMessageEditedTagStyle(theme)}>{strings.editedTag}</div> : undefined
-          }
-          positionActionMenu={false}
-          actionMenu={actionMenuProps}
-        />
-      </div>
+      <Chat.Message
+        className={mergeStyles(messageContainerStyle as IStyle)}
+        styles={messageContainerStyle}
+        content={<ChatMessageContent message={message} liveAuthorIntro={strings.liveAuthorIntro} />}
+        author={<Text className={chatMessageDateStyle}>{message.senderDisplayName}</Text>}
+        mine={message.mine}
+        timestamp={
+          <Text data-ui-id={ids.messageTimestamp}>
+            {message.createdOn
+              ? showDate
+                ? formatTimestampForChatMessage(message.createdOn, new Date(), strings)
+                : formatTimeForChatMessage(message.createdOn)
+              : undefined}
+          </Text>
+        }
+        details={
+          message.editedOn ? <div className={chatMessageEditedTagStyle(theme)}>{strings.editedTag}</div> : undefined
+        }
+        positionActionMenu={false}
+        actionMenu={actionMenuProps}
+        onTouchStart={() => (wasInteractionByTouch.current = true)}
+        onPointerDown={() => (wasInteractionByTouch.current = false)}
+        onKeyDown={() => (wasInteractionByTouch.current = false)}
+      />
 
       {chatActionsEnabled && (
         <ChatMessageActionFlyout
-          hidden={!chatMessageActionFlyoutTarget}
-          target={chatMessageActionFlyoutTarget}
-          increaseFlyoutItemSize={actionFlyoutLastOpenedByTouch.current}
+          hidden={!showActionFlyout}
+          target={messageActionButtonRef}
+          increaseFlyoutItemSize={wasInteractionByTouch.current}
           onDismiss={onActionFlyoutDismiss}
           onEditClick={onEditClick}
           onRemoveClick={onRemoveClick}


### PR DESCRIPTION
# What
Remove press hold gesture message thread - instead open context menu when the message is touch clicked

# Why
UX wasn't great

# How Tested
Storybook web only
Touch: 
![image](https://user-images.githubusercontent.com/2684369/142508534-2241da1d-2c61-49af-9d1f-2cba5ba7dab1.png)

Keyboard:
![image](https://user-images.githubusercontent.com/2684369/142508578-807fcf21-c949-4c02-8b34-b556c04b076b.png)

Mouse: 
![image](https://user-images.githubusercontent.com/2684369/142508612-8f232376-810f-4f7e-ae6e-1d5766a0e1d3.png)
