### PR TITLE
Alcail/a11y dropdown label too informative

### DIFF
--- a/change/@internal-react-composites-366c4d6e-1f5a-4ae0-a34a-c4b54f99a082.json
+++ b/change/@internal-react-composites-366c4d6e-1f5a-4ae0-a34a-c4b54f99a082.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "separate label from dropdown for Camera devices",
+  "packageName": "@internal/react-composites",
+  "email": "alcail@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
@@ -93,34 +93,43 @@ export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element
 
   return (
     <Stack data-ui-id="call-composite-device-settings" tokens={mainStackTokens}>
-      <Dropdown
-        data-ui-id="call-composite-local-camera-settings"
-        label={cameraLabel}
-        placeholder={defaultPlaceHolder}
-        options={
-          props.cameraPermissionGranted ? getDropDownList(props.cameras) : [{ key: 'deniedOrUnknown', text: '' }]
-        }
-        styles={dropDownStyles(theme)}
-        disabled={!props.cameraPermissionGranted}
-        errorMessage={
-          props.cameraPermissionGranted === undefined || props.cameraPermissionGranted
-            ? undefined
-            : locale.strings.call.cameraPermissionDenied
-        }
-        defaultSelectedKey={
-          props.cameraPermissionGranted
-            ? props.selectedCamera
-              ? props.selectedCamera.id
-              : props.cameras
-              ? props.cameras[0]?.id
-              : ''
-            : 'deniedOrUnknown'
-        }
-        onChange={(event, option, index) => {
-          props.onSelectCamera(props.cameras[index ?? 0], localVideoViewOptions);
-        }}
-        onRenderTitle={(props?: IDropdownOption[]) => onRenderTitle('Camera', props)}
-      />
+      <Stack>
+        <Label
+          id={'call-composite-local-camera-settings-label'}
+          className={mergeStyles(dropDownStyles(theme).label)}
+          disabled={!props.cameraPermissionGranted} // follows dropdown disabled state
+        >
+          {cameraLabel}
+        </Label>
+        <Dropdown
+          data-ui-id="call-composite-local-camera-settings"
+          aria-labelledby={'call-composite-local-camera-settings-label'}
+          placeholder={defaultPlaceHolder}
+          options={
+            props.cameraPermissionGranted ? getDropDownList(props.cameras) : [{ key: 'deniedOrUnknown', text: '' }]
+          }
+          styles={dropDownStyles(theme)}
+          disabled={!props.cameraPermissionGranted}
+          errorMessage={
+            props.cameraPermissionGranted === undefined || props.cameraPermissionGranted
+              ? undefined
+              : locale.strings.call.cameraPermissionDenied
+          }
+          defaultSelectedKey={
+            props.cameraPermissionGranted
+              ? props.selectedCamera
+                ? props.selectedCamera.id
+                : props.cameras
+                ? props.cameras[0]?.id
+                : ''
+              : 'deniedOrUnknown'
+          }
+          onChange={(event, option, index) => {
+            props.onSelectCamera(props.cameras[index ?? 0], localVideoViewOptions);
+          }}
+          onRenderTitle={(props?: IDropdownOption[]) => onRenderTitle('Camera', props)}
+        />
+      </Stack>
       <Stack>
         <Label
           id={'call-composite-local-sound-settings-label'}


### PR DESCRIPTION
# What
separated label from Camera dropdown in Call composite Configuration page

# Why
a11y bug https://skype.visualstudio.com/SPOOL/_workitems/edit/2561946
Screen reader is announcing 'Camera Integrated Camera(xxx) Integrated Camera(xxx) combobox collapsed has popup' when it should only announce  'Camera Integrated Camera(xxx) combobox collapsed has popup'.
Issue is using the label prop of Dropdown component make the screen reader announcing the label followed by the selected item, and finally selected item and 'combobox collapsed has popup'.
To avoid repeating the selected item, we need to separate the label from the Dropdown component then add this label as a reference for aria purposes.

This double information of selected item is a FluentUI behaviour though :(

# How Tested
ran Call sample locally with Narrator on

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->