### PR TITLE
Remove spammy console log when rendering video

### DIFF
--- a/change/@internal-calling-stateful-client-64bff3c3-0a50-41ae-b701-843bd426722e.json
+++ b/change/@internal-calling-stateful-client-64bff3c3-0a50-41ae-b701-843bd426722e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove spammy console log when rendering video",
+  "packageName": "@internal/calling-stateful-client",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/src/StreamUtils.ts
+++ b/packages/calling-stateful-client/src/StreamUtils.ts
@@ -47,7 +47,8 @@ async function createViewRemoteVideo(
   }
 
   if (renderInfo.status === 'Rendering') {
-    console.warn('RemoteVideoStream rendering is already in progress');
+    // Do not log to console here as this is a very common situation due to UI rerenders while
+    // the video rendering is in progress.
     return;
   }
 
@@ -131,7 +132,8 @@ async function createViewLocalVideo(
   }
 
   if (renderInfo.status === 'Rendering') {
-    console.warn('LocalVideoStream rendering is already in progress');
+    // Do not log to console here as this is a very common situation due to UI rerenders while
+    // the video rendering is in progress.
     return;
   }
 
@@ -192,7 +194,8 @@ async function createViewUnparentedVideo(
   }
 
   if (renderInfo && renderInfo.status === 'Rendering') {
-    console.warn('Unparented LocalVideoStream rendering is already in progress');
+    // Do not log to console here as this is a very common situation due to UI rerenders while
+    // the video rendering is in progress.
     return;
   }
 


### PR DESCRIPTION
# Why

This is a fairly common situation as rendering a video takes a while and the VideoGallery rerenders frequently.