### PR TITLE
Prprabhu/rework icons

### DIFF
--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -649,6 +649,11 @@ export type CallWithChatCompositeIcons = {
     ControlBarChatButtonInactive?: JSX.Element;
     ControlBarPeopleButton?: JSX.Element;
     Link?: JSX.Element;
+    MoreDrawerMicrophones?: JSX.Element;
+    MoreDrawerPeople?: JSX.Element;
+    MoreDrawerSelectedMicrophone?: JSX.Element;
+    MoreDrawerSelectedSpeaker?: JSX.Element;
+    MoreDrawerSpeakers?: JSX.Element;
     ControlButtonCameraOff?: JSX.Element;
     ControlButtonCameraOn?: JSX.Element;
     ControlButtonEndCall?: JSX.Element;
@@ -1147,35 +1152,7 @@ export const COMPOSITE_LOCALE_ZH_CN: CompositeLocale;
 export const COMPOSITE_LOCALE_ZH_TW: CompositeLocale;
 
 // @public
-export const COMPOSITE_ONLY_ICONS: {
-    Cancel: JSX.Element;
-    ChevronLeft: JSX.Element;
-    Download: JSX.Element;
-    Link: JSX.Element;
-    LobbyScreenConnectingToCall: JSX.Element;
-    LobbyScreenWaitingToBeAdmitted: JSX.Element;
-    LocalDeviceSettingsCamera: JSX.Element;
-    LocalDeviceSettingsMic: JSX.Element;
-    LocalDeviceSettingsSpeaker: JSX.Element;
-    LocalPreviewPlaceholder: JSX.Element;
-    LocalCameraSwitch: JSX.Element;
-    ControlBarButtonBadgeIcon: JSX.Element;
-    ControlBarChatButtonActive: JSX.Element;
-    ControlBarChatButtonInactive: JSX.Element;
-    ControlBarPeopleButton: JSX.Element;
-    MoreDrawerMicrophones: JSX.Element;
-    MoreDrawerPeople: JSX.Element;
-    MoreDrawerSpeakers: JSX.Element;
-    MoreDrawerSelectedMicrophone: JSX.Element;
-    MoreDrawerSelectedSpeaker: JSX.Element;
-    Muted: JSX.Element;
-    NetworkReconnectIcon: JSX.Element;
-    NoticePageAccessDeniedTeamsMeeting: JSX.Element;
-    NoticePageJoinCallFailedDueToNoNetwork: JSX.Element;
-    NoticePageLeftCall: JSX.Element;
-    NoticePageRemovedFromCall: JSX.Element;
-    SendBoxAttachFile: JSX.Element;
-};
+export const COMPOSITE_ONLY_ICONS: CompositeIcons;
 
 // Warning: (ae-incompatible-release-tags) The symbol "CompositeIcons" is marked as @public, but its signature references "CallWithChatCompositeIcons" which is marked as @beta
 //
@@ -1361,33 +1338,21 @@ export const DEFAULT_COMPONENT_ICONS: {
 
 // @public
 export const DEFAULT_COMPOSITE_ICONS: {
-    Cancel: JSX.Element;
-    ChevronLeft: JSX.Element;
-    Download: JSX.Element;
-    Link: JSX.Element;
-    LobbyScreenConnectingToCall: JSX.Element;
-    LobbyScreenWaitingToBeAdmitted: JSX.Element;
-    LocalDeviceSettingsCamera: JSX.Element;
-    LocalDeviceSettingsMic: JSX.Element;
-    LocalDeviceSettingsSpeaker: JSX.Element;
-    LocalPreviewPlaceholder: JSX.Element;
-    LocalCameraSwitch: JSX.Element;
-    ControlBarButtonBadgeIcon: JSX.Element;
-    ControlBarChatButtonActive: JSX.Element;
-    ControlBarChatButtonInactive: JSX.Element;
-    ControlBarPeopleButton: JSX.Element;
-    MoreDrawerMicrophones: JSX.Element;
-    MoreDrawerPeople: JSX.Element;
-    MoreDrawerSpeakers: JSX.Element;
-    MoreDrawerSelectedMicrophone: JSX.Element;
-    MoreDrawerSelectedSpeaker: JSX.Element;
-    Muted: JSX.Element;
-    NetworkReconnectIcon: JSX.Element;
-    NoticePageAccessDeniedTeamsMeeting: JSX.Element;
-    NoticePageJoinCallFailedDueToNoNetwork: JSX.Element;
-    NoticePageLeftCall: JSX.Element;
-    NoticePageRemovedFromCall: JSX.Element;
-    SendBoxAttachFile: JSX.Element;
+    EditBoxCancel: JSX.Element;
+    EditBoxSubmit: JSX.Element;
+    MessageDelivered: JSX.Element;
+    MessageEdit: JSX.Element;
+    MessageFailed: JSX.Element;
+    MessageRemove: JSX.Element;
+    MessageSeen: JSX.Element;
+    MessageSending: JSX.Element;
+    ParticipantItemOptions: JSX.Element;
+    ParticipantItemOptionsHovered: JSX.Element;
+    SendBoxSend: JSX.Element;
+    SendBoxSendHovered: JSX.Element;
+    SendBoxAttachFile?: JSX.Element | undefined;
+    Download?: JSX.Element | undefined;
+    Cancel?: JSX.Element | undefined;
     ControlButtonCameraOff: JSX.Element;
     ControlButtonCameraOn: JSX.Element;
     ControlButtonEndCall: JSX.Element;
@@ -1397,8 +1362,6 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ControlButtonParticipants: JSX.Element;
     ControlButtonScreenShareStart: JSX.Element;
     ControlButtonScreenShareStop: JSX.Element;
-    EditBoxCancel: JSX.Element;
-    EditBoxSubmit: JSX.Element;
     ErrorBarCallCameraAccessDenied: JSX.Element;
     ErrorBarCallCameraAlreadyInUse: JSX.Element;
     ErrorBarCallLocalVideoFreeze: JSX.Element;
@@ -1411,22 +1374,36 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ErrorBarCallNoSpeakerFound: JSX.Element;
     HorizontalGalleryLeftButton: JSX.Element;
     HorizontalGalleryRightButton: JSX.Element;
-    MessageDelivered: JSX.Element;
-    MessageEdit: JSX.Element;
-    MessageFailed: JSX.Element;
-    MessageRemove: JSX.Element;
-    MessageSeen: JSX.Element;
-    MessageSending: JSX.Element;
+    LobbyScreenConnectingToCall?: JSX.Element | undefined;
+    LobbyScreenWaitingToBeAdmitted?: JSX.Element | undefined;
+    LocalDeviceSettingsCamera?: JSX.Element | undefined;
+    LocalDeviceSettingsMic?: JSX.Element | undefined;
+    LocalDeviceSettingsSpeaker?: JSX.Element | undefined;
+    LocalPreviewPlaceholder?: JSX.Element | undefined;
+    Muted?: JSX.Element | undefined;
+    NetworkReconnectIcon?: JSX.Element | undefined;
+    NoticePageAccessDeniedTeamsMeeting?: JSX.Element | undefined;
+    NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element | undefined;
+    NoticePageLeftCall?: JSX.Element | undefined;
+    NoticePageRemovedFromCall?: JSX.Element | undefined;
     OptionsCamera: JSX.Element;
     OptionsMic: JSX.Element;
     OptionsSpeaker: JSX.Element;
     ParticipantItemMicOff: JSX.Element;
-    ParticipantItemOptions: JSX.Element;
-    ParticipantItemOptionsHovered: JSX.Element;
     ParticipantItemScreenShareStart: JSX.Element;
-    SendBoxSend: JSX.Element;
-    SendBoxSendHovered: JSX.Element;
     VideoTileMicOff: JSX.Element;
+    LocalCameraSwitch?: JSX.Element | undefined;
+    ChevronLeft?: JSX.Element | undefined;
+    ControlBarButtonBadgeIcon?: JSX.Element | undefined;
+    ControlBarChatButtonActive?: JSX.Element | undefined;
+    ControlBarChatButtonInactive?: JSX.Element | undefined;
+    ControlBarPeopleButton?: JSX.Element | undefined;
+    Link?: JSX.Element | undefined;
+    MoreDrawerMicrophones?: JSX.Element | undefined;
+    MoreDrawerPeople?: JSX.Element | undefined;
+    MoreDrawerSelectedMicrophone?: JSX.Element | undefined;
+    MoreDrawerSelectedSpeaker?: JSX.Element | undefined;
+    MoreDrawerSpeakers?: JSX.Element | undefined;
 };
 
 // @public

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -302,7 +302,50 @@ export interface CallClientState {
 export const CallComposite: (props: CallCompositeProps) => JSX.Element;
 
 // @public
-export type CallCompositeIcons = Partial<Pick<CompositeIcons, 'ControlButtonCameraOff' | 'ControlButtonCameraOn' | 'ControlButtonEndCall' | 'ControlButtonMicOff' | 'ControlButtonMicOn' | 'ControlButtonOptions' | 'ControlButtonParticipants' | 'ControlButtonScreenShareStart' | 'ControlButtonScreenShareStop' | 'ErrorBarCallCameraAccessDenied' | 'ErrorBarCallCameraAlreadyInUse' | 'ErrorBarCallLocalVideoFreeze' | 'ErrorBarCallMacOsCameraAccessDenied' | 'ErrorBarCallMacOsMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneMutedBySystem' | 'ErrorBarCallNetworkQualityLow' | 'ErrorBarCallNoMicrophoneFound' | 'ErrorBarCallNoSpeakerFound' | 'HorizontalGalleryLeftButton' | 'HorizontalGalleryRightButton' | 'LobbyScreenConnectingToCall' | 'LobbyScreenWaitingToBeAdmitted' | 'LocalDeviceSettingsCamera' | 'LocalDeviceSettingsMic' | 'LocalDeviceSettingsSpeaker' | 'LocalPreviewPlaceholder' | 'Muted' | 'NetworkReconnectIcon' | 'NoticePageAccessDeniedTeamsMeeting' | 'NoticePageJoinCallFailedDueToNoNetwork' | 'NoticePageLeftCall' | 'NoticePageRemovedFromCall' | 'OptionsCamera' | 'OptionsMic' | 'OptionsSpeaker' | 'ParticipantItemMicOff' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'ParticipantItemScreenShareStart' | 'VideoTileMicOff' | /* @conditional-compile-remove(local-camera-switcher) */ 'LocalCameraSwitch'>>;
+export type CallCompositeIcons = {
+    ControlButtonCameraOff?: JSX.Element;
+    ControlButtonCameraOn?: JSX.Element;
+    ControlButtonEndCall?: JSX.Element;
+    ControlButtonMicOff?: JSX.Element;
+    ControlButtonMicOn?: JSX.Element;
+    ControlButtonOptions?: JSX.Element;
+    ControlButtonParticipants?: JSX.Element;
+    ControlButtonScreenShareStart?: JSX.Element;
+    ControlButtonScreenShareStop?: JSX.Element;
+    ErrorBarCallCameraAccessDenied?: JSX.Element;
+    ErrorBarCallCameraAlreadyInUse?: JSX.Element;
+    ErrorBarCallLocalVideoFreeze?: JSX.Element;
+    ErrorBarCallMacOsCameraAccessDenied?: JSX.Element;
+    ErrorBarCallMacOsMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneMutedBySystem?: JSX.Element;
+    ErrorBarCallNetworkQualityLow?: JSX.Element;
+    ErrorBarCallNoMicrophoneFound?: JSX.Element;
+    ErrorBarCallNoSpeakerFound?: JSX.Element;
+    HorizontalGalleryLeftButton?: JSX.Element;
+    HorizontalGalleryRightButton?: JSX.Element;
+    LobbyScreenConnectingToCall?: JSX.Element;
+    LobbyScreenWaitingToBeAdmitted?: JSX.Element;
+    LocalDeviceSettingsCamera?: JSX.Element;
+    LocalDeviceSettingsMic?: JSX.Element;
+    LocalDeviceSettingsSpeaker?: JSX.Element;
+    LocalPreviewPlaceholder?: JSX.Element;
+    Muted?: JSX.Element;
+    NetworkReconnectIcon?: JSX.Element;
+    NoticePageAccessDeniedTeamsMeeting?: JSX.Element;
+    NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element;
+    NoticePageLeftCall?: JSX.Element;
+    NoticePageRemovedFromCall?: JSX.Element;
+    OptionsCamera?: JSX.Element;
+    OptionsMic?: JSX.Element;
+    OptionsSpeaker?: JSX.Element;
+    ParticipantItemMicOff?: JSX.Element;
+    ParticipantItemOptions?: JSX.Element;
+    ParticipantItemOptionsHovered?: JSX.Element;
+    ParticipantItemScreenShareStart?: JSX.Element;
+    VideoTileMicOff?: JSX.Element;
+    LocalCameraSwitch?: JSX.Element;
+};
 
 // @public
 export type CallCompositeOptions = {
@@ -599,7 +642,66 @@ export interface CallWithChatClientState extends Pick<CallAdapterClientState, 'd
 export const CallWithChatComposite: (props: CallWithChatCompositeProps) => JSX.Element;
 
 // @beta
-export type CallWithChatCompositeIcons = Partial<Pick<CompositeIcons, /* @conditional-compile-remove(call-with-chat-composite) */ 'ChevronLeft' | /* @conditional-compile-remove(call-with-chat-composite) */ 'ControlBarButtonBadgeIcon' | /* @conditional-compile-remove(call-with-chat-composite) */ 'ControlBarChatButtonActive' | /* @conditional-compile-remove(call-with-chat-composite) */ 'ControlBarChatButtonInactive' | /* @conditional-compile-remove(call-with-chat-composite) */ 'ControlBarPeopleButton' | /* @conditional-compile-remove(call-with-chat-composite) */ 'Link' | 'ControlButtonCameraOff' | 'ControlButtonCameraOn' | 'ControlButtonEndCall' | 'ControlButtonMicOff' | 'ControlButtonMicOn' | 'ControlButtonOptions' | 'ControlButtonScreenShareStart' | 'ControlButtonScreenShareStop' | 'ErrorBarCallCameraAccessDenied' | 'ErrorBarCallCameraAlreadyInUse' | 'ErrorBarCallLocalVideoFreeze' | 'ErrorBarCallMacOsCameraAccessDenied' | 'ErrorBarCallMacOsMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneMutedBySystem' | 'ErrorBarCallNetworkQualityLow' | 'ErrorBarCallNoMicrophoneFound' | 'ErrorBarCallNoSpeakerFound' | 'HorizontalGalleryLeftButton' | 'HorizontalGalleryRightButton' | 'LobbyScreenConnectingToCall' | 'LobbyScreenWaitingToBeAdmitted' | 'LocalDeviceSettingsCamera' | 'LocalDeviceSettingsMic' | 'LocalDeviceSettingsSpeaker' | 'LocalPreviewPlaceholder' | 'Muted' | 'NetworkReconnectIcon' | 'NoticePageAccessDeniedTeamsMeeting' | 'NoticePageJoinCallFailedDueToNoNetwork' | 'NoticePageLeftCall' | 'NoticePageRemovedFromCall' | 'OptionsCamera' | 'OptionsMic' | 'OptionsSpeaker' | 'ParticipantItemMicOff' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'ParticipantItemScreenShareStart' | 'VideoTileMicOff' | /* @conditional-compile-remove(call-with-chat-composite) */ 'LocalCameraSwitch' | 'EditBoxCancel' | 'EditBoxSubmit' | 'MessageDelivered' | 'MessageEdit' | 'MessageFailed' | 'MessageRemove' | 'MessageSeen' | 'MessageSending' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'SendBoxSend' | 'SendBoxSendHovered' | /* @conditional-compile-remove(file-sharing) */ 'SendBoxAttachFile'>>;
+export type CallWithChatCompositeIcons = {
+    ChevronLeft?: JSX.Element;
+    ControlBarButtonBadgeIcon?: JSX.Element;
+    ControlBarChatButtonActive?: JSX.Element;
+    ControlBarChatButtonInactive?: JSX.Element;
+    ControlBarPeopleButton?: JSX.Element;
+    Link?: JSX.Element;
+    ControlButtonCameraOff?: JSX.Element;
+    ControlButtonCameraOn?: JSX.Element;
+    ControlButtonEndCall?: JSX.Element;
+    ControlButtonMicOff?: JSX.Element;
+    ControlButtonMicOn?: JSX.Element;
+    ControlButtonOptions?: JSX.Element;
+    ControlButtonScreenShareStart?: JSX.Element;
+    ControlButtonScreenShareStop?: JSX.Element;
+    ErrorBarCallCameraAccessDenied?: JSX.Element;
+    ErrorBarCallCameraAlreadyInUse?: JSX.Element;
+    ErrorBarCallLocalVideoFreeze?: JSX.Element;
+    ErrorBarCallMacOsCameraAccessDenied?: JSX.Element;
+    ErrorBarCallMacOsMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneMutedBySystem?: JSX.Element;
+    ErrorBarCallNetworkQualityLow?: JSX.Element;
+    ErrorBarCallNoMicrophoneFound?: JSX.Element;
+    ErrorBarCallNoSpeakerFound?: JSX.Element;
+    HorizontalGalleryLeftButton?: JSX.Element;
+    HorizontalGalleryRightButton?: JSX.Element;
+    LobbyScreenConnectingToCall?: JSX.Element;
+    LobbyScreenWaitingToBeAdmitted?: JSX.Element;
+    LocalDeviceSettingsCamera?: JSX.Element;
+    LocalDeviceSettingsMic?: JSX.Element;
+    LocalDeviceSettingsSpeaker?: JSX.Element;
+    LocalPreviewPlaceholder?: JSX.Element;
+    Muted?: JSX.Element;
+    NetworkReconnectIcon?: JSX.Element;
+    NoticePageAccessDeniedTeamsMeeting?: JSX.Element;
+    NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element;
+    NoticePageLeftCall?: JSX.Element;
+    NoticePageRemovedFromCall?: JSX.Element;
+    OptionsCamera?: JSX.Element;
+    OptionsMic?: JSX.Element;
+    OptionsSpeaker?: JSX.Element;
+    ParticipantItemMicOff?: JSX.Element;
+    ParticipantItemScreenShareStart?: JSX.Element;
+    VideoTileMicOff?: JSX.Element;
+    LocalCameraSwitch?: JSX.Element;
+    EditBoxCancel?: JSX.Element;
+    EditBoxSubmit?: JSX.Element;
+    MessageDelivered?: JSX.Element;
+    MessageEdit?: JSX.Element;
+    MessageFailed?: JSX.Element;
+    MessageRemove?: JSX.Element;
+    MessageSeen?: JSX.Element;
+    MessageSending?: JSX.Element;
+    SendBoxSend?: JSX.Element;
+    SendBoxSendHovered?: JSX.Element;
+    SendBoxAttachFile?: JSX.Element;
+    ParticipantItemOptions?: JSX.Element;
+    ParticipantItemOptionsHovered?: JSX.Element;
+};
 
 // @beta
 export type CallWithChatCompositeOptions = {
@@ -764,7 +866,23 @@ export type ChatCompositeClientState = {
 };
 
 // @public
-export type ChatCompositeIcons = Partial<Pick<CompositeIcons, 'EditBoxCancel' | 'EditBoxSubmit' | 'MessageDelivered' | 'MessageEdit' | 'MessageFailed' | 'MessageRemove' | 'MessageSeen' | 'MessageSending' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'SendBoxSend' | 'SendBoxSendHovered' | /* @conditional-compile-remove(file-sharing) */ 'SendBoxAttachFile' | /* @conditional-compile-remove(file-sharing) */ 'Download' | /* @conditional-compile-remove(file-sharing) */ 'Cancel'>>;
+export type ChatCompositeIcons = {
+    EditBoxCancel?: JSX.Element;
+    EditBoxSubmit?: JSX.Element;
+    MessageDelivered?: JSX.Element;
+    MessageEdit?: JSX.Element;
+    MessageFailed?: JSX.Element;
+    MessageRemove?: JSX.Element;
+    MessageSeen?: JSX.Element;
+    MessageSending?: JSX.Element;
+    ParticipantItemOptions?: JSX.Element;
+    ParticipantItemOptionsHovered?: JSX.Element;
+    SendBoxSend?: JSX.Element;
+    SendBoxSendHovered?: JSX.Element;
+    SendBoxAttachFile?: JSX.Element;
+    Download?: JSX.Element;
+    Cancel?: JSX.Element;
+};
 
 // @public
 export type ChatCompositeOptions = {
@@ -1059,8 +1177,10 @@ export const COMPOSITE_ONLY_ICONS: {
     SendBoxAttachFile: JSX.Element;
 };
 
+// Warning: (ae-incompatible-release-tags) The symbol "CompositeIcons" is marked as @public, but its signature references "CallWithChatCompositeIcons" which is marked as @beta
+//
 // @public
-export type CompositeIcons = ComponentIcons & Record<keyof typeof COMPOSITE_ONLY_ICONS, JSX.Element>;
+export type CompositeIcons = ChatCompositeIcons & CallCompositeIcons & CallWithChatCompositeIcons;
 
 // @public
 export interface CompositeLocale {

--- a/packages/communication-react/stable-review/communication-react.api.md
+++ b/packages/communication-react/stable-review/communication-react.api.md
@@ -894,20 +894,7 @@ export const COMPOSITE_LOCALE_ZH_CN: CompositeLocale;
 export const COMPOSITE_LOCALE_ZH_TW: CompositeLocale;
 
 // @public
-export const COMPOSITE_ONLY_ICONS: {
-    LobbyScreenConnectingToCall: JSX.Element;
-    LobbyScreenWaitingToBeAdmitted: JSX.Element;
-    LocalDeviceSettingsCamera: JSX.Element;
-    LocalDeviceSettingsMic: JSX.Element;
-    LocalDeviceSettingsSpeaker: JSX.Element;
-    LocalPreviewPlaceholder: JSX.Element;
-    Muted: JSX.Element;
-    NetworkReconnectIcon: JSX.Element;
-    NoticePageAccessDeniedTeamsMeeting: JSX.Element;
-    NoticePageJoinCallFailedDueToNoNetwork: JSX.Element;
-    NoticePageLeftCall: JSX.Element;
-    NoticePageRemovedFromCall: JSX.Element;
-};
+export const COMPOSITE_ONLY_ICONS: CompositeIcons;
 
 // @public
 export type CompositeIcons = ChatCompositeIcons & CallCompositeIcons;
@@ -1065,18 +1052,18 @@ export const DEFAULT_COMPONENT_ICONS: {
 
 // @public
 export const DEFAULT_COMPOSITE_ICONS: {
-    LobbyScreenConnectingToCall: JSX.Element;
-    LobbyScreenWaitingToBeAdmitted: JSX.Element;
-    LocalDeviceSettingsCamera: JSX.Element;
-    LocalDeviceSettingsMic: JSX.Element;
-    LocalDeviceSettingsSpeaker: JSX.Element;
-    LocalPreviewPlaceholder: JSX.Element;
-    Muted: JSX.Element;
-    NetworkReconnectIcon: JSX.Element;
-    NoticePageAccessDeniedTeamsMeeting: JSX.Element;
-    NoticePageJoinCallFailedDueToNoNetwork: JSX.Element;
-    NoticePageLeftCall: JSX.Element;
-    NoticePageRemovedFromCall: JSX.Element;
+    EditBoxCancel: JSX.Element;
+    EditBoxSubmit: JSX.Element;
+    MessageDelivered: JSX.Element;
+    MessageEdit: JSX.Element;
+    MessageFailed: JSX.Element;
+    MessageRemove: JSX.Element;
+    MessageSeen: JSX.Element;
+    MessageSending: JSX.Element;
+    ParticipantItemOptions: JSX.Element;
+    ParticipantItemOptionsHovered: JSX.Element;
+    SendBoxSend: JSX.Element;
+    SendBoxSendHovered: JSX.Element;
     ControlButtonCameraOff: JSX.Element;
     ControlButtonCameraOn: JSX.Element;
     ControlButtonEndCall: JSX.Element;
@@ -1086,8 +1073,6 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ControlButtonParticipants: JSX.Element;
     ControlButtonScreenShareStart: JSX.Element;
     ControlButtonScreenShareStop: JSX.Element;
-    EditBoxCancel: JSX.Element;
-    EditBoxSubmit: JSX.Element;
     ErrorBarCallCameraAccessDenied: JSX.Element;
     ErrorBarCallCameraAlreadyInUse: JSX.Element;
     ErrorBarCallLocalVideoFreeze: JSX.Element;
@@ -1100,21 +1085,23 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ErrorBarCallNoSpeakerFound: JSX.Element;
     HorizontalGalleryLeftButton: JSX.Element;
     HorizontalGalleryRightButton: JSX.Element;
-    MessageDelivered: JSX.Element;
-    MessageEdit: JSX.Element;
-    MessageFailed: JSX.Element;
-    MessageRemove: JSX.Element;
-    MessageSeen: JSX.Element;
-    MessageSending: JSX.Element;
+    LobbyScreenConnectingToCall?: JSX.Element | undefined;
+    LobbyScreenWaitingToBeAdmitted?: JSX.Element | undefined;
+    LocalDeviceSettingsCamera?: JSX.Element | undefined;
+    LocalDeviceSettingsMic?: JSX.Element | undefined;
+    LocalDeviceSettingsSpeaker?: JSX.Element | undefined;
+    LocalPreviewPlaceholder?: JSX.Element | undefined;
+    Muted?: JSX.Element | undefined;
+    NetworkReconnectIcon?: JSX.Element | undefined;
+    NoticePageAccessDeniedTeamsMeeting?: JSX.Element | undefined;
+    NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element | undefined;
+    NoticePageLeftCall?: JSX.Element | undefined;
+    NoticePageRemovedFromCall?: JSX.Element | undefined;
     OptionsCamera: JSX.Element;
     OptionsMic: JSX.Element;
     OptionsSpeaker: JSX.Element;
     ParticipantItemMicOff: JSX.Element;
-    ParticipantItemOptions: JSX.Element;
-    ParticipantItemOptionsHovered: JSX.Element;
     ParticipantItemScreenShareStart: JSX.Element;
-    SendBoxSend: JSX.Element;
-    SendBoxSendHovered: JSX.Element;
     VideoTileMicOff: JSX.Element;
 };
 

--- a/packages/communication-react/stable-review/communication-react.api.md
+++ b/packages/communication-react/stable-review/communication-react.api.md
@@ -276,7 +276,49 @@ export interface CallClientState {
 export const CallComposite: (props: CallCompositeProps) => JSX.Element;
 
 // @public
-export type CallCompositeIcons = Partial<Pick<CompositeIcons, 'ControlButtonCameraOff' | 'ControlButtonCameraOn' | 'ControlButtonEndCall' | 'ControlButtonMicOff' | 'ControlButtonMicOn' | 'ControlButtonOptions' | 'ControlButtonParticipants' | 'ControlButtonScreenShareStart' | 'ControlButtonScreenShareStop' | 'ErrorBarCallCameraAccessDenied' | 'ErrorBarCallCameraAlreadyInUse' | 'ErrorBarCallLocalVideoFreeze' | 'ErrorBarCallMacOsCameraAccessDenied' | 'ErrorBarCallMacOsMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneMutedBySystem' | 'ErrorBarCallNetworkQualityLow' | 'ErrorBarCallNoMicrophoneFound' | 'ErrorBarCallNoSpeakerFound' | 'HorizontalGalleryLeftButton' | 'HorizontalGalleryRightButton' | 'LobbyScreenConnectingToCall' | 'LobbyScreenWaitingToBeAdmitted' | 'LocalDeviceSettingsCamera' | 'LocalDeviceSettingsMic' | 'LocalDeviceSettingsSpeaker' | 'LocalPreviewPlaceholder' | 'Muted' | 'NetworkReconnectIcon' | 'NoticePageAccessDeniedTeamsMeeting' | 'NoticePageJoinCallFailedDueToNoNetwork' | 'NoticePageLeftCall' | 'NoticePageRemovedFromCall' | 'OptionsCamera' | 'OptionsMic' | 'OptionsSpeaker' | 'ParticipantItemMicOff' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'ParticipantItemScreenShareStart' | 'VideoTileMicOff'>>;
+export type CallCompositeIcons = {
+    ControlButtonCameraOff?: JSX.Element;
+    ControlButtonCameraOn?: JSX.Element;
+    ControlButtonEndCall?: JSX.Element;
+    ControlButtonMicOff?: JSX.Element;
+    ControlButtonMicOn?: JSX.Element;
+    ControlButtonOptions?: JSX.Element;
+    ControlButtonParticipants?: JSX.Element;
+    ControlButtonScreenShareStart?: JSX.Element;
+    ControlButtonScreenShareStop?: JSX.Element;
+    ErrorBarCallCameraAccessDenied?: JSX.Element;
+    ErrorBarCallCameraAlreadyInUse?: JSX.Element;
+    ErrorBarCallLocalVideoFreeze?: JSX.Element;
+    ErrorBarCallMacOsCameraAccessDenied?: JSX.Element;
+    ErrorBarCallMacOsMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneMutedBySystem?: JSX.Element;
+    ErrorBarCallNetworkQualityLow?: JSX.Element;
+    ErrorBarCallNoMicrophoneFound?: JSX.Element;
+    ErrorBarCallNoSpeakerFound?: JSX.Element;
+    HorizontalGalleryLeftButton?: JSX.Element;
+    HorizontalGalleryRightButton?: JSX.Element;
+    LobbyScreenConnectingToCall?: JSX.Element;
+    LobbyScreenWaitingToBeAdmitted?: JSX.Element;
+    LocalDeviceSettingsCamera?: JSX.Element;
+    LocalDeviceSettingsMic?: JSX.Element;
+    LocalDeviceSettingsSpeaker?: JSX.Element;
+    LocalPreviewPlaceholder?: JSX.Element;
+    Muted?: JSX.Element;
+    NetworkReconnectIcon?: JSX.Element;
+    NoticePageAccessDeniedTeamsMeeting?: JSX.Element;
+    NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element;
+    NoticePageLeftCall?: JSX.Element;
+    NoticePageRemovedFromCall?: JSX.Element;
+    OptionsCamera?: JSX.Element;
+    OptionsMic?: JSX.Element;
+    OptionsSpeaker?: JSX.Element;
+    ParticipantItemMicOff?: JSX.Element;
+    ParticipantItemOptions?: JSX.Element;
+    ParticipantItemOptionsHovered?: JSX.Element;
+    ParticipantItemScreenShareStart?: JSX.Element;
+    VideoTileMicOff?: JSX.Element;
+};
 
 // @public
 export type CallCompositeOptions = {
@@ -576,7 +618,20 @@ export type ChatCompositeClientState = {
 };
 
 // @public
-export type ChatCompositeIcons = Partial<Pick<CompositeIcons, 'EditBoxCancel' | 'EditBoxSubmit' | 'MessageDelivered' | 'MessageEdit' | 'MessageFailed' | 'MessageRemove' | 'MessageSeen' | 'MessageSending' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'SendBoxSend' | 'SendBoxSendHovered'>>;
+export type ChatCompositeIcons = {
+    EditBoxCancel?: JSX.Element;
+    EditBoxSubmit?: JSX.Element;
+    MessageDelivered?: JSX.Element;
+    MessageEdit?: JSX.Element;
+    MessageFailed?: JSX.Element;
+    MessageRemove?: JSX.Element;
+    MessageSeen?: JSX.Element;
+    MessageSending?: JSX.Element;
+    ParticipantItemOptions?: JSX.Element;
+    ParticipantItemOptionsHovered?: JSX.Element;
+    SendBoxSend?: JSX.Element;
+    SendBoxSendHovered?: JSX.Element;
+};
 
 // @public
 export type ChatCompositeOptions = {
@@ -855,7 +910,7 @@ export const COMPOSITE_ONLY_ICONS: {
 };
 
 // @public
-export type CompositeIcons = ComponentIcons & Record<keyof typeof COMPOSITE_ONLY_ICONS, JSX.Element>;
+export type CompositeIcons = ChatCompositeIcons & CallCompositeIcons;
 
 // @public
 export interface CompositeLocale {

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -449,6 +449,11 @@ export type CallWithChatCompositeIcons = {
     ControlBarChatButtonInactive?: JSX.Element;
     ControlBarPeopleButton?: JSX.Element;
     Link?: JSX.Element;
+    MoreDrawerMicrophones?: JSX.Element;
+    MoreDrawerPeople?: JSX.Element;
+    MoreDrawerSelectedMicrophone?: JSX.Element;
+    MoreDrawerSelectedSpeaker?: JSX.Element;
+    MoreDrawerSpeakers?: JSX.Element;
     ControlButtonCameraOff?: JSX.Element;
     ControlButtonCameraOn?: JSX.Element;
     ControlButtonEndCall?: JSX.Element;
@@ -680,35 +685,7 @@ export const COMPOSITE_LOCALE_ZH_CN: CompositeLocale;
 export const COMPOSITE_LOCALE_ZH_TW: CompositeLocale;
 
 // @public
-export const COMPOSITE_ONLY_ICONS: {
-    Cancel: JSX.Element;
-    ChevronLeft: JSX.Element;
-    Download: JSX.Element;
-    Link: JSX.Element;
-    LobbyScreenConnectingToCall: JSX.Element;
-    LobbyScreenWaitingToBeAdmitted: JSX.Element;
-    LocalDeviceSettingsCamera: JSX.Element;
-    LocalDeviceSettingsMic: JSX.Element;
-    LocalDeviceSettingsSpeaker: JSX.Element;
-    LocalPreviewPlaceholder: JSX.Element;
-    LocalCameraSwitch: JSX.Element;
-    ControlBarButtonBadgeIcon: JSX.Element;
-    ControlBarChatButtonActive: JSX.Element;
-    ControlBarChatButtonInactive: JSX.Element;
-    ControlBarPeopleButton: JSX.Element;
-    MoreDrawerMicrophones: JSX.Element;
-    MoreDrawerPeople: JSX.Element;
-    MoreDrawerSpeakers: JSX.Element;
-    MoreDrawerSelectedMicrophone: JSX.Element;
-    MoreDrawerSelectedSpeaker: JSX.Element;
-    Muted: JSX.Element;
-    NetworkReconnectIcon: JSX.Element;
-    NoticePageAccessDeniedTeamsMeeting: JSX.Element;
-    NoticePageJoinCallFailedDueToNoNetwork: JSX.Element;
-    NoticePageLeftCall: JSX.Element;
-    NoticePageRemovedFromCall: JSX.Element;
-    SendBoxAttachFile: JSX.Element;
-};
+export const COMPOSITE_ONLY_ICONS: CompositeIcons;
 
 // Warning: (ae-incompatible-release-tags) The symbol "CompositeIcons" is marked as @public, but its signature references "CallWithChatCompositeIcons" which is marked as @beta
 //
@@ -767,33 +744,21 @@ export interface CustomCallControlButtonProps extends ControlBarButtonProps {
 
 // @public
 export const DEFAULT_COMPOSITE_ICONS: {
-    Cancel: JSX.Element;
-    ChevronLeft: JSX.Element;
-    Download: JSX.Element;
-    Link: JSX.Element;
-    LobbyScreenConnectingToCall: JSX.Element;
-    LobbyScreenWaitingToBeAdmitted: JSX.Element;
-    LocalDeviceSettingsCamera: JSX.Element;
-    LocalDeviceSettingsMic: JSX.Element;
-    LocalDeviceSettingsSpeaker: JSX.Element;
-    LocalPreviewPlaceholder: JSX.Element;
-    LocalCameraSwitch: JSX.Element;
-    ControlBarButtonBadgeIcon: JSX.Element;
-    ControlBarChatButtonActive: JSX.Element;
-    ControlBarChatButtonInactive: JSX.Element;
-    ControlBarPeopleButton: JSX.Element;
-    MoreDrawerMicrophones: JSX.Element;
-    MoreDrawerPeople: JSX.Element;
-    MoreDrawerSpeakers: JSX.Element;
-    MoreDrawerSelectedMicrophone: JSX.Element;
-    MoreDrawerSelectedSpeaker: JSX.Element;
-    Muted: JSX.Element;
-    NetworkReconnectIcon: JSX.Element;
-    NoticePageAccessDeniedTeamsMeeting: JSX.Element;
-    NoticePageJoinCallFailedDueToNoNetwork: JSX.Element;
-    NoticePageLeftCall: JSX.Element;
-    NoticePageRemovedFromCall: JSX.Element;
-    SendBoxAttachFile: JSX.Element;
+    EditBoxCancel: JSX.Element;
+    EditBoxSubmit: JSX.Element;
+    MessageDelivered: JSX.Element;
+    MessageEdit: JSX.Element;
+    MessageFailed: JSX.Element;
+    MessageRemove: JSX.Element;
+    MessageSeen: JSX.Element;
+    MessageSending: JSX.Element;
+    ParticipantItemOptions: JSX.Element;
+    ParticipantItemOptionsHovered: JSX.Element;
+    SendBoxSend: JSX.Element;
+    SendBoxSendHovered: JSX.Element;
+    SendBoxAttachFile?: JSX.Element | undefined;
+    Download?: JSX.Element | undefined;
+    Cancel?: JSX.Element | undefined;
     ControlButtonCameraOff: JSX.Element;
     ControlButtonCameraOn: JSX.Element;
     ControlButtonEndCall: JSX.Element;
@@ -803,8 +768,6 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ControlButtonParticipants: JSX.Element;
     ControlButtonScreenShareStart: JSX.Element;
     ControlButtonScreenShareStop: JSX.Element;
-    EditBoxCancel: JSX.Element;
-    EditBoxSubmit: JSX.Element;
     ErrorBarCallCameraAccessDenied: JSX.Element;
     ErrorBarCallCameraAlreadyInUse: JSX.Element;
     ErrorBarCallLocalVideoFreeze: JSX.Element;
@@ -817,22 +780,36 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ErrorBarCallNoSpeakerFound: JSX.Element;
     HorizontalGalleryLeftButton: JSX.Element;
     HorizontalGalleryRightButton: JSX.Element;
-    MessageDelivered: JSX.Element;
-    MessageEdit: JSX.Element;
-    MessageFailed: JSX.Element;
-    MessageRemove: JSX.Element;
-    MessageSeen: JSX.Element;
-    MessageSending: JSX.Element;
+    LobbyScreenConnectingToCall?: JSX.Element | undefined;
+    LobbyScreenWaitingToBeAdmitted?: JSX.Element | undefined;
+    LocalDeviceSettingsCamera?: JSX.Element | undefined;
+    LocalDeviceSettingsMic?: JSX.Element | undefined;
+    LocalDeviceSettingsSpeaker?: JSX.Element | undefined;
+    LocalPreviewPlaceholder?: JSX.Element | undefined;
+    Muted?: JSX.Element | undefined;
+    NetworkReconnectIcon?: JSX.Element | undefined;
+    NoticePageAccessDeniedTeamsMeeting?: JSX.Element | undefined;
+    NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element | undefined;
+    NoticePageLeftCall?: JSX.Element | undefined;
+    NoticePageRemovedFromCall?: JSX.Element | undefined;
     OptionsCamera: JSX.Element;
     OptionsMic: JSX.Element;
     OptionsSpeaker: JSX.Element;
     ParticipantItemMicOff: JSX.Element;
-    ParticipantItemOptions: JSX.Element;
-    ParticipantItemOptionsHovered: JSX.Element;
     ParticipantItemScreenShareStart: JSX.Element;
-    SendBoxSend: JSX.Element;
-    SendBoxSendHovered: JSX.Element;
     VideoTileMicOff: JSX.Element;
+    LocalCameraSwitch?: JSX.Element | undefined;
+    ChevronLeft?: JSX.Element | undefined;
+    ControlBarButtonBadgeIcon?: JSX.Element | undefined;
+    ControlBarChatButtonActive?: JSX.Element | undefined;
+    ControlBarChatButtonInactive?: JSX.Element | undefined;
+    ControlBarPeopleButton?: JSX.Element | undefined;
+    Link?: JSX.Element | undefined;
+    MoreDrawerMicrophones?: JSX.Element | undefined;
+    MoreDrawerPeople?: JSX.Element | undefined;
+    MoreDrawerSelectedMicrophone?: JSX.Element | undefined;
+    MoreDrawerSelectedSpeaker?: JSX.Element | undefined;
+    MoreDrawerSpeakers?: JSX.Element | undefined;
 };
 
 // @public

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -19,7 +19,6 @@ import { CommunicationParticipant } from '@internal/react-components';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import type { CommunicationUserKind } from '@azure/communication-common';
-import { ComponentIcons } from '@internal/react-components';
 import { ComponentLocale } from '@internal/react-components';
 import { ControlBarButtonProps } from '@internal/react-components';
 import { DeviceManagerState } from '@internal/calling-stateful-client';
@@ -207,7 +206,50 @@ export interface CallAndChatLocator {
 export const CallComposite: (props: CallCompositeProps) => JSX.Element;
 
 // @public
-export type CallCompositeIcons = Partial<Pick<CompositeIcons, 'ControlButtonCameraOff' | 'ControlButtonCameraOn' | 'ControlButtonEndCall' | 'ControlButtonMicOff' | 'ControlButtonMicOn' | 'ControlButtonOptions' | 'ControlButtonParticipants' | 'ControlButtonScreenShareStart' | 'ControlButtonScreenShareStop' | 'ErrorBarCallCameraAccessDenied' | 'ErrorBarCallCameraAlreadyInUse' | 'ErrorBarCallLocalVideoFreeze' | 'ErrorBarCallMacOsCameraAccessDenied' | 'ErrorBarCallMacOsMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneMutedBySystem' | 'ErrorBarCallNetworkQualityLow' | 'ErrorBarCallNoMicrophoneFound' | 'ErrorBarCallNoSpeakerFound' | 'HorizontalGalleryLeftButton' | 'HorizontalGalleryRightButton' | 'LobbyScreenConnectingToCall' | 'LobbyScreenWaitingToBeAdmitted' | 'LocalDeviceSettingsCamera' | 'LocalDeviceSettingsMic' | 'LocalDeviceSettingsSpeaker' | 'LocalPreviewPlaceholder' | 'Muted' | 'NetworkReconnectIcon' | 'NoticePageAccessDeniedTeamsMeeting' | 'NoticePageJoinCallFailedDueToNoNetwork' | 'NoticePageLeftCall' | 'NoticePageRemovedFromCall' | 'OptionsCamera' | 'OptionsMic' | 'OptionsSpeaker' | 'ParticipantItemMicOff' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'ParticipantItemScreenShareStart' | 'VideoTileMicOff' | /* @conditional-compile-remove(local-camera-switcher) */ 'LocalCameraSwitch'>>;
+export type CallCompositeIcons = {
+    ControlButtonCameraOff?: JSX.Element;
+    ControlButtonCameraOn?: JSX.Element;
+    ControlButtonEndCall?: JSX.Element;
+    ControlButtonMicOff?: JSX.Element;
+    ControlButtonMicOn?: JSX.Element;
+    ControlButtonOptions?: JSX.Element;
+    ControlButtonParticipants?: JSX.Element;
+    ControlButtonScreenShareStart?: JSX.Element;
+    ControlButtonScreenShareStop?: JSX.Element;
+    ErrorBarCallCameraAccessDenied?: JSX.Element;
+    ErrorBarCallCameraAlreadyInUse?: JSX.Element;
+    ErrorBarCallLocalVideoFreeze?: JSX.Element;
+    ErrorBarCallMacOsCameraAccessDenied?: JSX.Element;
+    ErrorBarCallMacOsMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneMutedBySystem?: JSX.Element;
+    ErrorBarCallNetworkQualityLow?: JSX.Element;
+    ErrorBarCallNoMicrophoneFound?: JSX.Element;
+    ErrorBarCallNoSpeakerFound?: JSX.Element;
+    HorizontalGalleryLeftButton?: JSX.Element;
+    HorizontalGalleryRightButton?: JSX.Element;
+    LobbyScreenConnectingToCall?: JSX.Element;
+    LobbyScreenWaitingToBeAdmitted?: JSX.Element;
+    LocalDeviceSettingsCamera?: JSX.Element;
+    LocalDeviceSettingsMic?: JSX.Element;
+    LocalDeviceSettingsSpeaker?: JSX.Element;
+    LocalPreviewPlaceholder?: JSX.Element;
+    Muted?: JSX.Element;
+    NetworkReconnectIcon?: JSX.Element;
+    NoticePageAccessDeniedTeamsMeeting?: JSX.Element;
+    NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element;
+    NoticePageLeftCall?: JSX.Element;
+    NoticePageRemovedFromCall?: JSX.Element;
+    OptionsCamera?: JSX.Element;
+    OptionsMic?: JSX.Element;
+    OptionsSpeaker?: JSX.Element;
+    ParticipantItemMicOff?: JSX.Element;
+    ParticipantItemOptions?: JSX.Element;
+    ParticipantItemOptionsHovered?: JSX.Element;
+    ParticipantItemScreenShareStart?: JSX.Element;
+    VideoTileMicOff?: JSX.Element;
+    LocalCameraSwitch?: JSX.Element;
+};
 
 // @public
 export type CallCompositeOptions = {
@@ -400,7 +442,66 @@ export interface CallWithChatClientState extends Pick<CallAdapterClientState, 'd
 export const CallWithChatComposite: (props: CallWithChatCompositeProps) => JSX.Element;
 
 // @beta
-export type CallWithChatCompositeIcons = Partial<Pick<CompositeIcons, /* @conditional-compile-remove(call-with-chat-composite) */ 'ChevronLeft' | /* @conditional-compile-remove(call-with-chat-composite) */ 'ControlBarButtonBadgeIcon' | /* @conditional-compile-remove(call-with-chat-composite) */ 'ControlBarChatButtonActive' | /* @conditional-compile-remove(call-with-chat-composite) */ 'ControlBarChatButtonInactive' | /* @conditional-compile-remove(call-with-chat-composite) */ 'ControlBarPeopleButton' | /* @conditional-compile-remove(call-with-chat-composite) */ 'Link' | 'ControlButtonCameraOff' | 'ControlButtonCameraOn' | 'ControlButtonEndCall' | 'ControlButtonMicOff' | 'ControlButtonMicOn' | 'ControlButtonOptions' | 'ControlButtonScreenShareStart' | 'ControlButtonScreenShareStop' | 'ErrorBarCallCameraAccessDenied' | 'ErrorBarCallCameraAlreadyInUse' | 'ErrorBarCallLocalVideoFreeze' | 'ErrorBarCallMacOsCameraAccessDenied' | 'ErrorBarCallMacOsMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneMutedBySystem' | 'ErrorBarCallNetworkQualityLow' | 'ErrorBarCallNoMicrophoneFound' | 'ErrorBarCallNoSpeakerFound' | 'HorizontalGalleryLeftButton' | 'HorizontalGalleryRightButton' | 'LobbyScreenConnectingToCall' | 'LobbyScreenWaitingToBeAdmitted' | 'LocalDeviceSettingsCamera' | 'LocalDeviceSettingsMic' | 'LocalDeviceSettingsSpeaker' | 'LocalPreviewPlaceholder' | 'Muted' | 'NetworkReconnectIcon' | 'NoticePageAccessDeniedTeamsMeeting' | 'NoticePageJoinCallFailedDueToNoNetwork' | 'NoticePageLeftCall' | 'NoticePageRemovedFromCall' | 'OptionsCamera' | 'OptionsMic' | 'OptionsSpeaker' | 'ParticipantItemMicOff' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'ParticipantItemScreenShareStart' | 'VideoTileMicOff' | /* @conditional-compile-remove(call-with-chat-composite) */ 'LocalCameraSwitch' | 'EditBoxCancel' | 'EditBoxSubmit' | 'MessageDelivered' | 'MessageEdit' | 'MessageFailed' | 'MessageRemove' | 'MessageSeen' | 'MessageSending' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'SendBoxSend' | 'SendBoxSendHovered' | /* @conditional-compile-remove(file-sharing) */ 'SendBoxAttachFile'>>;
+export type CallWithChatCompositeIcons = {
+    ChevronLeft?: JSX.Element;
+    ControlBarButtonBadgeIcon?: JSX.Element;
+    ControlBarChatButtonActive?: JSX.Element;
+    ControlBarChatButtonInactive?: JSX.Element;
+    ControlBarPeopleButton?: JSX.Element;
+    Link?: JSX.Element;
+    ControlButtonCameraOff?: JSX.Element;
+    ControlButtonCameraOn?: JSX.Element;
+    ControlButtonEndCall?: JSX.Element;
+    ControlButtonMicOff?: JSX.Element;
+    ControlButtonMicOn?: JSX.Element;
+    ControlButtonOptions?: JSX.Element;
+    ControlButtonScreenShareStart?: JSX.Element;
+    ControlButtonScreenShareStop?: JSX.Element;
+    ErrorBarCallCameraAccessDenied?: JSX.Element;
+    ErrorBarCallCameraAlreadyInUse?: JSX.Element;
+    ErrorBarCallLocalVideoFreeze?: JSX.Element;
+    ErrorBarCallMacOsCameraAccessDenied?: JSX.Element;
+    ErrorBarCallMacOsMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneMutedBySystem?: JSX.Element;
+    ErrorBarCallNetworkQualityLow?: JSX.Element;
+    ErrorBarCallNoMicrophoneFound?: JSX.Element;
+    ErrorBarCallNoSpeakerFound?: JSX.Element;
+    HorizontalGalleryLeftButton?: JSX.Element;
+    HorizontalGalleryRightButton?: JSX.Element;
+    LobbyScreenConnectingToCall?: JSX.Element;
+    LobbyScreenWaitingToBeAdmitted?: JSX.Element;
+    LocalDeviceSettingsCamera?: JSX.Element;
+    LocalDeviceSettingsMic?: JSX.Element;
+    LocalDeviceSettingsSpeaker?: JSX.Element;
+    LocalPreviewPlaceholder?: JSX.Element;
+    Muted?: JSX.Element;
+    NetworkReconnectIcon?: JSX.Element;
+    NoticePageAccessDeniedTeamsMeeting?: JSX.Element;
+    NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element;
+    NoticePageLeftCall?: JSX.Element;
+    NoticePageRemovedFromCall?: JSX.Element;
+    OptionsCamera?: JSX.Element;
+    OptionsMic?: JSX.Element;
+    OptionsSpeaker?: JSX.Element;
+    ParticipantItemMicOff?: JSX.Element;
+    ParticipantItemScreenShareStart?: JSX.Element;
+    VideoTileMicOff?: JSX.Element;
+    LocalCameraSwitch?: JSX.Element;
+    EditBoxCancel?: JSX.Element;
+    EditBoxSubmit?: JSX.Element;
+    MessageDelivered?: JSX.Element;
+    MessageEdit?: JSX.Element;
+    MessageFailed?: JSX.Element;
+    MessageRemove?: JSX.Element;
+    MessageSeen?: JSX.Element;
+    MessageSending?: JSX.Element;
+    SendBoxSend?: JSX.Element;
+    SendBoxSendHovered?: JSX.Element;
+    SendBoxAttachFile?: JSX.Element;
+    ParticipantItemOptions?: JSX.Element;
+    ParticipantItemOptionsHovered?: JSX.Element;
+};
 
 // @beta
 export type CallWithChatCompositeOptions = {
@@ -496,7 +597,23 @@ export type ChatCompositeClientState = {
 };
 
 // @public
-export type ChatCompositeIcons = Partial<Pick<CompositeIcons, 'EditBoxCancel' | 'EditBoxSubmit' | 'MessageDelivered' | 'MessageEdit' | 'MessageFailed' | 'MessageRemove' | 'MessageSeen' | 'MessageSending' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'SendBoxSend' | 'SendBoxSendHovered' | /* @conditional-compile-remove(file-sharing) */ 'SendBoxAttachFile' | /* @conditional-compile-remove(file-sharing) */ 'Download' | /* @conditional-compile-remove(file-sharing) */ 'Cancel'>>;
+export type ChatCompositeIcons = {
+    EditBoxCancel?: JSX.Element;
+    EditBoxSubmit?: JSX.Element;
+    MessageDelivered?: JSX.Element;
+    MessageEdit?: JSX.Element;
+    MessageFailed?: JSX.Element;
+    MessageRemove?: JSX.Element;
+    MessageSeen?: JSX.Element;
+    MessageSending?: JSX.Element;
+    ParticipantItemOptions?: JSX.Element;
+    ParticipantItemOptionsHovered?: JSX.Element;
+    SendBoxSend?: JSX.Element;
+    SendBoxSendHovered?: JSX.Element;
+    SendBoxAttachFile?: JSX.Element;
+    Download?: JSX.Element;
+    Cancel?: JSX.Element;
+};
 
 // @public
 export type ChatCompositeOptions = {
@@ -593,8 +710,10 @@ export const COMPOSITE_ONLY_ICONS: {
     SendBoxAttachFile: JSX.Element;
 };
 
+// Warning: (ae-incompatible-release-tags) The symbol "CompositeIcons" is marked as @public, but its signature references "CallWithChatCompositeIcons" which is marked as @beta
+//
 // @public
-export type CompositeIcons = ComponentIcons & Record<keyof typeof COMPOSITE_ONLY_ICONS, JSX.Element>;
+export type CompositeIcons = ChatCompositeIcons & CallCompositeIcons & CallWithChatCompositeIcons;
 
 // @public
 export interface CompositeLocale {

--- a/packages/react-composites/src/composites/ChatComposite/FileDownloadCards.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/FileDownloadCards.tsx
@@ -48,7 +48,7 @@ export const FileDownloadCards = (props: FileDownloadCards): JSX.Element => {
             fileName={truncatedFileName(file.name, truncateLength)}
             key={file.name}
             fileExtension={extension(file.name)}
-            actionIcon={<ChatCompositeIcon iconName="Download" />}
+            actionIcon={<DownloadIconTrampoline />}
             actionHandler={() => {
               props.downloadHandler && props.downloadHandler(userId, file);
               !props.downloadHandler && window.open(file.url, '_blank', 'noopener,noreferrer');
@@ -57,4 +57,11 @@ export const FileDownloadCards = (props: FileDownloadCards): JSX.Element => {
         ))}
     </FileCardGroup>
   );
+};
+
+const DownloadIconTrampoline = (): JSX.Element => {
+  // @conditional-compile-remove(file-sharing)
+  return <ChatCompositeIcon iconName="Download" />;
+  // Return _some_ available icon, as the real icon is beta-only.
+  return <ChatCompositeIcon iconName="EditBoxCancel" />;
 };

--- a/packages/react-composites/src/composites/ChatComposite/FileUploadCards.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/FileUploadCards.tsx
@@ -26,7 +26,7 @@ export const FileUploadCards = (): JSX.Element => {
               progress={file.progress}
               key={file.id}
               fileExtension={extension(file.filename)}
-              actionIcon={<ChatCompositeIcon iconName="Cancel" />}
+              actionIcon={<CancelIconTrampoline />}
               actionHandler={() => {
                 adapter.cancelFileUpload && adapter.cancelFileUpload(file.id);
               }}
@@ -34,4 +34,11 @@ export const FileUploadCards = (): JSX.Element => {
           ))}
     </FileCardGroup>
   );
+};
+
+const CancelIconTrampoline = (): JSX.Element => {
+  // @conditional-compile-remove(file-sharing)
+  return <ChatCompositeIcon iconName="Cancel" />;
+  // Return _some_ available icon, as the real icon is beta-only.
+  return <ChatCompositeIcon iconName="EditBoxCancel" />;
 };

--- a/packages/react-composites/src/composites/common/TypeAssertions.tsx
+++ b/packages/react-composites/src/composites/common/TypeAssertions.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ComponentIcons } from '@internal/react-components';
+import { CallCompositeIcons, ChatCompositeIcons, COMPOSITE_ONLY_ICONS } from './icons';
+/* @conditional-compile-remove(call-with-chat-composite) */
+import { CallWithChatCompositeIcons } from './icons';
+
+/** Superset of all icons that composites can use. */
+type AllKnownCompositeIcons = ComponentIcons & Record<keyof typeof COMPOSITE_ONLY_ICONS, JSX.Element>;
+
+/** @private */
+export const ensureCallCompositeIconsListKnownIcons = (
+  icons: Required<AllKnownCompositeIcons>
+): Required<CallCompositeIcons> => icons;
+
+/** @private */
+export const ensureChatCompositeIconsListKnownIcons = (
+  icons: Required<AllKnownCompositeIcons>
+): Required<ChatCompositeIcons> => icons;
+
+/** @private
+ *
+ * @conditional-compile-remove(call-with-chat-composite)
+ */
+export const ensureCallWithChatCompositeIconsListKnownIcons = (
+  icons: Required<AllKnownCompositeIcons>
+): Required<CallWithChatCompositeIcons> => icons;

--- a/packages/react-composites/src/composites/common/icons.tsx
+++ b/packages/react-composites/src/composites/common/icons.tsx
@@ -49,7 +49,7 @@ const coffeeIconStyle = {
  *
  * @public
  */
-export const COMPOSITE_ONLY_ICONS = {
+export const COMPOSITE_ONLY_ICONS: CompositeIcons = {
   /* @conditional-compile-remove(file-sharing) */
   Cancel: <FontIcon iconName="Cancel" />,
   /* @conditional-compile-remove(call-with-chat-composite) */
@@ -219,6 +219,11 @@ export type CallWithChatCompositeIcons = {
   ControlBarChatButtonInactive?: JSX.Element;
   ControlBarPeopleButton?: JSX.Element;
   Link?: JSX.Element;
+  MoreDrawerMicrophones?: JSX.Element;
+  MoreDrawerPeople?: JSX.Element;
+  MoreDrawerSelectedMicrophone?: JSX.Element;
+  MoreDrawerSelectedSpeaker?: JSX.Element;
+  MoreDrawerSpeakers?: JSX.Element;
 
   // Call icons
   ControlButtonCameraOff?: JSX.Element;

--- a/packages/react-composites/src/composites/common/icons.tsx
+++ b/packages/react-composites/src/composites/common/icons.tsx
@@ -22,7 +22,7 @@ import {
   Chat20Regular,
   Chat20Filled
 } from '@fluentui/react-icons';
-import { ComponentIcons, DEFAULT_COMPONENT_ICONS } from '@internal/react-components';
+import { DEFAULT_COMPONENT_ICONS } from '@internal/react-components';
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { FontIcon, IIconProps, mergeStyles, Text } from '@fluentui/react';
@@ -104,15 +104,6 @@ export const DEFAULT_COMPOSITE_ICONS = {
   ...COMPOSITE_ONLY_ICONS
 };
 
-/**
- * Icons that can be overridden in one of the composites exported by this library.
- *
- * See {@link ChatCompositeIcons}, {@link CallCompositeIcons} and {@link CallWithChatCompositeIcons} for more targeted types.
- *
- * @public
- */
-export type CompositeIcons = ComponentIcons & Record<keyof typeof COMPOSITE_ONLY_ICONS, JSX.Element>;
-
 /** @private */
 export type CompositeIconProps<Icons> = IIconProps & { iconName: keyof Icons };
 
@@ -121,26 +112,26 @@ export type CompositeIconProps<Icons> = IIconProps & { iconName: keyof Icons };
  *
  * @public
  */
-export type ChatCompositeIcons = Partial<
-  Pick<
-    CompositeIcons,
-    | 'EditBoxCancel'
-    | 'EditBoxSubmit'
-    | 'MessageDelivered'
-    | 'MessageEdit'
-    | 'MessageFailed'
-    | 'MessageRemove'
-    | 'MessageSeen'
-    | 'MessageSending'
-    | 'ParticipantItemOptions'
-    | 'ParticipantItemOptionsHovered'
-    | 'SendBoxSend'
-    | 'SendBoxSendHovered'
-    | /* @conditional-compile-remove(file-sharing) */ 'SendBoxAttachFile'
-    | /* @conditional-compile-remove(file-sharing) */ 'Download'
-    | /* @conditional-compile-remove(file-sharing) */ 'Cancel'
-  >
->;
+export type ChatCompositeIcons = {
+  EditBoxCancel?: JSX.Element;
+  EditBoxSubmit?: JSX.Element;
+  MessageDelivered?: JSX.Element;
+  MessageEdit?: JSX.Element;
+  MessageFailed?: JSX.Element;
+  MessageRemove?: JSX.Element;
+  MessageSeen?: JSX.Element;
+  MessageSending?: JSX.Element;
+  ParticipantItemOptions?: JSX.Element;
+  ParticipantItemOptionsHovered?: JSX.Element;
+  SendBoxSend?: JSX.Element;
+  SendBoxSendHovered?: JSX.Element;
+  /* @conditional-compile-remove(file-sharing) */
+  SendBoxAttachFile?: JSX.Element;
+  /* @conditional-compile-remove(file-sharing) */
+  Download?: JSX.Element;
+  /* @conditional-compile-remove(file-sharing) */
+  Cancel?: JSX.Element;
+};
 
 /**
  * Icon wrapper to use when including customizable icons inside the ChatComposite.
@@ -158,53 +149,51 @@ export const ChatCompositeIcon = (props: CompositeIconProps<ChatCompositeIcons>)
  *
  * @public
  */
-export type CallCompositeIcons = Partial<
-  Pick<
-    CompositeIcons,
-    | 'ControlButtonCameraOff'
-    | 'ControlButtonCameraOn'
-    | 'ControlButtonEndCall'
-    | 'ControlButtonMicOff'
-    | 'ControlButtonMicOn'
-    | 'ControlButtonOptions'
-    | 'ControlButtonParticipants'
-    | 'ControlButtonScreenShareStart'
-    | 'ControlButtonScreenShareStop'
-    | 'ErrorBarCallCameraAccessDenied'
-    | 'ErrorBarCallCameraAlreadyInUse'
-    | 'ErrorBarCallLocalVideoFreeze'
-    | 'ErrorBarCallMacOsCameraAccessDenied'
-    | 'ErrorBarCallMacOsMicrophoneAccessDenied'
-    | 'ErrorBarCallMicrophoneAccessDenied'
-    | 'ErrorBarCallMicrophoneMutedBySystem'
-    | 'ErrorBarCallNetworkQualityLow'
-    | 'ErrorBarCallNoMicrophoneFound'
-    | 'ErrorBarCallNoSpeakerFound'
-    | 'HorizontalGalleryLeftButton'
-    | 'HorizontalGalleryRightButton'
-    | 'LobbyScreenConnectingToCall'
-    | 'LobbyScreenWaitingToBeAdmitted'
-    | 'LocalDeviceSettingsCamera'
-    | 'LocalDeviceSettingsMic'
-    | 'LocalDeviceSettingsSpeaker'
-    | 'LocalPreviewPlaceholder'
-    | 'Muted'
-    | 'NetworkReconnectIcon'
-    | 'NoticePageAccessDeniedTeamsMeeting'
-    | 'NoticePageJoinCallFailedDueToNoNetwork'
-    | 'NoticePageLeftCall'
-    | 'NoticePageRemovedFromCall'
-    | 'OptionsCamera'
-    | 'OptionsMic'
-    | 'OptionsSpeaker'
-    | 'ParticipantItemMicOff'
-    | 'ParticipantItemOptions'
-    | 'ParticipantItemOptionsHovered'
-    | 'ParticipantItemScreenShareStart'
-    | 'VideoTileMicOff'
-    | /* @conditional-compile-remove(local-camera-switcher) */ 'LocalCameraSwitch'
-  >
->;
+export type CallCompositeIcons = {
+  ControlButtonCameraOff?: JSX.Element;
+  ControlButtonCameraOn?: JSX.Element;
+  ControlButtonEndCall?: JSX.Element;
+  ControlButtonMicOff?: JSX.Element;
+  ControlButtonMicOn?: JSX.Element;
+  ControlButtonOptions?: JSX.Element;
+  ControlButtonParticipants?: JSX.Element;
+  ControlButtonScreenShareStart?: JSX.Element;
+  ControlButtonScreenShareStop?: JSX.Element;
+  ErrorBarCallCameraAccessDenied?: JSX.Element;
+  ErrorBarCallCameraAlreadyInUse?: JSX.Element;
+  ErrorBarCallLocalVideoFreeze?: JSX.Element;
+  ErrorBarCallMacOsCameraAccessDenied?: JSX.Element;
+  ErrorBarCallMacOsMicrophoneAccessDenied?: JSX.Element;
+  ErrorBarCallMicrophoneAccessDenied?: JSX.Element;
+  ErrorBarCallMicrophoneMutedBySystem?: JSX.Element;
+  ErrorBarCallNetworkQualityLow?: JSX.Element;
+  ErrorBarCallNoMicrophoneFound?: JSX.Element;
+  ErrorBarCallNoSpeakerFound?: JSX.Element;
+  HorizontalGalleryLeftButton?: JSX.Element;
+  HorizontalGalleryRightButton?: JSX.Element;
+  LobbyScreenConnectingToCall?: JSX.Element;
+  LobbyScreenWaitingToBeAdmitted?: JSX.Element;
+  LocalDeviceSettingsCamera?: JSX.Element;
+  LocalDeviceSettingsMic?: JSX.Element;
+  LocalDeviceSettingsSpeaker?: JSX.Element;
+  LocalPreviewPlaceholder?: JSX.Element;
+  Muted?: JSX.Element;
+  NetworkReconnectIcon?: JSX.Element;
+  NoticePageAccessDeniedTeamsMeeting?: JSX.Element;
+  NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element;
+  NoticePageLeftCall?: JSX.Element;
+  NoticePageRemovedFromCall?: JSX.Element;
+  OptionsCamera?: JSX.Element;
+  OptionsMic?: JSX.Element;
+  OptionsSpeaker?: JSX.Element;
+  ParticipantItemMicOff?: JSX.Element;
+  ParticipantItemOptions?: JSX.Element;
+  ParticipantItemOptionsHovered?: JSX.Element;
+  ParticipantItemScreenShareStart?: JSX.Element;
+  VideoTileMicOff?: JSX.Element;
+  /* @conditional-compile-remove(local-camera-switcher) */
+  LocalCameraSwitch?: JSX.Element;
+};
 
 /**
  * Icon wrapper to use when including customizable icons inside the CallComposite.
@@ -222,76 +211,73 @@ export const CallCompositeIcon = (props: CompositeIconProps<CallCompositeIcons>)
  *
  * @beta
  */
-export type CallWithChatCompositeIcons = Partial<
-  Pick<
-    CompositeIcons,
-    // CallWithChat Specific Icons
-    | /* @conditional-compile-remove-from(call-with-chat-composite) */ 'ChevronLeft'
-    | /* @conditional-compile-remove-from(call-with-chat-composite) */ 'ControlBarButtonBadgeIcon'
-    | /* @conditional-compile-remove-from(call-with-chat-composite) */ 'ControlBarChatButtonActive'
-    | /* @conditional-compile-remove-from(call-with-chat-composite) */ 'ControlBarChatButtonInactive'
-    | /* @conditional-compile-remove-from(call-with-chat-composite) */ 'ControlBarPeopleButton'
-    | /* @conditional-compile-remove-from(call-with-chat-composite) */ 'Link'
+export type CallWithChatCompositeIcons = {
+  // CallWithChat Specific Icons
+  ChevronLeft?: JSX.Element;
+  ControlBarButtonBadgeIcon?: JSX.Element;
+  ControlBarChatButtonActive?: JSX.Element;
+  ControlBarChatButtonInactive?: JSX.Element;
+  ControlBarPeopleButton?: JSX.Element;
+  Link?: JSX.Element;
 
-    // Call icons
-    | 'ControlButtonCameraOff'
-    | 'ControlButtonCameraOn'
-    | 'ControlButtonEndCall'
-    | 'ControlButtonMicOff'
-    | 'ControlButtonMicOn'
-    | 'ControlButtonOptions'
-    | 'ControlButtonScreenShareStart'
-    | 'ControlButtonScreenShareStop'
-    | 'ErrorBarCallCameraAccessDenied'
-    | 'ErrorBarCallCameraAlreadyInUse'
-    | 'ErrorBarCallLocalVideoFreeze'
-    | 'ErrorBarCallMacOsCameraAccessDenied'
-    | 'ErrorBarCallMacOsMicrophoneAccessDenied'
-    | 'ErrorBarCallMicrophoneAccessDenied'
-    | 'ErrorBarCallMicrophoneMutedBySystem'
-    | 'ErrorBarCallNetworkQualityLow'
-    | 'ErrorBarCallNoMicrophoneFound'
-    | 'ErrorBarCallNoSpeakerFound'
-    | 'HorizontalGalleryLeftButton'
-    | 'HorizontalGalleryRightButton'
-    | 'LobbyScreenConnectingToCall'
-    | 'LobbyScreenWaitingToBeAdmitted'
-    | 'LocalDeviceSettingsCamera'
-    | 'LocalDeviceSettingsMic'
-    | 'LocalDeviceSettingsSpeaker'
-    | 'LocalPreviewPlaceholder'
-    | 'Muted'
-    | 'NetworkReconnectIcon'
-    | 'NoticePageAccessDeniedTeamsMeeting'
-    | 'NoticePageJoinCallFailedDueToNoNetwork'
-    | 'NoticePageLeftCall'
-    | 'NoticePageRemovedFromCall'
-    | 'OptionsCamera'
-    | 'OptionsMic'
-    | 'OptionsSpeaker'
-    | 'ParticipantItemMicOff'
-    | 'ParticipantItemOptions'
-    | 'ParticipantItemOptionsHovered'
-    | 'ParticipantItemScreenShareStart'
-    | 'VideoTileMicOff'
-    | /* @conditional-compile-remove(call-with-chat-composite) */ 'LocalCameraSwitch'
+  // Call icons
+  ControlButtonCameraOff?: JSX.Element;
+  ControlButtonCameraOn?: JSX.Element;
+  ControlButtonEndCall?: JSX.Element;
+  ControlButtonMicOff?: JSX.Element;
+  ControlButtonMicOn?: JSX.Element;
+  ControlButtonOptions?: JSX.Element;
+  ControlButtonScreenShareStart?: JSX.Element;
+  ControlButtonScreenShareStop?: JSX.Element;
+  ErrorBarCallCameraAccessDenied?: JSX.Element;
+  ErrorBarCallCameraAlreadyInUse?: JSX.Element;
+  ErrorBarCallLocalVideoFreeze?: JSX.Element;
+  ErrorBarCallMacOsCameraAccessDenied?: JSX.Element;
+  ErrorBarCallMacOsMicrophoneAccessDenied?: JSX.Element;
+  ErrorBarCallMicrophoneAccessDenied?: JSX.Element;
+  ErrorBarCallMicrophoneMutedBySystem?: JSX.Element;
+  ErrorBarCallNetworkQualityLow?: JSX.Element;
+  ErrorBarCallNoMicrophoneFound?: JSX.Element;
+  ErrorBarCallNoSpeakerFound?: JSX.Element;
+  HorizontalGalleryLeftButton?: JSX.Element;
+  HorizontalGalleryRightButton?: JSX.Element;
+  LobbyScreenConnectingToCall?: JSX.Element;
+  LobbyScreenWaitingToBeAdmitted?: JSX.Element;
+  LocalDeviceSettingsCamera?: JSX.Element;
+  LocalDeviceSettingsMic?: JSX.Element;
+  LocalDeviceSettingsSpeaker?: JSX.Element;
+  LocalPreviewPlaceholder?: JSX.Element;
+  Muted?: JSX.Element;
+  NetworkReconnectIcon?: JSX.Element;
+  NoticePageAccessDeniedTeamsMeeting?: JSX.Element;
+  NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element;
+  NoticePageLeftCall?: JSX.Element;
+  NoticePageRemovedFromCall?: JSX.Element;
+  OptionsCamera?: JSX.Element;
+  OptionsMic?: JSX.Element;
+  OptionsSpeaker?: JSX.Element;
+  ParticipantItemMicOff?: JSX.Element;
+  ParticipantItemScreenShareStart?: JSX.Element;
+  VideoTileMicOff?: JSX.Element;
+  LocalCameraSwitch?: JSX.Element;
 
-    // Chat icons
-    | 'EditBoxCancel'
-    | 'EditBoxSubmit'
-    | 'MessageDelivered'
-    | 'MessageEdit'
-    | 'MessageFailed'
-    | 'MessageRemove'
-    | 'MessageSeen'
-    | 'MessageSending'
-    | 'ParticipantItemOptions'
-    | 'ParticipantItemOptionsHovered'
-    | 'SendBoxSend'
-    | 'SendBoxSendHovered'
-    | /* @conditional-compile-remove(file-sharing) */ 'SendBoxAttachFile'
-  >
->;
+  // Chat icons
+  EditBoxCancel?: JSX.Element;
+  EditBoxSubmit?: JSX.Element;
+  MessageDelivered?: JSX.Element;
+  MessageEdit?: JSX.Element;
+  MessageFailed?: JSX.Element;
+  MessageRemove?: JSX.Element;
+  MessageSeen?: JSX.Element;
+  MessageSending?: JSX.Element;
+  SendBoxSend?: JSX.Element;
+  SendBoxSendHovered?: JSX.Element;
+  SendBoxAttachFile?: JSX.Element;
+
+  // Icons common to Call and Chat.
+  ParticipantItemOptions?: JSX.Element;
+  ParticipantItemOptionsHovered?: JSX.Element;
+};
 
 /**
  * Icon wrapper to use when including customizable icons inside the CallWithChatComposite.
@@ -303,3 +289,14 @@ export type CallWithChatCompositeIcons = Partial<
 export const CallWithChatCompositeIcon = (props: CompositeIconProps<CallWithChatCompositeIcons>): JSX.Element => (
   <FontIcon {...props} />
 );
+
+/**
+ * Icons that can be overridden in one of the composites exported by this library.
+ *
+ * See {@link ChatCompositeIcons}, {@link CallCompositeIcons} and {@link CallWithChatCompositeIcons} for more targeted types.
+ *
+ * @public
+ */
+export type CompositeIcons = ChatCompositeIcons &
+  CallCompositeIcons &
+  /* @conditional-compile-remove(call-with-chat-composite) */ CallWithChatCompositeIcons;

--- a/packages/react-composites/stable-review/react-composites.api.md
+++ b/packages/react-composites/stable-review/react-composites.api.md
@@ -445,20 +445,7 @@ export const COMPOSITE_LOCALE_ZH_CN: CompositeLocale;
 export const COMPOSITE_LOCALE_ZH_TW: CompositeLocale;
 
 // @public
-export const COMPOSITE_ONLY_ICONS: {
-    LobbyScreenConnectingToCall: JSX.Element;
-    LobbyScreenWaitingToBeAdmitted: JSX.Element;
-    LocalDeviceSettingsCamera: JSX.Element;
-    LocalDeviceSettingsMic: JSX.Element;
-    LocalDeviceSettingsSpeaker: JSX.Element;
-    LocalPreviewPlaceholder: JSX.Element;
-    Muted: JSX.Element;
-    NetworkReconnectIcon: JSX.Element;
-    NoticePageAccessDeniedTeamsMeeting: JSX.Element;
-    NoticePageJoinCallFailedDueToNoNetwork: JSX.Element;
-    NoticePageLeftCall: JSX.Element;
-    NoticePageRemovedFromCall: JSX.Element;
-};
+export const COMPOSITE_ONLY_ICONS: CompositeIcons;
 
 // @public
 export type CompositeIcons = ChatCompositeIcons & CallCompositeIcons;
@@ -489,18 +476,18 @@ export const createAzureCommunicationChatAdapterFromClient: (chatClient: Statefu
 
 // @public
 export const DEFAULT_COMPOSITE_ICONS: {
-    LobbyScreenConnectingToCall: JSX.Element;
-    LobbyScreenWaitingToBeAdmitted: JSX.Element;
-    LocalDeviceSettingsCamera: JSX.Element;
-    LocalDeviceSettingsMic: JSX.Element;
-    LocalDeviceSettingsSpeaker: JSX.Element;
-    LocalPreviewPlaceholder: JSX.Element;
-    Muted: JSX.Element;
-    NetworkReconnectIcon: JSX.Element;
-    NoticePageAccessDeniedTeamsMeeting: JSX.Element;
-    NoticePageJoinCallFailedDueToNoNetwork: JSX.Element;
-    NoticePageLeftCall: JSX.Element;
-    NoticePageRemovedFromCall: JSX.Element;
+    EditBoxCancel: JSX.Element;
+    EditBoxSubmit: JSX.Element;
+    MessageDelivered: JSX.Element;
+    MessageEdit: JSX.Element;
+    MessageFailed: JSX.Element;
+    MessageRemove: JSX.Element;
+    MessageSeen: JSX.Element;
+    MessageSending: JSX.Element;
+    ParticipantItemOptions: JSX.Element;
+    ParticipantItemOptionsHovered: JSX.Element;
+    SendBoxSend: JSX.Element;
+    SendBoxSendHovered: JSX.Element;
     ControlButtonCameraOff: JSX.Element;
     ControlButtonCameraOn: JSX.Element;
     ControlButtonEndCall: JSX.Element;
@@ -510,8 +497,6 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ControlButtonParticipants: JSX.Element;
     ControlButtonScreenShareStart: JSX.Element;
     ControlButtonScreenShareStop: JSX.Element;
-    EditBoxCancel: JSX.Element;
-    EditBoxSubmit: JSX.Element;
     ErrorBarCallCameraAccessDenied: JSX.Element;
     ErrorBarCallCameraAlreadyInUse: JSX.Element;
     ErrorBarCallLocalVideoFreeze: JSX.Element;
@@ -524,21 +509,23 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ErrorBarCallNoSpeakerFound: JSX.Element;
     HorizontalGalleryLeftButton: JSX.Element;
     HorizontalGalleryRightButton: JSX.Element;
-    MessageDelivered: JSX.Element;
-    MessageEdit: JSX.Element;
-    MessageFailed: JSX.Element;
-    MessageRemove: JSX.Element;
-    MessageSeen: JSX.Element;
-    MessageSending: JSX.Element;
+    LobbyScreenConnectingToCall?: JSX.Element | undefined;
+    LobbyScreenWaitingToBeAdmitted?: JSX.Element | undefined;
+    LocalDeviceSettingsCamera?: JSX.Element | undefined;
+    LocalDeviceSettingsMic?: JSX.Element | undefined;
+    LocalDeviceSettingsSpeaker?: JSX.Element | undefined;
+    LocalPreviewPlaceholder?: JSX.Element | undefined;
+    Muted?: JSX.Element | undefined;
+    NetworkReconnectIcon?: JSX.Element | undefined;
+    NoticePageAccessDeniedTeamsMeeting?: JSX.Element | undefined;
+    NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element | undefined;
+    NoticePageLeftCall?: JSX.Element | undefined;
+    NoticePageRemovedFromCall?: JSX.Element | undefined;
     OptionsCamera: JSX.Element;
     OptionsMic: JSX.Element;
     OptionsSpeaker: JSX.Element;
     ParticipantItemMicOff: JSX.Element;
-    ParticipantItemOptions: JSX.Element;
-    ParticipantItemOptionsHovered: JSX.Element;
     ParticipantItemScreenShareStart: JSX.Element;
-    SendBoxSend: JSX.Element;
-    SendBoxSendHovered: JSX.Element;
     VideoTileMicOff: JSX.Element;
 };
 

--- a/packages/react-composites/stable-review/react-composites.api.md
+++ b/packages/react-composites/stable-review/react-composites.api.md
@@ -19,7 +19,6 @@ import { CommunicationParticipant } from '@internal/react-components';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import type { CommunicationUserKind } from '@azure/communication-common';
-import { ComponentIcons } from '@internal/react-components';
 import { ComponentLocale } from '@internal/react-components';
 import { DeviceManagerState } from '@internal/calling-stateful-client';
 import { GroupCallLocator } from '@azure/communication-calling';
@@ -180,7 +179,49 @@ export type CallAdapterUiState = {
 export const CallComposite: (props: CallCompositeProps) => JSX.Element;
 
 // @public
-export type CallCompositeIcons = Partial<Pick<CompositeIcons, 'ControlButtonCameraOff' | 'ControlButtonCameraOn' | 'ControlButtonEndCall' | 'ControlButtonMicOff' | 'ControlButtonMicOn' | 'ControlButtonOptions' | 'ControlButtonParticipants' | 'ControlButtonScreenShareStart' | 'ControlButtonScreenShareStop' | 'ErrorBarCallCameraAccessDenied' | 'ErrorBarCallCameraAlreadyInUse' | 'ErrorBarCallLocalVideoFreeze' | 'ErrorBarCallMacOsCameraAccessDenied' | 'ErrorBarCallMacOsMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneAccessDenied' | 'ErrorBarCallMicrophoneMutedBySystem' | 'ErrorBarCallNetworkQualityLow' | 'ErrorBarCallNoMicrophoneFound' | 'ErrorBarCallNoSpeakerFound' | 'HorizontalGalleryLeftButton' | 'HorizontalGalleryRightButton' | 'LobbyScreenConnectingToCall' | 'LobbyScreenWaitingToBeAdmitted' | 'LocalDeviceSettingsCamera' | 'LocalDeviceSettingsMic' | 'LocalDeviceSettingsSpeaker' | 'LocalPreviewPlaceholder' | 'Muted' | 'NetworkReconnectIcon' | 'NoticePageAccessDeniedTeamsMeeting' | 'NoticePageJoinCallFailedDueToNoNetwork' | 'NoticePageLeftCall' | 'NoticePageRemovedFromCall' | 'OptionsCamera' | 'OptionsMic' | 'OptionsSpeaker' | 'ParticipantItemMicOff' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'ParticipantItemScreenShareStart' | 'VideoTileMicOff'>>;
+export type CallCompositeIcons = {
+    ControlButtonCameraOff?: JSX.Element;
+    ControlButtonCameraOn?: JSX.Element;
+    ControlButtonEndCall?: JSX.Element;
+    ControlButtonMicOff?: JSX.Element;
+    ControlButtonMicOn?: JSX.Element;
+    ControlButtonOptions?: JSX.Element;
+    ControlButtonParticipants?: JSX.Element;
+    ControlButtonScreenShareStart?: JSX.Element;
+    ControlButtonScreenShareStop?: JSX.Element;
+    ErrorBarCallCameraAccessDenied?: JSX.Element;
+    ErrorBarCallCameraAlreadyInUse?: JSX.Element;
+    ErrorBarCallLocalVideoFreeze?: JSX.Element;
+    ErrorBarCallMacOsCameraAccessDenied?: JSX.Element;
+    ErrorBarCallMacOsMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneAccessDenied?: JSX.Element;
+    ErrorBarCallMicrophoneMutedBySystem?: JSX.Element;
+    ErrorBarCallNetworkQualityLow?: JSX.Element;
+    ErrorBarCallNoMicrophoneFound?: JSX.Element;
+    ErrorBarCallNoSpeakerFound?: JSX.Element;
+    HorizontalGalleryLeftButton?: JSX.Element;
+    HorizontalGalleryRightButton?: JSX.Element;
+    LobbyScreenConnectingToCall?: JSX.Element;
+    LobbyScreenWaitingToBeAdmitted?: JSX.Element;
+    LocalDeviceSettingsCamera?: JSX.Element;
+    LocalDeviceSettingsMic?: JSX.Element;
+    LocalDeviceSettingsSpeaker?: JSX.Element;
+    LocalPreviewPlaceholder?: JSX.Element;
+    Muted?: JSX.Element;
+    NetworkReconnectIcon?: JSX.Element;
+    NoticePageAccessDeniedTeamsMeeting?: JSX.Element;
+    NoticePageJoinCallFailedDueToNoNetwork?: JSX.Element;
+    NoticePageLeftCall?: JSX.Element;
+    NoticePageRemovedFromCall?: JSX.Element;
+    OptionsCamera?: JSX.Element;
+    OptionsMic?: JSX.Element;
+    OptionsSpeaker?: JSX.Element;
+    ParticipantItemMicOff?: JSX.Element;
+    ParticipantItemOptions?: JSX.Element;
+    ParticipantItemOptionsHovered?: JSX.Element;
+    ParticipantItemScreenShareStart?: JSX.Element;
+    VideoTileMicOff?: JSX.Element;
+};
 
 // @public
 export type CallCompositeOptions = {
@@ -326,7 +367,20 @@ export type ChatCompositeClientState = {
 };
 
 // @public
-export type ChatCompositeIcons = Partial<Pick<CompositeIcons, 'EditBoxCancel' | 'EditBoxSubmit' | 'MessageDelivered' | 'MessageEdit' | 'MessageFailed' | 'MessageRemove' | 'MessageSeen' | 'MessageSending' | 'ParticipantItemOptions' | 'ParticipantItemOptionsHovered' | 'SendBoxSend' | 'SendBoxSendHovered'>>;
+export type ChatCompositeIcons = {
+    EditBoxCancel?: JSX.Element;
+    EditBoxSubmit?: JSX.Element;
+    MessageDelivered?: JSX.Element;
+    MessageEdit?: JSX.Element;
+    MessageFailed?: JSX.Element;
+    MessageRemove?: JSX.Element;
+    MessageSeen?: JSX.Element;
+    MessageSending?: JSX.Element;
+    ParticipantItemOptions?: JSX.Element;
+    ParticipantItemOptionsHovered?: JSX.Element;
+    SendBoxSend?: JSX.Element;
+    SendBoxSendHovered?: JSX.Element;
+};
 
 // @public
 export type ChatCompositeOptions = {
@@ -407,7 +461,7 @@ export const COMPOSITE_ONLY_ICONS: {
 };
 
 // @public
-export type CompositeIcons = ComponentIcons & Record<keyof typeof COMPOSITE_ONLY_ICONS, JSX.Element>;
+export type CompositeIcons = ChatCompositeIcons & CallCompositeIcons;
 
 // @public
 export interface CompositeLocale {


### PR DESCRIPTION
* Rework icons to make the per-composite icon types explicit.
* Add type assertions to continue to ensure that per-composite icons are consistent with exported default icons.
* Add beta-guards for use of beta-only icons from public icon types.