### PR TITLE
ensure emoji background on chat sample are not transparent

### DIFF
--- a/samples/Chat/src/app/utils/utils.ts
+++ b/samples/Chat/src/app/utils/utils.ts
@@ -26,11 +26,11 @@ export const getBackgroundColor = (avatar: string): { backgroundColor: string } 
       };
     case MOUSE:
       return {
-        backgroundColor: 'rgb(33, 131, 196)'
+        backgroundColor: 'rgb(232, 242, 249)'
       };
     case KOALA:
       return {
-        backgroundColor: 'rgb(197, 179, 173)'
+        backgroundColor: 'rgb(237, 232, 230)'
       };
     case OCTOPUS:
       return {

--- a/samples/Chat/src/app/utils/utils.ts
+++ b/samples/Chat/src/app/utils/utils.ts
@@ -22,31 +22,31 @@ export const getBackgroundColor = (avatar: string): { backgroundColor: string } 
   switch (avatar) {
     case CAT:
       return {
-        backgroundColor: 'rgba(255, 250, 228, 1)'
+        backgroundColor: 'rgb(255, 250, 228,)'
       };
     case MOUSE:
       return {
-        backgroundColor: 'rgba(33, 131, 196, 0.1)'
+        backgroundColor: 'rgb(33, 131, 196)'
       };
     case KOALA:
       return {
-        backgroundColor: 'rgba(197, 179, 173, 0.3)'
+        backgroundColor: 'rgb(197, 179, 173)'
       };
     case OCTOPUS:
       return {
-        backgroundColor: 'rgba(255, 240, 245, 1)'
+        backgroundColor: 'rgb(255, 240, 245)'
       };
     case MONKEY:
       return {
-        backgroundColor: 'rgba(255, 245, 222, 1)'
+        backgroundColor: 'rgb(255, 245, 222)'
       };
     case FOX:
       return {
-        backgroundColor: 'rgba(255, 231, 205, 1)'
+        backgroundColor: 'rgb(255, 231, 205)'
       };
     default:
       return {
-        backgroundColor: 'rgba(255, 250, 228, 1)'
+        backgroundColor: 'rgb(255, 250, 228)'
       };
   }
 };

--- a/samples/Chat/src/app/utils/utils.ts
+++ b/samples/Chat/src/app/utils/utils.ts
@@ -22,7 +22,7 @@ export const getBackgroundColor = (avatar: string): { backgroundColor: string } 
   switch (avatar) {
     case CAT:
       return {
-        backgroundColor: 'rgb(255, 250, 228,)'
+        backgroundColor: 'rgb(255, 250, 228)'
       };
     case MOUSE:
       return {


### PR DESCRIPTION
# What
* ensure emoji background on chat sample are not transparent

# Why
Ultra low-hanging fruit bug

# How Tested
Ran chat sample locally
![image](https://user-images.githubusercontent.com/2684369/142536731-9a558859-94b8-445f-8e61-24ee05c75d3b.png)
