### PR TITLE
Fixed end call button to have red background in all accessibility modes 

### DIFF
--- a/change/@internal-react-components-2ea92f02-8df3-4e0b-9ce9-fa5687ba6cb1.json
+++ b/change/@internal-react-components-2ea92f02-8df3-4e0b-9ce9-fa5687ba6cb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Define fixed color for end call button",
+  "packageName": "@internal/react-components",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/EndCallButton.tsx
+++ b/packages/react-components/src/components/EndCallButton.tsx
@@ -80,7 +80,7 @@ const darkThemeCallButtonStyles = {
     color: darkTheme.callingPalette.iconWhite,
     background: darkTheme.callingPalette.callRed,
     '@media (forced-colors: active)': {
-      background: darkTheme.callingPalette.callRed
+      forcedColorAdjust: 'none'
     },
     ':focus::after': { outlineColor: `${darkTheme.callingPalette.iconWhite} !important` } // added !important to avoid override by FluentUI button styles
   },
@@ -88,14 +88,14 @@ const darkThemeCallButtonStyles = {
     color: darkTheme.callingPalette.iconWhite,
     background: darkTheme.callingPalette.callRed,
     '@media (forced-colors: active)': {
-      background: darkTheme.callingPalette.callRed
+      forcedColorAdjust: 'none'
     }
   },
   rootPressed: {
     color: darkTheme.callingPalette.iconWhite,
     background: darkTheme.callingPalette.callRed,
     '@media (forced-colors: active)': {
-      background: darkTheme.callingPalette.callRed
+      forcedColorAdjust: 'none'
     }
   },
   label: {
@@ -108,7 +108,7 @@ const lightThemeCallButtonStyles = {
     color: lightTheme.callingPalette.iconWhite,
     background: lightTheme.callingPalette.callRed,
     '@media (forced-colors: active)': {
-      background: lightTheme.callingPalette.callRed
+      forcedColorAdjust: 'none'
     },
     ':focus::after': { outlineColor: `${lightTheme.callingPalette.iconWhite} !important` } // added !important to avoid override by FluentUI button styles
   },
@@ -116,14 +116,14 @@ const lightThemeCallButtonStyles = {
     color: lightTheme.callingPalette.iconWhite,
     background: lightTheme.callingPalette.callRed,
     '@media (forced-colors: active)': {
-      background: lightTheme.callingPalette.callRed
+      forcedColorAdjust: 'none'
     }
   },
   rootPressed: {
     color: lightTheme.callingPalette.iconWhite,
     background: lightTheme.callingPalette.callRed,
     '@media (forced-colors: active)': {
-      background: lightTheme.callingPalette.callRed
+      forcedColorAdjust: 'none'
     }
   },
   label: {

--- a/packages/react-components/src/components/EndCallButton.tsx
+++ b/packages/react-components/src/components/EndCallButton.tsx
@@ -78,16 +78,25 @@ export const EndCallButton = (props: EndCallButtonProps): JSX.Element => {
 const darkThemeCallButtonStyles = {
   root: {
     color: darkTheme.callingPalette.iconWhite,
-    background: darkTheme.callingPalette.callRedDark,
+    background: darkTheme.callingPalette.callRed,
+    '@media (forced-colors: active)': {
+      background: darkTheme.callingPalette.callRed
+    },
     ':focus::after': { outlineColor: `${darkTheme.callingPalette.iconWhite} !important` } // added !important to avoid override by FluentUI button styles
   },
   rootHovered: {
     color: darkTheme.callingPalette.iconWhite,
-    background: darkTheme.callingPalette.callRedDark
+    background: darkTheme.callingPalette.callRed,
+    '@media (forced-colors: active)': {
+      background: darkTheme.callingPalette.callRed
+    }
   },
   rootPressed: {
     color: darkTheme.callingPalette.iconWhite,
-    background: darkTheme.callingPalette.callRedDark
+    background: darkTheme.callingPalette.callRed,
+    '@media (forced-colors: active)': {
+      background: darkTheme.callingPalette.callRed
+    }
   },
   label: {
     color: darkTheme.callingPalette.iconWhite
@@ -97,16 +106,25 @@ const darkThemeCallButtonStyles = {
 const lightThemeCallButtonStyles = {
   root: {
     color: lightTheme.callingPalette.iconWhite,
-    background: lightTheme.callingPalette.callRedDark,
+    background: lightTheme.callingPalette.callRed,
+    '@media (forced-colors: active)': {
+      background: lightTheme.callingPalette.callRed
+    },
     ':focus::after': { outlineColor: `${lightTheme.callingPalette.iconWhite} !important` } // added !important to avoid override by FluentUI button styles
   },
   rootHovered: {
     color: lightTheme.callingPalette.iconWhite,
-    background: lightTheme.callingPalette.callRedDark
+    background: lightTheme.callingPalette.callRed,
+    '@media (forced-colors: active)': {
+      background: lightTheme.callingPalette.callRed
+    }
   },
   rootPressed: {
     color: lightTheme.callingPalette.iconWhite,
-    background: lightTheme.callingPalette.callRedDark
+    background: lightTheme.callingPalette.callRed,
+    '@media (forced-colors: active)': {
+      background: lightTheme.callingPalette.callRed
+    }
   },
   label: {
     color: lightTheme.callingPalette.iconWhite

--- a/packages/react-components/src/components/EndCallButton.tsx
+++ b/packages/react-components/src/components/EndCallButton.tsx
@@ -74,7 +74,7 @@ export const EndCallButton = (props: EndCallButtonProps): JSX.Element => {
     />
   );
 };
-
+// using media query to prevent windows from overwriting the button color
 const darkThemeCallButtonStyles = {
   root: {
     color: darkTheme.callingPalette.iconWhite,

--- a/packages/react-components/src/components/HighContrastAwareIcon.tsx
+++ b/packages/react-components/src/components/HighContrastAwareIcon.tsx
@@ -24,11 +24,18 @@ export const HighContrastAwareIcon = (props: HighContrastAwareIconProps): JSX.El
   const { iconName, disabled } = props;
   const theme = useTheme();
   // setting colors for the icons using color from theme, so in dark mode or other accessibility modes, they have pre-defined contrast colors
+  // the media query is for when in specific window accessibility mode, change the svg colors
   return (
     <Icon
       iconName={iconName}
       className={mergeStyles({
-        svg: { fill: disabled ? theme.palette.neutralTertiary : theme.palette.neutralPrimaryAlt }
+        svg: {
+          fill: disabled ? theme.palette.neutralTertiary : theme.palette.neutralPrimaryAlt,
+
+          '@media (forced-colors: active) and (prefers-color-scheme: dark)': {
+            fill: disabled ? theme.palette.neutralPrimaryAlt : theme.palette.neutralTertiary
+          }
+        }
       })}
     />
   );


### PR DESCRIPTION
# What
Fixed end call button to have red background in all accessibility modes 
Fixed contrast issues for icons in dark window accessibility modes when using light theme

# Why
This is a fix for the high contrast accessibility error.
https://skype.visualstudio.com/SPOOL/_workitems/edit/2564703

# How Tested
Check Calling sample in different Windows accessibility modes and see if there are any contrast issues 
Please test all four modes in light/dark settings 

