### PR TITLE
Display a microphone tooltip in lobby informing users that it can not be toggled. 

### DIFF
--- a/change/@internal-react-composites-a2b7623e-f6db-43d8-b2db-2066a520f634.json
+++ b/change/@internal-react-composites-a2b7623e-f6db-43d8-b2db-2066a520f634.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add localized tooltip to microphone button in lobby informing users that it is disabled.",
+  "packageName": "@internal/react-composites",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -334,6 +334,7 @@ export interface CallCompositeStrings {
     lobbyScreenWaitingToBeAdmittedMoreDetails?: string;
     lobbyScreenWaitingToBeAdmittedTitle: string;
     microphonePermissionDenied: string;
+    microphoneToggleInLobbyNotAllowed: string;
     mutedMessage: string;
     networkReconnectMoreDetails: string;
     networkReconnectTitle: string;

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -243,6 +243,7 @@ export interface CallCompositeStrings {
     lobbyScreenWaitingToBeAdmittedMoreDetails?: string;
     lobbyScreenWaitingToBeAdmittedTitle: string;
     microphonePermissionDenied: string;
+    microphoneToggleInLobbyNotAllowed: string;
     mutedMessage: string;
     networkReconnectMoreDetails: string;
     networkReconnectTitle: string;

--- a/packages/react-composites/src/composites/CallComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Strings.tsx
@@ -169,4 +169,8 @@ export interface CallCompositeStrings {
    * More details text of the page shown to the user when there is intermittent network failure during a call.
    */
   networkReconnectMoreDetails: string;
+  /**
+   * Tooltip text used to inform a user that toggling microphone in lobby is not supported.
+   */
+  microphoneToggleInLobbyNotAllowed: string;
 }

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -15,6 +15,7 @@ import {
   useTheme
 } from '@internal/react-components';
 import React, { useMemo } from 'react';
+import { useLocale } from '../../localization';
 import { usePropsFor } from '../hooks/usePropsFor';
 import { useSelector } from '../hooks/useSelector';
 import { getCallStatus, getLocalMicrophoneEnabled } from '../selectors/baseSelectors';
@@ -99,6 +100,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
 
   const callStatus = useSelector(getCallStatus);
   const isLocalMicrophoneEnabled = useSelector(getLocalMicrophoneEnabled);
+  const strings = useLocale().strings.call;
 
   /**
    * When call is in Lobby, microphone button should be disabled.
@@ -111,6 +113,15 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
     // page until the user successfully joins the call.
     microphoneButtonProps.checked = isLocalMicrophoneEnabled;
   }
+  const microphoneStrings = _isInLobbyOrConnecting(callStatus)
+    ? {
+        strings: {
+          tooltipOffContent: strings.microphoneToggleInLobbyNotAllowed,
+          tooltipOnContent: strings.microphoneToggleInLobbyNotAllowed
+        }
+      }
+    : {};
+
   const cameraButtonProps = usePropsFor(CameraButton);
   const screenShareButtonProps = usePropsFor(ScreenShareButton);
   const participantsButtonProps = usePropsFor(ParticipantsButton);
@@ -142,6 +153,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
       {...microphoneButtonProps}
       showLabel={!compactMode}
       styles={controlButtonBaseStyle}
+      {...microphoneStrings}
     />
   );
 

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -113,7 +113,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
     // page until the user successfully joins the call.
     microphoneButtonProps.checked = isLocalMicrophoneEnabled;
   }
-  const microphoneStrings = _isInLobbyOrConnecting(callStatus)
+  const microphoneButtonStrings = _isInLobbyOrConnecting(callStatus)
     ? {
         strings: {
           tooltipOffContent: strings.microphoneToggleInLobbyNotAllowed,
@@ -153,7 +153,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
       {...microphoneButtonProps}
       showLabel={!compactMode}
       styles={controlButtonBaseStyle}
-      {...microphoneStrings}
+      {...microphoneButtonStrings}
     />
   );
 

--- a/packages/react-composites/src/composites/localization/locales/en-GB/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/en-GB/strings.json
@@ -30,7 +30,8 @@
     "removedFromCallTitle": "You were removed from the call",
     "soundLabel": "Sound",
     "startCallButtonLabel": "Start call",
-    "mutedMessage": "You're muted"
+    "mutedMessage": "You're muted",
+    "microphoneToggleInLobbyNotAllowed": "Cannot mute or unmute while in lobby."
   },
   "chat": {
     "chatListHeader": "In this chat"

--- a/packages/react-composites/src/composites/localization/locales/en-US/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/en-US/strings.json
@@ -36,7 +36,8 @@
     "removedFromCallMoreDetails": "Another participant removed you from the call.",
     "removedFromCallTitle": "You were removed",
     "soundLabel": "Sound",
-    "startCallButtonLabel": "Start call"
+    "startCallButtonLabel": "Start call",
+    "microphoneToggleInLobbyNotAllowed": "Cannot mute or unmute while in lobby."
   },
   "chat": {
     "chatListHeader": "In this chat"


### PR DESCRIPTION
# What
Display a microphone tooltip in lobby informing users that it can not be toggled. 

![MicrosoftTeams-image (7)](https://user-images.githubusercontent.com/9782747/143144484-023dc344-e59a-4999-b98f-4fc8346bdff9.png)

# Why
Headless SDK doesn't support toggling mute/unmute while a call is in lobby.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->