### PR TITLE
Remove `ChatContext` error recovery that leaked intermittent state

### DIFF
--- a/change/@internal-chat-stateful-client-8d899f9f-48a8-45b4-a62b-1ce885f80809.json
+++ b/change/@internal-chat-stateful-client-8d899f9f-48a8-45b4-a62b-1ce885f80809.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove ChatContext error recovery flow that leaked intermittent state",
+  "packageName": "@internal/chat-stateful-client",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -31,7 +31,7 @@ packages:
   /@azure/communication-calling/1.3.2:
     dependencies:
       '@azure/communication-common': 1.1.0
-      '@azure/logger': 1.0.2
+      '@azure/logger': 1.0.3
     dev: false
     resolution:
       integrity: sha512-dO0NAHJ2KqI9NGptmQtQP1C8S4tTokyplxtr4AT5bCgF6Iywg6FbN0R/8MXmMMLb4YJyuh6ewSAXZo4z2PaN6g==
@@ -52,7 +52,7 @@ packages:
       '@azure/core-paging': 1.1.3
       '@azure/core-rest-pipeline': 1.3.0
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.2
+      '@azure/logger': 1.0.3
       events: 3.3.0
       tslib: 2.3.1
       uuid: 8.3.2
@@ -98,7 +98,7 @@ packages:
       '@azure/core-lro': 1.0.5
       '@azure/core-paging': 1.1.3
       '@azure/core-tracing': 1.0.0-preview.10
-      '@azure/logger': 1.0.2
+      '@azure/logger': 1.0.3
       '@opentelemetry/api': 0.10.2
       events: 3.3.0
       tslib: 2.3.1
@@ -111,7 +111,7 @@ packages:
     dependencies:
       '@azure/core-http': 2.2.0
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.2
+      '@azure/logger': 1.0.3
       events: 3.3.0
       tslib: 1.14.1
     dev: false
@@ -123,7 +123,7 @@ packages:
     dependencies:
       '@azure/core-http': 2.2.0
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.2
+      '@azure/logger': 1.0.3
       events: 3.3.0
       tslib: 1.14.1
     dev: false
@@ -176,7 +176,7 @@ packages:
       '@azure/core-asynciterator-polyfill': 1.0.0
       '@azure/core-auth': 1.3.2
       '@azure/core-tracing': 1.0.0-preview.11
-      '@azure/logger': 1.0.2
+      '@azure/logger': 1.0.3
       '@types/node-fetch': 2.5.12
       '@types/tunnel': 0.0.1
       form-data: 3.0.1
@@ -198,7 +198,7 @@ packages:
       '@azure/core-asynciterator-polyfill': 1.0.0
       '@azure/core-auth': 1.3.2
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.2
+      '@azure/logger': 1.0.3
       '@types/node-fetch': 2.5.12
       '@types/tunnel': 0.0.3
       form-data: 4.0.0
@@ -239,7 +239,7 @@ packages:
       '@azure/abort-controller': 1.0.4
       '@azure/core-auth': 1.3.2
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.2
+      '@azure/logger': 1.0.3
       form-data: 4.0.0
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.0
@@ -297,6 +297,14 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-YZNjNV0vL3nN2nedmcjQBcpCTo3oqceXmgiQtEm6fLpucjRZyQKAQruhCmCpRlB1iykqKJJ/Y8CDmT5rIE6IJw==
+  /@azure/logger/1.0.3:
+    dependencies:
+      tslib: 2.3.1
+    dev: false
+    engines:
+      node: '>=12.0.0'
+    resolution:
+      integrity: sha512-aK4s3Xxjrx3daZr3VylxejK3vG5ExXck5WOHDJ8in/k9AqlfIyFMMT1uG7u8mNjX+QRILTIn0/Xgschfh/dQ9g==
   /@babel/cli/7.16.0_@babel+core@7.16.5:
     dependencies:
       '@babel/core': 7.16.5
@@ -18950,6 +18958,7 @@ packages:
       '@azure/communication-identity': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.12
       '@azure/core-http': 1.2.4
+      '@azure/logger': 1.0.3
       '@babel/core': 7.16.5
       '@babel/preset-env': 7.13.10_@babel+core@7.16.5
       '@babel/preset-react': 7.14.5_@babel+core@7.16.5
@@ -19012,7 +19021,7 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-qQebxOv6E+YkJVTFzmPy5lUVJtaFRlkI+mnSwmtGspvvp6Qs609N6Jww+2eiFK+GULzRR9mRZRjg3HKQZJKoqA==
+      integrity: sha512-7RWIp1DbeBaAUR8pWHXcLU6X6uZ8ElqHpPPI1iPFXp1K8bjO4tBpQmU4+j1hdQ9PnbFIunP/Y25/W8MkPfcX9Q==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19102,6 +19111,7 @@ packages:
       '@azure/communication-identity': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.12
       '@azure/core-http': 1.2.4
+      '@azure/logger': 1.0.3
       '@babel/core': 7.16.5
       '@fluentui/react': 8.17.4_c2a703770fc22cd5845ac34fc7d0fe24
       '@fluentui/react-icons': 1.1.137
@@ -19159,7 +19169,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-F1Y/Furs0Yz+zAO+ELwTQWhtbmQZCwfJq6mjle4Euip8bsKs/TxvNf50JFDK+Da3nF1t5LqtwsArScmGgVUehA==
+      integrity: sha512-FDjWNaMttFzeayYUAWoQyH+/nf48H5jtgG4XWouRTD3/cEtHCZDjwgwz166uoRcgvAPkkGhoSC0nT3F8east7Q==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19362,6 +19372,7 @@ packages:
       '@azure/communication-common': 1.0.0
       '@azure/communication-identity': 1.0.0
       '@azure/core-http': 1.2.4
+      '@azure/logger': 1.0.3
       '@babel/core': 7.16.5
       '@babel/preset-env': 7.13.10_@babel+core@7.16.5
       '@babel/preset-react': 7.14.5_@babel+core@7.16.5
@@ -19421,7 +19432,7 @@ packages:
     dev: false
     name: '@rush-temp/meeting'
     resolution:
-      integrity: sha512-+4BZckCdumh+n3jyX11PYws65POh9agrS1XHJSR15B9PIYM1DIJd7rwfBBRLK8cqEW/VnSV0G2Luqh/ivfFn4g==
+      integrity: sha512-dZb6Zqu5hPNs2tXmncnND5uC8nUT3o4IPrt1ZhbiRMPOrNtiJAnBd6jehJBBGnTzAbP9kDmdIMcmaifoBQTTGg==
       tarball: file:projects/meeting.tgz
     version: 0.0.0
   file:projects/react-components.tgz:
@@ -19682,6 +19693,7 @@ packages:
       '@azure/communication-common': 1.0.0
       '@azure/communication-identity': 1.0.0
       '@azure/core-http': 1.2.4
+      '@azure/logger': 1.0.3
       '@types/cookie-parser': 1.4.2
       '@types/copy-webpack-plugin': 6.4.3
       '@types/cors': 2.8.12

--- a/packages/chat-stateful-client/src/ChatContext.ts
+++ b/packages/chat-stateful-client/src/ChatContext.ts
@@ -412,7 +412,6 @@ export class ChatContext {
    *
    * - A maximum of one `stateChanged` event is emitted, at the end of the operations.
    * - No `stateChanged` event is emitted if the state did not change through the operations.
-   * - In case of an exception, state is reset to the prior value and no `stateChanged` event is emitted.
    *
    * All operations finished in this batch should be synchronous.
    * This function is not reentrant -- do not call batch() from within another batch().
@@ -422,18 +421,15 @@ export class ChatContext {
       throw new Error('batch() called from within another batch()');
     }
 
-    this._batchMode = true;
     const priorState = this._state;
+    this._batchMode = true;
     try {
       operations();
-      if (this._state !== priorState) {
-        this._emitter.emit('stateChanged', this._state);
-      }
-    } catch (e) {
-      this._state = priorState;
-      throw e;
     } finally {
       this._batchMode = false;
+    }
+    if (this._state !== priorState) {
+      this._emitter.emit('stateChanged', this._state);
     }
   }
 

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -26,6 +26,7 @@
     "@azure/communication-common": "1.0.0",
     "@azure/communication-react": "1.0.1-beta.2",
     "@azure/core-http": "1.2.4",
+    "@azure/logger": "1.0.3",
     "@babel/preset-react": "^7.12.7",
     "@fluentui/react": "~8.17.2",
     "@fluentui/react-icons": "~1.1.137",

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -3,6 +3,7 @@
 
 import { GroupCallLocator, GroupLocator, TeamsMeetingLinkLocator } from '@azure/communication-calling';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
+import { setLogLevel } from '@azure/logger';
 import { initializeIcons, Spinner } from '@fluentui/react';
 import React, { useEffect, useState } from 'react';
 import {
@@ -22,6 +23,8 @@ import { CallScreen } from './views/CallScreen';
 import { EndCall } from './views/EndCall';
 import { HomeScreen } from './views/HomeScreen';
 import { UnsupportedBrowserPage } from './views/UnsupportedBrowserPage';
+
+setLogLevel('warning');
 
 console.log(
   `ACS sample calling app. Last Updated ${buildTime} Using @azure/communication-calling:${callingSDKVersion}`

--- a/samples/Chat/package.json
+++ b/samples/Chat/package.json
@@ -26,6 +26,7 @@
     "@azure/communication-react": "1.0.1-beta.2",
     "@azure/communication-signaling": "1.0.0-beta.12",
     "@azure/core-http": "1.2.4",
+    "@azure/logger": "1.0.3",
     "@fluentui/react": "~8.17.2",
     "@fluentui/react-icons": "~1.1.137",
     "@internal/acs-ui-common": "1.0.1-beta.2",

--- a/samples/Chat/src/app/App.tsx
+++ b/samples/Chat/src/app/App.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { setLogLevel } from '@azure/logger';
 import { initializeIcons, Spinner } from '@fluentui/react';
 import React, { useState } from 'react';
 import { ChatScreen } from './ChatScreen';
@@ -10,6 +11,8 @@ import { ErrorScreen } from './ErrorScreen';
 import HomeScreen from './HomeScreen';
 import { getExistingThreadIdFromURL } from './utils/getExistingThreadIdFromURL';
 import { getBuildTime, getChatSDKVersion } from './utils/utils';
+
+setLogLevel('warning');
 
 console.info(`Thread chat sample using @azure/communication-chat : ${getChatSDKVersion()}`);
 console.info(`Build Date : ${getBuildTime()}`);

--- a/samples/Meeting/package.json
+++ b/samples/Meeting/package.json
@@ -26,6 +26,7 @@
     "@azure/communication-common": "1.0.0",
     "@azure/communication-react": "1.0.1-beta.2",
     "@azure/core-http": "1.2.4",
+    "@azure/logger": "1.0.3",
     "@babel/preset-react": "^7.12.7",
     "@fluentui/react": "~8.17.2",
     "@fluentui/react-icons": "~1.1.137",

--- a/samples/Meeting/src/app/App.tsx
+++ b/samples/Meeting/src/app/App.tsx
@@ -4,6 +4,7 @@
 import { GroupCallLocator, TeamsMeetingLinkLocator } from '@azure/communication-calling';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { CallAndChatLocator } from '@azure/communication-react';
+import { setLogLevel } from '@azure/logger';
 import { initializeIcons, Spinner } from '@fluentui/react';
 import React, { useState } from 'react';
 import {
@@ -28,6 +29,7 @@ import { getThread } from './utils/getThread';
 import { getExistingThreadIdFromURL } from './utils/getThreadId';
 import { WEB_APP_TITLE } from './utils/constants';
 
+setLogLevel('warning');
 initializeIcons();
 
 interface Credentials {


### PR DESCRIPTION
# What

Delete error recovery in `batch()`

# Why

This error recovery wasn't incorrect for two reasons:

- All current users were internal, where the batch operation contained multiple headless SDK method calls. Rolling back the state in the stateful client would actually create desync between stateful client and underlying service.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->