### PR TITLE
[Sample/Chat]  Pull Chat SDK version from version made in webpack and not at runtime in the Chat utils

### DIFF
--- a/samples/Chat/src/app/App.tsx
+++ b/samples/Chat/src/app/App.tsx
@@ -9,9 +9,9 @@ import { EndScreen } from './EndScreen';
 import { ErrorScreen } from './ErrorScreen';
 import HomeScreen from './HomeScreen';
 import { getExistingThreadIdFromURL } from './utils/getExistingThreadIdFromURL';
-import { chatSDKVersion, getBuildTime } from './utils/utils';
+import { getBuildTime, getChatSDKVersion } from './utils/utils';
 
-console.info(`Thread chat sample using @azure/communication-chat : ${chatSDKVersion}`);
+console.info(`Thread chat sample using @azure/communication-chat : ${getChatSDKVersion()}`);
 console.info(`Build Date : ${getBuildTime()}`);
 
 initializeIcons();

--- a/samples/Chat/src/app/App.tsx
+++ b/samples/Chat/src/app/App.tsx
@@ -9,9 +9,9 @@ import { EndScreen } from './EndScreen';
 import { ErrorScreen } from './ErrorScreen';
 import HomeScreen from './HomeScreen';
 import { getExistingThreadIdFromURL } from './utils/getExistingThreadIdFromURL';
-import { getBuildTime, getChatSDKVersion } from './utils/utils';
+import { chatSDKVersion, getBuildTime } from './utils/utils';
 
-console.info(`Thread chat sample using @azure/communication-chat : ${getChatSDKVersion()}`);
+console.info(`Thread chat sample using @azure/communication-chat : ${chatSDKVersion}`);
 console.info(`Build Date : ${getBuildTime()}`);
 
 initializeIcons();

--- a/samples/Chat/src/app/utils/utils.ts
+++ b/samples/Chat/src/app/utils/utils.ts
@@ -4,13 +4,9 @@
 import { GUID_FOR_INITIAL_TOPIC_NAME } from './constants';
 
 declare let __BUILDTIME__: string; // Injected by webpack
+declare let __CHATVERSION__: string; // Injected by webpack
+export const chatSDKVersion = __CHATVERSION__;
 export const getBuildTime = (): string => __BUILDTIME__;
-
-export function getChatSDKVersion(): string {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  return require('../../../package.json')['dependencies']['@azure/communication-chat'];
-}
-
 export const CAT = '🐱';
 export const MOUSE = '🐭';
 export const KOALA = '🐨';

--- a/samples/Chat/src/app/utils/utils.ts
+++ b/samples/Chat/src/app/utils/utils.ts
@@ -5,7 +5,7 @@ import { GUID_FOR_INITIAL_TOPIC_NAME } from './constants';
 
 declare let __BUILDTIME__: string; // Injected by webpack
 declare let __CHATVERSION__: string; // Injected by webpack
-export const chatSDKVersion = __CHATVERSION__;
+export const getChatSDKVersion = (): string => __CHATVERSION__;
 export const getBuildTime = (): string => __BUILDTIME__;
 export const CAT = '🐱';
 export const MOUSE = '🐭';

--- a/samples/Meeting/src/app/utils/utils.ts
+++ b/samples/Meeting/src/app/utils/utils.ts
@@ -4,13 +4,9 @@
 import { GUID_FOR_INITIAL_TOPIC_NAME } from './constants';
 
 declare let __BUILDTIME__: string; // Injected by webpack
+declare let __CHATVERSION__: string; // Injected by webpack
+export const chatSDKVersion = __CHATVERSION__;
 export const getBuildTime = (): string => __BUILDTIME__;
-
-export function getChatSDKVersion(): string {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  return require('../../../package.json')['dependencies']['@azure/communication-chat'];
-}
-
 export const CAT = '🐱';
 export const MOUSE = '🐭';
 export const KOALA = '🐨';

--- a/samples/Meeting/src/app/utils/utils.ts
+++ b/samples/Meeting/src/app/utils/utils.ts
@@ -5,7 +5,7 @@ import { GUID_FOR_INITIAL_TOPIC_NAME } from './constants';
 
 declare let __BUILDTIME__: string; // Injected by webpack
 declare let __CHATVERSION__: string; // Injected by webpack
-export const chatSDKVersion = __CHATVERSION__;
+export const getChatSDKVersion = (): string => __CHATVERSION__;
 export const getBuildTime = (): string => __BUILDTIME__;
 export const CAT = '🐱';
 export const MOUSE = '🐭';


### PR DESCRIPTION
# What
[Sample/Chat]  Pull Chat SDK version from version made in webpack and not at runtime in the Chat utils

# Why
Should not be reaching out to external folders to get version information