### PR TITLE
Revert "Only compile files following trace of entry.. (#1390)

### DIFF
--- a/change/@internal-acs-ui-common-1115c7f5-3291-4ff2-adf0-83473af56a32.json
+++ b/change/@internal-acs-ui-common-1115c7f5-3291-4ff2-adf0-83473af56a32.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Follow the import trace from every index.ts and not to compile non-exported files",
-  "packageName": "@internal/acs-ui-common",
-  "email": "jiangnanhello@live.com",
-  "dependentChangeType": "none"
-}

--- a/change/@internal-calling-component-bindings-35ac624b-8f5e-4294-8972-5c0314deb191.json
+++ b/change/@internal-calling-component-bindings-35ac624b-8f5e-4294-8972-5c0314deb191.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Follow the import trace from every index.ts and not to compile non-exported files",
-  "packageName": "@internal/calling-component-bindings",
-  "email": "jiangnanhello@live.com",
-  "dependentChangeType": "none"
-}

--- a/change/@internal-calling-stateful-client-f4021a85-21a3-48fd-90eb-63343fd3462a.json
+++ b/change/@internal-calling-stateful-client-f4021a85-21a3-48fd-90eb-63343fd3462a.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Follow the import trace from every index.ts and not to compile non-exported files",
-  "packageName": "@internal/calling-stateful-client",
-  "email": "jiangnanhello@live.com",
-  "dependentChangeType": "none"
-}

--- a/change/@internal-chat-component-bindings-f2ff6b32-3db9-41be-9151-59d392ba2346.json
+++ b/change/@internal-chat-component-bindings-f2ff6b32-3db9-41be-9151-59d392ba2346.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Follow the import trace from every index.ts and not to compile non-exported files",
-  "packageName": "@internal/chat-component-bindings",
-  "email": "jiangnanhello@live.com",
-  "dependentChangeType": "none"
-}

--- a/change/@internal-chat-stateful-client-d1bfac0e-c456-49da-81f8-0eb7050e58b3.json
+++ b/change/@internal-chat-stateful-client-d1bfac0e-c456-49da-81f8-0eb7050e58b3.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Follow the import trace from every index.ts and not to compile non-exported files",
-  "packageName": "@internal/chat-stateful-client",
-  "email": "jiangnanhello@live.com",
-  "dependentChangeType": "none"
-}

--- a/change/@internal-react-components-c726b7cb-2617-429a-b114-2a96fe44c58a.json
+++ b/change/@internal-react-components-c726b7cb-2617-429a-b114-2a96fe44c58a.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Follow the import trace from every index.ts and not to compile non-exported files",
-  "packageName": "@internal/react-components",
-  "email": "jiangnanhello@live.com",
-  "dependentChangeType": "none"
-}

--- a/change/@internal-react-composites-8ad22884-b6cf-472f-81aa-e24fc3f19ab9.json
+++ b/change/@internal-react-composites-8ad22884-b6cf-472f-81aa-e24fc3f19ab9.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Follow the import trace from every index.ts and not to compile non-exported files",
-  "packageName": "@internal/react-composites",
-  "email": "jiangnanhello@live.com",
-  "dependentChangeType": "none"
-}

--- a/packages/acs-ui-common/tsconfig.preprocess.json
+++ b/packages/acs-ui-common/tsconfig.preprocess.json
@@ -5,6 +5,6 @@
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],
-  "include": ["preprocessed/index.ts", "preprocessed/**/*.test.ts"],
+  "include": ["preprocessed/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/calling-component-bindings/tsconfig.preprocess.json
+++ b/packages/calling-component-bindings/tsconfig.preprocess.json
@@ -5,6 +5,6 @@
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],
-  "include": ["preprocessed/index.ts", "preprocessed/**/*.test.ts"],
+  "include": ["preprocessed/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/calling-stateful-client/tsconfig.preprocess.json
+++ b/packages/calling-stateful-client/tsconfig.preprocess.json
@@ -5,6 +5,6 @@
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],
-  "include": ["preprocessed/index.ts", "preprocessed/**/*.test.ts"],
+  "include": ["preprocessed/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/chat-component-bindings/tsconfig.preprocess.json
+++ b/packages/chat-component-bindings/tsconfig.preprocess.json
@@ -5,6 +5,6 @@
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],
-  "include": ["preprocessed/index.ts", "preprocessed/**/*.test.ts"],
+  "include": ["preprocessed/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/chat-stateful-client/tsconfig.preprocess.json
+++ b/packages/chat-stateful-client/tsconfig.preprocess.json
@@ -5,6 +5,6 @@
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],
-  "include": ["preprocessed/index.ts", "preprocessed/**/*.test.ts"],
+  "include": ["preprocessed/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/communication-react/tsconfig.preprocess.json
+++ b/packages/communication-react/tsconfig.preprocess.json
@@ -19,6 +19,6 @@
     ]
   },
   "typeRoots": ["./node_modules/@types"],
-  "include": ["preprocess-dist/*/src/index.ts"],
+  "include": ["preprocess-dist/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/react-components/tsconfig.preprocess.json
+++ b/packages/react-components/tsconfig.preprocess.json
@@ -5,6 +5,6 @@
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],
-  "include": ["preprocessed/index.ts", "preprocessed/**/*.test.ts"],
+  "include": ["preprocessed/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/packages/react-composites/tsconfig.preprocess.json
+++ b/packages/react-composites/tsconfig.preprocess.json
@@ -5,6 +5,6 @@
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],
-  "include": ["preprocessed/index.ts", "preprocessed/**/*.test.ts"],
+  "include": ["preprocessed/**/*"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
This reverts commit 8061151ddd7b6b13e387b8c591d9fc11cc2c43fe.

# Why

Reduce the diff between `beta` and `stable` flavor builds. The larger this diff, the higher the chances that build failures will leak in when we stabilize a feature (i.e., remove related conditional compilation directives).

A better approach for beta-only features is to define all internal types unconditionally and only restrict the exported API.
