### PR TITLE
Fix Double scroll bar in CallWithChatComposite (#1689)

### DIFF
--- a/change/@internal-react-composites-304ee089-2333-4a7b-a9d2-4cccdb4707c6.json
+++ b/change/@internal-react-composites-304ee089-2333-4a7b-a9d2-4cccdb4707c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Switch scroll behavior in chat styles so that the parent wrapper dosen't have scroll behavior when file sharing icon present.",
+  "packageName": "@internal/react-composites",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/ChatComposite/styles/Chat.styles.ts
+++ b/packages/react-composites/src/composites/ChatComposite/styles/Chat.styles.ts
@@ -44,7 +44,7 @@ export const chatContainer = mergeStyles({
 export const chatArea = mergeStyles({
   height: '100%',
   width: '100%',
-  overflow: 'hidden'
+  overflow: 'auto'
 });
 
 /**
@@ -53,7 +53,7 @@ export const chatArea = mergeStyles({
 export const chatWrapper = mergeStyles({
   height: '100%',
   width: '100%',
-  overflow: 'auto'
+  overflow: 'hidden'
 });
 
 /**


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Update syles for the chat screen
# Why
<!--- What problem does this change solve? -->
removes the double scroll bar in mobile when file sharing is turned on
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2791136
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran locally and visually inspected