### PR TITLE
Quick fix chat sample home&config screens for mobile (for bug bash)

### DIFF
--- a/samples/Chat/src/app/ConfigurationScreen.tsx
+++ b/samples/Chat/src/app/ConfigurationScreen.tsx
@@ -21,7 +21,6 @@ import {
   leftPreviewContainerStackTokens,
   leftPreviewContainerStyle,
   namePreviewStyle,
-  responsiveLayoutStackTokens,
   responsiveLayoutStyle,
   rightInputContainerStackTokens,
   rightInputContainerStyle,
@@ -165,66 +164,58 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
   const displayJoinChatArea = (): JSX.Element => {
     return (
       <Stack horizontal wrap horizontalAlign="center" verticalAlign="center" className={responsiveLayoutStyle}>
-        <Stack.Item>
-          <Stack
-            horizontalAlign="center"
-            tokens={leftPreviewContainerStackTokens}
-            className={leftPreviewContainerStyle}
-          >
-            <Text role={'heading'} aria-level={1} className={headerStyle}>
-              {PROFILE_LABEL}
-            </Text>
-            <Stack.Item className={largeAvatarContainerStyle(selectedAvatar)}>
-              <Stack aria-label={`${selectedAvatar} avatar`} className={largeAvatarStyle}>
-                {selectedAvatar}
-              </Stack>
-            </Stack.Item>
-            <Text className={namePreviewStyle(name !== '')}>{name !== '' ? name : NAME_DEFAULT}</Text>
-          </Stack>
-        </Stack.Item>
-        <Stack.Item>
-          <Stack className={rightInputContainerStyle} tokens={rightInputContainerStackTokens}>
-            <Text id={'avatar-list-label'} className={labelFontStyle}>
-              {AVATAR_LABEL}
-            </Text>
-            <FocusZone direction={FocusZoneDirection.horizontal}>
-              <Stack
-                horizontal
-                className={avatarListContainerStyle}
-                tokens={avatarListContainerStackTokens}
-                role="list"
-                aria-labelledby={'avatar-list-label'}
-              >
-                {avatarsList.map((avatar, index) => (
-                  <div
-                    role="listitem"
-                    id={avatar}
-                    key={index}
-                    data-is-focusable={true}
-                    className={smallAvatarContainerClassName(avatar)}
-                    onClick={() => onAvatarChange(avatar)}
-                  >
-                    <div className={smallAvatarStyle}>{avatar}</div>
-                  </div>
-                ))}
-              </Stack>
-            </FocusZone>
-            <DisplayNameField
-              setName={setName}
-              setEmptyWarning={setEmptyWarning}
-              validateName={validateName}
-              isEmpty={emptyWarning}
-            />
-            <PrimaryButton
-              disabled={disableJoinChatButton}
-              className={buttonStyle}
-              styles={buttonWithIconStyles}
-              text={JOIN_BUTTON_TEXT}
-              onClick={validateName}
-              onRenderIcon={() => <Chat20Filled className={chatIconStyle} />}
-            />
-          </Stack>
-        </Stack.Item>
+        <Stack horizontalAlign="center" tokens={leftPreviewContainerStackTokens} className={leftPreviewContainerStyle}>
+          <Text role={'heading'} aria-level={1} className={headerStyle}>
+            {PROFILE_LABEL}
+          </Text>
+          <Stack.Item className={largeAvatarContainerStyle(selectedAvatar)}>
+            <Stack aria-label={`${selectedAvatar} avatar`} className={largeAvatarStyle}>
+              {selectedAvatar}
+            </Stack>
+          </Stack.Item>
+          <Text className={namePreviewStyle(name !== '')}>{name !== '' ? name : NAME_DEFAULT}</Text>
+        </Stack>
+        <Stack className={rightInputContainerStyle} tokens={rightInputContainerStackTokens}>
+          <Text id={'avatar-list-label'} className={labelFontStyle}>
+            {AVATAR_LABEL}
+          </Text>
+          <FocusZone direction={FocusZoneDirection.horizontal}>
+            <Stack
+              horizontal
+              className={avatarListContainerStyle}
+              tokens={avatarListContainerStackTokens}
+              role="list"
+              aria-labelledby={'avatar-list-label'}
+            >
+              {avatarsList.map((avatar, index) => (
+                <div
+                  role="listitem"
+                  id={avatar}
+                  key={index}
+                  data-is-focusable={true}
+                  className={smallAvatarContainerClassName(avatar)}
+                  onClick={() => onAvatarChange(avatar)}
+                >
+                  <div className={smallAvatarStyle}>{avatar}</div>
+                </div>
+              ))}
+            </Stack>
+          </FocusZone>
+          <DisplayNameField
+            setName={setName}
+            setEmptyWarning={setEmptyWarning}
+            validateName={validateName}
+            isEmpty={emptyWarning}
+          />
+          <PrimaryButton
+            disabled={disableJoinChatButton}
+            className={buttonStyle}
+            styles={buttonWithIconStyles}
+            text={JOIN_BUTTON_TEXT}
+            onClick={validateName}
+            onRenderIcon={() => <Chat20Filled className={chatIconStyle} />}
+          />
+        </Stack>
       </Stack>
     );
   };

--- a/samples/Chat/src/app/ConfigurationScreen.tsx
+++ b/samples/Chat/src/app/ConfigurationScreen.tsx
@@ -164,66 +164,67 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
 
   const displayJoinChatArea = (): JSX.Element => {
     return (
-      <Stack
-        horizontal
-        wrap
-        horizontalAlign="center"
-        verticalAlign="center"
-        tokens={responsiveLayoutStackTokens}
-        className={responsiveLayoutStyle}
-      >
-        <Stack horizontalAlign="center" tokens={leftPreviewContainerStackTokens} className={leftPreviewContainerStyle}>
-          <Text role={'heading'} aria-level={1} className={headerStyle}>
-            {PROFILE_LABEL}
-          </Text>
-          <div className={largeAvatarContainerStyle(selectedAvatar)}>
-            <div aria-label={`${selectedAvatar} avatar`} className={largeAvatarStyle}>
-              {selectedAvatar}
-            </div>
-          </div>
-          <Text className={namePreviewStyle(name !== '')}>{name !== '' ? name : NAME_DEFAULT}</Text>
-        </Stack>
-        <Stack className={rightInputContainerStyle} tokens={rightInputContainerStackTokens}>
-          <Text id={'avatar-list-label'} className={labelFontStyle}>
-            {AVATAR_LABEL}
-          </Text>
-          <FocusZone direction={FocusZoneDirection.horizontal}>
-            <Stack
-              horizontal
-              className={avatarListContainerStyle}
-              tokens={avatarListContainerStackTokens}
-              role="list"
-              aria-labelledby={'avatar-list-label'}
-            >
-              {avatarsList.map((avatar, index) => (
-                <div
-                  role="listitem"
-                  id={avatar}
-                  key={index}
-                  data-is-focusable={true}
-                  className={smallAvatarContainerClassName(avatar)}
-                  onClick={() => onAvatarChange(avatar)}
-                >
-                  <div className={smallAvatarStyle}>{avatar}</div>
-                </div>
-              ))}
-            </Stack>
-          </FocusZone>
-          <DisplayNameField
-            setName={setName}
-            setEmptyWarning={setEmptyWarning}
-            validateName={validateName}
-            isEmpty={emptyWarning}
-          />
-          <PrimaryButton
-            disabled={disableJoinChatButton}
-            className={buttonStyle}
-            styles={buttonWithIconStyles}
-            text={JOIN_BUTTON_TEXT}
-            onClick={validateName}
-            onRenderIcon={() => <Chat20Filled className={chatIconStyle} />}
-          />
-        </Stack>
+      <Stack horizontal wrap horizontalAlign="center" verticalAlign="center" className={responsiveLayoutStyle}>
+        <Stack.Item>
+          <Stack
+            horizontalAlign="center"
+            tokens={leftPreviewContainerStackTokens}
+            className={leftPreviewContainerStyle}
+          >
+            <Text role={'heading'} aria-level={1} className={headerStyle}>
+              {PROFILE_LABEL}
+            </Text>
+            <Stack.Item className={largeAvatarContainerStyle(selectedAvatar)}>
+              <Stack aria-label={`${selectedAvatar} avatar`} className={largeAvatarStyle}>
+                {selectedAvatar}
+              </Stack>
+            </Stack.Item>
+            <Text className={namePreviewStyle(name !== '')}>{name !== '' ? name : NAME_DEFAULT}</Text>
+          </Stack>
+        </Stack.Item>
+        <Stack.Item>
+          <Stack className={rightInputContainerStyle} tokens={rightInputContainerStackTokens}>
+            <Text id={'avatar-list-label'} className={labelFontStyle}>
+              {AVATAR_LABEL}
+            </Text>
+            <FocusZone direction={FocusZoneDirection.horizontal}>
+              <Stack
+                horizontal
+                className={avatarListContainerStyle}
+                tokens={avatarListContainerStackTokens}
+                role="list"
+                aria-labelledby={'avatar-list-label'}
+              >
+                {avatarsList.map((avatar, index) => (
+                  <div
+                    role="listitem"
+                    id={avatar}
+                    key={index}
+                    data-is-focusable={true}
+                    className={smallAvatarContainerClassName(avatar)}
+                    onClick={() => onAvatarChange(avatar)}
+                  >
+                    <div className={smallAvatarStyle}>{avatar}</div>
+                  </div>
+                ))}
+              </Stack>
+            </FocusZone>
+            <DisplayNameField
+              setName={setName}
+              setEmptyWarning={setEmptyWarning}
+              validateName={validateName}
+              isEmpty={emptyWarning}
+            />
+            <PrimaryButton
+              disabled={disableJoinChatButton}
+              className={buttonStyle}
+              styles={buttonWithIconStyles}
+              text={JOIN_BUTTON_TEXT}
+              onClick={validateName}
+              onRenderIcon={() => <Chat20Filled className={chatIconStyle} />}
+            />
+          </Stack>
+        </Stack.Item>
       </Stack>
     );
   };

--- a/samples/Chat/src/app/styles/ConfigurationScreen.styles.ts
+++ b/samples/Chat/src/app/styles/ConfigurationScreen.styles.ts
@@ -17,7 +17,6 @@ export const responsiveLayoutStackTokens: IStackTokens = {
 };
 
 export const responsiveLayoutStyle = mergeStyles({
-  // height: '100%',
   width: '100% '
 });
 

--- a/samples/Chat/src/app/styles/ConfigurationScreen.styles.ts
+++ b/samples/Chat/src/app/styles/ConfigurationScreen.styles.ts
@@ -17,15 +17,8 @@ export const responsiveLayoutStackTokens: IStackTokens = {
 };
 
 export const responsiveLayoutStyle = mergeStyles({
-  height: '100%',
-  width: '100% ',
-  // half childrenGap from Stack
-  padding: '2.25rem',
-  // max of min-width from stack items + padding width * 2 = 20 + 2.25 * 2
-  minWidth: '24.5rem',
-  minHeight: 'auto',
-  // sum of max-height of stack items + childrenGap * (#items - 1) + padding * 2 = (15.0975 + 15.875) + 4.5 * 1 + 2.25 * 2 =
-  maxHeight: '39.97255rem'
+  // height: '100%',
+  width: '100% '
 });
 
 export const leftPreviewContainerStackTokens: IStackTokens = {
@@ -33,7 +26,7 @@ export const leftPreviewContainerStackTokens: IStackTokens = {
 };
 
 export const leftPreviewContainerStyle = mergeStyles({
-  width: '10rem',
+  width: '20rem',
   minHeight: '15.0975rem',
   padding: '0.5rem'
 });
@@ -68,7 +61,8 @@ export const smallAvatarContainerStyle = (avatar: string, selectedAvatar: string
     '&:focus': {
       border: `0.1875rem solid ${theme.palette.neutralSecondary}`,
       borderRadius: theme.effects.roundedCorner4
-    }
+    },
+    cursor: 'pointer'
   });
 
 export const largeAvatarContainerStyle = (avatar: string): string =>

--- a/samples/Chat/src/app/styles/HomeScreen.styles.ts
+++ b/samples/Chat/src/app/styles/HomeScreen.styles.ts
@@ -31,7 +31,6 @@ export const containerStyle = mergeStyles({
   height: '100%',
   width: '100% ',
   padding: '2rem', // half childrenGap from Stack (to add to compensate inner stack defined by 'wrap' prop of Stack)
-  minWidth: '27.188rem', // min-width from stack items + padding * 2 = 23.188 + 2 * 2
   minHeight: 'auto'
 });
 
@@ -79,7 +78,7 @@ export const buttonWithIconStyles: IButtonStyles = {
 };
 
 export const infoContainerStyle = mergeStyles({
-  width: '23.188rem'
+  maxWidth: '23.188rem'
 });
 
 export const configContainerStyle = mergeStyles({


### PR DESCRIPTION
# What
Super quickly fixup the chat home and config screen for mobile devices
(just removed problematic css and ensured we use fluent components to dictate layout)

# Why
We don't want erroneous bugs filed on screens we don't care about

# How Tested
| | before (iPhone SE) | after (iPhone SE) |
| -- | -- | -- |
| home | ![image](https://user-images.githubusercontent.com/2684369/144115554-22f265d7-9684-415a-be29-a38292db0e79.png) | ![image](https://user-images.githubusercontent.com/2684369/144115568-bc8d0f7e-f1b6-4ba6-adbd-99f13529a6c3.png) |
| config |  ![image](https://user-images.githubusercontent.com/2684369/144115440-d4e26ec9-fb16-43c1-b847-fdefffcce179.png) | ![image](https://user-images.githubusercontent.com/2684369/144115482-843d2e86-37ba-427a-b505-80efe2352046.png) |


Non mobile is unchanged:
| home | config |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/2684369/144116161-34383faf-bf1b-43c3-95eb-faaba5e39f85.png)|![image](https://user-images.githubusercontent.com/2684369/144116135-bfb1e2e6-1672-4c08-923f-ce0cb945bb86.png)|
