### PR TITLE
Bugfix for display name input showing "long name" validation error when it is empty

### DIFF
--- a/samples/Calling/src/app/views/DisplayNameField.tsx
+++ b/samples/Calling/src/app/views/DisplayNameField.tsx
@@ -25,7 +25,7 @@ const hasValidLength = (name: string): boolean => {
 
 export const DisplayNameField = (props: DisplayNameFieldProps): JSX.Element => {
   const { setName, setEmptyWarning, isEmpty, defaultName } = props;
-  const [isInvalidLength, setIsInvalidLength] = useState<ConstrainBoolean>(!hasValidLength(defaultName ?? ''));
+  const [isInvalidLength, setIsInvalidLength] = useState<boolean>(!hasValidLength(defaultName ?? ''));
 
   const onNameTextChange = (
     event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -37,6 +37,8 @@ export const DisplayNameField = (props: DisplayNameFieldProps): JSX.Element => {
 
     if (!hasValidLength(newValue)) {
       setIsInvalidLength(true);
+      // The button below DisplayNameField is being disabled if name is empty.
+      // To ensure that the Join Call button is disabled when the name is too long, we have to clear it from the state.
       setName('');
       return;
     } else {

--- a/samples/Calling/src/app/views/DisplayNameField.tsx
+++ b/samples/Calling/src/app/views/DisplayNameField.tsx
@@ -19,13 +19,13 @@ const TEXTFIELD_PLACEHOLDER = 'Enter a name';
 const TEXTFIELD_EMPTY_ERROR_MSG = 'Name cannot be empty';
 const TEXTFIELD_EXCEEDS_MAX_CHARS = `Name cannot exceed ${DISPLAY_NAME_MAX_CHARS} characters`;
 
+const hasValidLength = (name: string): boolean => {
+  return name.length <= DISPLAY_NAME_MAX_CHARS;
+};
+
 export const DisplayNameField = (props: DisplayNameFieldProps): JSX.Element => {
   const { setName, setEmptyWarning, isEmpty, defaultName } = props;
-  const [isInvalidLength, setIsInvalidLength] = useState<ConstrainBoolean>(true);
-
-  const hasValidLength = (name: string): boolean => {
-    return name.length <= DISPLAY_NAME_MAX_CHARS;
-  };
+  const [isInvalidLength, setIsInvalidLength] = useState<ConstrainBoolean>(!hasValidLength(defaultName ?? ''));
 
   const onNameTextChange = (
     event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,


### PR DESCRIPTION
# What
A previous bugfix introduced a minor bug in our calling sample where display name input is showing long display name validation error even when it is empty

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->