### PR TITLE
Fix img size for style defined element

### DIFF
--- a/change/@internal-react-components-85ee03eb-b6a4-4c20-8679-0856d6124c70.json
+++ b/change/@internal-react-components-85ee03eb-b6a4-4c20-8679-0856d6124c70.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix img size for style defined element",
+  "packageName": "@internal/react-components",
+  "email": "jiangnanhello@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/MessageThread.styles.ts
+++ b/packages/react-components/src/components/styles/MessageThread.styles.ts
@@ -107,8 +107,8 @@ export const defaultChatMessageContainer: ComponentSlotStyle = {
   minWidth: `${CHAT_MESSAGE_CONTAINER_MIN_WIDTH_REM}rem`,
   marginRight: '0rem',
   ' img': {
-    maxWidth: '100%',
-    height: 'auto'
+    maxWidth: '100% !important', // Add !important to make sure it won't be overridden by style defined in element
+    height: 'auto !important'
   },
   ' p': {
     // Deal with awkward padding seen in messages from Teams.


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
There is a case that img from iPhone client size wouldn't be limited because it is directly defined in element
This fix uses an important tag to override it

Before:
![image](https://user-images.githubusercontent.com/11863655/156474797-655d0497-165b-4ba2-a5ee-62b7db5fa683.png)

After(because we don't have the actual file, so it img is tented to be showed as a small icon instead of full size, which is correct):
![image](https://user-images.githubusercontent.com/11863655/156474834-bfabaa65-eab9-45ab-91a2-70ec985c1e62.png)

Thanks @alkwa-msft for help in testing!
# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->