### PR TITLE
stateful quickstart: initialize thread state

### DIFF
--- a/change/@internal-storybook-1f46df55-363a-4361-9586-fe5b06dbf1ef.json
+++ b/change/@internal-storybook-1f46df55-363a-4361-9586-fe5b06dbf1ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update stateful quickstarts to initialize chat state",
+  "packageName": "@internal/storybook",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/QuickStarts/snippets/ChatAppStateful.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/ChatAppStateful.snippet.tsx
@@ -1,3 +1,4 @@
+import { ChatThreadClient } from '@azure/communication-chat';
 import { AzureCommunicationTokenCredential } from '@azure/communication-common';
 import { createStatefulChatClient, DEFAULT_COMPONENT_ICONS } from '@azure/communication-react';
 import { registerIcons } from '@fluentui/react';
@@ -21,12 +22,22 @@ function App(): JSX.Element {
     credential: tokenCredential
   });
 
-  const chatThreadClient = statefulChatClient.getChatThreadClient(threadId);
-
-  //Listen to notifications
+  // Listen to notifications
   statefulChatClient.startRealtimeNotifications();
 
+  const chatThreadClient = statefulChatClient.getChatThreadClient(threadId);
+  // Fetch thread properties, participants etc.
+  // Past messages are fetched as needed when the user scrolls to them.
+  initializeThreadState(chatThreadClient);
+
   return <>{chatThreadClient && <h1>Hooray! You set up chat client 🎉🎉🎉</h1>};</>;
+}
+
+async function initializeThreadState(chatThreadClient: ChatThreadClient) {
+  await chatThreadClient.getProperties();
+  for await (const _page of chatThreadClient.listParticipants().byPage()) {
+    // Simply fetching participants updates the cached state in client.
+  }
 }
 
 export default App;

--- a/packages/storybook/stories/QuickStarts/snippets/ChatAppStateful.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/ChatAppStateful.snippet.tsx
@@ -33,7 +33,7 @@ function App(): JSX.Element {
   return <>{chatThreadClient && <h1>Hooray! You set up chat client 🎉🎉🎉</h1>};</>;
 }
 
-async function initializeThreadState(chatThreadClient: ChatThreadClient) {
+async function initializeThreadState(chatThreadClient: ChatThreadClient): Promise<void> {
   await chatThreadClient.getProperties();
   for await (const _page of chatThreadClient.listParticipants().byPage()) {
     // Simply fetching participants updates the cached state in client.

--- a/packages/storybook/stories/QuickStarts/snippets/ChatAppStatefulComplete.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/ChatAppStatefulComplete.snippet.tsx
@@ -1,3 +1,4 @@
+import { ChatThreadClient } from '@azure/communication-chat';
 import { AzureCommunicationTokenCredential } from '@azure/communication-common';
 import {
   createStatefulChatClient,
@@ -20,7 +21,7 @@ function App(): JSX.Element {
   const threadId = '<Get thread id from chat service>';
   const displayName = '<Display Name>';
 
-  //Instantiate the statefulChatClient
+  // Instantiate the statefulChatClient
   const statefulChatClient = createStatefulChatClient({
     userId: { communicationUserId: userId },
     displayName: displayName,
@@ -28,10 +29,13 @@ function App(): JSX.Element {
     credential: tokenCredential
   });
 
-  const chatThreadClient = statefulChatClient.getChatThreadClient(threadId);
-
-  //Listen to notifications
+  // Listen to notifications
   statefulChatClient.startRealtimeNotifications();
+
+  const chatThreadClient = statefulChatClient.getChatThreadClient(threadId);
+  // Fetch thread properties, participants etc.
+  // Past messages are fetched as needed when the user scrolls to them.
+  initializeThreadState(chatThreadClient);
 
   return (
     <FluentThemeProvider>
@@ -42,6 +46,13 @@ function App(): JSX.Element {
       </ChatClientProvider>
     </FluentThemeProvider>
   );
+}
+
+async function initializeThreadState(chatThreadClient: ChatThreadClient) {
+  await chatThreadClient.getProperties();
+  for await (const _page of chatThreadClient.listParticipants().byPage()) {
+    // Simply fetching participants updates the cached state in client.
+  }
 }
 
 export default App;

--- a/packages/storybook/stories/QuickStarts/snippets/ChatAppStatefulComplete.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/ChatAppStatefulComplete.snippet.tsx
@@ -48,7 +48,7 @@ function App(): JSX.Element {
   );
 }
 
-async function initializeThreadState(chatThreadClient: ChatThreadClient) {
+async function initializeThreadState(chatThreadClient: ChatThreadClient): Promise<void> {
   await chatThreadClient.getProperties();
   for await (const _page of chatThreadClient.listParticipants().byPage()) {
     // Simply fetching participants updates the cached state in client.

--- a/packages/storybook/stories/QuickStarts/snippets/ChatAppStatefulProviders.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/ChatAppStatefulProviders.snippet.tsx
@@ -1,3 +1,4 @@
+import { ChatThreadClient } from '@azure/communication-chat';
 import { AzureCommunicationTokenCredential } from '@azure/communication-common';
 import {
   createStatefulChatClient,
@@ -19,7 +20,7 @@ function App(): JSX.Element {
   const threadId = '<Get thread id from chat service>';
   const displayName = '<Display Name>';
 
-  //Instatiate the statefulChatClient
+  // Instantiate the statefulChatClient
   const statefulChatClient = createStatefulChatClient({
     userId: { communicationUserId: userId },
     displayName: displayName,
@@ -27,10 +28,13 @@ function App(): JSX.Element {
     credential: tokenCredential
   });
 
-  const chatThreadClient = statefulChatClient.getChatThreadClient(threadId);
-
-  //Listen to notifications
+  // Listen to notifications
   statefulChatClient.startRealtimeNotifications();
+
+  const chatThreadClient = statefulChatClient.getChatThreadClient(threadId);
+  // Fetch thread properties, participants etc.
+  // Past messages are fetched as needed when the user scrolls to them.
+  initializeThreadState(chatThreadClient);
 
   return (
     <FluentThemeProvider>
@@ -41,6 +45,13 @@ function App(): JSX.Element {
       </ChatClientProvider>
     </FluentThemeProvider>
   );
+}
+
+async function initializeThreadState(chatThreadClient: ChatThreadClient) {
+  await chatThreadClient.getProperties();
+  for await (const _page of chatThreadClient.listParticipants().byPage()) {
+    // Simply fetching participants updates the cached state in client.
+  }
 }
 
 export default App;

--- a/packages/storybook/stories/QuickStarts/snippets/ChatAppStatefulProviders.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/ChatAppStatefulProviders.snippet.tsx
@@ -47,7 +47,7 @@ function App(): JSX.Element {
   );
 }
 
-async function initializeThreadState(chatThreadClient: ChatThreadClient) {
+async function initializeThreadState(chatThreadClient: ChatThreadClient): Promise<void> {
   await chatThreadClient.getProperties();
   for await (const _page of chatThreadClient.listParticipants().byPage()) {
     // Simply fetching participants updates the cached state in client.


### PR DESCRIPTION
# What

* Initialize thread state in stateful chat quickstart

# Why

* It's non-trivial to know that this initialization is necessary. In the absence of this initialization, it's easy to be confused by the non-deterministic behaviour of when the thread properties are updated (depends on how events are received etc.)

# How Tested

Tried out quickstart in a scratch app.
