### PR TITLE
[Bugfix][Release 1.1.0] Conditionally removing participant button from chat sample header

### DIFF
--- a/samples/Chat/src/app/ChatHeader.tsx
+++ b/samples/Chat/src/app/ChatHeader.tsx
@@ -32,7 +32,7 @@ export const ChatHeader = (props: ChatHeaderProps): JSX.Element => {
     <Stack horizontal={true} verticalAlign={'center'} horizontalAlign="end" className={chatHeaderContainerStyle}>
       <div className={paneButtonContainerStyle}>
         {
-          /* @conditional-compile-remove-from(stable) meeting composite */
+          /* @conditional-compile-remove-from(stable) chat-composite-participant-pane*/
           <IconButton
             onRenderIcon={() => (props.isParticipantsDisplayed ? <People20Filled /> : <People20Regular />)}
             className={mergeStyles({ color: theme.palette.neutralPrimaryAlt })}

--- a/samples/Chat/src/app/ChatHeader.tsx
+++ b/samples/Chat/src/app/ChatHeader.tsx
@@ -31,11 +31,14 @@ export const ChatHeader = (props: ChatHeaderProps): JSX.Element => {
   return (
     <Stack horizontal={true} verticalAlign={'center'} horizontalAlign="end" className={chatHeaderContainerStyle}>
       <div className={paneButtonContainerStyle}>
-        <IconButton
-          onRenderIcon={() => (props.isParticipantsDisplayed ? <People20Filled /> : <People20Regular />)}
-          className={mergeStyles({ color: theme.palette.neutralPrimaryAlt })}
-          onClick={() => props.setHideParticipants(props.isParticipantsDisplayed)}
-        />
+        {
+          /* @conditional-compile-remove-from(stable) meeting composite */
+          <IconButton
+            onRenderIcon={() => (props.isParticipantsDisplayed ? <People20Filled /> : <People20Regular />)}
+            className={mergeStyles({ color: theme.palette.neutralPrimaryAlt })}
+            onClick={() => props.setHideParticipants(props.isParticipantsDisplayed)}
+          />
+        }
       </div>
       <DefaultButton
         className={mergeStyles(largeLeaveButtonContainerStyle, leaveButtonStyle, {


### PR DESCRIPTION
# What
Conditionally removing participant button from chat sample header

# Why
Participant button  stops working for stable builds as it is being conditionally compiled (meeting composite)
https://skype.visualstudio.com/SPOOL/_workitems/edit/2767067

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->