### PR TITLE
ScreenReaderMenuItemFix

### DIFF
--- a/change/@internal-react-components-37e41d21-2041-40d5-bf3c-5ed493952fe2.json
+++ b/change/@internal-react-components-37e41d21-2041-40d5-bf3c-5ed493952fe2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "added aria roles to the different menu props.",
+  "packageName": "@internal/react-components",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/DevicesButton.tsx
+++ b/packages/react-components/src/components/DevicesButton.tsx
@@ -214,6 +214,7 @@ const generateDefaultMenuProps = (
           itemProps: {
             styles: menuItemStyles
           },
+          role: 'menuitem',
           canCheck: true,
           isChecked: camera.id === selectedCamera?.id,
           onClick: () => {
@@ -241,6 +242,7 @@ const generateDefaultMenuProps = (
           itemProps: {
             styles: menuItemStyles
           },
+          role: 'menuitem',
           canCheck: true,
           isChecked: microphone.id === selectedMicrophone?.id,
           onClick: () => {
@@ -268,6 +270,7 @@ const generateDefaultMenuProps = (
           itemProps: {
             styles: menuItemStyles
           },
+          role: 'menuitem',
           canCheck: true,
           isChecked: speaker.id === selectedSpeaker?.id,
           onClick: () => {


### PR DESCRIPTION
# What
Added aria roles to the context menu items in the options button.

# Why
Before it wasn't reading out the quantity of items in the list. now it does
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2561987
# How Tested
used Narrator to make sure the right output was being read on that menu.
