### PR TITLE
Fix alpha releases again - Use yyymmddHHMM format instead to avoid trailing zeros

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Get datetime for alpha release name
         id: datetime
         run: |
-          echo "::set-output name=datetime::$(date +'%Y%m%d.%H%M')"
+          echo "::set-output name=datetime::$(date +'%Y%m%d%H%M')"
 
       # Bump alpha package versions
       - name: Bump alpha package versions
-        run: node common/config/node_modules/beachball/bin/beachball canary --canary-name alpha+${{ steps.datetime.outputs.datetime }} --tag dev --no-publish
+        run: node common/config/node_modules/beachball/bin/beachball canary --canary-name alpha-${{ steps.datetime.outputs.datetime }} --tag dev --no-publish
 
       - name: Synchronize package version reported to telemetry
         run: node common/scripts/sync-telemetry-package-version

--- a/.github/workflows/nightly-cd.yml
+++ b/.github/workflows/nightly-cd.yml
@@ -88,11 +88,11 @@ jobs:
       - name: Get datetime for alpha release name
         id: datetime
         run: |
-          echo "::set-output name=datetime::$(date +'%Y%m%d.%H%M')"
+          echo "::set-output name=datetime::$(date +'%Y%m%d%H%M')"
 
       # Bump alpha package versions
       - name: Bump alpha package versions
-        run: node common/config/node_modules/beachball/bin/beachball canary --canary-name alpha+${{ steps.datetime.outputs.datetime }} --tag dev --no-publish
+        run: node common/config/node_modules/beachball/bin/beachball canary --canary-name alpha-${{ steps.datetime.outputs.datetime }} --tag dev --no-publish
 
       - name: Synchronize package version reported to telemetry
         run: node common/scripts/sync-telemetry-package-version

--- a/change/@internal-acs-ui-common-211738ef-0a03-4f87-8ac9-35f9121d035c.json
+++ b/change/@internal-acs-ui-common-211738ef-0a03-4f87-8ac9-35f9121d035c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update unit test",
+  "packageName": "@internal/acs-ui-common",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/docs/infrastructure/beachball.md
+++ b/docs/infrastructure/beachball.md
@@ -18,7 +18,7 @@ Semantic version bumping is how we increment that version in our packages. Again
 
 Along with regular package version updates, we also produce alpha releases nightly, and beta releases when we are working towards a new major version release.
 
-* Nightly Alpha versions follow the following syntax: v.#.#.#-alpha+yyyymmdd-HHMM
+* Nightly Alpha versions follow the following syntax: v.#.#.#-alpha-yyyymmddHHMM
 * Beta versions follow the following syntax: v.#.#.#-beta.#
 
 See [creating a release](../references/creating-a-release.md) for more information.

--- a/docs/references/creating-a-release.md
+++ b/docs/references/creating-a-release.md
@@ -127,7 +127,7 @@ There is currently no GitHub action for creating a hotfix and must be done manua
 
 Alpha releases are created nightly using the [.github/workflows/nightly-ci.yml](https://github.com/Azure/communication-ui-library/blob/main/.github/workflows/nightly-ci.yml) GitHub action.
 
-They use beachball's `canary` CLI command to temporarily set all package versions to \<version\>-alpha+yyyymmdd-HHMM, then package up the npm packages and upload the packages to the azure release pipeline.
+They use beachball's `canary` CLI command to temporarily set all package versions to \<version\>-alpha-yyyymmddHHMM, then package up the npm packages and upload the packages to the azure release pipeline.
 
 ### Creating beta releases
 

--- a/packages/acs-ui-common/src/telemetry.test.ts
+++ b/packages/acs-ui-common/src/telemetry.test.ts
@@ -17,6 +17,6 @@ test('sanitize works for all versions in use', () => {
   expect(sanitize('acr/1.0.1')).toEqual('acr/1.0.1');
   expect(sanitize('acr/99.99.99')).toEqual('acr/99.99.99');
   expect(sanitize('acr/99.99.99-beta.99')).toEqual('acr/99.99.99-beta.99');
-  expect(sanitize('acr/1.0.0-alpha+20210805.10.0')).toEqual('acr/1.0.0-alpha');
-  expect(applicationIdFormat.test(sanitize('acr/1.0.0-alpha+20210805.10.0'))).toBe(true);
+  expect(sanitize('acr/1.0.0-alpha-202108050010.0')).toEqual('acr/1.0.0-alpha');
+  expect(applicationIdFormat.test(sanitize('acr/1.0.0-alpha-202108050010.0'))).toBe(true);
 });


### PR DESCRIPTION
# What
Use yyymmddHHMM format instead to avoid trailing zeros and revert #1192 

# Why
Using `+` is **silently** stripped away when the npm publish happens, see alpha package published last night: https://www.npmjs.com/package/@azure/communication-react/v/1.0.0-alpha

More info: https://github.com/npm/npm/issues/12825

So we are removing the `.` between yyymmdd and HHMM as HHMM might have trailing zeros, the original reason for #1192 

# How Tested
Triggered alpha release to verify:
* https://github.com/Azure/communication-ui-library/runs/4412163364
* https://dev.azure.com/azure-sdk/internal/_releaseProgress?_a=release-pipeline-progress&releaseId=19900

Result:
* https://www.npmjs.com/package/@azure/communication-react/v/1.0.0-alpha-202112031922.0