### PR TITLE
Update calling dependencies to 1.4.2-beta.1 that were missed

### DIFF
--- a/change/@internal-calling-stateful-client-79107d63-6480-404c-af2c-8c9afc81094b.json
+++ b/change/@internal-calling-stateful-client-79107d63-6480-404c-af2c-8c9afc81094b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update azure/communication-calling dependency version to match the rest of the repo",
+  "packageName": "@internal/calling-stateful-client",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-composites-ebd1d56e-81f3-4a56-a879-a7a0f3d2f2ef.json
+++ b/change/@internal-react-composites-ebd1d56e-81f3-4a56-a879-a7a0f3d2f2ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update azure/communication-calling dependency version to match the rest of the repo",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -24,7 +24,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "@azure/communication-calling": "1.3.2-beta.1"
+    "@azure/communication-calling": "1.4.2-beta.1"
   },
 
   /**
@@ -52,7 +52,7 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
-    "@azure/communication-calling": ["1.3.2-beta.1"],
+    "@azure/communication-calling": ["1.4.2-beta.1"],
     "webpack": [
       // All projects should use this version by default
       "5.38.1",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,5 +1,5 @@
 dependencies:
-  '@azure/communication-calling': 1.3.2-beta.1
+  '@azure/communication-calling': 1.4.2-beta.1
   '@rush-temp/acs-ui-common': file:projects/acs-ui-common.tgz
   '@rush-temp/calling': file:projects/calling.tgz
   '@rush-temp/calling-component-bindings': file:projects/calling-component-bindings.tgz
@@ -28,13 +28,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==
-  /@azure/communication-calling/1.3.2-beta.1:
-    dependencies:
-      '@azure/communication-common': 1.1.0
-      '@azure/logger': 1.0.2
-    dev: false
-    resolution:
-      integrity: sha512-uzEzesBoF++rNm02lPcLe2oQpuvOvYSeWLzViuzYZZ+sQ0UzkF8v+ZhySXCUCFXJF5aDT6xDnpBgOcRTYOIbAg==
   /@azure/communication-calling/1.4.2-beta.1:
     dependencies:
       '@azure/communication-common': 1.1.0
@@ -19894,7 +19887,7 @@ packages:
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:
-  '@azure/communication-calling': 1.3.2-beta.1
+  '@azure/communication-calling': 1.4.2-beta.1
   '@rush-temp/acs-ui-common': file:./projects/acs-ui-common.tgz
   '@rush-temp/calling': file:./projects/calling.tgz
   '@rush-temp/calling-component-bindings': file:./projects/calling-component-bindings.tgz

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -35,7 +35,7 @@
     "immer": "9.0.6"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.3.2"
+    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2"
   },
   "devDependencies": {
     "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -45,7 +45,7 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.3.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
     "@azure/communication-chat": "1.1.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -69,7 +69,7 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.3.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
     "@azure/communication-chat": "1.1.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",


### PR DESCRIPTION
# What
Update everywhere still using the previous 1.3.2-beta.1

# Why
Some places these weren't full updated

# How Tested
n/a (CI will test this)