### PR TITLE
Vertical control bar fix

### DIFF
--- a/change/@internal-react-components-7d849dc3-28a5-41bd-a4f5-159ed4d49b8e.json
+++ b/change/@internal-react-components-7d849dc3-28a5-41bd-a4f5-159ed4d49b8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Vertical ControlBar width set to fit-content. Maximum width of ControlBar and ControlBarButton to 8rem. Truncating long ControlBarButton labels.",
+  "packageName": "@internal/react-components",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/ControlBar.styles.ts
+++ b/packages/react-components/src/components/styles/ControlBar.styles.ts
@@ -26,7 +26,8 @@ export const controlBarStyles: IControlBarStyles = {
   },
   vertical: {
     flexFlow: 'column nowrap',
-    maxWidth: '3.5rem'
+    width: 'fit-content',
+    maxWidth: '8rem'
   },
   dockedTop: {
     flexFlow: 'row nowrap',
@@ -118,6 +119,8 @@ export const controlButtonStyles: IButtonStyles = {
     borderRadius: 0,
     minHeight: '3.5rem',
     minWidth: '3.5rem',
+    width: '100%',
+    maxWidth: '8rem',
     svg: {
       verticalAlign: 'text-top'
     }
@@ -132,7 +135,10 @@ export const controlButtonStyles: IButtonStyles = {
     lineHeight: '1rem',
     cursor: 'pointer',
     display: 'block',
-    margin: '0rem 0.25rem'
+    margin: '0rem 0.25rem',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
   }
 };
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Maximum width of ControlBar and ControlBarButton to 8rem after discussing with Alex P. Truncating long ControlBarButton labels after discussing with Alex P . Vertical ControlBar width set to fit-content. 

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2657885

# How Tested
<!--- How did you test your change. What tests have you added. -->
On storybook canvas in German in various layouts:
https://user-images.githubusercontent.com/79475487/145080644-3772ec37-f709-4713-ade7-081450ecb62f.mp4

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->