### PR TITLE
Delay entering 'lobby' state till underlying 'Call' object stabilizes

### DIFF
--- a/change/@internal-react-composites-504ab3cc-e042-4936-86bd-af658c9eab74.json
+++ b/change/@internal-react-composites-504ab3cc-e042-4936-86bd-af658c9eab74.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix transitional bug showing incorrect mute state when connecting call",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
+++ b/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
@@ -104,8 +104,11 @@ export const getCallCompositePage = (
       return 'call';
     } else {
       // When the call object has been constructed after clicking , but before 'connecting' has been
-      // set on the call object, we want to show the connecting screen (which is part of the lobby page currently)
-      return 'lobby';
+      // set on the call object, we continue to show the configuration screen.
+      // The call object does not correctly reflect local device state until `call.state` moves to `connecting`.
+      // Moving to the 'lobby' page too soon leads to components that depend on the `call` object to show incorrect
+      // transitional state.
+      return 'configuration';
     }
   }
 


### PR DESCRIPTION
# What

Delay transitional call page from 'configuration' to 'lobby' until call enters 'Connecting' state.

# Why

When the call object has been created, but is still in state 'None', we have observed that some properties have default values that don't reflect reality. This is problematic for local device state (e.g., whether the local participant is muted or not) as the default may not be correct, but the UI in configuration screen might already be showing the correct state. This creates an incorrect transitional UI update showing the wrong value.

# How Tested

Bug bash it.