### PR TITLE
Removing ae-incompatible-release-tags for beta builds

### DIFF
--- a/common/config/api-extractor/api-extractor.json
+++ b/common/config/api-extractor/api-extractor.json
@@ -26,10 +26,6 @@
       "ae-forgotten-export": {
         "logLevel": "error",
         "addToApiReportFile": false
-      },
-      "ae-incompatible-release-tags": {
-        "logLevel": "warning",
-        "addToApiReportFile": false
       }
     },
     "tsdocMessageReporting": {

--- a/common/config/api-extractor/api-extractor.json
+++ b/common/config/api-extractor/api-extractor.json
@@ -28,7 +28,7 @@
         "addToApiReportFile": false
       },
       "ae-incompatible-release-tags": {
-        "logLevel": "error",
+        "logLevel": "warning",
         "addToApiReportFile": false
       }
     },

--- a/common/config/api-extractor/api-extractor.stable.json
+++ b/common/config/api-extractor/api-extractor.stable.json
@@ -1,7 +1,41 @@
 {
-  "extends": "./api-extractor.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/dist-esm/index.d.ts",
+  "newlineKind": "lf",
   "apiReport": {
     "enabled": true,
     "reportFolder": "<projectFolder>/stable-review/"
+  },
+  "docModel": {
+    "enabled": true
+  },
+  "dtsRollup": {
+    "enabled": true
+  },
+  "messages": {
+    "extractorMessageReporting": {
+      "ae-missing-release-tag": {
+        "logLevel": "error"
+      },
+      "ae-unresolved-link": {
+        // This must be set to none, as when our individual packlets reference exports
+        // from other packlets this throws an error. Ideally we should turn this on just
+        // for the communication-react api.md file.
+        "logLevel": "none"
+      },
+      "ae-forgotten-export": {
+        "logLevel": "error",
+        "addToApiReportFile": false
+      },
+      "ae-incompatible-release-tags": {
+        "logLevel": "error",
+        "addToApiReportFile": false
+      }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-undefined-tag": {
+        "logLevel": "none"
+      }
+    }
   }
 }


### PR DESCRIPTION
# What
Removing ae-incompatible-release-tags for beta builds

# Why
Beta builds will always encounter scenarios where a public API contains beta features.
Current checks result in errors causing build failures.
Keeping this check for beta doesn't make sense.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->