### PR TITLE
Unblock release/1.2.0 ci

### DIFF
--- a/change/@internal-acs-ui-common-77c4eaed-5848-4790-b44f-981c9b93cbcc.json
+++ b/change/@internal-acs-ui-common-77c4eaed-5848-4790-b44f-981c9b93cbcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @azure/communication-react to 1.2.0",
+  "packageName": "@internal/acs-ui-common",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-calling-component-bindings-6152ab4d-a0a4-4ef5-843c-665c11aa070b.json
+++ b/change/@internal-calling-component-bindings-6152ab4d-a0a4-4ef5-843c-665c11aa070b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @azure/communication-react to 1.2.0",
+  "packageName": "@internal/calling-component-bindings",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-calling-stateful-client-81e635b4-5d23-49c3-92d3-3ebaccc7517e.json
+++ b/change/@internal-calling-stateful-client-81e635b4-5d23-49c3-92d3-3ebaccc7517e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @azure/communication-react to 1.2.0",
+  "packageName": "@internal/calling-stateful-client",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-chat-component-bindings-e1e97081-cd94-460c-9e5d-d9e875a6da8e.json
+++ b/change/@internal-chat-component-bindings-e1e97081-cd94-460c-9e5d-d9e875a6da8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @azure/communication-react to 1.2.0",
+  "packageName": "@internal/chat-component-bindings",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-chat-stateful-client-7f1ec708-1cd1-47c3-a488-236e73d8e1ea.json
+++ b/change/@internal-chat-stateful-client-7f1ec708-1cd1-47c3-a488-236e73d8e1ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @azure/communication-react to 1.2.0",
+  "packageName": "@internal/chat-stateful-client",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-components-44cb5573-fffb-4168-989b-81275bb99b0b.json
+++ b/change/@internal-react-components-44cb5573-fffb-4168-989b-81275bb99b0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @azure/communication-react to 1.2.0",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-composites-8b7b0f6b-6b8d-4e18-8431-13a4d58ce9b7.json
+++ b/change/@internal-react-composites-8b7b0f6b-6b8d-4e18-8431-13a4d58ce9b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @azure/communication-react to 1.2.0",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-storybook-9784a90e-d674-4220-b304-6726fb61e32c.json
+++ b/change/@internal-storybook-9784a90e-d674-4220-b304-6726fb61e32c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @azure/communication-react to 1.2.0",
+  "packageName": "@internal/storybook",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -42,6 +42,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MTT82cFqOyKVxVlaCRR36Qp9zUh2IZD2kJhr3fcmY5bPEB+BBJbI2rmHxmSmg9L8ri+9d6sN9Gkmjocp5yWhwg==
+  /@azure/communication-calling/1.4.4:
+    dependencies:
+      '@azure/communication-common': 1.1.0
+      '@azure/logger': 1.0.3
+    dev: false
+    resolution:
+      integrity: sha512-uWzULqnXB7pMIEH8x1mwwT45ncPfAryfoKxd4BtbcL1C3ckMknk/5gP3Ov2/V5DJkoOO3I6A4D1n05eSFRy+zA==
   /@azure/communication-chat/1.1.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -18908,7 +18915,7 @@ packages:
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-common': 1.1.0
       '@babel/cli': 7.16.0_@babel+core@7.16.5
       '@babel/core': 7.16.5
@@ -18943,12 +18950,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-cutADiM1bHbpA1YlPI2oAULa583pwzF4W44yFX8LUOls82nwErNxYvCxVXeLJfcvDTYYmbYhxFUr94Bd1G8qVg==
+      integrity: sha512-rrUbexYLks6N7n9b1bVlHclG2xePWboa+X8MUMCpnnRYhiUATqomdhh2f+rKqjllyFGr2AaVkXs85GX2Hz9ANg==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-common': 1.1.0
       '@azure/core-auth': 1.3.2
       '@azure/logger': 1.0.3
@@ -18983,12 +18990,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-kKHxs1VpmII9S99O6A4kWZ/tfoF8pi1uSt9QgVrFd1eNHsLVsiv64VVBdD5eJW3GSGBfSIE8+cHwtlyEUeJKkQ==
+      integrity: sha512-Mhefbxlnzv0aTJmHuRdrFjXAqSTPqnzxuESZmvXdvhu8nf9QI6u40b5WKcXV6IqorEHOYdh8vK56Kq6Ii9E9uw==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19059,12 +19066,12 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-8WxToH2/JoSiw9sFqfMa/EWKFFCcHuvoh4TVE5M8HU1HXU5HlnuQHx6ch/VEqrnK7y7+kk5yp2YoG2Jko9vVfA==
+      integrity: sha512-BJ4wgeYrRyXJIC5Y8195j+MQxR1xOvjRhdyYMUu11qo2C3ziAV+jWalzIh9o4RDRvO1il+VswUOd6xCovmwP2w==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19129,7 +19136,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-bJCy2c0fTqvxGIR8GHJ18PervoKhU7fstYlsxZEprsuhuNQ+zfpnzygoHn2RleZ2aqII5T2cyzFtC4Y8uKcSAQ==
+      integrity: sha512-QxUmL+kH1rmz4wqFM1KxoqmVViRaE0SYx5vk4S6E6GkqAoTTuhSNpDgtv87Bzl2nG0XMrS5LTlMHU3FRWpMBig==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19169,7 +19176,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-component-bindings'
     resolution:
-      integrity: sha512-5C5ZgVJZZ41p0UYeKnpZ1IW3uQ1WYqB1v2WfVy2b4P0P9z9iBWm9UT5ZkOC3K4/PwuEPNQgFfM0a35cZbcJBvg==
+      integrity: sha512-97IdhaRzB7QCPZg+fRLwpKXueWNnWQ3MiDDSuWY/cg80MfdQ90iBqaIEiiMsW/85PHti9P92hBr0rJqNccYFfA==
       tarball: file:projects/chat-component-bindings.tgz
     version: 0.0.0
   file:projects/chat-stateful-client.tgz:
@@ -19212,7 +19219,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-stateful-client'
     resolution:
-      integrity: sha512-u508FuuM/m+KxEJ1qUfX4FfZRUIIlw7W2uKtddvnir89Bbh6ykBRL0zUf4xSH4UFGvOWlPfeawasjBRKHOfSJA==
+      integrity: sha512-XaH8bmAhkG9dh69JMfR6swHZJomXI0wCkx727Ye2LfWWvwdg+EjI3lFyCBYOcz3dGSdtZm/FgIrUBrOzqz0U2w==
       tarball: file:projects/chat-stateful-client.tgz
     version: 0.0.0
   file:projects/chat.tgz:
@@ -19282,7 +19289,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-dLR+d77JSPP0dZkPSyMcn3NvkufjhwORHW7z5Y/iXMGMLbuo1YvyGjSTG3hcIzVGfr1KzdLafGM3t13INsKlXg==
+      integrity: sha512-7mY20R2H3DiHyQCRWmaZHt+cI2QBQq2XXnMHsVz4ZcOyV5SbOM7XgnYX40KPuDygBlmHdsyvS57AOsxRkDRBbw==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19301,12 +19308,12 @@ packages:
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-+/SvCeXHP+I+KGKtX3Z8Dh9J5kGV2oGndNmmjoudEyM52hnhllpI6vMCx9QZtz0iDmmPY0dLbeF4HIencKGymA==
+      integrity: sha512-ZPwZH38/URzpMh3AXPJj2PA3psgREvVD8iLY3IAUx22fDN3ZKfcuLRubqLKZpDhDQA+TQNGsHRqFQFaeTCnY9g==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-signaling': 1.0.0-beta.12
@@ -19389,12 +19396,12 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-oIo9MosnpVtKKBoHp6mcfAfxsAlO2NiJoJCgFt37Nhcj+3bX3+IHz/bw5myW7K8HlSdiYNTK7h2nE8CopNNn4Q==
+      integrity: sha512-NCQ0g9QTl5YXraJ161K3fZH1MM04o7XhTM63guxuOlccDmvip0pZjezeeWUHD9oxltvT/fGGZxcrDOi+6BCahA==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19459,7 +19466,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-VztexFd/MVSlsjQIKO+Kykf37w16Nxkv+aZ7fms96B7Ga+Qc6y5eRcwKm0aDHmW9aPz1dkjXwskgCrRU+WrP1g==
+      integrity: sha512-oqKWyqWzgEYwFU85YzsdXUFXVxCcNJ5F6QGfnh7+qqa6wbog3KtYfTKlI4AK2KllfjzD83RPZgs3Kxo3j1qxCQ==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19566,12 +19573,12 @@ packages:
     dev: false
     name: '@rush-temp/react-components'
     resolution:
-      integrity: sha512-4KweHP353P/kFewswei4CpiM+/Orr2CTWje6C/dhmsMuRDMLqNuWQNGQ/zActMqYnAPIc9MQPgugmfOFmvClXQ==
+      integrity: sha512-5CmAaidXTCN3nlngix61C+gEf6PXUJXGTrN1aURhHhYq1wMxJgFgTkdr08XCzP6BkObW/7flftMzzWRpBC4aXg==
       tarball: file:projects/react-components.tgz
     version: 0.0.0
   file:projects/react-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19674,12 +19681,12 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-HhD8oVWhGYj4bzj24as27zkvssgr3BGfAmuBZ97B/DsWenPcOg4GZS5bpzlMu/BmSSMjJ4TDUcAZDfJw5Xuxcg==
+      integrity: sha512-ncviZWHhb/ngbZxzqO7cCje47znajYy27MdE/elSx/nsjpDCtdJBCUlurylau8pPofXAPlqxKwcz9XnWjrV5wA==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19698,12 +19705,12 @@ packages:
     dev: false
     name: '@rush-temp/sample-automation-tests'
     resolution:
-      integrity: sha512-D8c8CL1xH+5Di19CtD1k+XqawIOV6lqN95seVGex5wJG/4viNh4KfNpEd6YSsWj7l/NLETTQ7OhYYR3S/8SHbw==
+      integrity: sha512-tw4PK04DSX8kwoUMt0rpIRauc8LczC0unwfygclALjiVVX+9uiPlkVcgQEU4PK0TY/8kK7J+2RvLFRM1Pn6drg==
       tarball: file:projects/sample-automation-tests.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19734,7 +19741,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-RbD3GUsavvligolgodsm7EHmnB06b02suNCt/TCclDoocXqVL/lPWtUz1gVpbqdACtFpv2JLzx2O/x+O7jz3QQ==
+      integrity: sha512-zomd4S+9HRuX0QXbW8MfalqBwdPmH8+sEPsT63PXnNXvKOI1M6ih+BuT7udwjCWa0IVk4Z/ICGbHUATKIZ/z8Q==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -19794,7 +19801,7 @@ packages:
     version: 0.0.0
   file:projects/storybook.tgz:
     dependencies:
-      '@azure/communication-calling': 1.4.3-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.1.0
       '@azure/communication-common': 1.1.0
       '@azure/communication-identity': 1.0.0
@@ -19892,7 +19899,7 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-9Px40j9S3ClncRJTQB24Um9o35B0ATXOPr0Y0FCnuNnwfvruybWyNl9Z5ifsjWlefO+Q6Xpb0Jo+07jbGbKLaQ==
+      integrity: sha512-beRGMphDXp62dDoqxaSKltzpnE+LTWLfvgfClvU/1cyey1XwXbIlgg+48XrwQSgOUGcLkXzCpR3hwwvL3A2URQ==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:


### PR DESCRIPTION
# What
* Generate release branch no-op changelogs
* Update primary lockfile as this branch has choosen just stable deps.

CI still failing as potentially it should only build stable on the stable release branch?