### PR TITLE
Added identity quickstart to composite initiate screens

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "markdownlint.config": {
+    "MD028": false,
+    "MD025": {
+      "front_matter_title": ""
+    }
+  }
+}

--- a/change/@internal-storybook-302bde39-d6aa-4a54-b5d8-95512a648cf1.json
+++ b/change/@internal-storybook-302bde39-d6aa-4a54-b5d8-95512a648cf1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "added link to quickstart to get identities/tokens",
+  "packageName": "@internal/storybook",
+  "email": "dademath@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/CallComposite/snippets/Utils.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/Utils.tsx
@@ -2,15 +2,25 @@
 // Licensed under the MIT license.
 
 import React from 'react';
-import { CompositeConnectionParamsErrMessage } from '../../CompositeStringUtils';
+import { CompositeConnectionParamsErrMessage, CreateIdentityLink } from '../../CompositeStringUtils';
 
 export const ConfigHintBanner = (): JSX.Element => {
   const emptyConfigTips = 'Please provide an access token, userId and display name to use.';
-  return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;
+  return (
+    <>
+      {CompositeConnectionParamsErrMessage([emptyConfigTips])}
+      {CreateIdentityLink()}
+    </>
+  );
 };
 
 export const ConfigJoinCallHintBanner = (): JSX.Element => {
   const emptyConfigTips =
     'Please provide an access token, userId, display name, and a group call Id (or a teams meeting link).';
-  return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;
+  return (
+    <>
+      {CompositeConnectionParamsErrMessage([emptyConfigTips])}
+      {CreateIdentityLink()}
+    </>
+  );
 };

--- a/packages/storybook/stories/ChatComposite/snippets/Utils.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/Utils.tsx
@@ -5,7 +5,7 @@ import { ChatClient } from '@azure/communication-chat';
 import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from '@azure/communication-common';
 import React from 'react';
 
-import { CompositeConnectionParamsErrMessage } from '../../CompositeStringUtils';
+import { CompositeConnectionParamsErrMessage, CreateIdentityLink } from '../../CompositeStringUtils';
 
 // Adds a bot to the thread that sends out provided canned messages one by one.
 export const addParrotBotToThread = async (
@@ -51,12 +51,22 @@ const sendMessagesAsBot = async (
 export const ConfigHintBanner = (): JSX.Element => {
   const emptyConfigTips =
     'Please provide an access token, userId for each participant, endpointUrl and display name to use.';
-  return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;
+  return (
+    <>
+      {CompositeConnectionParamsErrMessage([emptyConfigTips])}
+      {CreateIdentityLink()}
+    </>
+  );
 };
 
 export const ConfigJoinChatThreadHintBanner = (): JSX.Element => {
   const emptyConfigTips = 'Please provide an access token, userId, thread id, endpoint url, and display name to use.';
-  return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;
+  return (
+    <>
+      {CompositeConnectionParamsErrMessage([emptyConfigTips])}
+      {CreateIdentityLink()}
+    </>
+  );
 };
 
 export type ChatCompositeSetupProps = {

--- a/packages/storybook/stories/CompositeStringUtils.tsx
+++ b/packages/storybook/stories/CompositeStringUtils.tsx
@@ -13,3 +13,13 @@ export const CompositeConnectionParamsErrMessage = (errors: string[]): JSX.Eleme
     })}
   </>
 );
+
+export const CreateIdentityLink = (): JSX.Element => {
+  const identityLink =
+    'https://docs.microsoft.com/azure/communication-services/quickstarts/identity/quick-create-identity';
+  return (
+    <>
+      <a href={identityLink}>Refer to our documentation for generating test identities and tokens.</a>
+    </>
+  );
+};

--- a/packages/storybook/stories/MeetingComposite/Utils.tsx
+++ b/packages/storybook/stories/MeetingComposite/Utils.tsx
@@ -2,15 +2,25 @@
 // Licensed under the MIT license.
 
 import React from 'react';
-import { CompositeConnectionParamsErrMessage } from '../CompositeStringUtils';
+import { CompositeConnectionParamsErrMessage, CreateIdentityLink } from '../CompositeStringUtils';
 
 export const ConfigHintBanner = (): JSX.Element => {
   const emptyConfigTips = 'Please provide an access token, userId, endpointUrl and display name to use.';
-  return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;
+  return (
+    <>
+      {CompositeConnectionParamsErrMessage([emptyConfigTips])}
+      {CreateIdentityLink()}
+    </>
+  );
 };
 
 export const ConfigJoinMeetingHintBanner = (): JSX.Element => {
   const emptyConfigTips =
     'Please provide the an access token, userId, endpointUrl, display name, and teams meeting link.';
-  return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;
+  return (
+    <>
+      {CompositeConnectionParamsErrMessage([emptyConfigTips])}
+      {CreateIdentityLink()}
+    </>
+  );
 };


### PR DESCRIPTION
# What
Added links to composite screens to point to identity quickstarts

# Why
Today developers don't necessarily know what to do when it comes to getting tokens to initiate the composites.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->