### PR TITLE
Hide `TabHeader` buttons in `CallWithChatComposite` on mobile when chat/people are hidden

### DIFF
--- a/change/@internal-react-composites-d0c51282-4a08-46b4-bb38-706d6319af52.json
+++ b/change/@internal-react-composites-d0c51282-4a08-46b4-bb38-706d6319af52.json
@@ -1,0 +1,10 @@
+{
+  "type": "patch",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -221,6 +221,7 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
   const hasJoinedCall = !!(currentPage && hasJoinedCallFn(currentPage, currentCallState ?? 'None'));
   const showControlBar = isInLobbyOrConnecting || hasJoinedCall;
   const isMobileWithActivePane = mobileView && activePane !== 'none';
+  const showTabHeader = props.callControls;
 
   return (
     <Stack verticalFill grow styles={compositeOuterContainerStyles}>
@@ -244,8 +245,8 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
             chatAdapter={chatProps.adapter}
             callAdapter={callAdapter}
             onFetchAvatarPersonaData={props.onFetchAvatarPersonaData}
-            onChatButtonClicked={selectChat}
-            onPeopleButtonClicked={selectPeople}
+            onChatButtonClicked={shouldShowTabHeaderButtons(props.callControls) ? selectChat : undefined}
+            onPeopleButtonClicked={shouldShowTabHeaderButtons(props.callControls) ? selectPeople : undefined}
             modalLayerHostId={modalLayerHostId}
             mobileView={mobileView}
             activePane={activePane}
@@ -316,3 +317,14 @@ export const CallWithChatComposite = (props: CallWithChatCompositeProps): JSX.El
 
 const hasJoinedCallFn = (page: CallCompositePage, callStatus: CallState): boolean =>
   page === 'call' && callStatus === 'Connected';
+
+const shouldShowTabHeaderButtons = (callControls?: boolean | CallWithChatControlOptions): boolean => {
+  if (callControls === undefined || callControls === true) {
+    return true;
+  }
+  if (callControls === false) {
+    return false;
+  }
+  // If either people or chat button is hidden, there is no need to provide ways to toggle between the two.
+  return callControls.peopleButton !== false && callControls.chatButton !== false;
+};

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
@@ -32,8 +32,8 @@ export const CallWithChatPane = (props: {
   onClose: () => void;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
-  onChatButtonClicked: () => void;
-  onPeopleButtonClicked: () => void;
+  onChatButtonClicked?: () => void;
+  onPeopleButtonClicked?: () => void;
   modalLayerHostId: string;
   activePane: CallWithChatPaneOption;
   mobileView?: boolean;

--- a/packages/react-composites/src/composites/CallWithChatComposite/TabHeader.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/TabHeader.tsx
@@ -16,8 +16,10 @@ import {
  */
 type TabHeaderProps = {
   onClose: () => void;
-  onChatButtonClicked: () => void;
-  onPeopleButtonClicked: () => void;
+  // If set, show a button to open chat tab.
+  onChatButtonClicked?: () => void;
+  // If set, show a button to open people tab.
+  onPeopleButtonClicked?: () => void;
   activeTab: TabHeaderTab;
 };
 
@@ -46,20 +48,24 @@ export const TabHeader = (props: TabHeaderProps): JSX.Element => {
         styles={mobilePaneBackButtonStyles}
         onRenderIcon={() => <ChevronLeftIconTrampoline />}
       ></DefaultButton>
-      <DefaultButton
-        onClick={props.onChatButtonClicked}
-        styles={mobilePaneButtonStylesThemed}
-        checked={props.activeTab === 'chat'}
-      >
-        {strings.chatButtonLabel}
-      </DefaultButton>
-      <DefaultButton
-        onClick={props.onPeopleButtonClicked}
-        styles={mobilePaneButtonStylesThemed}
-        checked={props.activeTab === 'people'}
-      >
-        {strings.peopleButtonLabel}
-      </DefaultButton>
+      {props.onChatButtonClicked && (
+        <DefaultButton
+          onClick={props.onChatButtonClicked}
+          styles={mobilePaneButtonStylesThemed}
+          checked={props.activeTab === 'chat'}
+        >
+          {strings.chatButtonLabel}
+        </DefaultButton>
+      )}
+      {props.onPeopleButtonClicked && (
+        <DefaultButton
+          onClick={props.onPeopleButtonClicked}
+          styles={mobilePaneButtonStylesThemed}
+          checked={props.activeTab === 'people'}
+        >
+          {strings.peopleButtonLabel}
+        </DefaultButton>
+      )}
     </Stack>
   );
 };


### PR DESCRIPTION
# What

When the chat or people button are hidden via `CallWithChatCompositeProps.options.callControls`, we now hide the tab headers shown for switching between people and chat panes on `mobileView`.

# Why

The intention of hiding those buttons is to hide the way to open the people and chat pane, so we hide all the UX that opens those tabs.

# How Tested


https://user-images.githubusercontent.com/82062616/158490919-7744edfb-e0db-4f1f-85ee-7e683bd2c6f5.mp4
