### PR TITLE
Chat sample - Config page - a11y label issue on display name TextField

### DIFF
--- a/samples/Chat/src/app/ConfigurationScreen.tsx
+++ b/samples/Chat/src/app/ConfigurationScreen.tsx
@@ -53,6 +53,16 @@ const CONFIGURATIONSCREEN_SHOWING_JOIN_CHAT = 2;
 const CONFIGURATIONSCREEN_SHOWING_INVALID_THREAD = 3;
 const CONFIGURATIONSCREEN_SHOWING_SPINNER_INITIALIZE_CHAT = 4;
 
+const ALERT_TEXT_TRY_AGAIN = "You can't be added at this moment. Please wait at least 60 seconds to try again.";
+const AVATAR_LABEL = 'Avatar';
+const ERROR_TEXT_THREAD_INVALID = 'Thread Id is not valid, please revisit home page to create a new thread';
+const ERROR_TEXT_THREAD_NOT_RECORDED = 'Thread id is not recorded in server';
+const ERROR_TEXT_THREAD_NULL = 'Thread id is null';
+const INITIALIZE_CHAT_SPINNER_LABEL = 'Initializing chat client...';
+const JOIN_BTN_TEXT = 'Join chat';
+const LOADING_SPINNER_LABEL = 'Loading...';
+const NAME_DEFAULT = 'Name';
+
 /**
  * There are four states of ConfigurationScreen.
  * 1. Loading configuration screen state. This will show 'loading' spinner on the screen.
@@ -64,8 +74,6 @@ const CONFIGURATIONSCREEN_SHOWING_SPINNER_INITIALIZE_CHAT = 4;
  */
 export default (props: ConfigurationScreenProps): JSX.Element => {
   const avatarsList = [CAT, MOUSE, KOALA, OCTOPUS, MONKEY, FOX];
-  const loadingSpinnerLabel = 'Loading...';
-  const initializeChatSpinnerLabel = 'Initializing chat client...';
   const [name, setName] = useState('');
   const [emptyWarning, setEmptyWarning] = useState(false);
   const [selectedAvatar, setSelectedAvatar] = useState(CAT);
@@ -84,7 +92,7 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
       const endpointUrl = await getEndpointUrl();
 
       if (!threadId) {
-        throw new Error('Thread id is null');
+        throw new Error(ERROR_TEXT_THREAD_NULL);
       }
 
       setToken(token.token);
@@ -97,7 +105,7 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
 
       const result = await joinThread(threadId, token.identity, name);
       if (!result) {
-        alert("You can't be added at this moment. Please wait at least 60 seconds to try again.");
+        alert(ALERT_TEXT_TRY_AGAIN);
         setDisableJoinChatButton(false);
         return;
       }
@@ -114,7 +122,7 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
         try {
           const threadId = getThreadId();
           if (!(await checkThreadValid(threadId))) {
-            throw new Error('Thread id is not recorded in server');
+            throw new Error(ERROR_TEXT_THREAD_NOT_RECORDED);
           }
         } catch (error) {
           setConfigurationScreenState(CONFIGURATIONSCREEN_SHOWING_INVALID_THREAD);
@@ -162,22 +170,36 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
         tokens={responsiveLayoutStackTokens}
         className={responsiveLayoutStyle}
       >
-        <Stack className={leftPreviewContainerStyle} tokens={leftPreviewContainerStackTokens}>
+        <Stack
+          role={'heading'}
+          aria-level={1}
+          className={leftPreviewContainerStyle}
+          tokens={leftPreviewContainerStackTokens}
+        >
           <div className={largeAvatarContainerStyle(selectedAvatar)}>
-            <div className={largeAvatarStyle}>{selectedAvatar}</div>
+            <div aria-label={`${selectedAvatar} avatar`} className={largeAvatarStyle}>
+              {selectedAvatar}
+            </div>
           </div>
-          <Text className={namePreviewStyle(name !== '')}>{name !== '' ? name : 'Name'}</Text>
+          <Text className={namePreviewStyle(name !== '')}>{name !== '' ? name : NAME_DEFAULT}</Text>
         </Stack>
         <Stack className={rightInputContainerStyle} tokens={rightInputContainerStackTokens}>
-          <Text className={labelFontStyle}>Avatar</Text>
+          <Text id={'avatar-list-label'} className={labelFontStyle}>
+            {AVATAR_LABEL}
+          </Text>
           <FocusZone direction={FocusZoneDirection.horizontal}>
-            <Stack role="list" horizontal className={avatarListContainerStyle} tokens={avatarListContainerStackTokens}>
+            <Stack
+              horizontal
+              className={avatarListContainerStyle}
+              tokens={avatarListContainerStackTokens}
+              role="list"
+              aria-labelledby={'avatar-list-label'}
+            >
               {avatarsList.map((avatar, index) => (
                 <div
                   role="listitem"
                   id={avatar}
                   key={index}
-                  tabIndex={0}
                   data-is-focusable={true}
                   className={smallAvatarContainerClassName(avatar)}
                   onClick={() => onAvatarChange(avatar)}
@@ -197,7 +219,7 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
             disabled={disableJoinChatButton}
             className={buttonStyle}
             styles={buttonWithIconStyles}
-            text={'Join chat'}
+            text={JOIN_BTN_TEXT}
             onClick={validateName}
             onRenderIcon={() => <Chat20Filled className={chatIconStyle} />}
           />
@@ -209,7 +231,7 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
   const displayInvalidThreadError = (): JSX.Element => {
     return (
       <div>
-        <p>Thread Id is not valid, please revisit home page to create a new thread</p>
+        <p>{ERROR_TEXT_THREAD_INVALID}</p>
       </div>
     );
   };
@@ -223,13 +245,13 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
   };
 
   if (configurationScreenState === CONFIGURATIONSCREEN_SHOWING_SPINNER_LOADING) {
-    return displaySpinner(loadingSpinnerLabel);
+    return displaySpinner(LOADING_SPINNER_LABEL);
   } else if (configurationScreenState === CONFIGURATIONSCREEN_SHOWING_JOIN_CHAT) {
     return displayWithStack(displayJoinChatArea());
   } else if (configurationScreenState === CONFIGURATIONSCREEN_SHOWING_INVALID_THREAD) {
     return displayWithStack(displayInvalidThreadError());
   } else if (configurationScreenState === CONFIGURATIONSCREEN_SHOWING_SPINNER_INITIALIZE_CHAT) {
-    return displaySpinner(initializeChatSpinnerLabel);
+    return displaySpinner(INITIALIZE_CHAT_SPINNER_LABEL);
   } else {
     throw new Error('configuration screen state ' + configurationScreenState.toString() + ' is invalid');
   }

--- a/samples/Chat/src/app/ConfigurationScreen.tsx
+++ b/samples/Chat/src/app/ConfigurationScreen.tsx
@@ -59,7 +59,7 @@ const ERROR_TEXT_THREAD_INVALID = 'Thread Id is not valid, please revisit home p
 const ERROR_TEXT_THREAD_NOT_RECORDED = 'Thread id is not recorded in server';
 const ERROR_TEXT_THREAD_NULL = 'Thread id is null';
 const INITIALIZE_CHAT_SPINNER_LABEL = 'Initializing chat client...';
-const JOIN_BTN_TEXT = 'Join chat';
+const JOIN_BUTTON_TEXT = 'Join chat';
 const LOADING_SPINNER_LABEL = 'Loading...';
 const NAME_DEFAULT = 'Name';
 
@@ -219,7 +219,7 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
             disabled={disableJoinChatButton}
             className={buttonStyle}
             styles={buttonWithIconStyles}
-            text={JOIN_BTN_TEXT}
+            text={JOIN_BUTTON_TEXT}
             onClick={validateName}
             onRenderIcon={() => <Chat20Filled className={chatIconStyle} />}
           />

--- a/samples/Chat/src/app/DisplayNameField.tsx
+++ b/samples/Chat/src/app/DisplayNameField.tsx
@@ -1,14 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  TextFieldStyleProps,
-  inputBoxStyle,
-  inputBoxTextStyle,
-  inputBoxWarningStyle,
-  labelFontStyle,
-  warningStyle
-} from './styles/DisplayNameField.styles';
+import { TextFieldStyleProps, inputBoxStyle, inputBoxTextStyle } from './styles/DisplayNameField.styles';
 import { ENTER_KEY } from './utils/constants';
 
 import React from 'react';
@@ -21,6 +14,11 @@ interface DisplayNameFieldProps {
   defaultName?: string;
   validateName?(): void;
 }
+
+const TEXTFIELD_LABEL = 'Name';
+const TEXTFIELD_ID = 'displayName';
+const TEXTFIELD_PLACEHOLDER = 'Enter your name';
+const TEXTFIELD_EMPTY_ERROR_MSG = 'Name cannot be empty';
 
 const DisplayNameFieldComponent = (props: DisplayNameFieldProps): JSX.Element => {
   const { setName, setEmptyWarning, isEmpty, defaultName, validateName } = props;
@@ -40,33 +38,23 @@ const DisplayNameFieldComponent = (props: DisplayNameFieldProps): JSX.Element =>
   };
 
   return (
-    <div>
-      <div className={labelFontStyle}>Name</div>
-      <TextField
-        autoComplete="off"
-        defaultValue={defaultName}
-        inputClassName={inputBoxTextStyle}
-        ariaLabel="Choose your name"
-        className={isEmpty ? inputBoxWarningStyle : inputBoxStyle}
-        onChange={onNameTextChange}
-        id="displayName"
-        placeholder="Enter your name"
-        onKeyDown={(ev) => {
-          if (ev.which === ENTER_KEY) {
-            validateName && validateName();
-          }
-        }}
-        styles={TextFieldStyleProps}
-        errorMessage={
-          isEmpty ? (
-            <div role="alert" className={warningStyle}>
-              {' '}
-              Name cannot be empty{' '}
-            </div>
-          ) : undefined
+    <TextField
+      autoComplete="off"
+      defaultValue={defaultName}
+      inputClassName={inputBoxTextStyle}
+      label={TEXTFIELD_LABEL}
+      className={inputBoxStyle}
+      onChange={onNameTextChange}
+      id={TEXTFIELD_ID}
+      placeholder={TEXTFIELD_PLACEHOLDER}
+      onKeyDown={(ev) => {
+        if (ev.which === ENTER_KEY) {
+          validateName && validateName();
         }
-      />
-    </div>
+      }}
+      styles={TextFieldStyleProps}
+      errorMessage={isEmpty ? TEXTFIELD_EMPTY_ERROR_MSG : undefined}
+    />
   );
 };
 

--- a/samples/Chat/src/app/styles/DisplayNameField.styles.ts
+++ b/samples/Chat/src/app/styles/DisplayNameField.styles.ts
@@ -11,6 +11,7 @@ export const TextFieldStyleProps = {
 
 export const inputBoxStyle = mergeStyles({
   boxSizing: 'border-box',
+  width: '18.75rem',
   borderRadius: '0.125rem'
 });
 

--- a/samples/Chat/src/app/styles/DisplayNameField.styles.ts
+++ b/samples/Chat/src/app/styles/DisplayNameField.styles.ts
@@ -4,9 +4,6 @@
 import { mergeStyles } from '@fluentui/react';
 
 export const TextFieldStyleProps = {
-  wrapper: {
-    height: '2.3rem'
-  },
   fieldGroup: {
     height: '2.3rem'
   }
@@ -14,8 +11,6 @@ export const TextFieldStyleProps = {
 
 export const inputBoxStyle = mergeStyles({
   boxSizing: 'border-box',
-  height: '2.5rem',
-  width: '18.75rem',
   borderRadius: '0.125rem'
 });
 
@@ -35,34 +30,4 @@ export const inputBoxTextStyle = mergeStyles({
     fontSize: '0.875rem',
     fontWeight: 600
   }
-});
-
-export const inputBoxWarningStyle = mergeStyles({
-  boxSizing: 'border-box',
-  height: '2.5rem',
-  width: '18.75rem',
-  borderRadius: '2px',
-  fontSize: '0.875rem'
-});
-
-export const labelFontStyle = mergeStyles({
-  fontSize: '0.875rem',
-  fontWeight: 600,
-  boxSizing: 'border-box',
-  boxShadow: 'none',
-  margin: 0,
-  display: 'inline-block',
-  padding: '5px 0px',
-  overflowWrap: 'break-word'
-});
-
-export const warningStyle = mergeStyles({
-  width: '18.75rem',
-  marginTop: '0.188rem',
-  marginBottom: '0.188rem',
-  marginLeft: '0.188rem',
-  color: '#e81123',
-  fontSize: '.7375rem',
-  fontWeight: '400',
-  position: 'absolute'
 });


### PR DESCRIPTION
# What
* updated text field label of Configuration page of Chat sample to be a prop of this component and not a separated text so now the narrator can read it properly
* added page heading and aria-label to Avatar list so Narrator announce what the list is for

No visual change
![image](https://user-images.githubusercontent.com/82416644/142575587-760fd5f7-611b-4f9b-9084-0ed63b1f146d.png)

# Why
bug https://skype.visualstudio.com/SPOOL/_workitems/edit/2583860

# How Tested
ran sample Chat locally and used Narrator

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->