### PR TITLE
Bump `@azure/communication-calling` to `1.4.4`

### DIFF
--- a/change/@internal-calling-component-bindings-9654ac72-bace-418e-831b-ba2fb11261b3.json
+++ b/change/@internal-calling-component-bindings-9654ac72-bace-418e-831b-ba2fb11261b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump @azure/communication-calling to 1.4.3",
+  "packageName": "@internal/calling-component-bindings",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-calling-stateful-client-cdf97a1e-7c2f-4512-b7f7-5cc5dd442df5.json
+++ b/change/@internal-calling-stateful-client-cdf97a1e-7c2f-4512-b7f7-5cc5dd442df5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump @azure/communication-calling to 1.4.3",
+  "packageName": "@internal/calling-stateful-client",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-react-composites-1ab3de8c-14a2-4d9e-80c6-39395bfd8a72.json
+++ b/change/@internal-react-composites-1ab3de8c-14a2-4d9e-80c6-39395bfd8a72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump @azure/communication-calling to 1.4.3",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-storybook-3d25be32-5f0f-48fa-9876-2ce86df205c6.json
+++ b/change/@internal-storybook-3d25be32-5f0f-48fa-9876-2ce86df205c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump @azure/communication-calling to 1.4.3",
+  "packageName": "@internal/storybook",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -35,6 +35,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-dO0NAHJ2KqI9NGptmQtQP1C8S4tTokyplxtr4AT5bCgF6Iywg6FbN0R/8MXmMMLb4YJyuh6ewSAXZo4z2PaN6g==
+  /@azure/communication-calling/1.4.3:
+    dependencies:
+      '@azure/communication-common': 1.1.0
+      '@azure/logger': 1.0.3
+    dev: false
+    resolution:
+      integrity: sha512-sREQScjYPR5Ba17p1gh6bzSLFkQWk/tpBq8fK2dBNhM1RvFVQrMqBqzNJV+I06K3CQLTTIDGB+uOazbPPvP1jA==
   /@azure/communication-chat/1.1.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -18900,7 +18907,7 @@ packages:
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
     dependencies:
-      '@azure/communication-calling': 1.3.2
+      '@azure/communication-calling': 1.4.3
       '@azure/communication-common': 1.1.0
       '@babel/cli': 7.16.0_@babel+core@7.16.5
       '@babel/core': 7.16.5
@@ -18935,12 +18942,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-u7PlTa8HlETYqvsI00YvSoquP3N/DF4wLjAHF4HFlc7mhpEneixKYYRG4NXL7Om/2nugzU4gEcHbIh01xbVClg==
+      integrity: sha512-tLO9qirVT8DJ55EIQIp0205uejWIk2MFO8FACsgX5pNhohZFfdmFAw4gR0E17eQUzgZdDlTvUXwS1e+AbH84Bw==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
     dependencies:
-      '@azure/communication-calling': 1.3.2
+      '@azure/communication-calling': 1.4.3
       '@azure/communication-common': 1.1.0
       '@azure/core-auth': 1.3.2
       '@azure/logger': 1.0.3
@@ -18975,12 +18982,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-d+Q1JueUZvSssYxfNULigcc41xUqCPr0k8mjGvU+q372XAPJ4V5PheZaHlqwbvHjJ4sXnO1wbyY09YGHyqAO/w==
+      integrity: sha512-sCoA2iqKrkROnZumfyKjmkGP3vwQcTUcdc1BWUhf5Ef6IZ1QgghMcs6HgMrlU/SwsgwOrP5vUJcRcmKJJfM3Sg==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
     dependencies:
-      '@azure/communication-calling': 1.3.2
+      '@azure/communication-calling': 1.4.3
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19051,12 +19058,12 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-2AVUiPhQo1ETu3UorqzSQhOKNaxj4tHYNu8HZUq6zhixE0/wBqYdRUTcHDAIC+8pQgTLWykiVJ6KyW1YBucL6g==
+      integrity: sha512-JP23jNJRfvaQ1HDCuIBdXSwQDxGMiLMgi1QOTnsmYj+BwfTg0Bv5fKmFNdhgrZkyFHbjqJOyLrEAf+E8Y2bOuw==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
     dependencies:
-      '@azure/communication-calling': 1.3.2
+      '@azure/communication-calling': 1.4.3
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19121,7 +19128,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-GM5h7+4b2jTN17vQXtXWLMekwkGZFfDyiSlsh3hT/rL54OeCTuQOfbGVeaAKUf0wuaa4sVqFDFHSknTkP5VTsg==
+      integrity: sha512-CEOlXj+ShzueKoHxYBPV4eQzx1Aqq+LelE3jcKzQULQ64FvDkIUCI2AvWWemaWuyN65+vfrmINcu5P+tCxHaqA==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19294,7 +19301,7 @@ packages:
     version: 0.0.0
   file:projects/communication-react.tgz:
     dependencies:
-      '@azure/communication-calling': 1.3.2
+      '@azure/communication-calling': 1.4.3
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19377,12 +19384,12 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-uwGPn/GiKgtodr8EEPcw5dnlIIX6dq9Jfa7O+ZQ31+M0aJhKqR/8lGWMO8RAQ10NRgjKL1qXXnfnEuIUee2rWg==
+      integrity: sha512-H35eiFLGmN4iY1DDqT3LrCRt4SLgWr1hglFWbPnEgtC7hk1BLGWNUocRAzOTc3TWNqlWXiexMI8z5wfL+t0+SA==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
     dependencies:
-      '@azure/communication-calling': 1.3.2
+      '@azure/communication-calling': 1.4.3
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19447,7 +19454,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-1ZacFe5Uu5pDhnP/CzpvU6l727+rpe2wqeGmNtr+uPAMZZxIkdO2hTpYkBOnN9/UE5kYIRvUPyGmqoAsjpVvhg==
+      integrity: sha512-zLgwY4kmD1WWhli8gNKKKNcRDmpN39xNNGi8uC2+izv76Mw1dRUvc6yvR3VTkN3/dnX2N1dP9PWq4GJ4XFSNxw==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19557,7 +19564,7 @@ packages:
     version: 0.0.0
   file:projects/react-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.3.2
+      '@azure/communication-calling': 1.4.3
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19660,12 +19667,12 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-k6C2BxWAi49/M+Ak7g/BfX3i8ZZtJQaqOTNih7dvvvh8l9VIpo8JSCkOpcjc4GPejSWF9R5WRg1pBkwD90ffmw==
+      integrity: sha512-fBVKU0dvtYwUxsESmLc1Y6kzpS2TsY3xYypxvmwJKmJItuG2msKn2F2SP7O+F3QJBYNTW3YpkkrecGBt/tOdDw==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
     dependencies:
-      '@azure/communication-calling': 1.3.2
+      '@azure/communication-calling': 1.4.3
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19684,12 +19691,12 @@ packages:
     dev: false
     name: '@rush-temp/sample-automation-tests'
     resolution:
-      integrity: sha512-7Zd6gpcAVfYtUNf2yV+ivQHcrOy7DG+v2ErsCWsrEqvun1p4o0o31gCmvEyjOjbzpA7GPyAkoPvWld7LLaknEQ==
+      integrity: sha512-TuryJdZbcA9crxrD85/bseZMG28m+pgBN6KmYFZEH+NN2tqTOPlZqUs9qUVGZeLnByeggpjAKg8EAZl9E/Rhiw==
       tarball: file:projects/sample-automation-tests.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.3.2
+      '@azure/communication-calling': 1.4.3
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19720,7 +19727,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-8AQ8l73adiufPPS6Hs+HQ7mkhi54CIFxitG0+hTmQs74FWerilMMf/4wKICtAyQW862Q5BrYdpkXIkL4En5H1Q==
+      integrity: sha512-TUcHozi3rt5+jEESsigYacOFiLY2kUWOuWG7IKy4s3vfaRsIMPI0QG7TPIG5ZURrjwR9kgmQ1RI7WGm6u23UyA==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -19779,7 +19786,7 @@ packages:
     version: 0.0.0
   file:projects/storybook.tgz:
     dependencies:
-      '@azure/communication-calling': 1.3.2
+      '@azure/communication-calling': 1.4.3
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19877,7 +19884,7 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-3ggLpUrTsXzt49f6/TzTPyYz0M1C1mewkY9bA2o+vBpVl0F+NE8jvLMgcxshL/WUeoGkvrLz7w1kvhcyXpME+w==
+      integrity: sha512-zj/ST3siF9WSPVNaQjepq1rhJpqq/IL0ZO51rX3SUhn/StNocgEuZAWbkPb9AeFa6nLbURuUjW/dndBsBspy0g==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -35,13 +35,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-dO0NAHJ2KqI9NGptmQtQP1C8S4tTokyplxtr4AT5bCgF6Iywg6FbN0R/8MXmMMLb4YJyuh6ewSAXZo4z2PaN6g==
-  /@azure/communication-calling/1.4.3:
+  /@azure/communication-calling/1.4.4:
     dependencies:
       '@azure/communication-common': 1.1.0
       '@azure/logger': 1.0.3
     dev: false
     resolution:
-      integrity: sha512-sREQScjYPR5Ba17p1gh6bzSLFkQWk/tpBq8fK2dBNhM1RvFVQrMqBqzNJV+I06K3CQLTTIDGB+uOazbPPvP1jA==
+      integrity: sha512-uWzULqnXB7pMIEH8x1mwwT45ncPfAryfoKxd4BtbcL1C3ckMknk/5gP3Ov2/V5DJkoOO3I6A4D1n05eSFRy+zA==
   /@azure/communication-chat/1.1.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -18907,7 +18907,7 @@ packages:
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-common': 1.1.0
       '@babel/cli': 7.16.0_@babel+core@7.16.5
       '@babel/core': 7.16.5
@@ -18942,12 +18942,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-tLO9qirVT8DJ55EIQIp0205uejWIk2MFO8FACsgX5pNhohZFfdmFAw4gR0E17eQUzgZdDlTvUXwS1e+AbH84Bw==
+      integrity: sha512-riXB8KMcD6xpmNv7W/6dd2EguMmibqmYk1Q9B4cXlNkhsq0R4ik4QdKUQjUncxbdBz7nnPvYCn0r0GUDfP68fQ==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-common': 1.1.0
       '@azure/core-auth': 1.3.2
       '@azure/logger': 1.0.3
@@ -18982,12 +18982,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-sCoA2iqKrkROnZumfyKjmkGP3vwQcTUcdc1BWUhf5Ef6IZ1QgghMcs6HgMrlU/SwsgwOrP5vUJcRcmKJJfM3Sg==
+      integrity: sha512-gnyZzjBTmBsD9mazd3d1WVMLRFA0MVslTIFYkW6E32R3Ez+bDwbfQopgXXx3TjOJkaYc5BbdCxZdWyYEyZdw2Q==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19058,12 +19058,12 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-JP23jNJRfvaQ1HDCuIBdXSwQDxGMiLMgi1QOTnsmYj+BwfTg0Bv5fKmFNdhgrZkyFHbjqJOyLrEAf+E8Y2bOuw==
+      integrity: sha512-9BhBeyWvoV+rZAMUJjgjO3JaW70Um71AuoGvK+wqF78Wt3lhHMv4N+QVyg260nLyeYgOCaWnciWWrDo4XroqDA==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19128,7 +19128,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-CEOlXj+ShzueKoHxYBPV4eQzx1Aqq+LelE3jcKzQULQ64FvDkIUCI2AvWWemaWuyN65+vfrmINcu5P+tCxHaqA==
+      integrity: sha512-JNZxAtsdZv9UQWJdyhl+uusvsnfEY/hnUpHgqU/VMjlp/1ecu4TCctdDtyWcRomwhzMBYZGfmNJo6eYRPnXWZg==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19301,7 +19301,7 @@ packages:
     version: 0.0.0
   file:projects/communication-react.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19384,12 +19384,12 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-H35eiFLGmN4iY1DDqT3LrCRt4SLgWr1hglFWbPnEgtC7hk1BLGWNUocRAzOTc3TWNqlWXiexMI8z5wfL+t0+SA==
+      integrity: sha512-6ZKqrOp7UlwVQd+Tm4S+qqX+cMb1+55h/THLtM5GuMpt/9ozhbga1h90GcPDlW/x69NBeTRckqo+HxqbBbfejw==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19454,7 +19454,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-zLgwY4kmD1WWhli8gNKKKNcRDmpN39xNNGi8uC2+izv76Mw1dRUvc6yvR3VTkN3/dnX2N1dP9PWq4GJ4XFSNxw==
+      integrity: sha512-u3jbpfPonYHyKEZ3JuTqw3vXlq+h/qvjb5ahnUPWMVnWIJw98vezJxuoVHdMjfTravGciuHIaVrVVJ2tlklL+g==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19564,7 +19564,7 @@ packages:
     version: 0.0.0
   file:projects/react-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19667,12 +19667,12 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-fBVKU0dvtYwUxsESmLc1Y6kzpS2TsY3xYypxvmwJKmJItuG2msKn2F2SP7O+F3QJBYNTW3YpkkrecGBt/tOdDw==
+      integrity: sha512-aH+b4vzCbWLheWYpGcFfewztrvgiXxzi3WSWxV9za/fSON/KOkK+pUQ7THtTvr02GGfzLVVFVPkP/ehJx6YqaA==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19691,12 +19691,12 @@ packages:
     dev: false
     name: '@rush-temp/sample-automation-tests'
     resolution:
-      integrity: sha512-TuryJdZbcA9crxrD85/bseZMG28m+pgBN6KmYFZEH+NN2tqTOPlZqUs9qUVGZeLnByeggpjAKg8EAZl9E/Rhiw==
+      integrity: sha512-hIvKMFMG24a7EqmSaNjzkqOWLGsHosaUPfFbm799FMIGYH8Q4WofYbu5EWr85tm0V6HHYrDASdxEWBAsCrcvKA==
       tarball: file:projects/sample-automation-tests.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19727,7 +19727,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-TUcHozi3rt5+jEESsigYacOFiLY2kUWOuWG7IKy4s3vfaRsIMPI0QG7TPIG5ZURrjwR9kgmQ1RI7WGm6u23UyA==
+      integrity: sha512-uQDFTpYrLz/3fxu1+TR7z7qoH5nErLKCyEXwTOFjNmN2byEQN06DVZLZcFzetYLjtIjr3T0JwFVW3Akx5rLm6A==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -19786,7 +19786,7 @@ packages:
     version: 0.0.0
   file:projects/storybook.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19884,7 +19884,7 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-zj/ST3siF9WSPVNaQjepq1rhJpqq/IL0ZO51rX3SUhn/StNocgEuZAWbkPb9AeFa6nLbURuUjW/dndBsBspy0g==
+      integrity: sha512-MDVKWn4u6K8ZjQj2NxwuBWNQbsHFYWbvsKfiVoaMbo51cXb+Tzp2vcC9mwauUf0B+RS7wxCgulVPuEewXRFd3w==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:

--- a/packages/calling-component-bindings/package.json
+++ b/packages/calling-component-bindings/package.json
@@ -36,12 +36,12 @@
     "reselect": "~4.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@types/react": ">=16.8.0 <18.0.0",
     "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",
     "@microsoft/api-documenter": "~7.12.11",

--- a/packages/calling-component-bindings/package.json
+++ b/packages/calling-component-bindings/package.json
@@ -36,12 +36,12 @@
     "reselect": "~4.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@types/react": ">=16.8.0 <18.0.0",
     "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",
     "@microsoft/api-documenter": "~7.12.11",

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -35,10 +35,10 @@
     "immer": "9.0.6"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2"
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/core-auth": "1.3.2",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -35,10 +35,10 @@
     "immer": "9.0.6"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3"
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/core-auth": "1.3.2",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",

--- a/packages/calling-stateful-client/src/TestUtils.ts
+++ b/packages/calling-stateful-client/src/TestUtils.ts
@@ -19,7 +19,7 @@ import {
   CallFeatureFactory,
   CallFeature
 } from '@azure/communication-calling';
-import { CollectionUpdatedEvent, RecordingInfo } from '@azure/communication-calling';
+import { CollectionUpdatedEvent } from '@azure/communication-calling';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { AccessToken } from '@azure/core-auth';
 
@@ -94,13 +94,15 @@ export class MockRecordingCallFeatureImpl implements RecordingCallFeature {
   public recordings;
   public emitter = new EventEmitter();
   on(event: 'isRecordingActiveChanged', listener: PropertyChangedEvent): void;
-  on(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<RecordingInfo>): void;
+  // TODO: revert to using `RecordingInfo`.
+  on(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<any>): void;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   on(event: any, listener: any): void {
     this.emitter.on(event, listener);
   }
   off(event: 'isRecordingActiveChanged', listener: PropertyChangedEvent): void;
-  off(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<RecordingInfo>): void;
+  // TODO: revert to using `RecordingInfo`.
+  off(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<any>): void;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   off(event: any, listener: any): void {
     this.emitter.on(event, listener);

--- a/packages/calling-stateful-client/src/TestUtils.ts
+++ b/packages/calling-stateful-client/src/TestUtils.ts
@@ -19,7 +19,7 @@ import {
   CallFeatureFactory,
   CallFeature
 } from '@azure/communication-calling';
-import { CollectionUpdatedEvent } from '@azure/communication-calling';
+import { CollectionUpdatedEvent, RecordingInfo } from '@azure/communication-calling';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { AccessToken } from '@azure/core-auth';
 
@@ -94,15 +94,13 @@ export class MockRecordingCallFeatureImpl implements RecordingCallFeature {
   public recordings;
   public emitter = new EventEmitter();
   on(event: 'isRecordingActiveChanged', listener: PropertyChangedEvent): void;
-  // TODO: revert to using `RecordingInfo`.
-  on(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<any>): void;
+  on(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<RecordingInfo>): void;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   on(event: any, listener: any): void {
     this.emitter.on(event, listener);
   }
   off(event: 'isRecordingActiveChanged', listener: PropertyChangedEvent): void;
-  // TODO: revert to using `RecordingInfo`.
-  off(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<any>): void;
+  off(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<RecordingInfo>): void;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   off(event: any, listener: any): void {
     this.emitter.on(event, listener);

--- a/packages/calling-stateful-client/src/TestUtils.ts
+++ b/packages/calling-stateful-client/src/TestUtils.ts
@@ -19,7 +19,6 @@ import {
   CallFeatureFactory,
   CallFeature
 } from '@azure/communication-calling';
-/* @conditional-compile-remove(calling-1.4.3-beta.1) */
 import { CollectionUpdatedEvent, RecordingInfo } from '@azure/communication-calling';
 import { CommunicationTokenCredential } from '@azure/communication-common';
 import { AccessToken } from '@azure/core-auth';
@@ -95,14 +94,12 @@ export class MockRecordingCallFeatureImpl implements RecordingCallFeature {
   public recordings;
   public emitter = new EventEmitter();
   on(event: 'isRecordingActiveChanged', listener: PropertyChangedEvent): void;
-  /* @conditional-compile-remove(calling-1.4.3-beta.1) */
   on(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<RecordingInfo>): void;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   on(event: any, listener: any): void {
     this.emitter.on(event, listener);
   }
   off(event: 'isRecordingActiveChanged', listener: PropertyChangedEvent): void;
-  /* @conditional-compile-remove(calling-1.4.3-beta.1) */
   off(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<RecordingInfo>): void;
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   off(event: any, listener: any): void {

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -45,7 +45,7 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/communication-chat": "1.1.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
@@ -80,7 +80,7 @@
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/communication-chat": "1.1.0",
     "@azure/core-auth": "1.3.2",
     "@babel/cli": "~7.16.0",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -45,7 +45,7 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/communication-chat": "1.1.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
@@ -80,7 +80,7 @@
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/communication-chat": "1.1.0",
     "@azure/core-auth": "1.3.2",
     "@babel/cli": "~7.16.0",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -70,7 +70,7 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/communication-chat": "1.1.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
@@ -78,7 +78,7 @@
     "react-dom": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-identity": "1.0.0",
     "@babel/cli": "~7.16.0",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -70,7 +70,7 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/communication-chat": "1.1.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
@@ -78,7 +78,7 @@
     "react-dom": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-identity": "1.0.0",
     "@babel/cli": "~7.16.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,7 @@
     "lint:quiet": "npm run lint -- --quiet"
   },
   "dependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-identity": "1.0.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,7 @@
     "lint:quiet": "npm run lint -- --quiet"
   },
   "dependencies": {
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-identity": "1.0.0",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@azure/communication-identity": "1.0.0",
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-react": "1.1.1-beta.1",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@azure/communication-identity": "1.0.0",
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-react": "1.1.1-beta.1",

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@azure/communication-identity": "1.0.0",
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-react": "1.1.1-beta.1",
     "@azure/core-http": "1.2.4",

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@azure/communication-identity": "1.0.0",
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-react": "1.1.1-beta.1",
     "@azure/core-http": "1.2.4",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@azure/communication-chat": "1.1.0",
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-identity": "1.0.0",
     "@azure/communication-react": "1.1.1-beta.1",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@azure/communication-chat": "1.1.0",
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/communication-common": "1.1.0",
     "@azure/communication-identity": "1.0.0",
     "@azure/communication-react": "1.1.1-beta.1",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/communication-react": "1.1.1-beta.1",
     "@azure/communication-common": "1.1.0",
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/communication-chat": "1.1.0",
     "react": "~16.14.0",
     "react-dom": "16.13.1",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/communication-react": "1.1.1-beta.1",
     "@azure/communication-common": "1.1.0",
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/communication-chat": "1.1.0",
     "react": "~16.14.0",
     "react-dom": "16.13.1",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/communication-react": "1.1.1-beta.1",
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.3.2",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-common": "1.1.0",
     "uuid": "^8.1.0",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/communication-react": "1.1.1-beta.1",
-    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.3",
+    "@azure/communication-calling": "1.4.3-beta.1 || 1.4.4",
     "@azure/communication-chat": "1.1.0",
     "@azure/communication-common": "1.1.0",
     "uuid": "^8.1.0",


### PR DESCRIPTION
# What

Bump stable headless calling SDK.

# Why

Has loads of bug fixes and improvements that we'd want our customers to get in our own stable release next.

# How Tested

CI, local calling sample smoke test.
