### PR TITLE
Re-add filesharing to callwithchat composite

### DIFF
--- a/change/@internal-react-composites-cfcad608-226c-417d-8a2d-92d86c376774.json
+++ b/change/@internal-react-composites-cfcad608-226c-417d-8a2d-92d86c376774.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add filesharing to callwithchat composite",
+  "packageName": "@internal/react-composites",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -250,6 +250,8 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
             modalLayerHostId={modalLayerHostId}
             mobileView={mobileView}
             activePane={activePane}
+            /* @conditional-compile-remove(file-sharing) */
+            fileSharing={props.fileSharing}
           />
         )}
       </Stack>


### PR DESCRIPTION
# What
FileSharing props in CallWithChat composite got removed by this PR
https://github.com/Azure/communication-ui-library/pull/1617

Need to add them again to make it work

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->