### PR TITLE
`useAzureCommunicationCallWithChatAdapter`: Dispose adapter on unmount

### DIFF
--- a/change/@internal-react-composites-7d731dcb-276f-4bb3-bc2f-036764ec4d2b.json
+++ b/change/@internal-react-composites-7d731dcb-276f-4bb3-bc2f-036764ec4d2b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "bugfix: Dispose adapter in hook when component unmounts",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -610,6 +610,21 @@ export const useAzureCommunicationCallWithChatAdapter = (
     [adapterRef, afterCreateRef, beforeDisposeRef, credential, displayName, endpoint, locator, userId]
   );
 
+  // Dispose any existing adapter when the component unmounts.
+  useEffect(() => {
+    return () => {
+      (async () => {
+        if (adapterRef.current) {
+          if (beforeDisposeRef.current) {
+            await beforeDisposeRef.current(adapterRef.current);
+          }
+          adapterRef.current.dispose();
+          adapterRef.current = undefined;
+        }
+      })();
+    };
+  }, []);
+
   return adapter;
 };
 


### PR DESCRIPTION
# Why

Discovered bug while working on `useAzureCommunicationCallAdapter` -- if the parent component unmounts, we need to dispose the adapter.

# How Tested

`rush build`
