### PR TITLE
Vertically center menuitem icons

### DIFF
--- a/change/@internal-react-components-b2c9bd47-c161-49b8-adb2-98aa648d39bd.json
+++ b/change/@internal-react-components-b2c9bd47-c161-49b8-adb2-98aa648d39bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix DrawerMenu MenuItem Icons to be vertically centered",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-storybook-55bc3ef5-8978-4ee8-9b1c-b64085226e27.json
+++ b/change/@internal-storybook-55bc3ef5-8978-4ee8-9b1c-b64085226e27.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove unnecessary styling",
+  "packageName": "@internal/storybook",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/Drawer/DrawerMenuItem.tsx
+++ b/packages/react-components/src/components/Drawer/DrawerMenuItem.tsx
@@ -1,7 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { FontIcon, Icon, IIconProps, IRawStyle, IStackStyles, IStyle, mergeStyles, Stack, Text } from '@fluentui/react';
+import {
+  FontIcon,
+  IFontIconProps,
+  IIconProps,
+  IRawStyle,
+  IStackStyles,
+  IStyle,
+  mergeStyles,
+  Stack,
+  Text
+} from '@fluentui/react';
 import React from 'react';
 import { useTheme } from '../../theming/FluentThemeProvider';
 import { BaseCustomStyles } from '../../types';
@@ -42,9 +52,9 @@ export const DrawerMenuItem = (props: _DrawerMenuItemProps): JSX.Element => {
   const onKeyPress = (ev: React.KeyboardEvent<HTMLElement>): void => onClick && submitWithKeyboard(ev, onClick);
 
   const secondaryIcon = props.secondaryIconProps ? (
-    <FontIcon {...props.secondaryIconProps} />
+    <MenuItemIcon {...props.secondaryIconProps} />
   ) : props.subMenuProps ? (
-    <FontIcon iconName="ChevronRight" />
+    <MenuItemIcon iconName="ChevronRight" />
   ) : undefined;
 
   return (
@@ -62,7 +72,7 @@ export const DrawerMenuItem = (props: _DrawerMenuItemProps): JSX.Element => {
     >
       {props.iconProps && (
         <Stack.Item role="presentation">
-          <Icon {...props.iconProps} />
+          <MenuItemIcon {...props.iconProps} />
         </Stack.Item>
       )}
       <Stack.Item styles={drawerMenuItemTextStyles} grow>
@@ -77,6 +87,10 @@ export const DrawerMenuItem = (props: _DrawerMenuItemProps): JSX.Element => {
     </Stack>
   );
 };
+
+const MenuItemIcon = (props: IFontIconProps): JSX.Element => (
+  <FontIcon className={mergeStyles(iconStyles)} {...props} />
+);
 
 const menuItemChildrenGap = { childrenGap: '0.5rem' };
 
@@ -98,4 +112,11 @@ const drawerMenuItemTextStyles: IStackStyles = {
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap'
   }
+};
+
+const iconStyles: IStyle = {
+  // Vertically center icons in the menu item. Using line-height does not work for centering fluent SVG icons.
+  display: 'flex',
+  alignItems: 'center',
+  height: '100%'
 };

--- a/packages/react-components/src/components/Drawer/DrawerMenuItem.tsx
+++ b/packages/react-components/src/components/Drawer/DrawerMenuItem.tsx
@@ -118,5 +118,12 @@ const iconStyles: IStyle = {
   // Vertically center icons in the menu item. Using line-height does not work for centering fluent SVG icons.
   display: 'flex',
   alignItems: 'center',
-  height: '100%'
+  height: '100%',
+
+  // This can be removed when we upgrade to fluent-react-icons v2 (that removes the inner span element)
+  ' span': {
+    display: 'flex',
+    alignItems: 'center',
+    height: '100%'
+  }
 };

--- a/packages/storybook/stories/INTERNAL/Drawer/DrawerMenu.stories.tsx
+++ b/packages/storybook/stories/INTERNAL/Drawer/DrawerMenu.stories.tsx
@@ -21,42 +21,42 @@ const DrawerMenuStory = (/*args*/): JSX.Element => {
     {
       itemKey: 'raiseHand',
       text: 'Raise hand',
-      iconProps: { iconName: 'RightHand', styles: iconStyles },
+      iconProps: { iconName: 'RightHand' },
       onItemClick: () => setIsDrawerShowing(false)
     },
     {
       itemKey: 'speaker',
       text: 'Speaker',
       secondaryText: 'Speaker1',
-      iconProps: { iconName: 'OptionsSpeaker', styles: iconStyles },
+      iconProps: { iconName: 'OptionsSpeaker' },
       subMenuProps: [
         {
           itemKey: 'speaker1',
           text: 'Default Speaker 1',
-          iconProps: { iconName: 'OptionsSpeaker', styles: iconStyles },
+          iconProps: { iconName: 'OptionsSpeaker' },
           onItemClick: () => setIsDrawerShowing(false)
         },
         {
           itemKey: 'speaker2',
           text: 'Default Speaker 2',
-          iconProps: { iconName: 'OptionsSpeaker', styles: iconStyles },
+          iconProps: { iconName: 'OptionsSpeaker' },
           onItemClick: () => setIsDrawerShowing(false)
         },
         {
           itemKey: 'speaker3',
           text: 'Choose from more speakers',
-          iconProps: { iconName: 'OptionsSpeaker', styles: iconStyles },
+          iconProps: { iconName: 'OptionsSpeaker' },
           subMenuProps: [
             {
               itemKey: 'speakerMore1',
               text: 'Another Speaker',
-              iconProps: { iconName: 'OptionsSpeaker', styles: iconStyles },
+              iconProps: { iconName: 'OptionsSpeaker' },
               onItemClick: () => setIsDrawerShowing(false)
             },
             {
               itemKey: 'speakerMore2',
               text: 'Another another Speaker',
-              iconProps: { iconName: 'OptionsSpeaker', styles: iconStyles },
+              iconProps: { iconName: 'OptionsSpeaker' },
               onItemClick: () => setIsDrawerShowing(false)
             }
           ]
@@ -66,14 +66,14 @@ const DrawerMenuStory = (/*args*/): JSX.Element => {
     {
       itemKey: 'people',
       text: 'People',
-      iconProps: { iconName: 'Participants', styles: iconStyles },
-      secondaryIconProps: { iconName: 'Open', styles: iconStyles },
+      iconProps: { iconName: 'Participants' },
+      secondaryIconProps: { iconName: 'Open' },
       onItemClick: () => setIsDrawerShowing(false)
     },
     {
       itemKey: 'recording',
       text: 'Start Recording',
-      iconProps: { iconName: 'Record', styles: iconStyles },
+      iconProps: { iconName: 'Record' },
       onItemClick: () => setIsDrawerShowing(false)
     }
   ];
@@ -96,8 +96,6 @@ const DrawerMenuStory = (/*args*/): JSX.Element => {
     </MobilePreviewContainer>
   );
 };
-
-const iconStyles = { root: { fontSize: '1.75rem' } };
 
 // This must be the only named export from this module, and must be named to match the storybook path suffix.
 // This ensures that storybook hoists the story instead of creating a folder with a single entry.


### PR DESCRIPTION
# What
Apply some styling to ensure menuitem icons are vertically centered

# Why
Icons by default were not vertically centered in the DrawerMenu

# How Tested
* Storybook (check out PR link when generated)
* Local sample (tbd screenshot)