### PR TITLE
Mobile pane option to disable back button

### DIFF
--- a/change/@internal-react-composites-897c4ea6-a590-4e0b-b1a5-24b5b6ce603a.json
+++ b/change/@internal-react-composites-897c4ea6-a590-4e0b-b1a5-24b5b6ce603a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added option to disable back button when mobile pane is active in CallWithChat composite",
+  "packageName": "@internal/react-composites",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -711,6 +711,7 @@ export type CallWithChatCompositeIcons = {
 // @beta
 export type CallWithChatCompositeOptions = {
     callControls?: boolean | CallWithChatControlOptions;
+    mobilePane?: MobilePaneOptions;
 };
 
 // @beta
@@ -1948,6 +1949,12 @@ export interface MicrophoneButtonStrings {
 // @public
 export interface MicrophoneButtonStyles extends ControlBarButtonStyles {
     menuStyles?: Partial<MicrophoneButtonContextualMenuStyles>;
+}
+
+// @beta
+export interface MobilePaneOptions {
+    // (undocumented)
+    disabledBackButton?: boolean;
 }
 
 // @public

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -511,6 +511,7 @@ export type CallWithChatCompositeIcons = {
 // @beta
 export type CallWithChatCompositeOptions = {
     callControls?: boolean | CallWithChatControlOptions;
+    mobilePane?: MobilePaneOptions;
 };
 
 // @beta
@@ -927,6 +928,12 @@ export type MessageReceivedListener = (event: {
 
 // @public
 export type MessageSentListener = MessageReceivedListener;
+
+// @beta
+export interface MobilePaneOptions {
+    // (undocumented)
+    disabledBackButton?: boolean;
+}
 
 // @public
 export type NetworkDiagnosticChangedEvent = NetworkDiagnosticChangedEventArgs & {

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -68,7 +68,22 @@ export type CallWithChatCompositeOptions = {
    * If using the boolean values, true will cause default behavior across the whole control bar. False hides the whole control bar.
    */
   callControls?: boolean | CallWithChatControlOptions;
+  /**
+   * Mobile pane options to disable browser back button functionality when a mobile pane is active. Clicking
+   * the back button will close the mobile pane instead.
+   */
+  mobilePane?: MobilePaneOptions;
 };
+
+/**
+ * {@link CallWithChatComposite} mobile pane options.
+ *
+ * @beta
+ */
+export interface MobilePaneOptions {
+  disabledBackButton?: boolean;
+}
+
 /**
  * {@link CallWithChatComposite} Call controls to show or hide buttons on the calling control bar.
  *
@@ -95,6 +110,7 @@ type CallWithChatScreenProps = {
   joinInvitationURL?: string;
   callControls?: boolean | CallWithChatControlOptions;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
+  mobilePane?: MobilePaneOptions;
 };
 
 const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
@@ -198,6 +214,7 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
             onChatButtonClick={selectChat}
             onPeopleButtonClick={selectPeople}
             mobileView={isMobile}
+            disableBackButton={props.mobilePane?.disabledBackButton}
           />
         )}
         {callAdapter && chatProps.adapter && hasJoinedCall && (
@@ -212,6 +229,7 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
               onChatButtonClick={selectChat}
               onPeopleButtonClick={selectPeople}
               mobileView={isMobile}
+              disableBackButton={props.mobilePane?.disabledBackButton}
             />
           </CallAdapterProvider>
         )}
@@ -260,9 +278,9 @@ export const CallWithChatComposite = (props: CallWithChatCompositeProps): JSX.El
         {...props}
         callWithChatAdapter={callWithChatAdapter}
         formFactor={formFactor}
-        callControls={options?.callControls}
         joinInvitationURL={joinInvitationURL}
         fluentTheme={fluentTheme}
+        {...options}
       />
     </BaseProvider>
   );

--- a/packages/react-composites/src/composites/CallWithChatComposite/EmbeddedChatPane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/EmbeddedChatPane.tsx
@@ -21,6 +21,7 @@ export const EmbeddedChatPane = (props: {
   onChatButtonClick: () => void;
   onPeopleButtonClick: () => void;
   mobileView?: boolean;
+  disableBackButton?: boolean;
 }): JSX.Element => {
   const callWithChatStrings = useCallWithChatCompositeStrings();
 
@@ -46,6 +47,7 @@ export const EmbeddedChatPane = (props: {
         activeTab="chat"
         onChatButtonClicked={props.onChatButtonClick}
         onPeopleButtonClicked={props.onPeopleButtonClick}
+        disableBackButton={props.disableBackButton}
       >
         {chatComposite}
       </MobilePane>

--- a/packages/react-composites/src/composites/CallWithChatComposite/EmbeddedPeoplePane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/EmbeddedPeoplePane.tsx
@@ -29,6 +29,7 @@ export const EmbeddedPeoplePane = (props: {
   onChatButtonClick: () => void;
   onPeopleButtonClick: () => void;
   mobileView?: boolean;
+  disableBackButton?: boolean;
 }): JSX.Element => {
   const { callAdapter, chatAdapter, inviteLink } = props;
   const participantListDefaultProps = usePropsFor(ParticipantList);
@@ -61,6 +62,7 @@ export const EmbeddedPeoplePane = (props: {
         activeTab="people"
         onChatButtonClicked={props.onChatButtonClick}
         onPeopleButtonClicked={props.onPeopleButtonClick}
+        disableBackButton={props.disableBackButton}
       >
         <Stack verticalFill tokens={peoplePaneContainerTokens}>
           {participantList}

--- a/packages/react-composites/src/composites/CallWithChatComposite/MobilePane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/MobilePane.tsx
@@ -60,7 +60,7 @@ export const MobilePane = (props: {
       };
     } else {
       // remove onpopstate listener otherwise
-      window.onpopstate = () => {};
+      window.onpopstate = null;
     }
   }, [props.disableBackButton, props.hidden]);
 

--- a/packages/react-composites/src/composites/CallWithChatComposite/MobilePane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/MobilePane.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 import { concatStyleSets, DefaultButton, Stack } from '@fluentui/react';
 import { useTheme } from '@internal/react-components';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { CallWithChatCompositeIcon } from '../common/icons';
 import {
   paneBodyContainer,
@@ -31,6 +31,7 @@ export const MobilePane = (props: {
   hidden: boolean;
   dataUiId: string;
   activeTab: MobilePaneTab;
+  disableBackButton?: boolean;
 }): JSX.Element => {
   // We hide the mobile pane instead of not rendering the entire pane to persist certain elements
   // between renders. An example of this is composing a chat message - a chat message that has been
@@ -49,6 +50,19 @@ export const MobilePane = (props: {
     });
   }, [theme]);
   const strings = useCallWithChatCompositeStrings();
+
+  useEffect(() => {
+    // disable back button when boolean is true and mobile pane is not hidden
+    if (props.disableBackButton && !props.hidden) {
+      window.onpopstate = function () {
+        window.history.forward();
+        props.onClose();
+      };
+    } else {
+      // remove onpopstate listener otherwise
+      window.onpopstate = () => {};
+    }
+  }, [props.disableBackButton, props.hidden]);
 
   return (
     <Stack verticalFill grow styles={mobilePaneStyles} data-ui-id={props.dataUiId}>

--- a/samples/CallWithChat/src/app/views/CallScreen.tsx
+++ b/samples/CallWithChat/src/app/views/CallScreen.tsx
@@ -100,6 +100,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
       rtl={currentRtl}
       joinInvitationURL={window.location.href}
       formFactor={isMobileSession ? 'mobile' : 'desktop'}
+      options={{ mobilePane: { disabledBackButton: true } }}
     />
   );
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Added mobile pane option to disable button in CallWithChat composite

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2590659

# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested on CallWithChat sample.
https://user-images.githubusercontent.com/79475487/156122640-42a13d07-17a5-4d78-a258-1e9d61f2283e.mp4
Notice that when the back button is clicked that the threadId argument in the url disappears and immediately reappears. 
It is not the cleanest solution but it is the simplest without pushing state to the browser history.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->