### PR TITLE
fix security issue on incomplete string encoding

### DIFF
--- a/change/@internal-storybook-05a1606e-de4e-4508-a60b-0581adc5578e.json
+++ b/change/@internal-storybook-05a1606e-de4e-4508-a60b-0581adc5578e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix security issue on incomplete string encoding",
+  "packageName": "@internal/storybook",
+  "email": "alcail@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/MeetingComposite/snippets/Server.snippet.tsx
+++ b/packages/storybook/stories/MeetingComposite/snippets/Server.snippet.tsx
@@ -9,7 +9,7 @@ const getChatThreadFromTeamsLink = (teamsMeetingLink: string): string => {
   // Get the threadId from the url - this also contains the call locator ID that will be removed in the threadId.split
   let threadId = teamsMeetingLink.replace('https://teams.microsoft.com/l/meetup-join/', '');
   // Decode characters that outlook links encode
-  threadId = threadId.replaceAll('%3a', ':').replace('%40', '@');
+  threadId = threadId.replaceAll('%3a', ':').replaceAll('%40', '@');
   // Extract just the chat guid from the link, stripping away the call locator ID
   threadId = threadId.split(/^(.*?@thread\.v2)/gm)[1];
 


### PR DESCRIPTION
# What
Replacing all occurrences of '%40' in thread ID and not just the first one

# Why
issue: https://github.com/Azure/communication-ui-library/security/code-scanning/7?query=ref%3Arefs%2Fheads%2Fmain

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->