### PR TITLE
[API DESIGN FEEBDACK REQUEST] Place adhoc call to teams user

### DIFF
--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -85,7 +85,9 @@ export type AzureCommunicationCallAdapterArgs = {
 };
 
 // @public (undocumented)
-export type AzureCommunicationCallAdapterLocator = TeamsMeetingLinkLocator | GroupCallLocator | TeamsUserLocator;
+export type AzureCommunicationCallAdapterLocator = TeamsMeetingLinkLocator | GroupCallLocator | {
+    participantIDs: [string];
+};
 
 // @public
 export type AzureCommunicationChatAdapterArgs = {
@@ -130,6 +132,8 @@ export interface CallAdapterCallManagement {
     removeParticipant(userId: string): Promise<void>;
     startCall(participants: string[]): Call | undefined;
     startCamera(options?: VideoStreamOptions): Promise<void>;
+    // @beta
+    startOrJoinCall(): Call | undefined;
     startScreenShare(): Promise<void>;
     stopCamera(): Promise<void>;
     stopScreenShare(): Promise<void>;
@@ -750,11 +754,6 @@ export type ParticipantsRemovedListener = (event: {
     participantsRemoved: ChatParticipant[];
     removedBy: ChatParticipant;
 }) => void;
-
-// @public
-export type TeamsUserLocator = {
-    teamsUserID: string;
-};
 
 // @public
 export type TopicChangedListener = (event: {

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -81,8 +81,11 @@ export type AzureCommunicationCallAdapterArgs = {
     userId: CommunicationUserIdentifier;
     displayName: string;
     credential: CommunicationTokenCredential;
-    locator: TeamsMeetingLinkLocator | GroupCallLocator;
+    locator: AzureCommunicationCallAdapterLocator;
 };
+
+// @public (undocumented)
+export type AzureCommunicationCallAdapterLocator = TeamsMeetingLinkLocator | GroupCallLocator | TeamsUserLocator;
 
 // @public
 export type AzureCommunicationChatAdapterArgs = {
@@ -447,7 +450,7 @@ export interface CompositeStrings {
 export const createAzureCommunicationCallAdapter: ({ userId, displayName, credential, locator }: AzureCommunicationCallAdapterArgs) => Promise<CallAdapter>;
 
 // @public
-export const createAzureCommunicationCallAdapterFromClient: (callClient: StatefulCallClient, callAgent: CallAgent, locator: TeamsMeetingLinkLocator | GroupCallLocator) => Promise<CallAdapter>;
+export const createAzureCommunicationCallAdapterFromClient: (callClient: StatefulCallClient, callAgent: CallAgent, locator: AzureCommunicationCallAdapterLocator) => Promise<CallAdapter>;
 
 // @public
 export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;
@@ -747,6 +750,11 @@ export type ParticipantsRemovedListener = (event: {
     participantsRemoved: ChatParticipant[];
     removedBy: ChatParticipant;
 }) => void;
+
+// @public
+export type TeamsUserLocator = {
+    teamsUserID: string;
+};
 
 // @public
 export type TopicChangedListener = (event: {

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -89,7 +89,15 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
         <ConfigurationPage
           mobileView={props.mobileView}
           startCallHandler={(): void => {
-            adapter.joinCall();
+            let call;
+            /* @conditional-compile-remove-from(stable) TEAMS_ADHOC_CALLING */
+            // eslint-disable-next-line prefer-const
+            call = adapter.startOrJoinCall();
+
+            // Remove check once TEAMS_ADHOC_CALLING condition compile removed.
+            if (!call) {
+              adapter.joinCall();
+            }
           }}
         />
       );

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -514,22 +514,16 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
   }
 }
 
-/* @conditional-compile-remove-from(stable) TEAMS_ADHOC_CALLING */
-/**
- * Locator for calling a Teams user ID.
- *
- * // NOTE: This feature is in beta -- however using this inside AzureCommunicationCallAdapterLocator requires it to be marked `@public`
- * @public
- */
-export type TeamsUserLocator = {
-  /** Teams user ID should being with `8:orgid:` */
-  teamsUserID: string;
-};
-
 /**
  * @public
  */
-export type AzureCommunicationCallAdapterLocator = TeamsMeetingLinkLocator | GroupCallLocator | TeamsUserLocator;
+export type AzureCommunicationCallAdapterLocator =
+  | TeamsMeetingLinkLocator
+  | GroupCallLocator
+  | {
+      /* @conditional-compile-remove-from(stable) TEAMS_ADHOC_CALLING */
+      teamsUserIDs: [string];
+    };
 
 /**
  * Arguments for creating the Azure Communication Services implementation of {@link CallAdapter}.

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -123,6 +123,8 @@ const findLatestEndedCall = (calls: { [key: string]: CallState }): CallState | u
   return latestCall;
 };
 
+// type CallType = 'ACS Call' | 'TeamsInteropMeeting' | 'TeamsAdhocCall';
+
 /**
  * @private
  */
@@ -131,7 +133,8 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
   private callAgent: CallAgent;
   private deviceManager: StatefulDeviceManager;
   private localStream: SDKLocalVideoStream | undefined;
-  private locator: TeamsMeetingLinkLocator | GroupCallLocator;
+  private locator: AzureCommunicationCallAdapterLocator;
+  // private callType: CallType;
   // Never use directly, even internally. Use `call` property instead.
   private _call?: Call;
   private context: CallContext;
@@ -152,7 +155,7 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
 
   constructor(
     callClient: StatefulCallClient,
-    locator: TeamsMeetingLinkLocator | GroupCallLocator,
+    locator: AzureCommunicationCallAdapterLocator,
     callAgent: CallAgent,
     deviceManager: StatefulDeviceManager
   ) {
@@ -511,6 +514,23 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
   }
 }
 
+/* @conditional-compile-remove-from(stable) TEAMS_ADHOC_CALLING */
+/**
+ * Locator for calling a Teams user ID.
+ *
+ * // NOTE: This feature is in beta -- however using this inside AzureCommunicationCallAdapterLocator requires it to be marked `@public`
+ * @public
+ */
+export type TeamsUserLocator = {
+  /** Teams user ID should being with `8:orgid:` */
+  teamsUserID: string;
+};
+
+/**
+ * @public
+ */
+export type AzureCommunicationCallAdapterLocator = TeamsMeetingLinkLocator | GroupCallLocator | TeamsUserLocator;
+
 /**
  * Arguments for creating the Azure Communication Services implementation of {@link CallAdapter}.
  *
@@ -522,7 +542,7 @@ export type AzureCommunicationCallAdapterArgs = {
   userId: CommunicationUserIdentifier;
   displayName: string;
   credential: CommunicationTokenCredential;
-  locator: TeamsMeetingLinkLocator | GroupCallLocator;
+  locator: AzureCommunicationCallAdapterLocator;
 };
 
 /**
@@ -557,7 +577,7 @@ export const createAzureCommunicationCallAdapter = async ({
 export const createAzureCommunicationCallAdapterFromClient = async (
   callClient: StatefulCallClient,
   callAgent: CallAgent,
-  locator: TeamsMeetingLinkLocator | GroupCallLocator
+  locator: AzureCommunicationCallAdapterLocator
 ): Promise<CallAdapter> => {
   const deviceManager = (await callClient.getDeviceManager()) as StatefulDeviceManager;
   return new AzureCommunicationCallAdapter(callClient, locator, callAgent, deviceManager);

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -204,6 +204,12 @@ export interface CallAdapterCallManagement {
    * @public
    */
   unmute(): Promise<void>;
+  /* @conditional-compile-remove-from(stable) TEAMS_ADHOC_CALLING */
+  /**
+   * Allow the adapter to decide whether to start a new call or join an existing call as appropriate.
+   * @beta
+   */
+  startOrJoinCall(): Call | undefined;
   /**
    * Start the call.
    *

--- a/packages/react-composites/src/composites/CallComposite/adapter/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/index.ts
@@ -5,7 +5,12 @@ export {
   createAzureCommunicationCallAdapter,
   createAzureCommunicationCallAdapterFromClient
 } from './AzureCommunicationCallAdapter';
-export type { AzureCommunicationCallAdapterArgs } from './AzureCommunicationCallAdapter';
+export type {
+  AzureCommunicationCallAdapterArgs,
+  AzureCommunicationCallAdapterLocator,
+  /* @conditional-compile-remove-from(stable) TEAMS_ADHOC_CALLING */
+  TeamsUserLocator
+} from './AzureCommunicationCallAdapter';
 
 export type {
   CallAdapter,

--- a/packages/react-composites/src/composites/CallComposite/adapter/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/index.ts
@@ -7,9 +7,7 @@ export {
 } from './AzureCommunicationCallAdapter';
 export type {
   AzureCommunicationCallAdapterArgs,
-  AzureCommunicationCallAdapterLocator,
-  /* @conditional-compile-remove-from(stable) TEAMS_ADHOC_CALLING */
-  TeamsUserLocator
+  AzureCommunicationCallAdapterLocator
 } from './AzureCommunicationCallAdapter';
 
 export type {

--- a/packages/react-composites/src/composites/CallComposite/pages/NoticePage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/NoticePage.tsx
@@ -37,6 +37,7 @@ export function NoticePage(props: NoticePageProps): JSX.Element {
         <Text className={mergeStyles(titleStyles)}>{props.title}</Text>
         <Text className={mergeStyles(moreDetailsStyles)}>{props.moreDetails}</Text>
         <Stack styles={rejoinCallButtonContainerStyles}>
+          {/* TODO: update joinCall to startOrJoinCall after gaining PR feedback */}
           <StartCallButton onClickHandler={() => adapter.joinCall()} isDisabled={false} rejoinCall={true} />
         </Stack>
       </Stack>

--- a/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedCallAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/MeetingBackedCallAdapter.ts
@@ -81,6 +81,10 @@ export class MeetingBackedCallAdapter implements CallAdapter {
   public joinCall = (microphoneOn?: boolean): Call | undefined => {
     return this.meetingAdapter.joinMeeting(microphoneOn);
   };
+  /* @conditional-compile-remove-from(stable) TEAMS_ADHOC_CALLING */
+  public startOrJoinCall = (): Call | undefined => {
+    throw new Error('Not implemented -- awaiting feedback before implementing this plumbing');
+  };
   public leaveCall = async (): Promise<void> => await this.meetingAdapter.leaveMeeting();
   public startCall = (participants: string[]): Call | undefined => {
     return this.meetingAdapter.startMeeting(participants);


### PR DESCRIPTION
# Key Changes
* Locator can take an array of participants that are to be called
  * Currently we will only officially support a single Teams user but this API allows future expansion
* New CallAdapter fn `startOrJoinCall` to allow the adapter to decide whether callAgent->startCall or callAgent->joinCall should be called 
  * The adapter implementation decides based on the type of locator whether a call should be started or joined

# Why
For supporting Teams Adhoc 1:1 calls, Flow of how an adhoc call works in this design:
* Contoso's User clicks "Call user(s)" somewhere on their webapp 
  * Contoso's app page knows the participants IDs to call
  * This could be through a Graph search, or Contoso's web app could have this information elsewhere (irrelevant to us)
* Contoso's web app creates an ACSCallAdapter (with locator set) and shows the call composite (starts at configuration page)
* Contoso's user hits start call on configuration page
  * (Adapter calls startOrJoinCall)
* Ringing page shows (same as lobby page)
* Rest of normal call compsite flow follows

# How Tested
Draft PR to get API feedback