### PR TITLE
Alcail/camera tooltip when waiting for stream

### DIFF
--- a/change/@internal-react-components-9a822f88-c39d-4d91-9b15-36af563aa5b7.json
+++ b/change/@internal-react-components-9a822f88-c39d-4d91-9b15-36af563aa5b7.json
@@ -1,0 +1,7 @@
+{
+  "comment": "add tooltipVideoLoadingContent to Camera strings",
+  "type": "none",
+  "packageName": "@internal/react-components",
+  "email": "alcail@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -488,6 +488,7 @@ export interface CameraButtonStrings {
     tooltipDisabledContent?: string;
     tooltipOffContent?: string;
     tooltipOnContent?: string;
+    tooltipVideoLoadingContent?: string;
 }
 
 // @public

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -72,6 +72,7 @@ export interface CameraButtonStrings {
     tooltipDisabledContent?: string;
     tooltipOffContent?: string;
     tooltipOnContent?: string;
+    tooltipVideoLoadingContent?: string;
 }
 
 // @public

--- a/packages/react-components/src/components/CameraButton.tsx
+++ b/packages/react-components/src/components/CameraButton.tsx
@@ -28,6 +28,8 @@ export interface CameraButtonStrings {
   tooltipOnContent?: string;
   /** Tooltip content when the button is off. */
   tooltipOffContent?: string;
+  /** Tooltip content when the button is disabled due to video loading. */
+  tooltipVideoLoadingContent?: string;
 }
 
 /**
@@ -69,6 +71,9 @@ export const CameraButton = (props: CameraButtonProps): JSX.Element => {
 
   const localeStrings = useLocale().strings.cameraButton;
   const strings = { ...localeStrings, ...props.strings };
+  if (waitForCamera && strings.tooltipVideoLoadingContent) {
+    strings.tooltipDisabledContent = strings.tooltipVideoLoadingContent;
+  }
 
   const onToggleClick = useCallback(async () => {
     // Throttle click on camera, need to await onToggleCamera then allow another click

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -36,7 +36,8 @@
     "offLabel": "Turn on",
     "tooltipDisabledContent": "Camera is disabled",
     "tooltipOnContent": "Turn off camera",
-    "tooltipOffContent": "Turn on camera"
+    "tooltipOffContent": "Turn on camera",
+    "tooltipVideoLoadingContent": "Video is loading"
   },
   "microphoneButton": {
     "onLabel": "Mute",


### PR DESCRIPTION
# What
added Tooltip string to camera button for case of video loading
![image](https://user-images.githubusercontent.com/82416644/146275205-482d893c-5085-4e1f-946b-6617841e2854.png)

# Why
bug https://skype.visualstudio.com/SPOOL/_workitems/edit/2659175

# How Tested
ran calling sample locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [x] This change causes current functionality to break.
added string to CameraButtonStrings