### PR TITLE
Disable RR details in meeting interop

### DIFF
--- a/change/@internal-chat-component-bindings-82459451-1502-436b-bf85-94bc70a93fc2.json
+++ b/change/@internal-chat-component-bindings-82459451-1502-436b-bf85-94bc70a93fc2.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Disable RR in meeting interop",
+  "comment": "Disable Read Receipt details in meeting interop",
   "packageName": "@internal/chat-component-bindings",
   "email": "jiangnanhello@live.com",
   "dependentChangeType": "patch"

--- a/change/@internal-chat-component-bindings-82459451-1502-436b-bf85-94bc70a93fc2.json
+++ b/change/@internal-chat-component-bindings-82459451-1502-436b-bf85-94bc70a93fc2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disable RR in meeting interop",
+  "packageName": "@internal/chat-component-bindings",
+  "email": "jiangnanhello@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-component-bindings/src/messageThreadSelector.ts
+++ b/packages/chat-component-bindings/src/messageThreadSelector.ts
@@ -32,8 +32,8 @@ const memoizedAllConvertChatMessage = memoizeFnAll(
     userId: string,
     isSeen: boolean,
     isLargeGroup: boolean,
-    readNumber: number,
-    readBy: { id: string; name: string }[]
+    readNumber?: number,
+    readBy?: { id: string; name: string }[]
   ): Message => {
     const messageType = chatMessage.type.toLowerCase();
     if (
@@ -53,8 +53,8 @@ const convertToUiChatMessage = (
   userId: string,
   isSeen: boolean,
   isLargeGroup: boolean,
-  readNumber: number,
-  readBy: { id: string; name: string }[]
+  readNumber?: number,
+  readBy?: { id: string; name: string }[]
 ): ChatMessage => {
   const messageSenderId = message.sender !== undefined ? toFlatCommunicationIdentifier(message.sender) : userId;
   return {
@@ -143,7 +143,7 @@ export const messageThreadSelector: MessageThreadSelector = createSelector(
     // filter out the non valid participants (no display name)
     // Read Receipt details will be disabled when participant count is 0
     const messageThreadParticipantCount = isTeamsInterop
-      ? 0
+      ? undefined
       : Object.values(participants).filter((p) => p.displayName && p.displayName !== '').length;
 
     // creating key value pairs of senderID: last read message information
@@ -175,10 +175,9 @@ export const messageThreadSelector: MessageThreadSelector = createSelector(
         )
         .filter((message) => message.content && message.content.message !== '') // TODO: deal with deleted message and remove
         .map((message) => {
-          const readBy: { id: string; name: string }[] = getParticipantsWhoHaveReadMessage(
-            message,
-            readReceiptForEachSender
-          );
+          const readBy = isTeamsInterop
+            ? undefined
+            : getParticipantsWhoHaveReadMessage(message, readReceiptForEachSender);
 
           return memoizedFn(
             message.id ?? message.clientMessageId,
@@ -186,7 +185,7 @@ export const messageThreadSelector: MessageThreadSelector = createSelector(
             userId,
             message.createdOn <= latestReadTime,
             isLargeGroup,
-            readBy.length,
+            readBy?.length,
             readBy
           );
         })

--- a/packages/chat-component-bindings/src/messageThreadSelector.ts
+++ b/packages/chat-component-bindings/src/messageThreadSelector.ts
@@ -136,11 +136,15 @@ const hasValidParticipant = (chatMessage: ChatMessageWithStatus): boolean =>
 export const messageThreadSelector: MessageThreadSelector = createSelector(
   [getUserId, getChatMessages, getLatestReadTime, getIsLargeGroup, getReadReceipts, getParticipants],
   (userId, chatMessages, latestReadTime, isLargeGroup, readReceipts, participants) => {
+    // We can't get displayName in teams meeting interop for now, disable rr feature when it is teams interop
+    const isTeamsInterop = Object.values(participants).find((p) => 'microsoftTeamsUserId' in p.id) !== undefined;
+
     // get number of participants
     // filter out the non valid participants (no display name)
-    const messageThreadParticipantCount = Object.values(participants).filter(
-      (p) => p.displayName && p.displayName !== ''
-    ).length;
+    // Read Receipt details will be disabled when participant count is 0
+    const messageThreadParticipantCount = isTeamsInterop
+      ? 0
+      : Object.values(participants).filter((p) => p.displayName && p.displayName !== '').length;
 
     // creating key value pairs of senderID: last read message information
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Disable RR details in meeting interop 

This is to not introduce problematic behavior into 1.2.0 when it is teams interop

Currently we can't get display name when it is meeting interop - because teams user are not joining using ACS, so the display name roster doesn't include displayName for teams user.

There are 2 solutions we might want to consider for future work:
1. Get display name from calling side when it is callWithChat component - no extra setup, but will only work for meeting scenarios
2. Provide our customers snippet on render custom display name and connect teams user name using AAD (extra set up and coding needed, but a more general solution)
Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->

