### PR TITLE
Converting filesharing functions to arrow functions in CallWithChatBackendChatAdapter

### DIFF
--- a/change/@internal-react-composites-a452ee02-2e0c-48a2-acf0-1046466876e9.json
+++ b/change/@internal-react-composites-a452ee02-2e0c-48a2-acf0-1046466876e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Converting filesharing functions to arrow functions in CallWithChatBackendChatAdapter",
+  "packageName": "@internal/react-composites",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedChatAdapter.ts
@@ -89,18 +89,21 @@ export class CallWithChatBackedChatAdapter implements ChatAdapter {
   public setTopic = async (topicName: string): Promise<void> => {
     throw new Error(`Chat Topics are not supported in CallWithChatComposite.`);
   };
+
   /* @conditional-compile-remove(file-sharing) */
-  public registerFileUploads(fileUploads: ObservableFileUpload[]): void {
+  public registerFileUploads = (fileUploads: ObservableFileUpload[]): void => {
     this.callWithChatAdapter.registerFileUploads(fileUploads);
-  }
+  };
+
   /* @conditional-compile-remove(file-sharing) */
-  public clearFileUploads(): void {
+  public clearFileUploads = (): void => {
     this.callWithChatAdapter.clearFileUploads();
-  }
+  };
+
   /* @conditional-compile-remove(file-sharing) */
-  public cancelFileUpload(id: string): void {
+  public cancelFileUpload = (id: string): void => {
     this.callWithChatAdapter.cancelFileUpload(id);
-  }
+  };
 }
 
 function chatAdapterStateFromCallWithChatAdapterState(


### PR DESCRIPTION
# What
Converting filesharing functions to arrow functions in CallWithChatBackendChatAdapter

# Why
Need to implicitly bind this to the functions so that they can be called from components

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->