### PR TITLE
Update install instructions for beta channel

### DIFF
--- a/change/@internal-storybook-417ec129-0071-4ad4-a19a-b66986a8c0ac.json
+++ b/change/@internal-storybook-417ec129-0071-4ad4-a19a-b66986a8c0ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update install instructions for beta channel",
+  "packageName": "@internal/storybook",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-storybook-417ec129-0071-4ad4-a19a-b66986a8c0ac.json
+++ b/change/@internal-storybook-417ec129-0071-4ad4-a19a-b66986a8c0ac.json
@@ -1,7 +1,7 @@
 {
-  "type": "prerelease",
+  "type": "none",
   "comment": "Update install instructions for beta channel",
   "packageName": "@internal/storybook",
   "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/packages/communication-react/README.md
+++ b/packages/communication-react/README.md
@@ -12,8 +12,24 @@ Read more about Azure Communication Services - UI Library [here](https://azure.g
 
 ## Installing
 
+`@azure/communication-react` is a React library. It requires a reasonable React environment.
+The environment is already setup if you use [Create React App](https://create-react-app.dev/) or a similar tool to initialize your application.
+
 ```bash
 npm i @azure/communication-react
+```
+
+### Beta-channel setup
+
+`@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
+you can most consistently use the API from the core libraries in your application.
+
+If you are using a beta package (has a `beta` suffix) >= `@azure/communication-react@1.0.1-beta.2`, you need to install
+the low-level client libraries as well:
+
+```bash
+npm i @azure/communication-calling@1.3.2-beta.1
+npm i @azure/communication-chat@1.1.0
 ```
 
 ## Storybook

--- a/packages/storybook/stories/Overview.stories.mdx
+++ b/packages/storybook/stories/Overview.stories.mdx
@@ -59,7 +59,7 @@ They provide full [localization](./?path=/docs/localization--page) to enable dev
 ## Installing UI Library
 
 ```bash
-npm i --save @azure/communication-react
+npm i @azure/communication-react
 ```
 
 ## Composites Overview

--- a/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
@@ -71,7 +71,7 @@ npm install @azure/communication-react
 
 ```
 
-#### Beta-channel setup
+**Beta-channel setup**
 
 `@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
 you can most consistently use the API from the core libraries in your application.

--- a/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
@@ -67,11 +67,24 @@ Use the `npm install` command to install the Azure Communication Services UI Lib
 
 ```bash
 
-npm install --save @azure/communication-react
+npm install @azure/communication-react
 
 ```
 
-The `--save` option lists the library as a dependency in your **package.json** file.
+#### Beta-channel setup
+
+`@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
+you can most consistently use the API from the core libraries in your application.
+
+If you are using a beta package (has a `beta` suffix) >= `@azure/communication-react@1.0.1-beta.2`, you need to install
+the low-level client libraries as well:
+
+```bash
+
+npm install @azure/communication-calling@1.3.2-beta.1
+npm install @azure/communication-chat@1.1.0
+
+```
 
 ### Run Create React App
 

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
@@ -72,11 +72,24 @@ Use the `npm install` command to install the `@azure/communication-react` librar
 
 ```bash
 
-npm install --save @azure/communication-react
+npm install @azure/communication-react
 
 ```
 
-The `--save` option lists the library as a dependency in your **package.json** file.
+#### Beta-channel setup
+
+`@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
+you can most consistently use the API from the core libraries in your application.
+
+If you are using a beta package (has a `beta` suffix) >= `@azure/communication-react@1.0.1-beta.2`, you need to install
+the low-level client libraries as well:
+
+```bash
+
+npm install @azure/communication-calling@1.3.2-beta.1
+npm install @azure/communication-chat@1.1.0
+
+```
 
 ### Run Create React App
 

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
@@ -76,7 +76,7 @@ npm install @azure/communication-react
 
 ```
 
-#### Beta-channel setup
+**Beta-channel setup**
 
 `@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
 you can most consistently use the API from the core libraries in your application.

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulChat.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulChat.stories.mdx
@@ -77,7 +77,7 @@ npm install @azure/communication-react
 
 ```
 
-#### Beta-channel setup
+**Beta-channel setup**
 
 `@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
 you can most consistently use the API from the core libraries in your application.

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulChat.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulChat.stories.mdx
@@ -73,11 +73,24 @@ Use the `npm install` command to install the `@azure/communication-react` librar
 
 ```bash
 
-npm install --save @azure/communication-react
+npm install @azure/communication-react
 
 ```
 
-The `--save` option lists the library as a dependency in your **package.json** file.
+#### Beta-channel setup
+
+`@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
+you can most consistently use the API from the core libraries in your application.
+
+If you are using a beta package (has a `beta` suffix) >= `@azure/communication-react@1.0.1-beta.2`, you need to install
+the low-level client libraries as well:
+
+```bash
+
+npm install @azure/communication-calling@1.3.2-beta.1
+npm install @azure/communication-chat@1.1.0
+
+```
 
 ### Run Create React App
 

--- a/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
@@ -58,7 +58,7 @@ npm install --save @azure/communication-react
 
 ```
 
-#### Beta-channel setup
+**Beta-channel setup**
 
 `@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
 you can most consistently use the API from the core libraries in your application.

--- a/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
@@ -58,7 +58,20 @@ npm install --save @azure/communication-react
 
 ```
 
-The `--save` option lists the library as a dependency in your **package.json** file.
+#### Beta-channel setup
+
+`@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
+you can most consistently use the API from the core libraries in your application.
+
+If you are using a beta package (has a `beta` suffix) >= `@azure/communication-react@1.0.1-beta.2`, you need to install
+the low-level client libraries as well:
+
+```bash
+
+npm install @azure/communication-calling@1.3.2-beta.1
+npm install @azure/communication-chat@1.1.0
+
+```
 
 ### Run Create React App
 

--- a/packages/storybook/stories/Stateful Client/OverviewStateful.stories.mdx
+++ b/packages/storybook/stories/Stateful Client/OverviewStateful.stories.mdx
@@ -30,7 +30,7 @@ npm i @azure/communication-react
 
 ```
 
-### Beta-channel setup
+**Beta-channel setup**
 
 `@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
 you can most consistently use the API from the core libraries in your application.

--- a/packages/storybook/stories/Stateful Client/OverviewStateful.stories.mdx
+++ b/packages/storybook/stories/Stateful Client/OverviewStateful.stories.mdx
@@ -26,8 +26,21 @@ Stateful clients are found as part of the `@azure/communication-react` package.
 
 ```bash
 
-npm i --save @azure/communication-react
+npm i @azure/communication-react
 
+```
+
+### Beta-channel setup
+
+`@azure/communication-react` is in the process of migrating the core Azure Communication Services dependencies to `peerDependencies` so that
+you can most consistently use the API from the core libraries in your application.
+
+If you are using a beta package (has a `beta` suffix) >= `@azure/communication-react@1.0.1-beta.2`, you need to install
+the low-level client libraries as well:
+
+```bash
+npm i @azure/communication-calling@1.3.2-beta.1
+npm i @azure/communication-chat@1.1.0
 ```
 
 ## Calling StatefulClient


### PR DESCRIPTION
# Why

With `1.0.1-beta.2`, clients will need to install ACS SDKs themselves.
The stable packages still install those SDKs internally.

This PR updates the documentation to point out  this difference.