### PR TITLE
Skip beta snapshots in update-snapshot

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - flavor: 'beta'
           - flavor: 'stable'
     steps:
       # Checkout repo
@@ -104,7 +103,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - flavor: 'beta'
           - flavor: 'stable'
     steps:
       # Checkout repo
@@ -193,7 +191,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - flavor: 'beta'
           - flavor: 'stable'
     steps:
       # Checkout repo


### PR DESCRIPTION
Same as https://github.com/Azure/communication-ui-library/pull/1642 but now we need to also update snapshots on the release branch.