### PR TITLE
Release alpha package off of feature branch

### DIFF
--- a/.github/workflows/nightly-cd.yml
+++ b/.github/workflows/nightly-cd.yml
@@ -1,4 +1,4 @@
-name: Nightly CI/CD
+name: Nightly alpha package release
 
 on:
   schedule:
@@ -19,6 +19,9 @@ jobs:
     steps:
       # Check-out repo
       - uses: actions/checkout@v2
+        with:
+          # TODO: Revert to releasing alpha package off of `main` after GA.
+          ref: feature/conditional-compilation
 
       # Check if any changes have been pushed to main since last release
       - name: Check latest commit age
@@ -59,6 +62,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          # TODO: Revert to releasing alpha package off of `main` after GA.
+          ref: feature/conditional-compilation
 
       # Ensure node version is great enough
       - name: Use Node.js v14.x


### PR DESCRIPTION
# What

Release nightly alpha package off of `feature/conditional-compilation` instead of `main`.

# Why

We've removed all beta features from main in preparation for GA. But we'd like our alpha packages to include those.

# How Tested

Not tested. Will observe the nightly release after this lands.