### PR TITLE
Added entry for endpointUrl in appsettings.json instead of using connectionString twice

### DIFF
--- a/change/@internal-storybook-be26839f-8828-4631-8911-5f9d225abb12.json
+++ b/change/@internal-storybook-be26839f-8828-4631-8911-5f9d225abb12.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added entry for endpointUrl in appsettings.json instead of using connectionString twice",
+  "packageName": "@internal/storybook",
+  "email": "97124699+prabhjot-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/NonReact/NonReactComposites.stories.mdx
+++ b/packages/storybook/stories/NonReact/NonReactComposites.stories.mdx
@@ -125,10 +125,12 @@ After finishing building the bundle, you can also try the sample
 
 1. Replace the `ResourceConnectionString` in the `samples/Server/appsettings.json` file with the connection string from your Azure Communication Services resource, which is listed in the Azure Portal under _Keys_.
 
-2. Run this command to start the server:
+2. Replace the `EndpointUrl` in the `samples/Server/appsettings.json` file with the connection string and remove "endpoint=" from the beginning of the string.
+
+3. Run this command to start the server:
 
 ```bash
 rushx start
 ```
 
-3. Browse to http://localhost:3000
+4. Browse to http://localhost:3000

--- a/packages/storybook/stories/NonReact/NonReactComposites.stories.mdx
+++ b/packages/storybook/stories/NonReact/NonReactComposites.stories.mdx
@@ -125,7 +125,7 @@ After finishing building the bundle, you can also try the sample
 
 1. Replace the `ResourceConnectionString` in the `samples/Server/appsettings.json` file with the connection string from your Azure Communication Services resource, which is listed in the Azure Portal under _Keys_.
 
-2. Replace the `EndpointUrl` in the `samples/Server/appsettings.json` file with the connection string and remove "endpoint=" from the beginning of the string.
+2. Replace the `EndpointUrl` in the `samples/Server/appsettings.json` file with the endpoint from your Azure Communication Services resource, which is listed in the Azure Portal under _Keys_.
 
 3. Run this command to start the server:
 

--- a/samples/Server/appsettings.json
+++ b/samples/Server/appsettings.json
@@ -7,5 +7,6 @@
     }
   },
   "AllowedHosts": "*",
-  "ResourceConnectionString": "REPLACE_WITH_CONNECTION_STRING"
+  "ResourceConnectionString": "REPLACE_WITH_CONNECTION_STRING",
+  "EndpointUrl":"REPLACE_WITH_ENDPOINT_URL"
 }

--- a/samples/Server/src/lib/envHelper.ts
+++ b/samples/Server/src/lib/envHelper.ts
@@ -14,6 +14,7 @@ export const getResourceConnectionString = (): string => {
 };
 
 export const getEnvUrl = (): string => {
-  const uri = new URL(getResourceConnectionString().replace('endpoint=', ''));
+  const uri = process.env['EndpointUrl'] || appSettings.EndpointUrl;
+
   return `${uri.protocol}//${uri.host}`;
 };


### PR DESCRIPTION
# What
Added entry for endpointUrl in appsettings.json instead of using connectionString twice

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/2691366

# How Tested

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->