### PR TITLE
aria label missing in Call composite configuration page

### DIFF
--- a/change/@internal-react-composites-05c7878d-2e39-4a68-856b-13bb72b4e090.json
+++ b/change/@internal-react-composites-05c7878d-2e39-4a68-856b-13bb72b4e090.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix common label for mic and speakers in Call composite configuration page",
+  "packageName": "@internal/react-composites",
+  "email": "alcail@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
@@ -125,7 +125,7 @@ export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element
         <Label
           id={'call-composite-local-sound-settings-label'}
           className={mergeStyles(dropDownStyles(theme).label)}
-          disabled={!props.microphonePermissionGranted || props.speakers.length === 0} // depends on dropdowns disabled state in the sound settings stack
+          disabled={!props.microphonePermissionGranted} // follows Start button disabled state in ConfigurationPage
         >
           {soundLabel}
         </Label>

--- a/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { AudioDeviceInfo, VideoDeviceInfo } from '@azure/communication-calling';
-import { Dropdown, Icon, IDropdownOption, Stack } from '@fluentui/react';
+import { Dropdown, Icon, IDropdownOption, Label, mergeStyles, Stack } from '@fluentui/react';
 import { useTheme, VideoStreamOptions } from '@internal/react-components';
 import React from 'react';
 import { useLocale } from '../../localization';
@@ -121,52 +121,64 @@ export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element
         }}
         onRenderTitle={(props?: IDropdownOption[]) => onRenderTitle('Camera', props)}
       />
-      <Dropdown
-        label={soundLabel}
-        placeholder={defaultPlaceHolder}
-        styles={dropDownStyles(theme)}
-        disabled={!props.microphonePermissionGranted}
-        errorMessage={
-          props.microphonePermissionGranted === undefined || props.microphonePermissionGranted
-            ? undefined
-            : locale.strings.call.microphonePermissionDenied
-        }
-        options={
-          props.microphonePermissionGranted
-            ? getDropDownList(props.microphones)
-            : [{ key: 'deniedOrUnknown', text: '' }]
-        }
-        defaultSelectedKey={
-          props.microphonePermissionGranted
-            ? props.selectedMicrophone
-              ? props.selectedMicrophone.id
-              : defaultDeviceId(props.microphones)
-            : 'deniedOrUnknown'
-        }
-        onChange={(
-          event: React.FormEvent<HTMLDivElement>,
-          option?: IDropdownOption | undefined,
-          index?: number | undefined
-        ) => {
-          props.onSelectMicrophone(props.microphones[index ?? 0]);
-        }}
-        onRenderTitle={(props?: IDropdownOption[]) => onRenderTitle('Microphone', props)}
-      />
-      <Dropdown
-        placeholder={defaultPlaceHolder}
-        styles={dropDownStyles(theme)}
-        disabled={props.speakers.length === 0}
-        options={getDropDownList(props.speakers)}
-        defaultSelectedKey={props.selectedSpeaker ? props.selectedSpeaker.id : defaultDeviceId(props.speakers)}
-        onChange={(
-          event: React.FormEvent<HTMLDivElement>,
-          option?: IDropdownOption | undefined,
-          index?: number | undefined
-        ) => {
-          props.onSelectSpeaker(props.speakers[index ?? 0]);
-        }}
-        onRenderTitle={(props?: IDropdownOption[]) => onRenderTitle('Speaker', props)}
-      />
+      <Stack>
+        <Label
+          id={'call-composite-local-sound-settings-label'}
+          className={mergeStyles(dropDownStyles(theme).label)}
+          disabled={!props.microphonePermissionGranted || props.speakers.length === 0} // depends on dropdowns disabled state in the sound settings stack
+        >
+          {soundLabel}
+        </Label>
+        <Stack data-ui-id="call-composite-sound-settings" tokens={mainStackTokens}>
+          <Dropdown
+            aria-labelledby={'call-composite-local-sound-settings-label'}
+            placeholder={defaultPlaceHolder}
+            styles={dropDownStyles(theme)}
+            disabled={!props.microphonePermissionGranted}
+            errorMessage={
+              props.microphonePermissionGranted === undefined || props.microphonePermissionGranted
+                ? undefined
+                : locale.strings.call.microphonePermissionDenied
+            }
+            options={
+              props.microphonePermissionGranted
+                ? getDropDownList(props.microphones)
+                : [{ key: 'deniedOrUnknown', text: '' }]
+            }
+            defaultSelectedKey={
+              props.microphonePermissionGranted
+                ? props.selectedMicrophone
+                  ? props.selectedMicrophone.id
+                  : defaultDeviceId(props.microphones)
+                : 'deniedOrUnknown'
+            }
+            onChange={(
+              event: React.FormEvent<HTMLDivElement>,
+              option?: IDropdownOption | undefined,
+              index?: number | undefined
+            ) => {
+              props.onSelectMicrophone(props.microphones[index ?? 0]);
+            }}
+            onRenderTitle={(props?: IDropdownOption[]) => onRenderTitle('Microphone', props)}
+          />
+          <Dropdown
+            aria-labelledby={'call-composite-local-sound-settings-label'}
+            placeholder={defaultPlaceHolder}
+            styles={dropDownStyles(theme)}
+            disabled={props.speakers.length === 0}
+            options={getDropDownList(props.speakers)}
+            defaultSelectedKey={props.selectedSpeaker ? props.selectedSpeaker.id : defaultDeviceId(props.speakers)}
+            onChange={(
+              event: React.FormEvent<HTMLDivElement>,
+              option?: IDropdownOption | undefined,
+              index?: number | undefined
+            ) => {
+              props.onSelectSpeaker(props.speakers[index ?? 0]);
+            }}
+            onRenderTitle={(props?: IDropdownOption[]) => onRenderTitle('Speaker', props)}
+          />
+        </Stack>
+      </Stack>
     </Stack>
   );
 };


### PR DESCRIPTION
# What
replace mic label by a common label for both mic and speakers dropdown

# Why
bug: https://skype.visualstudio.com/SPOOL/_workitems/edit/2565537

# How Tested
Ran calling sample locally and checked with Accessibility Insights
![image](https://user-images.githubusercontent.com/82416644/143625172-382c7047-5e6d-4fc3-a50a-5ca3e6f3f2c8.png)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->