### PR TITLE
[samples/Meeting] Simplified Call Id ref by relocating console log in MeetingScreen.tsx

### DIFF
--- a/samples/Meeting/src/app/views/MeetingScreen.tsx
+++ b/samples/Meeting/src/app/views/MeetingScreen.tsx
@@ -32,13 +32,6 @@ export const MeetingScreen = (props: MeetingScreenProps): JSX.Element => {
   const { currentTheme, currentRtl } = useSwitchableFluentTheme();
   const [isMobileSession, setIsMobileSession] = useState<boolean>(detectMobileSession());
 
-  useEffect(() => {
-    if (!callIdRef.current) {
-      return;
-    }
-    console.log(`Call Id: ${callIdRef.current}`);
-  }, [callIdRef.current]);
-
   // Whenever the sample is changed from desktop -> mobile using the emulator, make sure we update the formFactor.
   useEffect(() => {
     const updateIsMobile = (): void => setIsMobileSession(detectMobileSession());
@@ -63,7 +56,10 @@ export const MeetingScreen = (props: MeetingScreenProps): JSX.Element => {
         const pageTitle = convertPageStateToString(state);
         document.title = `${pageTitle} - ${webAppTitle}`;
 
-        callIdRef.current = state?.meeting?.id;
+        if (state?.meeting?.id && callIdRef.current !== state?.meeting?.id) {
+          callIdRef.current = state?.meeting?.id;
+          console.log(`Call Id: ${callIdRef.current}`);
+        }
       });
       setAdapter(adapter);
       adapterRef.current = adapter;


### PR DESCRIPTION
# What
Simplified use of ref in MeetingScreen.tsx by relocating Call Id console log in samples/Meeting 

# Why
Simplified code as callid is a ref and won't retrigger a re-render. 
https://skype.visualstudio.com/SPOOL/_workitems/edit/2711297

# How Tested
Tested on local chrome browser. 
Entered, exited, rejoined, and started a new meeting session to confirm if id gets logged upon joining a call.

# Process & policy checklist
- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.