### PR TITLE
dmceachernmsft/meetingSampleAsyncHookandErrorPage

### DIFF
--- a/samples/Meeting/src/app/App.tsx
+++ b/samples/Meeting/src/app/App.tsx
@@ -73,7 +73,7 @@ const App = (): JSX.Element => {
   }, []);
 
   useEffect(() => {
-    const internalSetupAndJoinChatThread = async (): Promise<void> => {
+    (async () => {
       if (callArgs?.displayName && credentials !== undefined) {
         const newThreadId = await getThread();
         const result = await joinThread(newThreadId, credentials.userId.communicationUserId, callArgs.displayName);
@@ -85,8 +85,7 @@ const App = (): JSX.Element => {
         setThreadId(newThreadId);
         pushQSPUrl({ name: 'threadId', value: newThreadId });
       }
-    };
-    internalSetupAndJoinChatThread();
+    })();
   }, [callArgs?.displayName, credentials?.userId.communicationUserId]);
 
   if (isOnIphoneAndNotSafari()) {
@@ -145,17 +144,6 @@ const App = (): JSX.Element => {
           webAppTitle={webAppTitle}
           endpoint={endpointUrl}
           threadId={threadId}
-        />
-      );
-    }
-    case 'error': {
-      document.title = `error - ${webAppTitle}`;
-      return (
-        <CallError
-          title="Error getting user credentials from server"
-          reason="Ensure the sample server is running."
-          rejoinHandler={() => setPage('meeting')}
-          homeHandler={navigateToHomePage}
         />
       );
     }


### PR DESCRIPTION


# What
updated hook to be more inline with other hooks in code. removed the meeting sample error page.

# Why
Streamline code for readability. 
makes the sample use the built in error screen in the meeting composite.
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2691308
https://skype.visualstudio.com/SPOOL/_workitems/edit/2691310
# How Tested
Ran locally to ensure nothing was broken.