### PR TITLE
Hotfix: Wrap JSON.stringify in try-catch when logging state changes

### DIFF
--- a/change/@internal-acs-ui-common-b3e501bf-fec9-4958-9ab0-3e5acd854892.json
+++ b/change/@internal-acs-ui-common-b3e501bf-fec9-4958-9ab0-3e5acd854892.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add _safeStringify function",
+  "comment": "Add _safeJSONStringify function",
   "packageName": "@internal/acs-ui-common",
   "email": "2684369+JamesBurnside@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@internal-acs-ui-common-b3e501bf-fec9-4958-9ab0-3e5acd854892.json
+++ b/change/@internal-acs-ui-common-b3e501bf-fec9-4958-9ab0-3e5acd854892.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add _safeStringify function",
+  "packageName": "@internal/acs-ui-common",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-calling-stateful-client-563d8d8e-11c8-4a1f-90b9-f36dbcbf879e.json
+++ b/change/@internal-calling-stateful-client-563d8d8e-11c8-4a1f-90b9-f36dbcbf879e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix exception thrown when trying to log stringified state when azure logger is set to verbose",
+  "packageName": "@internal/calling-stateful-client",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-chat-stateful-client-3863a9d0-f774-4976-8bed-f33498dffa51.json
+++ b/change/@internal-chat-stateful-client-3863a9d0-f774-4976-8bed-f33498dffa51.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix exception thrown when trying to log stringified state when azure logger is set to verbose",
+  "packageName": "@internal/chat-stateful-client",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/acs-ui-common/review/acs-ui-common.api.md
+++ b/packages/acs-ui-common/review/acs-ui-common.api.md
@@ -56,7 +56,7 @@ export const memoizeFnAll: <KeyT, ArgsT extends unknown[], FnRetT, CallBackT ext
 export type MessageStatus = 'delivered' | 'sending' | 'seen' | 'failed';
 
 // @internal
-export const _safeJSONStringify: (value: unknown, replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined, space?: string | number | undefined) => string;
+export const _safeJSONStringify: (value: unknown, replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined, space?: string | number | undefined) => string | undefined;
 
 // @public
 export const toFlatCommunicationIdentifier: (identifier: CommunicationIdentifier) => string;

--- a/packages/acs-ui-common/review/acs-ui-common.api.md
+++ b/packages/acs-ui-common/review/acs-ui-common.api.md
@@ -56,7 +56,7 @@ export const memoizeFnAll: <KeyT, ArgsT extends unknown[], FnRetT, CallBackT ext
 export type MessageStatus = 'delivered' | 'sending' | 'seen' | 'failed';
 
 // @internal
-export const _safeStringify: (value: unknown, replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined, space?: string | number | undefined) => string;
+export const _safeJSONStringify: (value: unknown, replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined, space?: string | number | undefined) => string;
 
 // @public
 export const toFlatCommunicationIdentifier: (identifier: CommunicationIdentifier) => string;

--- a/packages/acs-ui-common/review/acs-ui-common.api.md
+++ b/packages/acs-ui-common/review/acs-ui-common.api.md
@@ -55,6 +55,9 @@ export const memoizeFnAll: <KeyT, ArgsT extends unknown[], FnRetT, CallBackT ext
 // @public
 export type MessageStatus = 'delivered' | 'sending' | 'seen' | 'failed';
 
+// @internal
+export const _safeStringify: (value: unknown, replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined, space?: string | number | undefined) => string;
+
 // @public
 export const toFlatCommunicationIdentifier: (identifier: CommunicationIdentifier) => string;
 

--- a/packages/acs-ui-common/src/index.ts
+++ b/packages/acs-ui-common/src/index.ts
@@ -5,7 +5,7 @@ export { memoizeFnAll } from './memoizeFnAll';
 export { fromFlatCommunicationIdentifier, toFlatCommunicationIdentifier } from './identifier';
 export { _getApplicationId } from './telemetry';
 export { _formatString } from './localizationUtils';
-export { _safeStringify } from './safeStringify';
+export { _safeJSONStringify } from './safeStringify';
 
 export type { Common, CommonProperties } from './commonProperties';
 export type { CallbackType, FunctionWithKey } from './memoizeFnAll';

--- a/packages/acs-ui-common/src/index.ts
+++ b/packages/acs-ui-common/src/index.ts
@@ -5,6 +5,7 @@ export { memoizeFnAll } from './memoizeFnAll';
 export { fromFlatCommunicationIdentifier, toFlatCommunicationIdentifier } from './identifier';
 export { _getApplicationId } from './telemetry';
 export { _formatString } from './localizationUtils';
+export { _safeStringify } from './safeStringify';
 
 export type { Common, CommonProperties } from './commonProperties';
 export type { CallbackType, FunctionWithKey } from './memoizeFnAll';

--- a/packages/acs-ui-common/src/safeStringify.ts
+++ b/packages/acs-ui-common/src/safeStringify.ts
@@ -8,7 +8,7 @@
  *
  * @internal
  */
-export const _safeStringify = (
+export const _safeJSONStringify = (
   value: unknown,
   replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined,
   space?: string | number | undefined

--- a/packages/acs-ui-common/src/safeStringify.ts
+++ b/packages/acs-ui-common/src/safeStringify.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Wrap JSON.stringify in a try-catch as JSON.stringify throws an exception if it fails.
+ *
+ * Use this only in areas where the JSON.stringify is non-critical and OK for the JSON.stringify to fail, such as logging.
+ *
+ * @internal
+ */
+export const _safeStringify = (
+  value: unknown,
+  replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined,
+  space?: string | number | undefined
+): string => {
+  try {
+    return JSON.stringify(value, replacer, space);
+  } catch (e) {
+    console.error(e);
+    return '';
+  }
+};

--- a/packages/acs-ui-common/src/safeStringify.ts
+++ b/packages/acs-ui-common/src/safeStringify.ts
@@ -12,11 +12,11 @@ export const _safeJSONStringify = (
   value: unknown,
   replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined,
   space?: string | number | undefined
-): string => {
+): string | undefined => {
   try {
     return JSON.stringify(value, replacer, space);
   } catch (e) {
     console.error(e);
-    return '';
+    return undefined;
   }
 };

--- a/packages/acs-ui-common/stable-review/acs-ui-common.api.md
+++ b/packages/acs-ui-common/stable-review/acs-ui-common.api.md
@@ -56,7 +56,7 @@ export const memoizeFnAll: <KeyT, ArgsT extends unknown[], FnRetT, CallBackT ext
 export type MessageStatus = 'delivered' | 'sending' | 'seen' | 'failed';
 
 // @internal
-export const _safeJSONStringify: (value: unknown, replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined, space?: string | number | undefined) => string;
+export const _safeJSONStringify: (value: unknown, replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined, space?: string | number | undefined) => string | undefined;
 
 // @public
 export const toFlatCommunicationIdentifier: (identifier: CommunicationIdentifier) => string;

--- a/packages/acs-ui-common/stable-review/acs-ui-common.api.md
+++ b/packages/acs-ui-common/stable-review/acs-ui-common.api.md
@@ -56,7 +56,7 @@ export const memoizeFnAll: <KeyT, ArgsT extends unknown[], FnRetT, CallBackT ext
 export type MessageStatus = 'delivered' | 'sending' | 'seen' | 'failed';
 
 // @internal
-export const _safeStringify: (value: unknown, replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined, space?: string | number | undefined) => string;
+export const _safeJSONStringify: (value: unknown, replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined, space?: string | number | undefined) => string;
 
 // @public
 export const toFlatCommunicationIdentifier: (identifier: CommunicationIdentifier) => string;

--- a/packages/acs-ui-common/stable-review/acs-ui-common.api.md
+++ b/packages/acs-ui-common/stable-review/acs-ui-common.api.md
@@ -55,6 +55,9 @@ export const memoizeFnAll: <KeyT, ArgsT extends unknown[], FnRetT, CallBackT ext
 // @public
 export type MessageStatus = 'delivered' | 'sending' | 'seen' | 'failed';
 
+// @internal
+export const _safeStringify: (value: unknown, replacer?: ((this: unknown, key: string, value: unknown) => unknown) | undefined, space?: string | number | undefined) => string;
+
 // @public
 export const toFlatCommunicationIdentifier: (identifier: CommunicationIdentifier) => string;
 

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -11,7 +11,7 @@ import {
   CallState as CallStatus,
   RemoteParticipantState as RemoteParticipantStatus
 } from '@azure/communication-calling';
-import { _safeStringify, toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
+import { _safeJSONStringify, toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 import {
   CallState,
   CallClientState,
@@ -78,7 +78,7 @@ export class CallContext {
     this._state = produce(this._state, modifier, (patches: Patch[]) => {
       if (getLogLevel() === 'verbose') {
         // Log to `info` because AzureLogger.verbose() doesn't show up in console.
-        this._logger.info(`State change: ${_safeStringify(patches)}`);
+        this._logger.info(`State change: ${_safeJSONStringify(patches)}`);
       }
     });
     if (!this._batchMode) {

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -11,7 +11,7 @@ import {
   CallState as CallStatus,
   RemoteParticipantState as RemoteParticipantStatus
 } from '@azure/communication-calling';
-import { toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
+import { _safeStringify, toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 import {
   CallState,
   CallClientState,
@@ -78,7 +78,7 @@ export class CallContext {
     this._state = produce(this._state, modifier, (patches: Patch[]) => {
       if (getLogLevel() === 'verbose') {
         // Log to `info` because AzureLogger.verbose() doesn't show up in console.
-        this._logger.info(`State change: ${JSON.stringify(patches)}`);
+        this._logger.info(`State change: ${_safeStringify(patches)}`);
       }
     });
     if (!this._batchMode) {

--- a/packages/chat-stateful-client/src/ChatContext.ts
+++ b/packages/chat-stateful-client/src/ChatContext.ts
@@ -15,7 +15,7 @@ import { ChatMessageWithStatus } from './types/ChatMessageWithStatus';
 import { ChatMessageReadReceipt, ChatParticipant } from '@azure/communication-chat';
 import { CommunicationIdentifierKind, UnknownIdentifierKind } from '@azure/communication-common';
 import { AzureLogger, createClientLogger, getLogLevel } from '@azure/logger';
-import { _safeStringify, toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
+import { _safeJSONStringify, toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 import { Constants } from './Constants';
 import { TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
 
@@ -61,7 +61,7 @@ export class ChatContext {
     this._state = produce(this._state, modifier, (patches: Patch[]) => {
       if (getLogLevel() === 'verbose') {
         // Log to `info` because AzureLogger.verbose() doesn't show up in console.
-        this._logger.info(`State change: ${_safeStringify(patches)}`);
+        this._logger.info(`State change: ${_safeJSONStringify(patches)}`);
       }
     });
     if (!this._batchMode) {
@@ -401,7 +401,7 @@ export class ChatContext {
     } catch (e) {
       this._state = priorState;
       if (getLogLevel() === 'verbose') {
-        this._logger.warning(`State rollback to: ${_safeStringify(priorState)}`);
+        this._logger.warning(`State rollback to: ${_safeJSONStringify(priorState)}`);
       }
       throw e;
     } finally {

--- a/packages/chat-stateful-client/src/ChatContext.ts
+++ b/packages/chat-stateful-client/src/ChatContext.ts
@@ -15,7 +15,7 @@ import { ChatMessageWithStatus } from './types/ChatMessageWithStatus';
 import { ChatMessageReadReceipt, ChatParticipant } from '@azure/communication-chat';
 import { CommunicationIdentifierKind, UnknownIdentifierKind } from '@azure/communication-common';
 import { AzureLogger, createClientLogger, getLogLevel } from '@azure/logger';
-import { toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
+import { _safeStringify, toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 import { Constants } from './Constants';
 import { TypingIndicatorReceivedEvent } from '@azure/communication-signaling';
 
@@ -61,7 +61,7 @@ export class ChatContext {
     this._state = produce(this._state, modifier, (patches: Patch[]) => {
       if (getLogLevel() === 'verbose') {
         // Log to `info` because AzureLogger.verbose() doesn't show up in console.
-        this._logger.info(`State change: ${JSON.stringify(patches)}`);
+        this._logger.info(`State change: ${_safeStringify(patches)}`);
       }
     });
     if (!this._batchMode) {
@@ -401,7 +401,7 @@ export class ChatContext {
     } catch (e) {
       this._state = priorState;
       if (getLogLevel() === 'verbose') {
-        this._logger.warning(`State rollback to: ${JSON.stringify(priorState)}`);
+        this._logger.warning(`State rollback to: ${_safeStringify(priorState)}`);
       }
       throw e;
     } finally {


### PR DESCRIPTION
# What
* Wrap state changes in verbose logging with a try catch

# Why
* Causing exceptions:
   ![image](https://user-images.githubusercontent.com/2684369/155607229-d9773369-fef7-434c-a32b-12a93c4a50df.png)

This error was seen when updating the selfhosting app. Still investigating _why_ the selfhost app sees this but the samples in this repo are not.

# How Tested
n/a