### PR TITLE
Updating calling sdk for beta to 1.4.3-beta.1

### DIFF
--- a/change/@internal-calling-component-bindings-7000ef8d-bfac-4ca8-8394-9d55de340323.json
+++ b/change/@internal-calling-component-bindings-7000ef8d-bfac-4ca8-8394-9d55de340323.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrading calling to 1.4.3-beta.1",
+  "packageName": "@internal/calling-component-bindings",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-calling-stateful-client-2c86a0ae-ec23-4a11-8b74-0c7cb5048296.json
+++ b/change/@internal-calling-stateful-client-2c86a0ae-ec23-4a11-8b74-0c7cb5048296.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrading calling to 1.4.3-beta.1",
+  "packageName": "@internal/calling-stateful-client",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-react-composites-0b7ebfa3-5289-4d84-ba16-0008ae2bf3dd.json
+++ b/change/@internal-react-composites-0b7ebfa3-5289-4d84-ba16-0008ae2bf3dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrading calling to 1.4.3-beta.1",
+  "packageName": "@internal/react-composites",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-storybook-e533c5b6-8118-41fb-9b23-c8a3402c174a.json
+++ b/change/@internal-storybook-e533c5b6-8118-41fb-9b23-c8a3402c174a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrading calling to 1.4.3-beta.1",
+  "packageName": "@internal/storybook",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/babel/.babelrc.js
+++ b/common/config/babel/.babelrc.js
@@ -11,7 +11,7 @@ process.env['COMMUNICATION_REACT_FLAVOR'] === 'stable' &&
         'call-with-chat-composite',
         // Flag to add API only available in beta calling SDK to mocks and internal types.
         // This feature should be stabilized whenever calling SDK is stabilized.
-        'calling-1.4.2-beta.1',
+        'calling-1.4.3-beta.1',
         // Participant pane in the `ChatComposite`.
         'chat-composite-participant-pane',
         // API for injecting custom buttons in he control bar for

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -24,7 +24,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "@azure/communication-calling": "1.4.2-beta.1"
+    "@azure/communication-calling": "1.4.3-beta.1"
   },
 
   /**
@@ -52,7 +52,7 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
-    "@azure/communication-calling": ["1.4.2-beta.1"],
+    "@azure/communication-calling": ["1.4.3-beta.1"],
     "webpack": [
       // All projects should use this version by default
       "5.38.1",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,5 +1,5 @@
 dependencies:
-  '@azure/communication-calling': 1.4.3-beta.1
+  '@azure/communication-calling': 1.4.2-beta.1
   '@rush-temp/acs-ui-common': file:projects/acs-ui-common.tgz
   '@rush-temp/calling': file:projects/calling.tgz
   '@rush-temp/calling-component-bindings': file:projects/calling-component-bindings.tgz
@@ -35,13 +35,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-TiUsXQroFt6xy3yydMfaybi/q9z0mO8V/PL9CqPDIpkbQhgcDI7t+6fSP8DBCtWzpuq8gbTPPOvTgZCDb48BIA==
-  /@azure/communication-calling/1.4.3-beta.1:
-    dependencies:
-      '@azure/communication-common': 1.1.0
-      '@azure/logger': 1.0.3
-    dev: false
-    resolution:
-      integrity: sha512-MTT82cFqOyKVxVlaCRR36Qp9zUh2IZD2kJhr3fcmY5bPEB+BBJbI2rmHxmSmg9L8ri+9d6sN9Gkmjocp5yWhwg==
   /@azure/communication-chat/1.1.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -18908,7 +18901,7 @@ packages:
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.2-beta.1
       '@azure/communication-common': 1.1.0
       '@babel/cli': 7.16.0_@babel+core@7.16.5
       '@babel/core': 7.16.5
@@ -18943,12 +18936,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-cutADiM1bHbpA1YlPI2oAULa583pwzF4W44yFX8LUOls82nwErNxYvCxVXeLJfcvDTYYmbYhxFUr94Bd1G8qVg==
+      integrity: sha512-yH3HaUlLpmJpBR9rV5P2I0ECibbmgkQrGYiKbrVGG2+UGAKmfJW3894+/w6PL4sj9bxi83uxtgWz6XDPrzHTfw==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.2-beta.1
       '@azure/communication-common': 1.1.0
       '@azure/core-auth': 1.3.2
       '@azure/logger': 1.0.3
@@ -18983,12 +18976,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-kKHxs1VpmII9S99O6A4kWZ/tfoF8pi1uSt9QgVrFd1eNHsLVsiv64VVBdD5eJW3GSGBfSIE8+cHwtlyEUeJKkQ==
+      integrity: sha512-qSlFf8gBjtMW1O/dSGJv3MgNfJt7DdLlnl1iahtw0/ruQryGzrE9eoafLDMYjMDEGbKZ+2XvFWRYb9esWI5x/Q==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.2-beta.1
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19059,12 +19052,12 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-8WxToH2/JoSiw9sFqfMa/EWKFFCcHuvoh4TVE5M8HU1HXU5HlnuQHx6ch/VEqrnK7y7+kk5yp2YoG2Jko9vVfA==
+      integrity: sha512-bHZzPHVkBztaCvIyrLjlCd327INL76KzA4qmHXaVg7ajIuOt6DF1d+UAjmpgdIhs+lLW/RNmNQGzReiTNXNzMw==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.2-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19129,7 +19122,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-bJCy2c0fTqvxGIR8GHJ18PervoKhU7fstYlsxZEprsuhuNQ+zfpnzygoHn2RleZ2aqII5T2cyzFtC4Y8uKcSAQ==
+      integrity: sha512-pCYcwO9PuNXywIX2zMN2ZUwoD0y7yHVaF554yHZEIHeMs0WnKjbKHPNhb+bUrkzZ9sK8mR5KOXcmZZQ50mAJvQ==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19169,7 +19162,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-component-bindings'
     resolution:
-      integrity: sha512-5C5ZgVJZZ41p0UYeKnpZ1IW3uQ1WYqB1v2WfVy2b4P0P9z9iBWm9UT5ZkOC3K4/PwuEPNQgFfM0a35cZbcJBvg==
+      integrity: sha512-adgLJEXkz3WFvsr5O6IZLebKuXXCMfKscUgmWNMtIBBc8q9MsL4ARhct7QlJYY2/YQMOUqIytfAIZVdIXg+UwA==
       tarball: file:projects/chat-component-bindings.tgz
     version: 0.0.0
   file:projects/chat-stateful-client.tgz:
@@ -19212,7 +19205,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-stateful-client'
     resolution:
-      integrity: sha512-u508FuuM/m+KxEJ1qUfX4FfZRUIIlw7W2uKtddvnir89Bbh6ykBRL0zUf4xSH4UFGvOWlPfeawasjBRKHOfSJA==
+      integrity: sha512-wPk2IRkBCzPbcirc9G54Uknb6adDm5lSIJWCjJ0rduWC9iWF0ciVUevtLuUb7LFDnba4z2g9yrCnTMMC/KnACQ==
       tarball: file:projects/chat-stateful-client.tgz
     version: 0.0.0
   file:projects/chat.tgz:
@@ -19282,7 +19275,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-dLR+d77JSPP0dZkPSyMcn3NvkufjhwORHW7z5Y/iXMGMLbuo1YvyGjSTG3hcIzVGfr1KzdLafGM3t13INsKlXg==
+      integrity: sha512-mZe/28aynVme9M4UV9udZD+QFtACLNmtnIAKX73phcINw7MYnPvM257R2gGguriUrTFeWBhCMwfuCPTz2hsviA==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19301,12 +19294,12 @@ packages:
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-+/SvCeXHP+I+KGKtX3Z8Dh9J5kGV2oGndNmmjoudEyM52hnhllpI6vMCx9QZtz0iDmmPY0dLbeF4HIencKGymA==
+      integrity: sha512-bObzxLGBLUumCqTl+ryU7DrGh2N+BQ1FJ/9oBr9vnCznqSaodDzA245Xy8XzzVnjiq4UxsXzogltVdyvVGDxbg==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.2-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19389,12 +19382,12 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-oIo9MosnpVtKKBoHp6mcfAfxsAlO2NiJoJCgFt37Nhcj+3bX3+IHz/bw5myW7K8HlSdiYNTK7h2nE8CopNNn4Q==
+      integrity: sha512-r+Pco15/qKUlnL9YgYT3mU/8VAnCXhRtJozZufVoGmrYVE0m4syseHjfc2ZPS8+P0bLWFE52/3rhazCYEXWqzg==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.2-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19459,7 +19452,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-VztexFd/MVSlsjQIKO+Kykf37w16Nxkv+aZ7fms96B7Ga+Qc6y5eRcwKm0aDHmW9aPz1dkjXwskgCrRU+WrP1g==
+      integrity: sha512-vf5eOrCMY/7OW7weLtfQXRFHC3LJ+NXF7S+XEwNoanGwDbkM4QDJTvXidcEvqnsGUx3BLz+IroI5JtKQgybSyQ==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19565,12 +19558,12 @@ packages:
     dev: false
     name: '@rush-temp/react-components'
     resolution:
-      integrity: sha512-sjSb69iJfvBK+EBQ7bYCBPaHfjW+x0H0brUXoWnk1IZaLAggVcJLweDve3Ljr963YiDysrrrpgcMMt1GFaRpWQ==
+      integrity: sha512-MQlgnk/LDTFnjOolauZk0Ptz6XpcclU+wvDzyids/CpyiTJhXZs5t8Sw/EkXXNY7BlwpYvceEywfhE8tsSbhPQ==
       tarball: file:projects/react-components.tgz
     version: 0.0.0
   file:projects/react-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.2-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19673,12 +19666,12 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-HhD8oVWhGYj4bzj24as27zkvssgr3BGfAmuBZ97B/DsWenPcOg4GZS5bpzlMu/BmSSMjJ4TDUcAZDfJw5Xuxcg==
+      integrity: sha512-zGkskmhaxO4pHSzHZ0o/VXdb2z1M5WTxOPEuAkQjjzoYrEBylswLCtobEDvZ9pNDFQXyygRBOVhaCkpFw4lEVQ==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.2-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19697,12 +19690,12 @@ packages:
     dev: false
     name: '@rush-temp/sample-automation-tests'
     resolution:
-      integrity: sha512-D8c8CL1xH+5Di19CtD1k+XqawIOV6lqN95seVGex5wJG/4viNh4KfNpEd6YSsWj7l/NLETTQ7OhYYR3S/8SHbw==
+      integrity: sha512-xgz3WpbmiiSWadyOiEkX/NLVIJdI3d4WkK4pHmMzFGAvwW0g9fOT5bFuJNBljxoQHONy2xE12rJlcZiv9V/dKw==
       tarball: file:projects/sample-automation-tests.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.2-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19733,7 +19726,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-RbD3GUsavvligolgodsm7EHmnB06b02suNCt/TCclDoocXqVL/lPWtUz1gVpbqdACtFpv2JLzx2O/x+O7jz3QQ==
+      integrity: sha512-0Ny7H1RUdKj9DhYMZXem49H0MrS9SQc+nglNoHR0iZgrqRsHNKubkYR5I6b5wtL26YLIZpR82DZyHN8oKF4iBw==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -19793,7 +19786,7 @@ packages:
     version: 0.0.0
   file:projects/storybook.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.2-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19891,11 +19884,11 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-9Px40j9S3ClncRJTQB24Um9o35B0ATXOPr0Y0FCnuNnwfvruybWyNl9Z5ifsjWlefO+Q6Xpb0Jo+07jbGbKLaQ==
+      integrity: sha512-d3bFIiFLBYQkPFNanlbWjhSrSFxwdpJJ+N+SbUP5YOAahWqOgryqbXMIvjRmAkEtChviVf7+Q7nW9isA7YK+lQ==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:
-  '@azure/communication-calling': 1.4.3-beta.1
+  '@azure/communication-calling': 1.4.2-beta.1
   '@rush-temp/acs-ui-common': file:./projects/acs-ui-common.tgz
   '@rush-temp/calling': file:./projects/calling.tgz
   '@rush-temp/calling-component-bindings': file:./projects/calling-component-bindings.tgz

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,5 +1,5 @@
 dependencies:
-  '@azure/communication-calling': 1.4.2-beta.1
+  '@azure/communication-calling': 1.4.3-beta.1
   '@rush-temp/acs-ui-common': file:projects/acs-ui-common.tgz
   '@rush-temp/calling': file:projects/calling.tgz
   '@rush-temp/calling-component-bindings': file:projects/calling-component-bindings.tgz
@@ -35,6 +35,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-TiUsXQroFt6xy3yydMfaybi/q9z0mO8V/PL9CqPDIpkbQhgcDI7t+6fSP8DBCtWzpuq8gbTPPOvTgZCDb48BIA==
+  /@azure/communication-calling/1.4.3-beta.1:
+    dependencies:
+      '@azure/communication-common': 1.1.0
+      '@azure/logger': 1.0.3
+    dev: false
+    resolution:
+      integrity: sha512-MTT82cFqOyKVxVlaCRR36Qp9zUh2IZD2kJhr3fcmY5bPEB+BBJbI2rmHxmSmg9L8ri+9d6sN9Gkmjocp5yWhwg==
   /@azure/communication-chat/1.1.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -18901,7 +18908,7 @@ packages:
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-common': 1.1.0
       '@babel/cli': 7.16.0_@babel+core@7.16.5
       '@babel/core': 7.16.5
@@ -18936,12 +18943,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-yH3HaUlLpmJpBR9rV5P2I0ECibbmgkQrGYiKbrVGG2+UGAKmfJW3894+/w6PL4sj9bxi83uxtgWz6XDPrzHTfw==
+      integrity: sha512-cutADiM1bHbpA1YlPI2oAULa583pwzF4W44yFX8LUOls82nwErNxYvCxVXeLJfcvDTYYmbYhxFUr94Bd1G8qVg==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-common': 1.1.0
       '@azure/core-auth': 1.3.2
       '@azure/logger': 1.0.3
@@ -18976,12 +18983,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-qSlFf8gBjtMW1O/dSGJv3MgNfJt7DdLlnl1iahtw0/ruQryGzrE9eoafLDMYjMDEGbKZ+2XvFWRYb9esWI5x/Q==
+      integrity: sha512-kKHxs1VpmII9S99O6A4kWZ/tfoF8pi1uSt9QgVrFd1eNHsLVsiv64VVBdD5eJW3GSGBfSIE8+cHwtlyEUeJKkQ==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19052,12 +19059,12 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-bHZzPHVkBztaCvIyrLjlCd327INL76KzA4qmHXaVg7ajIuOt6DF1d+UAjmpgdIhs+lLW/RNmNQGzReiTNXNzMw==
+      integrity: sha512-8WxToH2/JoSiw9sFqfMa/EWKFFCcHuvoh4TVE5M8HU1HXU5HlnuQHx6ch/VEqrnK7y7+kk5yp2YoG2Jko9vVfA==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19122,7 +19129,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-pCYcwO9PuNXywIX2zMN2ZUwoD0y7yHVaF554yHZEIHeMs0WnKjbKHPNhb+bUrkzZ9sK8mR5KOXcmZZQ50mAJvQ==
+      integrity: sha512-bJCy2c0fTqvxGIR8GHJ18PervoKhU7fstYlsxZEprsuhuNQ+zfpnzygoHn2RleZ2aqII5T2cyzFtC4Y8uKcSAQ==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19162,7 +19169,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-component-bindings'
     resolution:
-      integrity: sha512-adgLJEXkz3WFvsr5O6IZLebKuXXCMfKscUgmWNMtIBBc8q9MsL4ARhct7QlJYY2/YQMOUqIytfAIZVdIXg+UwA==
+      integrity: sha512-5C5ZgVJZZ41p0UYeKnpZ1IW3uQ1WYqB1v2WfVy2b4P0P9z9iBWm9UT5ZkOC3K4/PwuEPNQgFfM0a35cZbcJBvg==
       tarball: file:projects/chat-component-bindings.tgz
     version: 0.0.0
   file:projects/chat-stateful-client.tgz:
@@ -19205,7 +19212,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-stateful-client'
     resolution:
-      integrity: sha512-wPk2IRkBCzPbcirc9G54Uknb6adDm5lSIJWCjJ0rduWC9iWF0ciVUevtLuUb7LFDnba4z2g9yrCnTMMC/KnACQ==
+      integrity: sha512-u508FuuM/m+KxEJ1qUfX4FfZRUIIlw7W2uKtddvnir89Bbh6ykBRL0zUf4xSH4UFGvOWlPfeawasjBRKHOfSJA==
       tarball: file:projects/chat-stateful-client.tgz
     version: 0.0.0
   file:projects/chat.tgz:
@@ -19275,7 +19282,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-mZe/28aynVme9M4UV9udZD+QFtACLNmtnIAKX73phcINw7MYnPvM257R2gGguriUrTFeWBhCMwfuCPTz2hsviA==
+      integrity: sha512-dLR+d77JSPP0dZkPSyMcn3NvkufjhwORHW7z5Y/iXMGMLbuo1YvyGjSTG3hcIzVGfr1KzdLafGM3t13INsKlXg==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19294,12 +19301,12 @@ packages:
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-bObzxLGBLUumCqTl+ryU7DrGh2N+BQ1FJ/9oBr9vnCznqSaodDzA245Xy8XzzVnjiq4UxsXzogltVdyvVGDxbg==
+      integrity: sha512-+/SvCeXHP+I+KGKtX3Z8Dh9J5kGV2oGndNmmjoudEyM52hnhllpI6vMCx9QZtz0iDmmPY0dLbeF4HIencKGymA==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19382,12 +19389,12 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-r+Pco15/qKUlnL9YgYT3mU/8VAnCXhRtJozZufVoGmrYVE0m4syseHjfc2ZPS8+P0bLWFE52/3rhazCYEXWqzg==
+      integrity: sha512-oIo9MosnpVtKKBoHp6mcfAfxsAlO2NiJoJCgFt37Nhcj+3bX3+IHz/bw5myW7K8HlSdiYNTK7h2nE8CopNNn4Q==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19452,7 +19459,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-vf5eOrCMY/7OW7weLtfQXRFHC3LJ+NXF7S+XEwNoanGwDbkM4QDJTvXidcEvqnsGUx3BLz+IroI5JtKQgybSyQ==
+      integrity: sha512-VztexFd/MVSlsjQIKO+Kykf37w16Nxkv+aZ7fms96B7Ga+Qc6y5eRcwKm0aDHmW9aPz1dkjXwskgCrRU+WrP1g==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19558,12 +19565,12 @@ packages:
     dev: false
     name: '@rush-temp/react-components'
     resolution:
-      integrity: sha512-MQlgnk/LDTFnjOolauZk0Ptz6XpcclU+wvDzyids/CpyiTJhXZs5t8Sw/EkXXNY7BlwpYvceEywfhE8tsSbhPQ==
+      integrity: sha512-sjSb69iJfvBK+EBQ7bYCBPaHfjW+x0H0brUXoWnk1IZaLAggVcJLweDve3Ljr963YiDysrrrpgcMMt1GFaRpWQ==
       tarball: file:projects/react-components.tgz
     version: 0.0.0
   file:projects/react-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19666,12 +19673,12 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-zGkskmhaxO4pHSzHZ0o/VXdb2z1M5WTxOPEuAkQjjzoYrEBylswLCtobEDvZ9pNDFQXyygRBOVhaCkpFw4lEVQ==
+      integrity: sha512-HhD8oVWhGYj4bzj24as27zkvssgr3BGfAmuBZ97B/DsWenPcOg4GZS5bpzlMu/BmSSMjJ4TDUcAZDfJw5Xuxcg==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19690,12 +19697,12 @@ packages:
     dev: false
     name: '@rush-temp/sample-automation-tests'
     resolution:
-      integrity: sha512-xgz3WpbmiiSWadyOiEkX/NLVIJdI3d4WkK4pHmMzFGAvwW0g9fOT5bFuJNBljxoQHONy2xE12rJlcZiv9V/dKw==
+      integrity: sha512-D8c8CL1xH+5Di19CtD1k+XqawIOV6lqN95seVGex5wJG/4viNh4KfNpEd6YSsWj7l/NLETTQ7OhYYR3S/8SHbw==
       tarball: file:projects/sample-automation-tests.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19726,7 +19733,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-0Ny7H1RUdKj9DhYMZXem49H0MrS9SQc+nglNoHR0iZgrqRsHNKubkYR5I6b5wtL26YLIZpR82DZyHN8oKF4iBw==
+      integrity: sha512-RbD3GUsavvligolgodsm7EHmnB06b02suNCt/TCclDoocXqVL/lPWtUz1gVpbqdACtFpv2JLzx2O/x+O7jz3QQ==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -19786,7 +19793,7 @@ packages:
     version: 0.0.0
   file:projects/storybook.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19884,11 +19891,11 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-d3bFIiFLBYQkPFNanlbWjhSrSFxwdpJJ+N+SbUP5YOAahWqOgryqbXMIvjRmAkEtChviVf7+Q7nW9isA7YK+lQ==
+      integrity: sha512-9Px40j9S3ClncRJTQB24Um9o35B0ATXOPr0Y0FCnuNnwfvruybWyNl9Z5ifsjWlefO+Q6Xpb0Jo+07jbGbKLaQ==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:
-  '@azure/communication-calling': 1.4.2-beta.1
+  '@azure/communication-calling': 1.4.3-beta.1
   '@rush-temp/acs-ui-common': file:./projects/acs-ui-common.tgz
   '@rush-temp/calling': file:./projects/calling.tgz
   '@rush-temp/calling-component-bindings': file:./projects/calling-component-bindings.tgz

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,5 +1,5 @@
 dependencies:
-  '@azure/communication-calling': 1.4.2-beta.1
+  '@azure/communication-calling': 1.4.3-beta.1
   '@rush-temp/acs-ui-common': file:projects/acs-ui-common.tgz
   '@rush-temp/calling': file:projects/calling.tgz
   '@rush-temp/calling-component-bindings': file:projects/calling-component-bindings.tgz
@@ -35,6 +35,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-TiUsXQroFt6xy3yydMfaybi/q9z0mO8V/PL9CqPDIpkbQhgcDI7t+6fSP8DBCtWzpuq8gbTPPOvTgZCDb48BIA==
+  /@azure/communication-calling/1.4.3-beta.1:
+    dependencies:
+      '@azure/communication-common': 1.1.0
+      '@azure/logger': 1.0.3
+    dev: false
+    resolution:
+      integrity: sha512-MTT82cFqOyKVxVlaCRR36Qp9zUh2IZD2kJhr3fcmY5bPEB+BBJbI2rmHxmSmg9L8ri+9d6sN9Gkmjocp5yWhwg==
   /@azure/communication-chat/1.1.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -18901,7 +18908,7 @@ packages:
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-common': 1.1.0
       '@babel/cli': 7.16.0_@babel+core@7.16.5
       '@babel/core': 7.16.5
@@ -18936,12 +18943,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-u7PlTa8HlETYqvsI00YvSoquP3N/DF4wLjAHF4HFlc7mhpEneixKYYRG4NXL7Om/2nugzU4gEcHbIh01xbVClg==
+      integrity: sha512-cutADiM1bHbpA1YlPI2oAULa583pwzF4W44yFX8LUOls82nwErNxYvCxVXeLJfcvDTYYmbYhxFUr94Bd1G8qVg==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-common': 1.1.0
       '@azure/core-auth': 1.3.2
       '@azure/logger': 1.0.3
@@ -18976,12 +18983,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-d+Q1JueUZvSssYxfNULigcc41xUqCPr0k8mjGvU+q372XAPJ4V5PheZaHlqwbvHjJ4sXnO1wbyY09YGHyqAO/w==
+      integrity: sha512-kKHxs1VpmII9S99O6A4kWZ/tfoF8pi1uSt9QgVrFd1eNHsLVsiv64VVBdD5eJW3GSGBfSIE8+cHwtlyEUeJKkQ==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19052,12 +19059,12 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-2AVUiPhQo1ETu3UorqzSQhOKNaxj4tHYNu8HZUq6zhixE0/wBqYdRUTcHDAIC+8pQgTLWykiVJ6KyW1YBucL6g==
+      integrity: sha512-8WxToH2/JoSiw9sFqfMa/EWKFFCcHuvoh4TVE5M8HU1HXU5HlnuQHx6ch/VEqrnK7y7+kk5yp2YoG2Jko9vVfA==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19122,7 +19129,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-GM5h7+4b2jTN17vQXtXWLMekwkGZFfDyiSlsh3hT/rL54OeCTuQOfbGVeaAKUf0wuaa4sVqFDFHSknTkP5VTsg==
+      integrity: sha512-bJCy2c0fTqvxGIR8GHJ18PervoKhU7fstYlsxZEprsuhuNQ+zfpnzygoHn2RleZ2aqII5T2cyzFtC4Y8uKcSAQ==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19299,7 +19306,7 @@ packages:
     version: 0.0.0
   file:projects/communication-react.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19382,12 +19389,12 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-uwGPn/GiKgtodr8EEPcw5dnlIIX6dq9Jfa7O+ZQ31+M0aJhKqR/8lGWMO8RAQ10NRgjKL1qXXnfnEuIUee2rWg==
+      integrity: sha512-oIo9MosnpVtKKBoHp6mcfAfxsAlO2NiJoJCgFt37Nhcj+3bX3+IHz/bw5myW7K8HlSdiYNTK7h2nE8CopNNn4Q==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19452,7 +19459,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-1ZacFe5Uu5pDhnP/CzpvU6l727+rpe2wqeGmNtr+uPAMZZxIkdO2hTpYkBOnN9/UE5kYIRvUPyGmqoAsjpVvhg==
+      integrity: sha512-VztexFd/MVSlsjQIKO+Kykf37w16Nxkv+aZ7fms96B7Ga+Qc6y5eRcwKm0aDHmW9aPz1dkjXwskgCrRU+WrP1g==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19564,7 +19571,7 @@ packages:
     version: 0.0.0
   file:projects/react-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19667,12 +19674,12 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-k6C2BxWAi49/M+Ak7g/BfX3i8ZZtJQaqOTNih7dvvvh8l9VIpo8JSCkOpcjc4GPejSWF9R5WRg1pBkwD90ffmw==
+      integrity: sha512-HhD8oVWhGYj4bzj24as27zkvssgr3BGfAmuBZ97B/DsWenPcOg4GZS5bpzlMu/BmSSMjJ4TDUcAZDfJw5Xuxcg==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19691,12 +19698,12 @@ packages:
     dev: false
     name: '@rush-temp/sample-automation-tests'
     resolution:
-      integrity: sha512-7Zd6gpcAVfYtUNf2yV+ivQHcrOy7DG+v2ErsCWsrEqvun1p4o0o31gCmvEyjOjbzpA7GPyAkoPvWld7LLaknEQ==
+      integrity: sha512-D8c8CL1xH+5Di19CtD1k+XqawIOV6lqN95seVGex5wJG/4viNh4KfNpEd6YSsWj7l/NLETTQ7OhYYR3S/8SHbw==
       tarball: file:projects/sample-automation-tests.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19727,7 +19734,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-8AQ8l73adiufPPS6Hs+HQ7mkhi54CIFxitG0+hTmQs74FWerilMMf/4wKICtAyQW862Q5BrYdpkXIkL4En5H1Q==
+      integrity: sha512-RbD3GUsavvligolgodsm7EHmnB06b02suNCt/TCclDoocXqVL/lPWtUz1gVpbqdACtFpv2JLzx2O/x+O7jz3QQ==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -19787,7 +19794,7 @@ packages:
     version: 0.0.0
   file:projects/storybook.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.2-beta.1
+      '@azure/communication-calling': 1.4.3-beta.1
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19885,11 +19892,11 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-3ggLpUrTsXzt49f6/TzTPyYz0M1C1mewkY9bA2o+vBpVl0F+NE8jvLMgcxshL/WUeoGkvrLz7w1kvhcyXpME+w==
+      integrity: sha512-9Px40j9S3ClncRJTQB24Um9o35B0ATXOPr0Y0FCnuNnwfvruybWyNl9Z5ifsjWlefO+Q6Xpb0Jo+07jbGbKLaQ==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:
-  '@azure/communication-calling': 1.4.2-beta.1
+  '@azure/communication-calling': 1.4.3-beta.1
   '@rush-temp/acs-ui-common': file:./projects/acs-ui-common.tgz
   '@rush-temp/calling': file:./projects/calling.tgz
   '@rush-temp/calling-component-bindings': file:./projects/calling-component-bindings.tgz

--- a/packages/calling-component-bindings/package.json
+++ b/packages/calling-component-bindings/package.json
@@ -36,12 +36,12 @@
     "reselect": "~4.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@types/react": ">=16.8.0 <18.0.0",
     "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",
     "@microsoft/api-documenter": "~7.12.11",

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -35,10 +35,10 @@
     "immer": "9.0.6"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2"
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/core-auth": "1.3.2",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",

--- a/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
@@ -15,7 +15,7 @@ import {
   TranscriptionCallFeature,
   CallFeatureFactory
 } from '@azure/communication-calling';
-/* @conditional-compile-remove(calling-1.4.2-beta.1) */
+/* @conditional-compile-remove(calling-1.4.3-beta.1) */
 import { GroupChatCallLocator, MeetingLocator, RoomLocator } from '@azure/communication-calling';
 import { CommunicationUserIdentifier, PhoneNumberIdentifier, UnknownIdentifier } from '@azure/communication-common';
 import EventEmitter from 'events';
@@ -79,12 +79,12 @@ class MockCallAgent implements CallAgent {
     return call;
   }
   join(groupLocator: GroupLocator, options?: JoinCallOptions): Call;
-  /* @conditional-compile-remove(calling-1.4.2-beta.1) */
+  /* @conditional-compile-remove(calling-1.4.3-beta.1) */
   join(groupChatCallLoctor: GroupChatCallLocator, options?: JoinCallOptions): Call;
   join(meetingLocator: TeamsMeetingLinkLocator, options?: JoinCallOptions): Call;
-  /* @conditional-compile-remove(calling-1.4.2-beta.1) */
+  /* @conditional-compile-remove(calling-1.4.3-beta.1) */
   join(meetingLocator: MeetingLocator, options?: JoinCallOptions): Call;
-  /* @conditional-compile-remove(calling-1.4.2-beta.1) */
+  /* @conditional-compile-remove(calling-1.4.3-beta.1) */
   join(roomLocator: RoomLocator, options?: JoinCallOptions): Call;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   join(meetingLocator: any, options?: any): Call {
@@ -133,12 +133,12 @@ class MockCallAgentWithMultipleCalls implements CallAgent {
     return call;
   }
   join(groupLocator: GroupLocator, options?: JoinCallOptions): Call;
-  /* @conditional-compile-remove(calling-1.4.2-beta.1) */
+  /* @conditional-compile-remove(calling-1.4.3-beta.1) */
   join(groupChatCallLoctor: GroupChatCallLocator, options?: JoinCallOptions): Call;
   join(meetingLocator: TeamsMeetingLinkLocator, options?: JoinCallOptions): Call;
-  /* @conditional-compile-remove(calling-1.4.2-beta.1) */
+  /* @conditional-compile-remove(calling-1.4.3-beta.1) */
   join(meetingLocator: MeetingLocator, options?: JoinCallOptions): Call;
-  /* @conditional-compile-remove(calling-1.4.2-beta.1) */
+  /* @conditional-compile-remove(calling-1.4.3-beta.1) */
   join(roomLocator: RoomLocator, options?: JoinCallOptions): Call;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   join(meetingLocator: any, options?: any): Call {

--- a/packages/calling-stateful-client/src/TestUtils.ts
+++ b/packages/calling-stateful-client/src/TestUtils.ts
@@ -19,7 +19,7 @@ import {
   CallFeatureFactory,
   CallFeature
 } from '@azure/communication-calling';
-/* @conditional-compile-remove(calling-1.4.2-beta.1) */
+/* @conditional-compile-remove(calling-1.4.3-beta.1) */
 import { CollectionUpdatedEvent, RecordingInfo } from '@azure/communication-calling';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { AccessToken } from '@azure/core-auth';
@@ -95,14 +95,14 @@ export class MockRecordingCallFeatureImpl implements RecordingCallFeature {
   public recordings;
   public emitter = new EventEmitter();
   on(event: 'isRecordingActiveChanged', listener: PropertyChangedEvent): void;
-  /* @conditional-compile-remove(calling-1.4.2-beta.1) */
+  /* @conditional-compile-remove(calling-1.4.3-beta.1) */
   on(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<RecordingInfo>): void;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   on(event: any, listener: any): void {
     this.emitter.on(event, listener);
   }
   off(event: 'isRecordingActiveChanged', listener: PropertyChangedEvent): void;
-  /* @conditional-compile-remove(calling-1.4.2-beta.1) */
+  /* @conditional-compile-remove(calling-1.4.3-beta.1) */
   off(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<RecordingInfo>): void;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   off(event: any, listener: any): void {

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -45,7 +45,7 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/communication-chat": "1.1.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
@@ -80,7 +80,7 @@
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/communication-chat": "1.1.0",
     "@azure/core-auth": "1.3.2",
     "@babel/cli": "~7.16.0",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -70,7 +70,7 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/communication-chat": "1.1.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
@@ -78,7 +78,7 @@
     "react-dom": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-identity": "1.0.0",
     "@babel/cli": "~7.16.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,7 @@
     "lint:quiet": "npm run lint -- --quiet"
   },
   "dependencies": {
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-identity": "1.0.0",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@azure/communication-identity": "1.0.0",
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-react": "1.1.1-beta.1",

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@azure/communication-identity": "1.0.0",
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-react": "1.1.1-beta.1",
     "@azure/core-http": "1.2.4",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@azure/communication-chat": "1.1.0",
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-identity": "1.0.0",
     "@azure/communication-react": "1.1.1-beta.1",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/communication-react": "1.1.1-beta.1",
     "@azure/communication-common": "1.1.0",
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/communication-chat": "1.1.0",
     "react": "~16.14.0",
     "react-dom": "16.13.1",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/communication-react": "1.1.1-beta.1",
-    "@azure/communication-calling": "1.4.2-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-common": "1.1.0",
     "uuid": "^8.1.0",


### PR DESCRIPTION
# What
Upgrading calling to 1.4.3-beta.1

# Why
We want to make sure our customers are on the latest and greatest calling offering.
Customer request to have Calling updated from 1.4.2-beta.1 to 1.4.3-beta.1