### PR TITLE
Fix missing storybook stories by updating the story glob path check

### DIFF
--- a/change/@internal-storybook-486cb5cd-dbbb-4138-84ad-71266f8d2637.json
+++ b/change/@internal-storybook-486cb5cd-dbbb-4138-84ad-71266f8d2637.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix missing storybook stories by updating the story glob path check",
+  "packageName": "@internal/storybook",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -7,10 +7,16 @@ const webpack = require('webpack4');
 const DEVELOPMENT_BUILD = process.env.NODE_ENV === 'development';
 console.log(`Creating storybook with internal-only stories: ${DEVELOPMENT_BUILD}`);
 
+// Include all stories that have .ts, .tsx or .mdx extensions in development builds.
+const storybookDevGlobPaths = ['../stories/**/*.stories.@(ts|tsx|mdx)'];
+// In production builds include all stories except those in the INTERNAL/ folder
+const storybookProdGlobPaths = [
+  '../stories/!(INTERNAL)/**/*.stories.@(ts|tsx|mdx)', // excludes anything in the INTERNAL folder
+  '../stories/*.stories.@(ts|tsx|mdx)' // includes all top level stories
+];
+
 module.exports = {
-  // Include all stories that have .ts, .tsx or .mdx extensions. When in production do not
-  // include the INTERNAL/ folder.
-  stories: [`../stories/${!DEVELOPMENT_BUILD ? '!(INTERNAL)/' : ''}**/*.stories.@(ts|tsx|mdx)`],
+  stories: DEVELOPMENT_BUILD ? storybookDevGlobPaths : storybookProdGlobPaths,
   // Speeds up webpack build time after every code change. Improvements of up
   // to 4-5 seconds can be seen. Comment if components don't render properly.
   typescript: { reactDocgen: 'react-docgen' },

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -11,7 +11,7 @@ console.log(`Creating storybook with internal-only stories: ${DEVELOPMENT_BUILD}
 const storybookDevGlobPaths = ['../stories/**/*.stories.@(ts|tsx|mdx)'];
 // In production builds include all stories except those in the INTERNAL/ folder
 const storybookProdGlobPaths = [
-  '../stories/!(INTERNAL)/**/*.stories.@(ts|tsx|mdx)', // excludes anything in the INTERNAL folder
+  '../stories/!(INTERNAL)/**/*.stories.@(ts|tsx|mdx)', // includes all stories in folders, *excluding* anything in the INTERNAL folder
   '../stories/*.stories.@(ts|tsx|mdx)' // includes all top level stories
 ];
 


### PR DESCRIPTION
# What
* update glob path check to include top-level stories

# Why
Storybook was not showing all mdx files that are not in folders in the code structure (e.g. the homepage)

# How Tested
Locally:

| development | production |
| -- | -- |
| Correctly shows all *including* internal ![image](https://user-images.githubusercontent.com/2684369/156037655-3829e180-93ca-4ce7-b0d7-66dfd6b12180.png) | Correctly shows all *excluding* internal ![image](https://user-images.githubusercontent.com/2684369/156037627-330a8e9a-860e-48d9-a9fa-95d4cb4a97f5.png) |
