### PR TITLE
Fixed inability to click the horizontal gallery left/right button by changing pointerEvents of LayerHost

### DIFF
--- a/change/@internal-react-components-36765647-e480-42d7-a08a-f51645dec1d3.json
+++ b/change/@internal-react-components-36765647-e480-42d7-a08a-f51645dec1d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed inability to click the horizontal gallery left/right button by changing pointerEvents of LayerHost.",
+  "packageName": "@internal/react-components",
+  "email": "kaurprabhjot@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/VideoGallery.styles.ts
+++ b/packages/react-components/src/components/styles/VideoGallery.styles.ts
@@ -146,5 +146,7 @@ export const layerHostStyle: IStyle = {
   top: 0,
   width: '100%',
   height: '100%',
-  overflow: 'hidden'
+  overflow: 'hidden',
+  // pointer events for layerHost set to none to make descendants interactive
+  pointerEvents: 'none'
 };


### PR DESCRIPTION
# What
Fixed inability to click the horizontal gallery left/right button by changing pointerEvents of LayerHost

# Why
https://skype.visualstudio.com/SPOOL/_queries/edit/2674355/?fullScreen=true&triage=true

# How Tested
Manually

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->