### PR TITLE
Flatten pick and omit APIs in CallWithChatComposite

### DIFF
--- a/change/@internal-react-composites-05ee0a21-695f-4ad6-8e3e-86429894292e.json
+++ b/change/@internal-react-composites-05ee0a21-695f-4ad6-8e3e-86429894292e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Flatten pick and omit APIs in CallWithChatComposite",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -50,7 +50,7 @@ import { MediaStreamType } from '@azure/communication-calling';
 import { MicrosoftTeamsUserKind } from '@azure/communication-common';
 import type { NetworkDiagnosticChangedEventArgs } from '@azure/communication-calling';
 import { PartialTheme } from '@fluentui/react';
-import type { PermissionConstraints } from '@azure/communication-calling';
+import { PermissionConstraints } from '@azure/communication-calling';
 import { PersonaInitialsColor } from '@fluentui/react';
 import { PersonaPresence } from '@fluentui/react';
 import { PersonaSize } from '@fluentui/react';
@@ -560,8 +560,51 @@ export interface CallWithChatAdapter extends CallWithChatAdapterManagement, Adap
 }
 
 // @beta
-export interface CallWithChatAdapterManagement extends Pick<CallAdapterCallManagement, 'startCamera' | 'stopCamera' | 'mute' | 'unmute' | 'startScreenShare' | 'stopScreenShare' | 'createStreamView' | 'disposeStreamView' | 'joinCall' | 'leaveCall' | 'startCall'>, Pick<CallAdapterDeviceManagement, 'setCamera' | 'setMicrophone' | 'setSpeaker' | 'askDevicePermission' | 'queryCameras' | 'queryMicrophones' | 'querySpeakers'>, Pick<ChatAdapterThreadManagement, 'fetchInitialData' | 'sendMessage' | 'sendReadReceipt' | 'sendTypingIndicator' | 'loadPreviousChatMessages' | 'updateMessage' | 'deleteMessage'> {
+export interface CallWithChatAdapterManagement {
+    // @public
+    askDevicePermission(constrain: PermissionConstraints): Promise<void>;
+    // @public
+    createStreamView(remoteUserId?: string, options?: VideoStreamOptions): Promise<void>;
+    deleteMessage(messageId: string): Promise<void>;
+    // @public
+    disposeStreamView(remoteUserId?: string, options?: VideoStreamOptions): Promise<void>;
+    fetchInitialData(): Promise<void>;
+    // @public
+    joinCall(microphoneOn?: boolean): Call | undefined;
+    // @public
+    leaveCall(forEveryone?: boolean): Promise<void>;
+    loadPreviousChatMessages(messagesToLoad: number): Promise<boolean>;
+    // @public
+    mute(): Promise<void>;
+    // @public
+    queryCameras(): Promise<VideoDeviceInfo[]>;
+    // @public
+    queryMicrophones(): Promise<AudioDeviceInfo[]>;
+    // @public
+    querySpeakers(): Promise<AudioDeviceInfo[]>;
     removeParticipant(userId: string): Promise<void>;
+    sendMessage(content: string, options?: SendMessageOptions): Promise<void>;
+    sendReadReceipt(chatMessageId: string): Promise<void>;
+    sendTypingIndicator(): Promise<void>;
+    // @public
+    setCamera(sourceInfo: VideoDeviceInfo, options?: VideoStreamOptions): Promise<void>;
+    // @public
+    setMicrophone(sourceInfo: AudioDeviceInfo): Promise<void>;
+    // @public
+    setSpeaker(sourceInfo: AudioDeviceInfo): Promise<void>;
+    // @public
+    startCall(participants: string[]): Call | undefined;
+    // @public
+    startCamera(options?: VideoStreamOptions): Promise<void>;
+    // @public
+    startScreenShare(): Promise<void>;
+    // @public
+    stopCamera(): Promise<void>;
+    // @public
+    stopScreenShare(): Promise<void>;
+    // @public
+    unmute(): Promise<void>;
+    updateMessage(messageId: string, content: string): Promise<void>;
 }
 
 // @beta
@@ -633,14 +676,21 @@ export interface CallWithChatAdapterSubscriptions {
 }
 
 // @beta
-export interface CallWithChatAdapterUiState extends CallAdapterUiState, Omit<ChatAdapterUiState, 'error'> {
+export interface CallWithChatAdapterUiState extends Omit<ChatAdapterUiState, 'error'> {
+    fileUploads?: FileUploadsUiState;
+    // (undocumented)
+    isLocalPreviewMicrophoneEnabled: boolean;
+    // (undocumented)
+    page: CallCompositePage;
 }
 
 // @beta
-export interface CallWithChatClientState extends Pick<CallAdapterClientState, 'devices' | 'isTeamsCall'> {
+export interface CallWithChatClientState {
     call?: CallState;
     chat?: ChatThreadClientState;
+    devices: DeviceManagerState;
     displayName: string | undefined;
+    isTeamsCall: boolean;
     latestCallErrors: AdapterErrors;
     latestChatErrors: AdapterErrors;
     userId: CommunicationIdentifierKind;
@@ -747,8 +797,15 @@ export interface CallWithChatCompositeStrings {
 
 // @beta
 export interface CallWithChatControlOptions extends Pick<CallControlOptions, 'cameraButton' | 'microphoneButton' | 'screenShareButton' | 'displayType'> {
+    cameraButton?: boolean;
     chatButton?: boolean;
+    displayType?: CallControlDisplayType;
+    endCallButton?: boolean;
+    microphoneButton?: boolean;
     peopleButton?: boolean;
+    screenShareButton?: boolean | {
+        disabled: boolean;
+    };
 }
 
 // @beta

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -561,48 +561,30 @@ export interface CallWithChatAdapter extends CallWithChatAdapterManagement, Adap
 
 // @beta
 export interface CallWithChatAdapterManagement {
-    // @public
     askDevicePermission(constrain: PermissionConstraints): Promise<void>;
-    // @public
     createStreamView(remoteUserId?: string, options?: VideoStreamOptions): Promise<void>;
     deleteMessage(messageId: string): Promise<void>;
-    // @public
     disposeStreamView(remoteUserId?: string, options?: VideoStreamOptions): Promise<void>;
     fetchInitialData(): Promise<void>;
-    // @public
     joinCall(microphoneOn?: boolean): Call | undefined;
-    // @public
     leaveCall(forEveryone?: boolean): Promise<void>;
     loadPreviousChatMessages(messagesToLoad: number): Promise<boolean>;
-    // @public
     mute(): Promise<void>;
-    // @public
     queryCameras(): Promise<VideoDeviceInfo[]>;
-    // @public
     queryMicrophones(): Promise<AudioDeviceInfo[]>;
-    // @public
     querySpeakers(): Promise<AudioDeviceInfo[]>;
     removeParticipant(userId: string): Promise<void>;
     sendMessage(content: string, options?: SendMessageOptions): Promise<void>;
     sendReadReceipt(chatMessageId: string): Promise<void>;
     sendTypingIndicator(): Promise<void>;
-    // @public
     setCamera(sourceInfo: VideoDeviceInfo, options?: VideoStreamOptions): Promise<void>;
-    // @public
     setMicrophone(sourceInfo: AudioDeviceInfo): Promise<void>;
-    // @public
     setSpeaker(sourceInfo: AudioDeviceInfo): Promise<void>;
-    // @public
     startCall(participants: string[]): Call | undefined;
-    // @public
     startCamera(options?: VideoStreamOptions): Promise<void>;
-    // @public
     startScreenShare(): Promise<void>;
-    // @public
     stopCamera(): Promise<void>;
-    // @public
     stopScreenShare(): Promise<void>;
-    // @public
     unmute(): Promise<void>;
     updateMessage(messageId: string, content: string): Promise<void>;
 }
@@ -678,9 +660,7 @@ export interface CallWithChatAdapterSubscriptions {
 // @beta
 export interface CallWithChatAdapterUiState extends Omit<ChatAdapterUiState, 'error'> {
     fileUploads?: FileUploadsUiState;
-    // (undocumented)
     isLocalPreviewMicrophoneEnabled: boolean;
-    // (undocumented)
     page: CallCompositePage;
 }
 

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -353,48 +353,30 @@ export interface CallWithChatAdapter extends CallWithChatAdapterManagement, Adap
 
 // @beta
 export interface CallWithChatAdapterManagement {
-    // @public
     askDevicePermission(constrain: PermissionConstraints): Promise<void>;
-    // @public
     createStreamView(remoteUserId?: string, options?: VideoStreamOptions): Promise<void>;
     deleteMessage(messageId: string): Promise<void>;
-    // @public
     disposeStreamView(remoteUserId?: string, options?: VideoStreamOptions): Promise<void>;
     fetchInitialData(): Promise<void>;
-    // @public
     joinCall(microphoneOn?: boolean): Call | undefined;
-    // @public
     leaveCall(forEveryone?: boolean): Promise<void>;
     loadPreviousChatMessages(messagesToLoad: number): Promise<boolean>;
-    // @public
     mute(): Promise<void>;
-    // @public
     queryCameras(): Promise<VideoDeviceInfo[]>;
-    // @public
     queryMicrophones(): Promise<AudioDeviceInfo[]>;
-    // @public
     querySpeakers(): Promise<AudioDeviceInfo[]>;
     removeParticipant(userId: string): Promise<void>;
     sendMessage(content: string, options?: SendMessageOptions): Promise<void>;
     sendReadReceipt(chatMessageId: string): Promise<void>;
     sendTypingIndicator(): Promise<void>;
-    // @public
     setCamera(sourceInfo: VideoDeviceInfo, options?: VideoStreamOptions): Promise<void>;
-    // @public
     setMicrophone(sourceInfo: AudioDeviceInfo): Promise<void>;
-    // @public
     setSpeaker(sourceInfo: AudioDeviceInfo): Promise<void>;
-    // @public
     startCall(participants: string[]): Call | undefined;
-    // @public
     startCamera(options?: VideoStreamOptions): Promise<void>;
-    // @public
     startScreenShare(): Promise<void>;
-    // @public
     stopCamera(): Promise<void>;
-    // @public
     stopScreenShare(): Promise<void>;
-    // @public
     unmute(): Promise<void>;
     updateMessage(messageId: string, content: string): Promise<void>;
 }
@@ -470,9 +452,7 @@ export interface CallWithChatAdapterSubscriptions {
 // @beta
 export interface CallWithChatAdapterUiState extends Omit<ChatAdapterUiState, 'error'> {
     fileUploads?: FileUploadsUiState;
-    // (undocumented)
     isLocalPreviewMicrophoneEnabled: boolean;
-    // (undocumented)
     page: CallCompositePage;
 }
 

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -6,8 +6,8 @@
 
 /// <reference types="react" />
 
-import type { AudioDeviceInfo } from '@azure/communication-calling';
-import type { Call } from '@azure/communication-calling';
+import { AudioDeviceInfo } from '@azure/communication-calling';
+import { Call } from '@azure/communication-calling';
 import { CallAgent } from '@azure/communication-calling';
 import { CallState } from '@internal/calling-stateful-client';
 import type { ChatMessage } from '@azure/communication-chat';
@@ -29,15 +29,15 @@ import { MessageRenderer } from '@internal/react-components';
 import type { NetworkDiagnosticChangedEventArgs } from '@azure/communication-calling';
 import { PartialTheme } from '@fluentui/react';
 import { ParticipantMenuItemsCallback } from '@internal/react-components';
-import type { PermissionConstraints } from '@azure/communication-calling';
+import { PermissionConstraints } from '@azure/communication-calling';
 import { PersonaInitialsColor } from '@fluentui/react';
 import type { RemoteParticipant } from '@azure/communication-calling';
-import type { SendMessageOptions } from '@azure/communication-chat';
+import { SendMessageOptions } from '@azure/communication-chat';
 import { StatefulCallClient } from '@internal/calling-stateful-client';
 import { StatefulChatClient } from '@internal/chat-stateful-client';
 import { TeamsMeetingLinkLocator } from '@azure/communication-calling';
 import { Theme } from '@fluentui/react';
-import type { VideoDeviceInfo } from '@azure/communication-calling';
+import { VideoDeviceInfo } from '@azure/communication-calling';
 import { VideoStreamOptions } from '@internal/react-components';
 
 // @public
@@ -352,8 +352,51 @@ export interface CallWithChatAdapter extends CallWithChatAdapterManagement, Adap
 }
 
 // @beta
-export interface CallWithChatAdapterManagement extends Pick<CallAdapterCallManagement, 'startCamera' | 'stopCamera' | 'mute' | 'unmute' | 'startScreenShare' | 'stopScreenShare' | 'createStreamView' | 'disposeStreamView' | 'joinCall' | 'leaveCall' | 'startCall'>, Pick<CallAdapterDeviceManagement, 'setCamera' | 'setMicrophone' | 'setSpeaker' | 'askDevicePermission' | 'queryCameras' | 'queryMicrophones' | 'querySpeakers'>, Pick<ChatAdapterThreadManagement, 'fetchInitialData' | 'sendMessage' | 'sendReadReceipt' | 'sendTypingIndicator' | 'loadPreviousChatMessages' | 'updateMessage' | 'deleteMessage'> {
+export interface CallWithChatAdapterManagement {
+    // @public
+    askDevicePermission(constrain: PermissionConstraints): Promise<void>;
+    // @public
+    createStreamView(remoteUserId?: string, options?: VideoStreamOptions): Promise<void>;
+    deleteMessage(messageId: string): Promise<void>;
+    // @public
+    disposeStreamView(remoteUserId?: string, options?: VideoStreamOptions): Promise<void>;
+    fetchInitialData(): Promise<void>;
+    // @public
+    joinCall(microphoneOn?: boolean): Call | undefined;
+    // @public
+    leaveCall(forEveryone?: boolean): Promise<void>;
+    loadPreviousChatMessages(messagesToLoad: number): Promise<boolean>;
+    // @public
+    mute(): Promise<void>;
+    // @public
+    queryCameras(): Promise<VideoDeviceInfo[]>;
+    // @public
+    queryMicrophones(): Promise<AudioDeviceInfo[]>;
+    // @public
+    querySpeakers(): Promise<AudioDeviceInfo[]>;
     removeParticipant(userId: string): Promise<void>;
+    sendMessage(content: string, options?: SendMessageOptions): Promise<void>;
+    sendReadReceipt(chatMessageId: string): Promise<void>;
+    sendTypingIndicator(): Promise<void>;
+    // @public
+    setCamera(sourceInfo: VideoDeviceInfo, options?: VideoStreamOptions): Promise<void>;
+    // @public
+    setMicrophone(sourceInfo: AudioDeviceInfo): Promise<void>;
+    // @public
+    setSpeaker(sourceInfo: AudioDeviceInfo): Promise<void>;
+    // @public
+    startCall(participants: string[]): Call | undefined;
+    // @public
+    startCamera(options?: VideoStreamOptions): Promise<void>;
+    // @public
+    startScreenShare(): Promise<void>;
+    // @public
+    stopCamera(): Promise<void>;
+    // @public
+    stopScreenShare(): Promise<void>;
+    // @public
+    unmute(): Promise<void>;
+    updateMessage(messageId: string, content: string): Promise<void>;
 }
 
 // @beta
@@ -425,14 +468,21 @@ export interface CallWithChatAdapterSubscriptions {
 }
 
 // @beta
-export interface CallWithChatAdapterUiState extends CallAdapterUiState, Omit<ChatAdapterUiState, 'error'> {
+export interface CallWithChatAdapterUiState extends Omit<ChatAdapterUiState, 'error'> {
+    fileUploads?: FileUploadsUiState;
+    // (undocumented)
+    isLocalPreviewMicrophoneEnabled: boolean;
+    // (undocumented)
+    page: CallCompositePage;
 }
 
 // @beta
-export interface CallWithChatClientState extends Pick<CallAdapterClientState, 'devices' | 'isTeamsCall'> {
+export interface CallWithChatClientState {
     call?: CallState;
     chat?: ChatThreadClientState;
+    devices: DeviceManagerState;
     displayName: string | undefined;
+    isTeamsCall: boolean;
     latestCallErrors: AdapterErrors;
     latestChatErrors: AdapterErrors;
     userId: CommunicationIdentifierKind;
@@ -539,8 +589,15 @@ export interface CallWithChatCompositeStrings {
 
 // @beta
 export interface CallWithChatControlOptions extends Pick<CallControlOptions, 'cameraButton' | 'microphoneButton' | 'screenShareButton' | 'displayType'> {
+    cameraButton?: boolean;
     chatButton?: boolean;
+    displayType?: CallControlDisplayType;
+    endCallButton?: boolean;
+    microphoneButton?: boolean;
     peopleButton?: boolean;
+    screenShareButton?: boolean | {
+        disabled: boolean;
+    };
 }
 
 // @beta

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -3,7 +3,7 @@
 
 import React, { useCallback, useState, useMemo, useEffect } from 'react';
 import { LayerHost, mergeStyles, PartialTheme, Stack, Theme } from '@fluentui/react';
-import { CallComposite, CallCompositePage, CallControlOptions } from '../CallComposite';
+import { CallComposite, CallCompositePage, CallControlDisplayType, CallControlOptions } from '../CallComposite';
 import { CallAdapterProvider } from '../CallComposite/adapter/CallAdapterProvider';
 import { EmbeddedChatPane } from './EmbeddedChatPane';
 import { EmbeddedPeoplePane } from './EmbeddedPeoplePane';
@@ -79,6 +79,36 @@ export type CallWithChatCompositeOptions = {
  */
 export interface CallWithChatControlOptions
   extends Pick<CallControlOptions, 'cameraButton' | 'microphoneButton' | 'screenShareButton' | 'displayType'> {
+  /**
+   * {@link CallControlDisplayType} to change how the call controls are displayed.
+   * `'compact'` display type will decreases the size of buttons and hide the labels.
+   *
+   * @remarks
+   * If the composite `formFactor` is set to `'mobile'`, the control bar will always use compact view.
+   *
+   * @defaultValue 'default'
+   */
+  displayType?: CallControlDisplayType;
+  /**
+   * Show or Hide Microphone button during a call.
+   * @defaultValue true
+   */
+  microphoneButton?: boolean;
+  /**
+   * Show or Hide Camera Button during a call
+   * @defaultValue true
+   */
+  cameraButton?: boolean;
+  /**
+   * Show, Hide or Disable the screen share button during a call.
+   * @defaultValue true
+   */
+  screenShareButton?: boolean | { disabled: boolean };
+  /**
+   * Show or Hide EndCall button during a call.
+   * @defaultValue true
+   */
+  endCallButton?: boolean;
   /**
    * Show or hide the chat button in the call-with-chat composite control bar.
    * @defaultValue true

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
@@ -36,6 +36,8 @@ export interface CallWithChatAdapterManagement {
   /**
    * Remove a participant from a Call
    * @param userId - UserId of the participant to remove.
+   *
+   * @beta
    */
   removeParticipant(userId: string): Promise<void>;
 
@@ -45,7 +47,7 @@ export interface CallWithChatAdapterManagement {
    *
    * @param microphoneOn - Whether microphone is initially enabled
    *
-   * @public
+   * @beta
    */
   joinCall(microphoneOn?: boolean): Call | undefined;
   /**
@@ -53,7 +55,7 @@ export interface CallWithChatAdapterManagement {
    *
    * @param forEveryone - Whether to remove all participants when leaving
    *
-   * @public
+   * @beta
    */
   leaveCall(forEveryone?: boolean): Promise<void>;
   /**
@@ -62,26 +64,26 @@ export interface CallWithChatAdapterManagement {
    *
    * @param options - Options to control how video streams are rendered {@link @azure/communication-calling#VideoStreamOptions }
    *
-   * @public
+   * @beta
    */
   startCamera(options?: VideoStreamOptions): Promise<void>;
   /**
    * Stop the camera
    * This method will stop rendering a local camera view when the call is not active
    *
-   * @public
+   * @beta
    */
   stopCamera(): Promise<void>;
   /**
    * Mute the current user during the call or disable microphone locally
    *
-   * @public
+   * @beta
    */
   mute(): Promise<void>;
   /**
    * Unmute the current user during the call or enable microphone locally
    *
-   * @public
+   * @beta
    */
   unmute(): Promise<void>;
   /**
@@ -89,19 +91,19 @@ export interface CallWithChatAdapterManagement {
    *
    * @param participants - An array of participant ids to join
    *
-   * @public
+   * @beta
    */
   startCall(participants: string[]): Call | undefined;
   /**
    * Start sharing the screen during a call.
    *
-   * @public
+   * @beta
    */
   startScreenShare(): Promise<void>;
   /**
    * Stop sharing the screen
    *
-   * @public
+   * @beta
    */
   stopScreenShare(): Promise<void>;
   /**
@@ -113,7 +115,7 @@ export interface CallWithChatAdapterManagement {
    * @param remoteUserId - Id of the participant to render, leave it undefined to create the local camera view
    * @param options - Options to control how video streams are rendered {@link @azure/communication-calling#VideoStreamOptions }
    *
-   * @public
+   * @beta
    */
   createStreamView(remoteUserId?: string, options?: VideoStreamOptions): Promise<void>;
   /**
@@ -125,7 +127,7 @@ export interface CallWithChatAdapterManagement {
    * @param remoteUserId - Id of the participant to render, leave it undefined to dispose the local camera view
    * @param options - Options to control how video streams are rendered {@link @azure/communication-calling#VideoStreamOptions }
    *
-   * @public
+   * @beta
    */
   disposeStreamView(remoteUserId?: string, options?: VideoStreamOptions): Promise<void>;
   /**
@@ -136,7 +138,7 @@ export interface CallWithChatAdapterManagement {
    *
    * @param constrain - Define constraints for accessing local devices {@link @azure/communication-calling#PermissionConstraints }
    *
-   * @public
+   * @beta
    */
   askDevicePermission(constrain: PermissionConstraints): Promise<void>;
   /**
@@ -147,7 +149,7 @@ export interface CallWithChatAdapterManagement {
    *
    * @return An array of video device information entities {@link @azure/communication-calling#VideoDeviceInfo }
    *
-   * @public
+   * @beta
    */
   queryCameras(): Promise<VideoDeviceInfo[]>;
   /**
@@ -158,7 +160,7 @@ export interface CallWithChatAdapterManagement {
    *
    * @return An array of audio device information entities {@link @azure/communication-calling#AudioDeviceInfo }
    *
-   * @public
+   * @beta
    */
   queryMicrophones(): Promise<AudioDeviceInfo[]>;
   /**
@@ -169,7 +171,7 @@ export interface CallWithChatAdapterManagement {
    *
    * @return An array of audio device information entities {@link @azure/communication-calling#AudioDeviceInfo }
    *
-   * @public
+   * @beta
    */
   querySpeakers(): Promise<AudioDeviceInfo[]>;
   /**
@@ -178,7 +180,7 @@ export interface CallWithChatAdapterManagement {
    * @param sourceInfo - Camera device to choose, pick one returned by  {@link CallAdapterDeviceManagement#queryCameras }
    * @param options - Options to control how the camera stream is rendered {@link @azure/communication-calling#VideoStreamOptions }
    *
-   * @public
+   * @beta
    */
   setCamera(sourceInfo: VideoDeviceInfo, options?: VideoStreamOptions): Promise<void>;
   /**
@@ -186,7 +188,7 @@ export interface CallWithChatAdapterManagement {
    *
    * @param sourceInfo - Microphone device to choose, pick one returned by {@link CallAdapterDeviceManagement#queryMicrophones }
    *
-   * @public
+   * @beta
    */
   setMicrophone(sourceInfo: AudioDeviceInfo): Promise<void>;
   /**
@@ -194,7 +196,7 @@ export interface CallWithChatAdapterManagement {
    *
    * @param sourceInfo - Speaker device to choose, pick one returned by {@link CallAdapterDeviceManagement#querySpeakers }
    *
-   * @public
+   * @beta
    */
   setSpeaker(sourceInfo: AudioDeviceInfo): Promise<void>;
 
@@ -203,26 +205,38 @@ export interface CallWithChatAdapterManagement {
    * Fetch initial state for the Chat adapter.
    *
    * Performs the minimal fetch necessary for ChatComposite and API methods.
+   *
+   * @beta
    */
   fetchInitialData(): Promise<void>;
   /**
    * Send a message in the thread.
+   *
+   * @beta
    */
   sendMessage(content: string, options?: SendMessageOptions): Promise<void>;
   /**
    * Send a read receipt for a message.
+   *
+   * @beta
    */
   sendReadReceipt(chatMessageId: string): Promise<void>;
   /**
    * Send typing indicator in the thread.
+   *
+   * @beta
    */
   sendTypingIndicator(): Promise<void>;
   /**
    * Update a message content.
+   *
+   * @beta
    */
   updateMessage(messageId: string, content: string): Promise<void>;
   /**
    * Delete a message in the thread.
+   *
+   * @beta
    */
   deleteMessage(messageId: string): Promise<void>;
   /**
@@ -231,6 +245,7 @@ export interface CallWithChatAdapterManagement {
    * @remarks
    * This method is usually used to control incremental fetch/infinite scroll
    *
+   * @beta
    */
   loadPreviousChatMessages(messagesToLoad: number): Promise<boolean>;
 }

--- a/packages/react-composites/src/composites/CallWithChatComposite/state/CallWithChatAdapterState.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/state/CallWithChatAdapterState.ts
@@ -16,13 +16,24 @@ import { AdapterErrors } from '../../common/adapters';
  * @beta
  */
 export interface CallWithChatAdapterUiState extends Omit<ChatAdapterUiState, 'error'> {
+  /**
+   * Microphone state before a call has joined.
+   *
+   * @beta
+   */
   isLocalPreviewMicrophoneEnabled: boolean;
+  /**
+   * Current page of the Composite.
+   *
+   * @beta
+   */
   page: CallCompositePage;
   /* @conditional-compile-remove(file-sharing) */
   /**
    * Files being uploaded by a user in the current thread.
    * Should be set to null once the upload is complete.
    * Array of type {@link FileUploadsUiState}
+   *
    * @beta
    */
   fileUploads?: FileUploadsUiState;

--- a/packages/react-composites/src/composites/CallWithChatComposite/state/CallWithChatAdapterState.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/state/CallWithChatAdapterState.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT license.
 
 import { CommunicationIdentifierKind } from '@azure/communication-common';
-import { CallState } from '@internal/calling-stateful-client';
+import { CallState, DeviceManagerState } from '@internal/calling-stateful-client';
 import { ChatThreadClientState } from '@internal/chat-stateful-client';
-import { CallAdapter, CallAdapterClientState, CallAdapterState, CallAdapterUiState } from '../../CallComposite';
+import { CallAdapter, CallAdapterState, CallCompositePage } from '../../CallComposite';
 import { ChatAdapter, ChatAdapterState, ChatAdapterUiState } from '../../ChatComposite';
+/* @conditional-compile-remove(file-sharing) */
+import { FileUploadsUiState } from '../../ChatComposite';
 import { AdapterErrors } from '../../common/adapters';
 
 /**
@@ -13,14 +15,25 @@ import { AdapterErrors } from '../../common/adapters';
  *
  * @beta
  */
-export interface CallWithChatAdapterUiState extends CallAdapterUiState, Omit<ChatAdapterUiState, 'error'> {}
+export interface CallWithChatAdapterUiState extends Omit<ChatAdapterUiState, 'error'> {
+  isLocalPreviewMicrophoneEnabled: boolean;
+  page: CallCompositePage;
+  /* @conditional-compile-remove(file-sharing) */
+  /**
+   * Files being uploaded by a user in the current thread.
+   * Should be set to null once the upload is complete.
+   * Array of type {@link FileUploadsUiState}
+   * @beta
+   */
+  fileUploads?: FileUploadsUiState;
+}
 
 /**
  * State from the backend services that drives {@link CallWithChatComposite}.
  *
  * @beta
  */
-export interface CallWithChatClientState extends Pick<CallAdapterClientState, 'devices' | 'isTeamsCall'> {
+export interface CallWithChatClientState {
   /** ID of the call participant using this CallWithChatAdapter. */
   userId: CommunicationIdentifierKind;
   /** Display name of the participant using this CallWithChatAdapter. */
@@ -33,6 +46,10 @@ export interface CallWithChatClientState extends Pick<CallAdapterClientState, 'd
   latestCallErrors: AdapterErrors;
   /** Latest chat error encountered for each operation performed via the adapter. */
   latestChatErrors: AdapterErrors;
+  /** State of available and currently selected devices */
+  devices: DeviceManagerState;
+  /** State of whether the active call is a Teams interop call */
+  isTeamsCall: boolean;
 }
 
 /**


### PR DESCRIPTION
# What
Flatten following CallWithChatComposite APIs that were using Pick and Omit:
* CallWithChatAdapterManagement
* CallWithChatAdapterUiState
* CallWithChatClientState
* CallWithChatControlOptions

# Why
Azure Review Board guidance -- doing so improves intellisense, improves doc generation and improves dev experience when looking at the API in the .d.ts file.

# How Tested
n/a