### PR TITLE
[samples/Calling] Simplified Call Id ref by relocating console log in CallScreen.tsx

### DIFF
--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -35,13 +35,6 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
   const { currentTheme, currentRtl } = useSwitchableFluentTheme();
   const [isMobileSession, setIsMobileSession] = useState<boolean>(detectMobileSession());
 
-  useEffect(() => {
-    if (!callIdRef.current) {
-      return;
-    }
-    console.log(`Call Id: ${callIdRef.current}`);
-  }, [callIdRef.current]);
-
   // Whenever the sample is changed from desktop -> mobile using the emulator, make sure we update the formFactor.
   useEffect(() => {
     const updateIsMobile = (): void => setIsMobileSession(detectMobileSession());
@@ -69,7 +62,10 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
         const pageTitle = convertPageStateToString(state);
         document.title = `${pageTitle} - ${webAppTitle}`;
 
-        callIdRef.current = state?.call?.id;
+        if (!callIdRef.current && state?.call?.id) {
+          callIdRef.current = state?.call?.id;
+          console.log(`Call Id: ${callIdRef.current}`);
+        }
       });
       setAdapter(adapter);
       adapterRef.current = adapter;

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -62,7 +62,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
         const pageTitle = convertPageStateToString(state);
         document.title = `${pageTitle} - ${webAppTitle}`;
 
-        if (!callIdRef.current && state?.call?.id) {
+        if (state?.call?.id && callIdRef.current !== state?.call?.id) {
           callIdRef.current = state?.call?.id;
           console.log(`Call Id: ${callIdRef.current}`);
         }


### PR DESCRIPTION
# What
Simplified use of ref in CallScreen.tsx by relocating Call Id console log in samples/Calling 

# Why
Simplified code as callid is a ref and won't retrigger a re-render. 
https://skype.visualstudio.com/SPOOL/_workitems/edit/2693381/

# How Tested
Tested on local chrome browser. 
Entered, exited, rejoined, and started a new call session to confirm if id gets logged upon joining a call.

# Process & policy checklist
- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.