### PR TITLE
Adding verbose flag to the command rush build:all-flavors

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -70,7 +70,7 @@
       "name": "build:all-flavors",
       "summary": "Build all flavor in one command (mainly for api update)",
       "description": "Build all flavor in one command (mainly for api update). This command will switch current flavor to beta.",
-      "shellCommand": "(rush switch-flavor:stable && rush rebuild) || rush switch-flavor:beta && rush rebuild",
+      "shellCommand": "(rush switch-flavor:stable && rush rebuild -v) || rush switch-flavor:beta && rush rebuild -v",
       "safeForSimultaneousRushProcesses": true
     },
     {


### PR DESCRIPTION
# What
Displays build errors when running rush build:all-flavors

# Why
Locally building conditional code didn't yield errors

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->