### PR TITLE
Allow complex conditional compilation directives in typescript types

### DIFF
--- a/common/scripts/babel-conditional-preprocess.js
+++ b/common/scripts/babel-conditional-preprocess.js
@@ -50,6 +50,22 @@ exports.default = babelHelper.declare((_api, opts) => {
         Handle(path, annotations);
       },
 
+      // TSType is fairly broad, but it is necessary for sanely extending existing types by adding disjuncts or conjucts.
+      // In other words, support this fairly common situation:
+      //
+      // stable build:
+      //   type SomeType = StableTypeA & StableTypeB;
+      //   type AwesomeType = StableTypeA | StableTypeB;
+      // beta build:
+      //   type SomeType = StableTypeA & StableTypeB & BetaTypeC;
+      //   type AwesomeType = StableTypeA | StableTypeB | BetaTypeC;
+      //
+      // As this only applies to TypeScript types, it is safe from a code-flow perspective: This does not enable any new
+      // conditional business logic flows.
+      TSType(path) {
+        Handle(path, annotations);
+      },
+
       Expression(path) {
         Handle(path, annotations);
       },


### PR DESCRIPTION
# What

... it says on the can.

# Why

Will allow us to get rid of some weird constructs we've seen this sprint to appease conditional compilation, with no risk in business logic complexity.

# How Tested

Replace some of those weird constructs with simpler logic.