### PR TITLE
Remove VideoGallery UUID for container

### DIFF
--- a/change/@internal-react-components-9df18ef2-48d8-4efa-86b8-160c29620aa6.json
+++ b/change/@internal-react-components-9df18ef2-48d8-4efa-86b8-160c29620aa6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Removed VideoGallery containuer uuid",
+  "packageName": "@internal/react-components",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -11,7 +11,7 @@ import {
   Modal,
   Stack
 } from '@fluentui/react';
-import React, { useCallback, useMemo, useRef, useEffect } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { GridLayoutStyles } from '.';
 import { smartDominantSpeakerParticipants } from '../gallery';
 import { useIdentifiers } from '../identifiers/IdentifierProvider';
@@ -46,7 +46,6 @@ import { isNarrowWidth, useContainerWidth } from './utils/responsive';
 import { LocalScreenShare } from './VideoGallery/LocalScreenShare';
 import { RemoteScreenShare } from './VideoGallery/RemoteScreenShare';
 import { VideoTile } from './VideoTile';
-import { v4 as uuidv4 } from 'uuid';
 import { useId } from '@fluentui/react-hooks';
 
 // Currently the Calling JS SDK supports up to 4 remote video streams
@@ -315,12 +314,6 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
       onDisposeRemoteStreamView={onDisposeRemoteStreamView}
     />
   );
-
-  useEffect(() => {
-    if (containerRef.current) {
-      containerRef.current.id = `video-gallery-${uuidv4()}`;
-    }
-  }, [containerRef]);
 
   const horizontalGalleryPresent = horizontalGalleryTiles && horizontalGalleryTiles.length > 0;
   const layerHostId = useId('layerhost');


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Remove VideoGallery UUID assignment to the container since we are now using a layer host. This generates its own unique id.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Remove unnecessary code and useEffect()

# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested two snippets on storybook with their own floating local video and verified each floating local video is uniquely anchored.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->