### PR TITLE
Immediately fetch initial chat data in adapter (+fix customDataModel flakey UI test)

### DIFF
--- a/change/@internal-react-composites-b180611a-ab99-4ff8-83ac-2a71c26ec1b7.json
+++ b/change/@internal-react-composites-b180611a-ab99-4ff8-83ac-2a71c26ec1b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Immediately fetch initial chat data when creating azure communication chat adapter",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -356,10 +356,11 @@ export const createAzureCommunicationChatAdapter = async ({
     credential: credential
   });
   const chatThreadClient = await chatClient.getChatThreadClient(threadId);
+  await chatClient.startRealtimeNotifications();
 
-  chatClient.startRealtimeNotifications();
+  const adapter = await createAzureCommunicationChatAdapterFromClient(chatClient, chatThreadClient);
+  await adapter.fetchInitialData();
 
-  const adapter = createAzureCommunicationChatAdapterFromClient(chatClient, chatThreadClient);
   return adapter;
 };
 


### PR DESCRIPTION
# What
When creating chatAdapter, immediately call `chatAdapter->fetchInitialData()`

# Why
Otherwise you can create a chat composite with missing information
* Chat composite will load with no topic header (then suddenly populate it)
* Chat composite will load with no previous messages (then suddenly populate them)
* We have had flakey UI tests from this for over a month now and tripped us up - likely will trip up others.

## Caveats
* Chat adapter will now takes longer to construct as it has to wait for fetchInitialData to complete

# Fixes
Flakey ui test where previous messages hadn't loaded before screenshot was taken:
![image](https://user-images.githubusercontent.com/2684369/143508778-44a024e5-9068-4ec3-9434-bb79544b7f01.png)
