### PR TITLE
Alkwa/update feedback section

### DIFF
--- a/change/@internal-storybook-c7f69b9d-5b83-4d4b-8a84-4e23400621dd.json
+++ b/change/@internal-storybook-c7f69b9d-5b83-4d4b-8a84-4e23400621dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "removing uservoice entry in feedback and updating Microsoft QA to Microsoft Q&A",
+  "packageName": "@internal/storybook",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/Feedback.stories.mdx
+++ b/packages/storybook/stories/Feedback.stories.mdx
@@ -19,12 +19,7 @@ To help us get to your issue faster use the GitHub labels provided.
 A team member will look to help out with outstanding issues and navigate them to the right owner.
 Issues on this repo should only be related to the UI Library. Issues for Azure Communication Services generally should be added to the main [repo](https://github.com/Azure/communication).
 
-## Microsoft QA
+## Microsoft Q&A
 
-For any questions on UI Library or Azure Communication Services, use [Microsoft QA](https://docs.microsoft.com/answers/topics/azure-communication-services.html).
+For any questions on UI Library or Azure Communication Services, use [Microsoft Q&A](https://docs.microsoft.com/answers/topics/azure-communication-services.html).
 There use the tag `azure-communication-services` for the question to be funneled to our team.
-
-## UserVoice
-
-For feedback on the UI Library or Azure Communication Services, use [UserVoice](https://feedback.azure.com/forums/934536-azure-communication-services).
-Make sure to use the Azure Communication Services UserVoice and use the category `UI Library` so that its indexed correctly.


### PR DESCRIPTION
# What
Updating the feedback section with some corrections we found during User testing

Before:
![image](https://user-images.githubusercontent.com/79329532/143080923-18ce7d53-b4d6-4fac-9b39-2f697ea9e86f.png)
After:
![image](https://user-images.githubusercontent.com/79329532/143080982-3d11805f-eb7a-4b23-97e1-ad69aba5ad49.png)


# Why
UserVoice is being replaced with Microsoft Q&A. We also wanted to make sure we are communicating out Microsoft Q&A and not Microsoft QA

# How Tested
Ran it locally