### PR TITLE
Wrap system messages that are too long

### DIFF
--- a/change/@internal-react-components-3b7d3c1d-edeb-44af-b63c-5fb2924ff2f4.json
+++ b/change/@internal-react-components-3b7d3c1d-edeb-44af-b63c-5fb2924ff2f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix text in system messages in the MessageThread to wrap when it is too long.",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/SystemMessage.tsx
+++ b/packages/react-components/src/components/SystemMessage.tsx
@@ -41,7 +41,7 @@ export const SystemMessage = (props: SystemMessageProps): JSX.Element => {
   return (
     <Stack horizontal className={mergeStyles(props?.containerStyle as IStyle)}>
       {Icon}
-      <span>{content}</span>
+      <span style={{ wordBreak: 'break-word' }}>{content}</span>
     </Stack>
   );
 };


### PR DESCRIPTION
# What
| before | after |
| -- | -- |
|![image](https://user-images.githubusercontent.com/2684369/142510265-4b6514bf-aaec-4691-a050-50cb19d5dad8.png) |![image](https://user-images.githubusercontent.com/2684369/142510228-c232f60e-f29f-47fb-afab-f51cda4101f4.png)|

# Why
Causes no bueno scrollbars

# How Tested
See above screenshots