### PR TITLE
set default composite display name in Storybook

### DIFF
--- a/change/@internal-storybook-d213f68d-8259-4efc-99e0-099e65c9dff5.json
+++ b/change/@internal-storybook-d213f68d-8259-4efc-99e0-099e65c9dff5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "set default composite display name in Storybook",
+  "packageName": "@internal/storybook",
+  "email": "alcail@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/CallComposite/__snapshots__/BasicExample.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/BasicExample.stories.storyshot
@@ -34,8 +34,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Basic Exam
             >
               access token, userId
             </a>
-             
-            and display name to use.
+            .
           </p>
         </span>
       </div>

--- a/packages/storybook/stories/CallComposite/__snapshots__/CustomDataModelExample.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/CustomDataModelExample.stories.storyshot
@@ -34,8 +34,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Custom Dat
             >
               access token, userId
             </a>
-             
-            and display name to use.
+            .
           </p>
         </span>
       </div>

--- a/packages/storybook/stories/CallComposite/__snapshots__/ThemeExample.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/ThemeExample.stories.storyshot
@@ -34,8 +34,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Theme Exam
             >
               access token, userId
             </a>
-             
-            and display name to use.
+            .
           </p>
         </span>
       </div>

--- a/packages/storybook/stories/CallComposite/snippets/Utils.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/Utils.tsx
@@ -11,8 +11,8 @@ export const ConfigHintBanner = (): JSX.Element => {
       Please provide an{' '}
       <a href={MICROSOFT_AZURE_ACCESS_TOKEN_QUICKSTART} target="_blank" rel="noreferrer">
         access token, userId
-      </a>{' '}
-      and display name to use.
+      </a>
+      .
     </p>
   );
   return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;

--- a/packages/storybook/stories/ChatComposite/__snapshots__/BasicExample.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/BasicExample.stories.storyshot
@@ -24,19 +24,24 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Basic Exam
         className="ms-Stack css-1"
       >
         <span>
-          <p>
-            Please provide an
-             
-            <a
-              href="https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/identity/quick-create-identity"
-              rel="noreferrer"
-              target="_blank"
-            >
-              access token, userId
-            </a>
-             
-            for each participant, endpointUrl and display name to use.
-          </p>
+          <div>
+            <p>
+              Please provide an
+               
+              <a
+                href="https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/identity/quick-create-identity"
+                rel="noreferrer"
+                target="_blank"
+              >
+                access token, userId
+              </a>
+               
+              for each participant, endpointUrl and display name to use.
+            </p>
+            <p>
+              A display name has already been set by default, but feel free to change it.
+            </p>
+          </div>
         </span>
       </div>
     </div>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/CustomBehavior.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/CustomBehavior.stories.storyshot
@@ -24,19 +24,24 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Beh
         className="ms-Stack css-1"
       >
         <span>
-          <p>
-            Please provide an
-             
-            <a
-              href="https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/identity/quick-create-identity"
-              rel="noreferrer"
-              target="_blank"
-            >
-              access token, userId
-            </a>
-             
-            for each participant, endpointUrl and display name to use.
-          </p>
+          <div>
+            <p>
+              Please provide an
+               
+              <a
+                href="https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/identity/quick-create-identity"
+                rel="noreferrer"
+                target="_blank"
+              >
+                access token, userId
+              </a>
+               
+              for each participant, endpointUrl and display name to use.
+            </p>
+            <p>
+              A display name has already been set by default, but feel free to change it.
+            </p>
+          </div>
         </span>
       </div>
     </div>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/CustomDataModelExample.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/CustomDataModelExample.stories.storyshot
@@ -24,19 +24,24 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Dat
         className="ms-Stack css-1"
       >
         <span>
-          <p>
-            Please provide an
-             
-            <a
-              href="https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/identity/quick-create-identity"
-              rel="noreferrer"
-              target="_blank"
-            >
-              access token, userId
-            </a>
-             
-            for each participant, endpointUrl and display name to use.
-          </p>
+          <div>
+            <p>
+              Please provide an
+               
+              <a
+                href="https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/identity/quick-create-identity"
+                rel="noreferrer"
+                target="_blank"
+              >
+                access token, userId
+              </a>
+               
+              for each participant, endpointUrl and display name to use.
+            </p>
+            <p>
+              A display name has already been set by default, but feel free to change it.
+            </p>
+          </div>
         </span>
       </div>
     </div>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/ThemesExample.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/ThemesExample.stories.storyshot
@@ -24,19 +24,24 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Theme Exam
         className="ms-Stack css-1"
       >
         <span>
-          <p>
-            Please provide an
-             
-            <a
-              href="https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/identity/quick-create-identity"
-              rel="noreferrer"
-              target="_blank"
-            >
-              access token, userId
-            </a>
-             
-            for each participant, endpointUrl and display name to use.
-          </p>
+          <div>
+            <p>
+              Please provide an
+               
+              <a
+                href="https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/identity/quick-create-identity"
+                rel="noreferrer"
+                target="_blank"
+              >
+                access token, userId
+              </a>
+               
+              for each participant, endpointUrl and display name to use.
+            </p>
+            <p>
+              A display name has already been set by default, but feel free to change it.
+            </p>
+          </div>
         </span>
       </div>
     </div>

--- a/packages/storybook/stories/ChatComposite/snippets/Utils.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/Utils.tsx
@@ -51,13 +51,16 @@ const sendMessagesAsBot = async (
 
 export const ConfigHintBanner = (): JSX.Element => {
   const emptyConfigTips = (
-    <p>
-      Please provide an{' '}
-      <a href={MICROSOFT_AZURE_ACCESS_TOKEN_QUICKSTART} target="_blank" rel="noreferrer">
-        access token, userId
-      </a>{' '}
-      for each participant, endpointUrl and display name to use.
-    </p>
+    <div>
+      <p>
+        Please provide an{' '}
+        <a href={MICROSOFT_AZURE_ACCESS_TOKEN_QUICKSTART} target="_blank" rel="noreferrer">
+          access token, userId
+        </a>{' '}
+        for each participant, endpointUrl and display name to use.
+      </p>
+      <p>A display name has already been set by default, but feel free to change it.</p>
+    </div>
   );
   return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;
 };

--- a/packages/storybook/stories/MeetingComposite/Utils.tsx.REMOVED
+++ b/packages/storybook/stories/MeetingComposite/Utils.tsx.REMOVED
@@ -7,13 +7,16 @@ import { MICROSOFT_AZURE_ACCESS_TOKEN_QUICKSTART } from '../constants';
 
 export const ConfigHintBanner = (): JSX.Element => {
   const emptyConfigTips = (
-    <p>
-      Please provide an{' '}
-      <a href={MICROSOFT_AZURE_ACCESS_TOKEN_QUICKSTART} target="_blank" rel="noreferrer">
-        access token, userId
-      </a>
-      , endpointUrl and display name to use.
-    </p>
+    <div>
+      <p>
+        Please provide an{' '}
+        <a href={MICROSOFT_AZURE_ACCESS_TOKEN_QUICKSTART} target="_blank" rel="noreferrer">
+          access token, userId
+        </a>
+        , endpointUrl and display name to use.
+      </p>
+      <p>A display name has already been set by default, but feel free to change it.</p>
+    </div>
   );
   return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;
 };

--- a/packages/storybook/stories/VideoTile/__snapshots__/VideoTile.stories.storyshot
+++ b/packages/storybook/stories/VideoTile/__snapshots__/VideoTile.stories.storyshot
@@ -21,21 +21,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
       }
     >
       <div
-        className="ms-Stack css-6"
+        className="ms-Stack css-7"
         data-ui-id="video-tile"
       >
         <div
           className="css-4"
         />
         <div
-          className="ms-Stack css-7"
+          className="ms-Stack css-8"
         >
           <div
-            className="ms-Stack css-9"
+            className="ms-Stack css-10"
           >
             <div
               aria-label=""
-              className="ms-Persona ms-Persona--size48 root-10"
+              className="ms-Persona ms-Persona--size48 root-11"
               style={
                 Object {
                   "height": 100,
@@ -44,11 +44,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
               }
             >
               <div
-                className="ms-Persona-coin ms-Persona--size48 coin-17"
+                className="ms-Persona-coin ms-Persona--size48 coin-18"
                 role="presentation"
               >
                 <div
-                  className="ms-Persona-imageArea imageArea-19"
+                  className="ms-Persona-imageArea imageArea-20"
                   role="presentation"
                   style={
                     Object {
@@ -59,7 +59,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
                 >
                   <div
                     aria-hidden="true"
-                    className="ms-Persona-initials initials-22"
+                    className="ms-Persona-initials initials-23"
                     style={
                       Object {
                         "height": 100,
@@ -67,17 +67,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
                       }
                     }
                   >
-                    <i
-                      aria-hidden={true}
-                      className="root-37 root-24"
-                      data-icon-name="Contact"
-                    >
-                      
-                    </i>
+                    <span>
+                      JS
+                    </span>
                   </div>
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+        <div
+          className="ms-Stack css-81 css-26"
+        >
+          <div
+            className="ms-Stack css-82 css-27"
+          >
+            <span
+              className="css-28"
+              title="John Smith"
+            >
+              John Smith
+            </span>
           </div>
         </div>
       </div>

--- a/packages/storybook/stories/controlsUtils.ts
+++ b/packages/storybook/stories/controlsUtils.ts
@@ -169,7 +169,7 @@ export const controlsToAdd = {
     name: 'Layout'
   },
   disabled: { control: 'boolean', defaultValue: false, name: 'Disable component' },
-  displayName: { control: 'text', defaultValue: '', name: 'Display Name' },
+  displayName: { control: 'text', defaultValue: 'John Smith', name: 'Display Name' },
   enableJumpToNewMessageButton: { control: 'boolean', defaultValue: true, name: 'Enable Jump To New Message' },
   endpointUrl: { control: 'text', defaultValue: '', name: 'Azure Communication Services endpoint URL' },
   errorTypes: {


### PR DESCRIPTION
# What
set a display name by default when needed in Storybook and updated required data messages for composites

# Why
task https://skype.visualstudio.com/SPOOL/_workitems/edit/2653791

# How Tested
Ran Storybook locally
* Call (display name is not required for Calling)
  ![image](https://user-images.githubusercontent.com/82416644/143142861-7a6b7c1b-eb6d-46e5-ad10-8e4e11cfaa49.png)

* Chat
  ![image](https://user-images.githubusercontent.com/82416644/143142975-dff5bafb-ff79-4937-9a2c-17b67228691b.png)

* Meeting
  ![image](https://user-images.githubusercontent.com/82416644/143142797-d388444e-574d-4d58-a6df-071ee67cc3c5.png)


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->