### PR TITLE
Dmceachernmsft/MeetingCompsiteAlternateProp

### DIFF
--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -64,7 +64,7 @@ export type CallCompositeOptions = {
    * Can be customized by providing an object of type {@link @azure/communication-react#CallControlOptions}.
    * @defaultValue true
    */
-  callControls?: boolean | CallControlOptions;
+  callControls?: CallControlOptions;
 };
 
 type MainScreenProps = {

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -23,7 +23,7 @@ export interface CallArrangementProps {
   complianceBannerProps: ComplianceBannerProps;
   errorBarProps: ErrorBarProps | false;
   mutedNotificationProps?: MutedNotificationProps;
-  callControlProps: CallControlsProps | false;
+  callControlProps: CallControlsProps;
   onRenderGalleryContent: () => JSX.Element;
   dataUiId: string;
   mobileView: boolean;

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -32,7 +32,7 @@ import {
 export type CallControlsProps = {
   callInvitationURL?: string;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
-  options?: boolean | CallControlOptions;
+  options?: CallControlOptions;
   /**
    * Option to increase the height of the button flyout menu items from 36px to 48px.
    * Recommended for mobile devices.
@@ -86,6 +86,10 @@ export type CallControlOptions = {
    * @defaultValue true
    */
   screenShareButton?: boolean | { disabled: boolean };
+  /**
+   * Hide or show the whole control bar.
+   */
+  showControlBar?: boolean;
 };
 
 /**
@@ -94,17 +98,8 @@ export type CallControlOptions = {
 export const CallControls = (props: CallControlsProps): JSX.Element => {
   const { callInvitationURL, onFetchParticipantMenuItems } = props;
 
-  const options =
-    typeof props.options === 'boolean'
-      ? {
-          microphoneButton: false,
-          cameraButton: false,
-          participantsButton: false,
-          devicesButton: false,
-          endCallButton: false,
-          screenShareButton: false
-        }
-      : props.options;
+  const showControlBar = props.options?.showControlBar;
+  const options = props.options;
 
   const callStatus = useSelector(getCallStatus);
   const isLocalMicrophoneEnabled = useSelector(getLocalMicrophoneEnabled);
@@ -148,7 +143,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
 
   const compactMode = options?.displayType === 'compact';
 
-  const microphoneButton = options?.microphoneButton !== false && (
+  const microphoneButton = options?.microphoneButton !== false && showControlBar !== false && (
     <MicrophoneButton
       data-ui-id="call-composite-microphone-button"
       {...microphoneButtonProps}
@@ -158,7 +153,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
     />
   );
 
-  const cameraButton = options?.cameraButton !== false && (
+  const cameraButton = options?.cameraButton !== false && showControlBar !== false && (
     <CameraButton
       data-ui-id="call-composite-camera-button"
       {...cameraButtonProps}
@@ -167,7 +162,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
     />
   );
 
-  const screenShareButton = options?.screenShareButton !== false && (
+  const screenShareButton = options?.screenShareButton !== false && showControlBar !== false && (
     <ScreenShareButton
       data-ui-id="call-composite-screenshare-button"
       {...screenShareButtonProps}
@@ -176,7 +171,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
     />
   );
 
-  const participantButton = options?.participantsButton !== false && (
+  const participantButton = options?.participantsButton !== false && showControlBar !== false && (
     <ParticipantsButton
       data-ui-id="call-composite-participants-button"
       {...participantsButtonProps}
@@ -188,7 +183,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
     />
   );
 
-  const devicesButton = options?.devicesButton !== false && (
+  const devicesButton = options?.devicesButton !== false && showControlBar !== false && (
     <DevicesButton
       /* By setting `persistMenu?` to true, we prevent options menu from getting hidden every time a participant joins or leaves. */
       persistMenu={true}
@@ -198,7 +193,7 @@ export const CallControls = (props: CallControlsProps): JSX.Element => {
     />
   );
 
-  const endCallButton = options?.endCallButton !== false && (
+  const endCallButton = options?.endCallButton !== false && showControlBar !== false && (
     <EndCallButton
       data-ui-id="call-composite-hangup-button"
       {...hangUpButtonProps}

--- a/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
@@ -55,21 +55,19 @@ export const CallPage = (props: CallPageProps): JSX.Element => {
   const networkReconnectTileProps = useSelector(networkReconnectTileSelector);
 
   // Reduce the controls shown when mobile view is enabled.
-  const callControlOptions = mobileView ? reduceCallControlsForMobile(options?.callControls) : options?.callControls;
+  const callControlOptions = mobileView ? reduceCallControlsForMobile(options?.callControls) : options?.callControls; // is this needed since the call controls object takes in a display type parameter?
 
   return (
     <CallArrangement
       complianceBannerProps={{ ...complianceBannerProps }}
       errorBarProps={options?.errorBar !== false && { ...errorBarProps }}
       mutedNotificationProps={mutedNotificationProps}
-      callControlProps={
-        callControlOptions !== false && {
-          callInvitationURL: callInvitationURL,
-          onFetchParticipantMenuItems: onFetchParticipantMenuItems,
-          options: callControlOptions,
-          increaseFlyoutItemSize: mobileView
-        }
-      }
+      callControlProps={{
+        callInvitationURL: callInvitationURL,
+        onFetchParticipantMenuItems: onFetchParticipantMenuItems,
+        options: options?.callControls,
+        increaseFlyoutItemSize: mobileView
+      }}
       mobileView={mobileView}
       onRenderGalleryContent={() =>
         callStatus === 'Connected' ? (

--- a/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
@@ -48,12 +48,10 @@ export const LobbyPage = (props: LobbyPageProps): JSX.Element => {
     <CallArrangement
       complianceBannerProps={{}}
       errorBarProps={props.options?.errorBar !== false && { ...errorBarProps }}
-      callControlProps={
-        callControlOptions !== false && {
-          options: callControlOptions,
-          increaseFlyoutItemSize: props.mobileView
-        }
-      }
+      callControlProps={{
+        options: props.options?.callControls,
+        increaseFlyoutItemSize: props.mobileView
+      }}
       mobileView={props.mobileView}
       onRenderGalleryContent={() => <LobbyTile {...lobbyProps} overlayProps={overlayProps(strings, inLobby)} />}
       dataUiId={'lobby-page'}

--- a/packages/react-composites/src/composites/MeetingComposite/MeetingCallControlBar.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/MeetingCallControlBar.tsx
@@ -23,7 +23,7 @@ export interface MeetingCallControlBarProps {
   onPeopleButtonClicked: () => void;
   mobileView: boolean;
   disableButtonsForLobbyPage: boolean;
-  meetingCallControlOptions?: boolean | MeetingCallControlOptions;
+  meetingCallControlOptions?: MeetingCallControlOptions;
 }
 
 /**
@@ -32,8 +32,8 @@ export interface MeetingCallControlBarProps {
 export const MeetingCallControlBar = (props: MeetingCallControlBarProps): JSX.Element => {
   // Set the desired control buttons from the meetings composite. particiapantsButton is always false since there is the peopleButton.
   let meetingCallControlOptions, callControlsOptions;
-  if (props.meetingCallControlOptions === false) {
-    // if meeting options is a boolean assign call controls the same value.
+  if (props.meetingCallControlOptions?.showControlBar === false) {
+    // if meeting options is false assign call controls to hide the call control bar.
     callControlsOptions = props.meetingCallControlOptions;
     meetingCallControlOptions = {
       chatButton: false,
@@ -45,8 +45,7 @@ export const MeetingCallControlBar = (props: MeetingCallControlBarProps): JSX.El
     callControlsOptions = {
       ...meetingCallControlOptions,
       participantsButton: false,
-      screenShareButton:
-        props.mobileView || meetingCallControlOptions === false ? false : { disabled: props.disableButtonsForLobbyPage }
+      screenShareButton: props.mobileView ? false : { disabled: props.disableButtonsForLobbyPage }
     };
   }
 
@@ -57,7 +56,7 @@ export const MeetingCallControlBar = (props: MeetingCallControlBarProps): JSX.El
   const isEnabled = (option: boolean | undefined): boolean => !(option === false);
 
   // Reduce the controls shown when mobile view is enabled.
-  if (props.mobileView && typeof callControlsOptions !== 'boolean') {
+  if (typeof props.mobileView !== 'boolean') {
     callControlsOptions = reduceCallControlsForMobile(callControlsOptions);
   }
 

--- a/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
+++ b/packages/react-composites/src/composites/MeetingComposite/MeetingComposite.tsx
@@ -44,9 +44,9 @@ export interface MeetingCompositeProps extends BaseCompositeProps<CallCompositeI
    */
   meetingInvitationURL?: string;
   /**
-   * Call control options to change what buttons show on the meeting composite control bar.
+   * Call control options to change what buttons show on the meeting composite control bar. showControlBar option hides whole bar.
    */
-  meetingCallControlOptions?: boolean | MeetingCallControlOptions;
+  meetingCallControlOptions?: MeetingCallControlOptions;
 }
 
 /**
@@ -57,7 +57,7 @@ export interface MeetingCompositeProps extends BaseCompositeProps<CallCompositeI
 export interface MeetingCallControlOptions
   extends Pick<
     CallControlOptions,
-    'cameraButton' | 'microphoneButton' | 'screenShareButton' | 'devicesButton' | 'displayType'
+    'cameraButton' | 'microphoneButton' | 'screenShareButton' | 'devicesButton' | 'displayType' | 'showControlBar'
   > {
   /**
    * Show or hide the chat button in the meeting control bar.
@@ -121,7 +121,7 @@ export const MeetingComposite = (props: MeetingCompositeProps): JSX.Element => {
             <CallComposite
               {...props}
               formFactor={formFactor}
-              options={{ callControls: false }}
+              options={{ callControls: { showControlBar: false } }}
               adapter={callAdapter}
               fluentTheme={fluentTheme}
             />

--- a/packages/storybook/stories/MeetingComposite/snippets/Meeting.snippet.tsx
+++ b/packages/storybook/stories/MeetingComposite/snippets/Meeting.snippet.tsx
@@ -18,7 +18,7 @@ export type MeetingExampleProps = {
   threadId: string;
   fluentTheme?: PartialTheme | Theme;
   callInvitationURL?: string;
-  meetingCallControlOptions?: boolean | MeetingCallControlOptions;
+  meetingCallControlOptions?: MeetingCallControlOptions;
 };
 
 export const MeetingExperience = (props: MeetingExampleProps): JSX.Element => {


### PR DESCRIPTION
# What
remove the boolean type for the ui options props for the meeting composite and call control component
# Why
Alternate change to PR: https://github.com/Azure/communication-ui-library/pull/1266/files 

# How Tested
Ran locally in story book with different meeting composite options props.