### PR TITLE
2nd fix for call id, set right view element to context for client state

### DIFF
--- a/packages/calling-stateful-client/src/InternalCallContext.ts
+++ b/packages/calling-stateful-client/src/InternalCallContext.ts
@@ -184,7 +184,7 @@ export class InternalCallContext {
     this._callIdHistory.set(oldCallId, newCallId);
   }
 
-  private latestCallId(callId: string): string {
+  public latestCallId(callId: string): string {
     let latest = callId;
     /* eslint no-constant-condition: ["error", { "checkLoops": false }] */
     while (true) {

--- a/packages/calling-stateful-client/src/StreamUtils.ts
+++ b/packages/calling-stateful-client/src/StreamUtils.ts
@@ -74,7 +74,9 @@ async function createViewRemoteVideo(
     // RenderInfo was removed. This should not happen unless stream was removed from the call so dispose the renderer
     // and clean up state.
     renderer.dispose();
-    context.setRemoteVideoStreamRendererView(callId, participantKey, streamId, undefined);
+    // get latest call ID because this happens after an await call
+    // Call Id could change between time gap
+    context.setRemoteVideoStreamRendererView(internalContext.latestCallId(callId), participantKey, streamId, undefined);
     return;
   }
 
@@ -90,7 +92,10 @@ async function createViewRemoteVideo(
       'NotRendered',
       undefined
     );
-    context.setRemoteVideoStreamRendererView(callId, participantKey, streamId, undefined);
+
+    // get latest call ID because this happens after an await call
+    // Call Id could change between time gap
+    context.setRemoteVideoStreamRendererView(internalContext.latestCallId(callId), participantKey, streamId, undefined);
     return;
   }
 
@@ -104,8 +109,11 @@ async function createViewRemoteVideo(
     'Rendered',
     renderer
   );
+
+  // get latest call ID because this happens after an await call
+  // Call Id could change between time gap
   context.setRemoteVideoStreamRendererView(
-    callId,
+    internalContext.latestCallId(callId),
     participantKey,
     streamId,
     convertFromSDKToDeclarativeVideoStreamRendererView(view)
@@ -161,7 +169,9 @@ async function createViewLocalVideo(
     // RenderInfo was removed. This should not happen unless stream was removed from the call so dispose the renderer
     // and clean up the state.
     renderer.dispose();
-    context.setLocalVideoStreamRendererView(callId, undefined);
+    // get latest call ID because this happens after an await call
+    // Call Id could change between time gap
+    context.setLocalVideoStreamRendererView(internalContext.latestCallId(callId), undefined);
     return;
   }
 
@@ -170,14 +180,17 @@ async function createViewLocalVideo(
     // put the view into the state.
     renderer.dispose();
     internalContext.setLocalRenderInfo(callId, refreshedRenderInfo.stream, 'NotRendered', undefined);
-    context.setLocalVideoStreamRendererView(callId, undefined);
+    context.setLocalVideoStreamRendererView(internalContext.latestCallId(callId), undefined);
     return;
   }
 
   // Else The stream still exists and status is not telling us to stop rendering. Complete the render process by
   // updating the state.
   internalContext.setLocalRenderInfo(callId, refreshedRenderInfo.stream, 'Rendered', renderer);
-  context.setLocalVideoStreamRendererView(callId, convertFromSDKToDeclarativeVideoStreamRendererView(view));
+  context.setLocalVideoStreamRendererView(
+    internalContext.latestCallId(callId),
+    convertFromSDKToDeclarativeVideoStreamRendererView(view)
+  );
 }
 
 async function createViewUnparentedVideo(


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Similar to the fix for internal context, this fix corrects the right behavior for view element in internal context when there is asynchronous problem happening

Tested in local environment - Combine these 2 fixes together - we are good to facing rapid changing call id issue - the rendering perf is not optimized, but the behavior looks all correct

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->