### PR TITLE
Fix drawer menu items' content not updating dynamically while the menu was open

### DIFF
--- a/change/@internal-react-components-a5fd2b69-6c60-4d4f-a510-14908ed361c4.json
+++ b/change/@internal-react-components-a5fd2b69-6c60-4d4f-a510-14908ed361c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix drawer menu items' content not updating dynamically while the menu is open when props are updated.",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/Drawer/DrawerMenu.tsx
+++ b/packages/react-components/src/components/Drawer/DrawerMenu.tsx
@@ -49,9 +49,9 @@ export const _DrawerMenu = (props: _DrawerMenuProps): JSX.Element => {
   // Get the menu items that should be rendered
   const menuItemsToRender = useMemo(() => {
     let items: _DrawerMenuItemProps[] | undefined = props.items;
-    selectedKeyPath.forEach(
-      (subMenuKey) => (items = props.items.find((item) => item.itemKey === subMenuKey)?.subMenuProps)
-    );
+    for (const subMenuKey of selectedKeyPath) {
+      items = items?.find((item) => item.itemKey === subMenuKey)?.subMenuProps;
+    }
     return items;
   }, [props.items, selectedKeyPath]);
 
@@ -87,13 +87,7 @@ export const _DrawerMenu = (props: _DrawerMenuProps): JSX.Element => {
   );
 
   return (
-    <_DrawerSurface
-      styles={props.styles?.drawerSurfaceStyles}
-      onLightDismiss={() => {
-        console.log('light dismiss!');
-        props.onLightDismiss();
-      }}
-    >
+    <_DrawerSurface styles={props.styles?.drawerSurfaceStyles} onLightDismiss={props.onLightDismiss}>
       <Stack styles={props.styles} role="menu">
         {menuItemsToRender?.slice(0, 1).map((item) => (
           <DrawerMenuItem

--- a/packages/react-components/src/components/Drawer/DrawerSurface.tsx
+++ b/packages/react-components/src/components/Drawer/DrawerSurface.tsx
@@ -57,6 +57,9 @@ export const _DrawerSurface = (props: _DrawerSurfaceProps): JSX.Element => {
             props.onLightDismiss && props.onLightDismiss();
           }
         }}
+        // Ensure when the focus trap has focus, the light dismiss area can still be clicked with mouse to dismiss.
+        // Note: this still correctly captures keyboard focus, this just allows mouse click outside of the focus trap.
+        isClickableOutsideFocusTrap={true}
       >
         <DrawerContentContainer styles={props.styles?.drawerContentContainer}>{props.children}</DrawerContentContainer>
       </FocusTrapZone>


### PR DESCRIPTION
# What
Change how we know we are showing a sub menu in the DrawerMenu.

## How fix works
Before we would set new `menuItems` when an item with a submenu was clicked, this meant if a menu item had a prop like its icon updated - this wouldn't be reflected in our cache of `menuItems` and thus wouldn't be updated.

Now we store an array of keys that result in the submenu using the mandatory itemKey field.

# Why
Menu item content like text or icon wouldn't update unless the whole menu was closed and reopened.

# How Tested
Locally running callwithchat sample (see how then chosen microphone icon updates when selected):

https://user-images.githubusercontent.com/2684369/155231402-82604e93-f87f-4e68-9a4c-eaf9ed46fb67.mp4


