### PR TITLE
Theme local storage refactor

### DIFF
--- a/samples/Calling/src/app/theming/SwitchableFluentThemeProvider.tsx
+++ b/samples/Calling/src/app/theming/SwitchableFluentThemeProvider.tsx
@@ -4,6 +4,7 @@
 import React, { useState, useMemo, createContext, useContext } from 'react';
 import { FluentThemeProvider, lightTheme, darkTheme } from '@internal/react-components';
 import { Theme, PartialTheme } from '@fluentui/react';
+import { getThemeFromLocalStorage, saveThemeToLocalStorage } from '../utils/localStorage';
 
 /**
  * A theme with an associated name.
@@ -61,20 +62,6 @@ interface SwitchableFluentThemeContext {
    */
   themeStore: ThemeCollection;
 }
-
-const LOCAL_STORAGE_KEY_PREFIX = 'AzureCommunicationUI_Theme';
-
-/**
- * Function to get theme from LocalStorage
- */
-const getThemeFromLocalStorage = (scopeId: string): string | null =>
-  window.localStorage.getItem(LOCAL_STORAGE_KEY_PREFIX + '_' + scopeId);
-
-/**
- * Function to save theme to LocalStorage
- */
-const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
-  window.localStorage.setItem(LOCAL_STORAGE_KEY_PREFIX + '_' + scopeId, theme);
 
 const defaultTheme: NamedTheme = defaultThemes.Light;
 

--- a/samples/Calling/src/app/utils/localStorage.ts
+++ b/samples/Calling/src/app/utils/localStorage.ts
@@ -4,7 +4,8 @@
 export const localStorageAvailable = typeof Storage !== 'undefined';
 
 export enum LocalStorageKeys {
-  DisplayName = 'DisplayName'
+  DisplayName = 'DisplayName',
+  Theme = 'AzureCommunicationUI_Theme'
 }
 
 /**
@@ -18,3 +19,15 @@ export const getDisplayNameFromLocalStorage = (): string | null =>
  */
 export const saveDisplayNameToLocalStorage = (displayName: string): void =>
   window.localStorage.setItem(LocalStorageKeys.DisplayName, displayName);
+
+/**
+ * Get theme from local storage.
+ */
+export const getThemeFromLocalStorage = (scopeId: string): string | null =>
+  window.localStorage.getItem(LocalStorageKeys.Theme + '_' + scopeId);
+
+/**
+ * Save theme into local storage.
+ */
+export const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
+  window.localStorage.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);

--- a/samples/Chat/src/app/theming/SwitchableFluentThemeProvider.tsx
+++ b/samples/Chat/src/app/theming/SwitchableFluentThemeProvider.tsx
@@ -4,6 +4,7 @@
 import React, { useState, useMemo, createContext, useContext } from 'react';
 import { FluentThemeProvider, lightTheme, darkTheme } from '@internal/react-components';
 import { Theme, PartialTheme } from '@fluentui/react';
+import { getThemeFromLocalStorage, saveThemeToLocalStorage } from '../utils/localStorage';
 
 /**
  * A theme with an associated name.
@@ -61,20 +62,6 @@ interface SwitchableFluentThemeContext {
    */
   themeStore: ThemeCollection;
 }
-
-const LOCAL_STORAGE_KEY_PREFIX = 'AzureCommunicationUI_Theme';
-
-/**
- * Function to get theme from LocalStorage
- */
-const getThemeFromLocalStorage = (scopeId: string): string | null =>
-  window.localStorage.getItem(LOCAL_STORAGE_KEY_PREFIX + '_' + scopeId);
-
-/**
- * Function to save theme to LocalStorage
- */
-const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
-  window.localStorage.setItem(LOCAL_STORAGE_KEY_PREFIX + '_' + scopeId, theme);
 
 const defaultTheme: NamedTheme = defaultThemes.Light;
 

--- a/samples/Chat/src/app/utils/localStorage.ts
+++ b/samples/Chat/src/app/utils/localStorage.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export const localStorageAvailable = typeof Storage !== 'undefined';
+
+export enum LocalStorageKeys {
+  Theme = 'AzureCommunicationUI_Theme'
+}
+
+/**
+ * Get theme from local storage.
+ */
+export const getThemeFromLocalStorage = (scopeId: string): string | null =>
+  window.localStorage.getItem(LocalStorageKeys.Theme + '_' + scopeId);
+
+/**
+ * Save theme into local storage.
+ */
+export const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
+  window.localStorage.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);

--- a/samples/Meeting/src/app/theming/SwitchableFluentThemeProvider.tsx
+++ b/samples/Meeting/src/app/theming/SwitchableFluentThemeProvider.tsx
@@ -4,6 +4,7 @@
 import React, { useState, useMemo, createContext, useContext } from 'react';
 import { FluentThemeProvider, lightTheme, darkTheme } from '@internal/react-components';
 import { Theme, PartialTheme } from '@fluentui/react';
+import { getThemeFromLocalStorage, saveThemeToLocalStorage } from '../utils/localStorage';
 
 /**
  * A theme with an associated name.
@@ -61,20 +62,6 @@ interface SwitchableFluentThemeContext {
    */
   themeStore: ThemeCollection;
 }
-
-const LOCAL_STORAGE_KEY_PREFIX = 'AzureCommunicationUI_Theme';
-
-/**
- * Function to get theme from LocalStorage
- */
-const getThemeFromLocalStorage = (scopeId: string): string | null =>
-  window.localStorage.getItem(LOCAL_STORAGE_KEY_PREFIX + '_' + scopeId);
-
-/**
- * Function to save theme to LocalStorage
- */
-const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
-  window.localStorage.setItem(LOCAL_STORAGE_KEY_PREFIX + '_' + scopeId, theme);
 
 const defaultTheme: NamedTheme = defaultThemes.Light;
 

--- a/samples/Meeting/src/app/utils/localStorage.ts
+++ b/samples/Meeting/src/app/utils/localStorage.ts
@@ -4,7 +4,8 @@
 export const localStorageAvailable = typeof Storage !== 'undefined';
 
 export enum LocalStorageKeys {
-  DisplayName = 'DisplayName'
+  DisplayName = 'DisplayName',
+  Theme = 'AzureCommunicationUI_Theme'
 }
 
 /**
@@ -18,3 +19,15 @@ export const getDisplayNameFromLocalStorage = (): string | null =>
  */
 export const saveDisplayNameToLocalStorage = (displayName: string): void =>
   window.localStorage.setItem(LocalStorageKeys.DisplayName, displayName);
+
+/**
+ * Get theme from local storage.
+ */
+export const getThemeFromLocalStorage = (scopeId: string): string | null =>
+  window.localStorage.getItem(LocalStorageKeys.Theme + '_' + scopeId);
+
+/**
+ * Save theme into local storage.
+ */
+export const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
+  window.localStorage.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
In the sample Calling, Chat, and Meeting apps, `SwitchableFluentThemeProvider` was refactored to use local storage from utils file.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2693380

# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested Calling, Chat, and Meeting apps by changing themes and seeing if they persist.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->
Ran 

- [x] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->