### PR TITLE
Update stop screen sharing label to `Stop sharing`

### DIFF
--- a/change/@internal-react-components-c6119c1d-a695-4a82-bf20-fd3eb6370db0.json
+++ b/change/@internal-react-components-c6119c1d-a695-4a82-bf20-fd3eb6370db0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update stop screen sharing label from stop to stop sharing",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -58,7 +58,7 @@
     "copyInviteLinkButtonLabel": "Copy invite link"
   },
   "screenShareButton": {
-    "onLabel": "Stop",
+    "onLabel": "Stop sharing",
     "offLabel": "Share",
     "tooltipOnContent": "Stop sharing your screen",
     "tooltipOffContent": "Share your screen"


### PR DESCRIPTION
# What
Update stop screen sharing label to `Stop sharing`

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/2633102

# How Tested
| not screensharing | screensharing |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/2684369/143494722-062a95df-4e4d-4364-8a82-cce07899a432.png) | ![image](https://user-images.githubusercontent.com/2684369/143494727-c698dd73-50cb-4765-9c54-99a4c766176d.png) |
