### PR TITLE
Fixed editbox border that disappeared after adding wrapper div for file sharing changes

### DIFF
--- a/change/@internal-react-components-4d2e6ba5-f7fa-466d-9fa2-7fd862965ae4.json
+++ b/change/@internal-react-components-4d2e6ba5-f7fa-466d-9fa2-7fd862965ae4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed Editbox border which disappeared after adding file sharing changes",
+  "packageName": "@internal/react-components",
+  "email": "97124699+prabhjot-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsEditBox.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsEditBox.tsx
@@ -1,12 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { concatStyleSets, Icon, ITextField, mergeStyles } from '@fluentui/react';
+import { concatStyleSets, Icon, ITextField, mergeStyles, Stack } from '@fluentui/react';
 import { _formatString } from '@internal/acs-ui-common';
 import { useTheme } from '../../theming/FluentThemeProvider';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { editBoxStyle, inputBoxIcon, editingButtonStyle, editBoxStyleSet } from '../styles/EditBox.styles';
+import {
+  editBoxStyle,
+  inputBoxIcon,
+  editingButtonStyle,
+  editBoxStyleSet,
+  borderAndBoxShadowStyle
+} from '../styles/EditBox.styles';
 import { InputBoxButton, InputBoxComponent } from '../InputBoxComponent';
 import { MessageThreadStrings } from '../MessageThread';
 
@@ -84,45 +90,47 @@ export const ChatMessageComponentAsEditBox = (props: ChatMessageComponentAsEditB
   }, [theme.palette.themePrimary]);
 
   return (
-    <InputBoxComponent
-      inlineChildren={props.inlineEditButtons}
-      id={'editbox'}
-      textFieldRef={editTextFieldRef}
-      inputClassName={editBoxStyle(props.inlineEditButtons)}
-      placeholderText={strings.editBoxPlaceholderText}
-      textValue={textValue}
-      onChange={setText}
-      onEnterKeyDown={() => {
-        onSubmit(textValue);
-      }}
-      supportNewline={false}
-      maxLength={MAXIMUM_LENGTH_OF_MESSAGE}
-      errorMessage={textTooLongMessage}
-      styles={editBoxStyles}
-    >
-      <InputBoxButton
-        className={editingButtonStyle}
-        ariaLabel={strings.editBoxCancelButton}
-        tooltipContent={strings.editBoxCancelButton}
-        onRenderIcon={onRenderThemedCancelIcon}
-        onClick={() => {
-          onCancel && onCancel();
+    <Stack className={mergeStyles(borderAndBoxShadowStyle(theme))}>
+      <InputBoxComponent
+        inlineChildren={props.inlineEditButtons}
+        id={'editbox'}
+        textFieldRef={editTextFieldRef}
+        inputClassName={editBoxStyle(props.inlineEditButtons)}
+        placeholderText={strings.editBoxPlaceholderText}
+        textValue={textValue}
+        onChange={setText}
+        onEnterKeyDown={() => {
+          onSubmit(textValue);
         }}
-        id={'dismissIconWrapper'}
-      />
-      <InputBoxButton
-        className={editingButtonStyle}
-        ariaLabel={strings.editBoxSubmitButton}
-        tooltipContent={strings.editBoxSubmitButton}
-        onRenderIcon={onRenderThemedSubmitIcon}
-        onClick={(e) => {
-          if (!textValueOverflow && textValue !== '') {
-            onSubmit(textValue);
-          }
-          e.stopPropagation();
-        }}
-        id={'submitIconWrapper'}
-      />
-    </InputBoxComponent>
+        supportNewline={false}
+        maxLength={MAXIMUM_LENGTH_OF_MESSAGE}
+        errorMessage={textTooLongMessage}
+        styles={editBoxStyles}
+      >
+        <InputBoxButton
+          className={editingButtonStyle}
+          ariaLabel={strings.editBoxCancelButton}
+          tooltipContent={strings.editBoxCancelButton}
+          onRenderIcon={onRenderThemedCancelIcon}
+          onClick={() => {
+            onCancel && onCancel();
+          }}
+          id={'dismissIconWrapper'}
+        />
+        <InputBoxButton
+          className={editingButtonStyle}
+          ariaLabel={strings.editBoxSubmitButton}
+          tooltipContent={strings.editBoxSubmitButton}
+          onRenderIcon={onRenderThemedSubmitIcon}
+          onClick={(e) => {
+            if (!textValueOverflow && textValue !== '') {
+              onSubmit(textValue);
+            }
+            e.stopPropagation();
+          }}
+          id={'submitIconWrapper'}
+        />
+      </InputBoxComponent>
+    </Stack>
   );
 };

--- a/packages/react-components/src/components/styles/EditBox.styles.ts
+++ b/packages/react-components/src/components/styles/EditBox.styles.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { mergeStyles } from '@fluentui/react';
+import { IStyle, mergeStyles, Theme } from '@fluentui/react';
 
 /**
  * @private
@@ -39,4 +39,16 @@ export const editBoxStyleSet = {
   root: {
     width: '100%'
   }
+};
+
+/**
+ * @private
+ */
+export const borderAndBoxShadowStyle = (theme: Theme): IStyle => {
+  const borderColor = theme.palette.blue;
+  return {
+    borderRadius: theme.effects.roundedCorner4,
+    border: `0.125rem solid ${borderColor}`,
+    width: '100%'
+  };
 };


### PR DESCRIPTION
# What
Fixed editbox border that disappeared after adding wrapper div for file sharing changes

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/2770107

# How Tested


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->