### PR TITLE
Anjulgarg/bugfix mic sync lobby

### DIFF
--- a/change/@internal-react-composites-65cd15ac-7be0-4103-bb09-418240fbbb13.json
+++ b/change/@internal-react-composites-65cd15ac-7be0-4103-bb09-418240fbbb13.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Bugfix for mic not reflecting local mic state in l",
+  "comment": "Bugfix for mic not reflecting local mic state in lobby",
   "packageName": "@internal/react-composites",
   "email": "anjulgarg@live.com",
   "dependentChangeType": "patch"

--- a/change/@internal-react-composites-65cd15ac-7be0-4103-bb09-418240fbbb13.json
+++ b/change/@internal-react-composites-65cd15ac-7be0-4103-bb09-418240fbbb13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bugfix for mic not reflecting local mic state in l",
+  "packageName": "@internal/react-composites",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -105,7 +105,10 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
    * This is due to to headless limitation where a call can not be muted/unmuted in lobby.
    */
   const microphoneButtonProps = usePropsFor(MicrophoneButton);
-  if (_isInLobbyOrConnecting(callStatus)) {
+  // We need to check for `callStatus` === 'None' as well since that's the first status of a call when
+  // we join an ACS or Teams interop call. If we don't handle 'None', the microphone status won't reflect
+  // the local microphone state when `callStatus` is 'None'.
+  if (_isInLobbyOrConnecting(callStatus) || callStatus === 'None') {
     microphoneButtonProps.disabled = true;
     // Lobby page should show the microphone status that was set on the local preview/configuration
     // page until the user successfully joins the call.

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -108,6 +108,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
   // We need to check for `callStatus` === 'None' as well since that's the first status of a call when
   // we join an ACS or Teams interop call. If we don't handle 'None', the microphone status won't reflect
   // the local microphone state when `callStatus` is 'None'.
+  // TODO: Ensure that mic toggle is not disabled during a non interop call as it is allowed to toggle mic in acs call while it is connecting.
   if (_isInLobbyOrConnecting(callStatus) || callStatus === 'None') {
     microphoneButtonProps.disabled = true;
     // Lobby page should show the microphone status that was set on the local preview/configuration


### PR DESCRIPTION
# What
Disable the microphone button in the connecting screen and lobby screen **always** - this is a stopgap fix while we investigate a proper fix to incorrect microphone state in the connecting screen.

# Why
Bugfix for mic not reflecting local mic state in lobby and connecting screen.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->