### PR TITLE
Do not dismiss the "remove" flyout in `ParticipantList` on resize events

### DIFF
--- a/change/@internal-react-components-0109ca59-ff94-4777-93b3-3236d097c7e3.json
+++ b/change/@internal-react-components-0109ca59-ff94-4777-93b3-3236d097c7e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix: Prevent participant remove flyout dismissal on resize events",
+  "packageName": "@internal/react-components",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ParticipantItem.tsx
+++ b/packages/react-components/src/components/ParticipantItem.tsx
@@ -205,6 +205,20 @@ export const ParticipantItem = (props: ParticipantItemProps): JSX.Element => {
             onDismiss={onDismissMenu}
             directionalHint={DirectionalHint.bottomRightEdge}
             className={contextualMenuStyle}
+            calloutProps={{
+              // Disable dismiss on resize to work around a couple Fluent UI bugs
+              // - The Callout is dismissed whenever *any child of window (inclusive)* is resized. In practice, this
+              //   happens when we change the VideoGallery layout, or even when the video stream element is internally resized
+              //   by the headless SDK.
+              // - There is a `preventDismissOnEvent` prop that we could theoretically use to only dismiss when the target of
+              //   of the 'resize' event is the window itself. But experimentation shows that setting that prop doesn't
+              //   deterministically avoid dismissal.
+              //
+              // A side effect of this workaround is that the context menu stays open when window is resized, and may
+              // get detached from original target visually. That bug is preferable to the bug when this value is not set -
+              // The Callout (frequently) gets dismissed automatically.
+              preventDismissOnResize: true
+            }}
           />
         </>
       )}


### PR DESCRIPTION
# Why

Resize events occur due to `VideoGallery` refresh and automatically dismiss the flyout.