### PR TITLE
Fix typo in exposed Strings field

### DIFF
--- a/change/@internal-react-composites-7962b1f6-6f34-4f1c-af4b-d6b4b88d3214.json
+++ b/change/@internal-react-composites-7962b1f6-6f34-4f1c-af4b-d6b4b88d3214.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix typo in strings field",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -305,7 +305,7 @@ export interface CallCompositeStrings {
     complianceBannerRecordingSaving: string;
     complianceBannerRecordingStarted: string;
     complianceBannerRecordingStopped: string;
-    complianceBannerTrancriptionStarted: string;
+    complianceBannerTranscriptionStarted: string;
     complianceBannerTranscriptionConsent: string;
     complianceBannerTranscriptionSaving: string;
     complianceBannerTranscriptionStopped: string;

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -305,9 +305,9 @@ export interface CallCompositeStrings {
     complianceBannerRecordingSaving: string;
     complianceBannerRecordingStarted: string;
     complianceBannerRecordingStopped: string;
-    complianceBannerTranscriptionStarted: string;
     complianceBannerTranscriptionConsent: string;
     complianceBannerTranscriptionSaving: string;
+    complianceBannerTranscriptionStarted: string;
     complianceBannerTranscriptionStopped: string;
     configurationPageCallDetails?: string;
     configurationPageTitle: string;

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -209,7 +209,7 @@ export interface CallCompositeStrings {
     complianceBannerRecordingSaving: string;
     complianceBannerRecordingStarted: string;
     complianceBannerRecordingStopped: string;
-    complianceBannerTrancriptionStarted: string;
+    complianceBannerTranscriptionStarted: string;
     complianceBannerTranscriptionConsent: string;
     complianceBannerTranscriptionSaving: string;
     complianceBannerTranscriptionStopped: string;

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -209,9 +209,9 @@ export interface CallCompositeStrings {
     complianceBannerRecordingSaving: string;
     complianceBannerRecordingStarted: string;
     complianceBannerRecordingStopped: string;
-    complianceBannerTranscriptionStarted: string;
     complianceBannerTranscriptionConsent: string;
     complianceBannerTranscriptionSaving: string;
+    complianceBannerTranscriptionStarted: string;
     complianceBannerTranscriptionStopped: string;
     configurationPageCallDetails?: string;
     configurationPageTitle: string;

--- a/packages/react-composites/src/composites/CallComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Strings.tsx
@@ -152,7 +152,7 @@ export interface CallCompositeStrings {
   /**
    * Message to let user know transcription of the meeting has started in ComplianceBanner.
    */
-  complianceBannerTrancriptionStarted: string;
+  complianceBannerTranscriptionStarted: string;
   /**
    * Message to let user know the transcription of the meeting has stopped in ComplianceBanner.
    */

--- a/packages/react-composites/src/composites/CallComposite/components/ComplianceBanner.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/ComplianceBanner.tsx
@@ -181,7 +181,7 @@ function BannerMessage(props: { variant: number; strings: CompositeStrings }): J
     case TRANSCRIPTION_STARTED:
       return (
         <>
-          <b>{strings.call.complianceBannerTrancriptionStarted}</b>
+          <b>{strings.call.complianceBannerTranscriptionStarted}</b>
           {` ${strings.call.complianceBannerTranscriptionConsent}`}
           <PrivacyPolicy linkText={strings.call.privacyPolicy} />
         </>

--- a/packages/react-composites/src/composites/localization/locales/de-DE/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/de-DE/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "Aufzeichnung wird gespeichert.",
     "complianceBannerRecordingStarted": "Die Aufzeichnung wurde gestartet.",
     "complianceBannerRecordingStopped": "Aufzeichnung wurde beendet.",
-    "complianceBannerTrancriptionStarted": "Die Transkription hat begonnen.",
+    "complianceBannerTranscriptionStarted": "Die Transkription hat begonnen.",
     "complianceBannerTranscriptionConsent": "Durch Ihre Teilnahme stimmen Sie zu, dass diese Besprechung transkribiert wird.",
     "complianceBannerTranscriptionSaving": "Die Transkription wird gespeichert.",
     "complianceBannerTranscriptionStopped": "Die Transkription wurde beendet.",

--- a/packages/react-composites/src/composites/localization/locales/en-GB/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/en-GB/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "Recording is being saved.",
     "complianceBannerRecordingStarted": "Recording has started.",
     "complianceBannerRecordingStopped": "Recording has stopped.",
-    "complianceBannerTrancriptionStarted": "Transcription has started.",
+    "complianceBannerTranscriptionStarted": "Transcription has started.",
     "complianceBannerTranscriptionConsent": "By joining, you are giving consent for this meeting to be transcribed.",
     "complianceBannerTranscriptionSaving": "Transcription is being saved.",
     "complianceBannerTranscriptionStopped": "Transcription has stopped.",

--- a/packages/react-composites/src/composites/localization/locales/en-US/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/en-US/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "Recording is being saved.",
     "complianceBannerRecordingStarted": "Recording has started.",
     "complianceBannerRecordingStopped": "Recording has stopped.",
-    "complianceBannerTrancriptionStarted": "Transcription has started.",
+    "complianceBannerTranscriptionStarted": "Transcription has started.",
     "complianceBannerTranscriptionConsent": "By joining, you are giving consent for this meeting to be transcribed.",
     "complianceBannerTranscriptionSaving": "Transcription is being saved.",
     "complianceBannerTranscriptionStopped": "Transcription has stopped.",

--- a/packages/react-composites/src/composites/localization/locales/es-ES/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/es-ES/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "La grabación se está guardando.",
     "complianceBannerRecordingStarted": "Se ha iniciado la grabación.",
     "complianceBannerRecordingStopped": "La grabación se ha detenido.",
-    "complianceBannerTrancriptionStarted": "La transcripción se ha iniciado.",
+    "complianceBannerTranscriptionStarted": "La transcripción se ha iniciado.",
     "complianceBannerTranscriptionConsent": "Al unirse, da su consentimiento para que se transcriba esta reunión.",
     "complianceBannerTranscriptionSaving": "Se está guardando la transcripción.",
     "complianceBannerTranscriptionStopped": "La transcripción se ha detenido.",

--- a/packages/react-composites/src/composites/localization/locales/fr-FR/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/fr-FR/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "Sauvegarde en cours de l'enregistrement.",
     "complianceBannerRecordingStarted": "L’enregistrement a démarré.",
     "complianceBannerRecordingStopped": "L’enregistrement a pris fin.",
-    "complianceBannerTrancriptionStarted": "Démarrage de la transcription.",
+    "complianceBannerTranscriptionStarted": "Démarrage de la transcription.",
     "complianceBannerTranscriptionConsent": "En participant, vous autorisez la transcription de cette réunion.",
     "complianceBannerTranscriptionSaving": "Sauvegarde en cours de la transcription.",
     "complianceBannerTranscriptionStopped": "La transcription a pris fin.",

--- a/packages/react-composites/src/composites/localization/locales/it-IT/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/it-IT/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "Salvataggio della registrazione in corso.",
     "complianceBannerRecordingStarted": "Registrazione avviata.",
     "complianceBannerRecordingStopped": "Registrazione arrestata.",
-    "complianceBannerTrancriptionStarted": "Trascrizione avviata.",
+    "complianceBannerTranscriptionStarted": "Trascrizione avviata.",
     "complianceBannerTranscriptionConsent": "Partecipando, fornisci il consenso per la trascrizione di questa riunione.",
     "complianceBannerTranscriptionSaving": "È in corso il salvataggio della trascrizione.",
     "complianceBannerTranscriptionStopped": "Trascrizione interrotta.",

--- a/packages/react-composites/src/composites/localization/locales/ja-JP/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/ja-JP/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "レコーディングを保存しています。",
     "complianceBannerRecordingStarted": "レコーディングを開始しました。",
     "complianceBannerRecordingStopped": "レコーディングを停止しました。",
-    "complianceBannerTrancriptionStarted": "トランスクリプトが開始しました。",
+    "complianceBannerTranscriptionStarted": "トランスクリプトが開始しました。",
     "complianceBannerTranscriptionConsent": "参加すると、この会議のトランスクリプトの作成に同意したことになります。",
     "complianceBannerTranscriptionSaving": "トランスクリプトを保存されました。",
     "complianceBannerTranscriptionStopped": "トランスクリプトが停止しました。",

--- a/packages/react-composites/src/composites/localization/locales/ko-KR/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/ko-KR/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "녹음/녹화를 저장하는 중입니다.",
     "complianceBannerRecordingStarted": "녹음/녹화를 시작했습니다.",
     "complianceBannerRecordingStopped": "녹음/녹화를 중단했습니다.",
-    "complianceBannerTrancriptionStarted": "전사를 시작했습니다.",
+    "complianceBannerTranscriptionStarted": "전사를 시작했습니다.",
     "complianceBannerTranscriptionConsent": "참가하면 이 모임이 전사되는 것에 동의하게 됩니다.",
     "complianceBannerTranscriptionSaving": "전사를 저장하는 중입니다.",
     "complianceBannerTranscriptionStopped": "전사를 중단했습니다.",

--- a/packages/react-composites/src/composites/localization/locales/nl-NL/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/nl-NL/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "De opname wordt opgeslagen.",
     "complianceBannerRecordingStarted": "De opname is gestart.",
     "complianceBannerRecordingStopped": "De opname is gestopt.",
-    "complianceBannerTrancriptionStarted": "Transcriptie is gestart.",
+    "complianceBannerTranscriptionStarted": "Transcriptie is gestart.",
     "complianceBannerTranscriptionConsent": "Door deel te nemen, geeft u toestemming voor het transcriberen van deze vergadering.",
     "complianceBannerTranscriptionSaving": "Transcriptie wordt opgeslagen.",
     "complianceBannerTranscriptionStopped": "Transcriptie is gestopt.",

--- a/packages/react-composites/src/composites/localization/locales/pt-BR/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/pt-BR/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "A gravação está sendo salva.",
     "complianceBannerRecordingStarted": "A gravação foi iniciada.",
     "complianceBannerRecordingStopped": "A gravação foi interrompida.",
-    "complianceBannerTrancriptionStarted": "A transcrição foi iniciada.",
+    "complianceBannerTranscriptionStarted": "A transcrição foi iniciada.",
     "complianceBannerTranscriptionConsent": "Ao ingressar, você está dando consentimento para que esta reunião seja transcrita.",
     "complianceBannerTranscriptionSaving": "A transcrição está sendo salva.",
     "complianceBannerTranscriptionStopped": "A transcrição foi interrompida.",

--- a/packages/react-composites/src/composites/localization/locales/ru-RU/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/ru-RU/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "Сохранение записи.",
     "complianceBannerRecordingStarted": "Запись начата.",
     "complianceBannerRecordingStopped": "Запись остановлена.",
-    "complianceBannerTrancriptionStarted": "Транскрибирование запущено.",
+    "complianceBannerTranscriptionStarted": "Транскрибирование запущено.",
     "complianceBannerTranscriptionConsent": "Присоединяясь, вы даете согласие на транскрибирование этого собрания.",
     "complianceBannerTranscriptionSaving": "Сохранение транскрибирования.",
     "complianceBannerTranscriptionStopped": "Транскрибирование остановлено.",

--- a/packages/react-composites/src/composites/localization/locales/tr-TR/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/tr-TR/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "Kayıt kaydediliyor.",
     "complianceBannerRecordingStarted": "Kayıt başladı.",
     "complianceBannerRecordingStopped": "Kayıt durduruldu.",
-    "complianceBannerTrancriptionStarted": "Döküm başlatıldı.",
+    "complianceBannerTranscriptionStarted": "Döküm başlatıldı.",
     "complianceBannerTranscriptionConsent": "Katılarak bu toplantının dökümünün çıkarılmasına onay verirsiniz.",
     "complianceBannerTranscriptionSaving": "Döküm kaydediliyor.",
     "complianceBannerTranscriptionStopped": "Döküm durduruldu.",

--- a/packages/react-composites/src/composites/localization/locales/zh-CN/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/zh-CN/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "正在保存录制。",
     "complianceBannerRecordingStarted": "录制已开始。",
     "complianceBannerRecordingStopped": "录制已停止。",
-    "complianceBannerTrancriptionStarted": "听录已开始。",
+    "complianceBannerTranscriptionStarted": "听录已开始。",
     "complianceBannerTranscriptionConsent": "加入即表示你同意转录此会议。",
     "complianceBannerTranscriptionSaving": "正在保存听录。",
     "complianceBannerTranscriptionStopped": "听录已停止。",

--- a/packages/react-composites/src/composites/localization/locales/zh-TW/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/zh-TW/strings.json
@@ -12,7 +12,7 @@
     "complianceBannerRecordingSaving": "正在儲存錄製內容。",
     "complianceBannerRecordingStarted": "已開始錄製。",
     "complianceBannerRecordingStopped": "已停止錄製。",
-    "complianceBannerTrancriptionStarted": "已開始轉錄。",
+    "complianceBannerTranscriptionStarted": "已開始轉錄。",
     "complianceBannerTranscriptionConsent": "一旦加入，即表示您同意轉譯此會議。",
     "complianceBannerTranscriptionSaving": "正在儲存轉錄。",
     "complianceBannerTranscriptionStopped": "已停止轉錄。",


### PR DESCRIPTION
# What

Fix a typo in `complianceBannerTranscriptionStarted`.

# Why

D'oh!