### PR TITLE
BUG 2677269 - Fixed ScreenShareButton component to allow custom styles

### DIFF
--- a/change/@internal-react-components-39662025-b3a6-41b3-b4db-0a8af3cc2d99.json
+++ b/change/@internal-react-components-39662025-b3a6-41b3-b4db-0a8af3cc2d99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed ScreenShareButton style to allow custom styles",
+  "packageName": "@internal/react-components",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ScreenShareButton.tsx
+++ b/packages/react-components/src/components/ScreenShareButton.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { useLocale } from '../localization';
 import { ControlBarButton, ControlBarButtonProps } from './ControlBarButton';
-import { DefaultPalette, IButtonStyles, Theme, useTheme } from '@fluentui/react';
+import { DefaultPalette, IButtonStyles, mergeStyles, Theme, useTheme } from '@fluentui/react';
 import { HighContrastAwareIcon } from './HighContrastAwareIcon';
 
 /**
@@ -66,9 +66,8 @@ export const ScreenShareButton = (props: ScreenShareButtonProps): JSX.Element =>
 
   return (
     <ControlBarButton
-      // merge in props
       {...props}
-      styles={styles}
+      className={mergeStyles(styles, props.styles)}
       onClick={props.onToggleScreenShare ?? props.onClick}
       onRenderOnIcon={props.onRenderOnIcon ?? onRenderScreenShareOnIcon}
       onRenderOffIcon={props.onRenderOffIcon ?? onRenderScreenShareOffIcon}

--- a/packages/react-components/src/components/ScreenShareButton.tsx
+++ b/packages/react-components/src/components/ScreenShareButton.tsx
@@ -66,6 +66,7 @@ export const ScreenShareButton = (props: ScreenShareButtonProps): JSX.Element =>
 
   return (
     <ControlBarButton
+      // merge in props
       {...props}
       styles={styles}
       onClick={props.onToggleScreenShare ?? props.onClick}

--- a/packages/storybook/stories/ControlBar/Buttons/ScreenShare/__snapshots__/ScreenShare.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/ScreenShare/__snapshots__/ScreenShare.stories.storyshot
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/S
       }
     >
       <div
-        className="ms-TooltipHost root-1"
+        className="ms-TooltipHost root-2"
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
         onKeyDown={[Function]}
@@ -30,7 +30,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/S
       >
         <button
           aria-label="Share your screen"
-          className="ms-Button ms-Button--default root-2"
+          className="ms-Button ms-Button--default root-3"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -41,12 +41,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/S
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-3"
+            className="ms-Button-flexContainer flexContainer-4"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="root-94 root-11"
+              className="root-94 root-12"
               data-icon-name="ControlButtonScreenShareStart"
             >
               <span

--- a/packages/storybook/stories/ControlBar/__snapshots__/ControlBar.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/__snapshots__/ControlBar.stories.storyshot
@@ -160,7 +160,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             >
               <button
                 aria-label="Share your screen"
-                className="ms-Button ms-Button--default root-5"
+                className="ms-Button ms-Button--default root-16"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -252,7 +252,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                   </i>
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-15 ms-Button-menuIcon menuIcon-10"
+                    className="ms-Icon root-94 css-17 ms-Button-menuIcon menuIcon-10"
                     data-icon-name="ChevronDown"
                     hidden={true}
                     style={
@@ -318,7 +318,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                   </i>
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-15 ms-Button-menuIcon menuIcon-10"
+                    className="ms-Icon root-94 css-17 ms-Button-menuIcon menuIcon-10"
                     data-icon-name="ChevronDown"
                     hidden={true}
                     style={
@@ -342,7 +342,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             >
               <button
                 aria-label="Leave Call"
-                className="ms-Button ms-Button--default root-16"
+                className="ms-Button ms-Button--default root-18"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}

--- a/packages/storybook/stories/Examples/Themes/__snapshots__/TeamsTheme.stories.storyshot
+++ b/packages/storybook/stories/Examples/Themes/__snapshots__/TeamsTheme.stories.storyshot
@@ -182,7 +182,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       >
                         <button
                           aria-label="Share your screen"
-                          className="ms-Button ms-Button--default root-20"
+                          className="ms-Button ms-Button--default root-21"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -232,7 +232,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       >
                         <button
                           aria-label="Leave Call"
-                          className="ms-Button ms-Button--default root-21"
+                          className="ms-Button ms-Button--default root-22"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -290,24 +290,24 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                 </div>
               </div>
               <div
-                className="css-111 css-23"
+                className="css-111 css-24"
               >
                 <div
-                  className="ms-Stack css-30"
+                  className="ms-Stack css-31"
                   data-ui-id="video-tile"
                 >
                   <div
-                    className="css-27"
+                    className="css-28"
                   />
                   <div
-                    className="ms-Stack css-31"
+                    className="ms-Stack css-32"
                   >
                     <div
-                      className="ms-Stack css-33"
+                      className="ms-Stack css-34"
                     >
                       <div
                         aria-label=""
-                        className="ms-Persona ms-Persona--size48 root-34"
+                        className="ms-Persona ms-Persona--size48 root-35"
                         style={
                           Object {
                             "height": 100,
@@ -316,11 +316,11 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                         }
                       >
                         <div
-                          className="ms-Persona-coin ms-Persona--size48 coin-41"
+                          className="ms-Persona-coin ms-Persona--size48 coin-42"
                           role="presentation"
                         >
                           <div
-                            className="ms-Persona-imageArea imageArea-43"
+                            className="ms-Persona-imageArea imageArea-44"
                             role="presentation"
                             style={
                               Object {
@@ -331,7 +331,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           >
                             <div
                               aria-hidden="true"
-                              className="ms-Persona-initials initials-46"
+                              className="ms-Persona-initials initials-47"
                               style={
                                 Object {
                                   "height": 100,
@@ -349,13 +349,13 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-136 css-49"
+                    className="ms-Stack css-136 css-50"
                   >
                     <div
-                      className="ms-Stack css-137 css-50"
+                      className="ms-Stack css-137 css-51"
                     >
                       <span
-                        className="css-51"
+                        className="css-52"
                         title="Michael"
                       >
                         Michael


### PR DESCRIPTION
# What
Fixed ScreenShareButton component to allow custom styles BUG 2677269.

# Why
ScreenShareButton component not applying custom styles.
https://skype.visualstudio.com/SPOOL/_workitems/edit/2677269 

# How Tested
Applied and removed custom styles to all buttons in ControlBar in Storybook to see if styles were being applied correctly.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->