### PR TITLE
[CallWithChat Composite] Split imports to remove unneeded conditional compilation

### DIFF
--- a/packages/react-composites/src/composites/MeetingComposite/adapter/AzureCommunicationMeetingAdapter.ts
+++ b/packages/react-composites/src/composites/MeetingComposite/adapter/AzureCommunicationMeetingAdapter.ts
@@ -52,11 +52,13 @@ import { getChatThreadFromTeamsLink } from './parseTeamsUrl';
 import { AdapterError } from '../../common/adapters';
 
 /* @conditional-compile-remove-from(stable) TEAMS_ADHOC_CALLING */
+import { CallParticipantsLocator } from '../../CallComposite/adapter/AzureCommunicationCallAdapter';
+
 import {
   CallAdapterLocator,
-  CallParticipantsLocator,
   createAzureCommunicationCallAdapterFromClient
 } from '../../CallComposite/adapter/AzureCommunicationCallAdapter';
+
 import { StatefulCallClient } from '@internal/calling-stateful-client';
 import { StatefulChatClient } from '@internal/chat-stateful-client';
 import { ChatThreadClient } from '@azure/communication-chat';


### PR DESCRIPTION
# What
Split imports for .../AzureCommunicationCallAdapter to remove unneeded conditional compilation for statefulclient

# Why
Would cause issues in stable if imports were conditional compiled but the methods using imports were not.
A PR on top of https://github.com/Azure/communication-ui-library/pull/1457 

# How Tested
build stable locally and check results in generated preprocessed folder