### PR TITLE
Delay entering 'lobby' state till underlying 'Call' object stabilizes…

### DIFF
--- a/change/@internal-react-composites-504ab3cc-e042-4936-86bd-af658c9eab74.json
+++ b/change/@internal-react-composites-504ab3cc-e042-4936-86bd-af658c9eab74.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix transitional bug showing incorrect mute state when connecting call",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
+++ b/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
@@ -104,8 +104,11 @@ export const getCallCompositePage = (
       return 'call';
     } else {
       // When the call object has been constructed after clicking , but before 'connecting' has been
-      // set on the call object, we want to show the connecting screen (which is part of the lobby page currently)
-      return 'lobby';
+      // set on the call object, we continue to show the configuration screen.
+      // The call object does not correctly reflect local device state until `call.state` moves to `connecting`.
+      // Moving to the 'lobby' page too soon leads to components that depend on the `call` object to show incorrect
+      // transitional state.
+      return 'configuration';
     }
   }
 


### PR DESCRIPTION
Cherry pick of (#1243)
