### PR TITLE
Upload `api.json` files in ci build action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
       # Tests
       - name: Test Packages
         run: rush test -t @azure/communication-react
+      # Upload azure-communication api.md files for easy access
+      - name: Upload communication-react api files
+        uses: actions/upload-artifact@v2
+        with:
+          name: communication-react.${{ matrix.flavor }}.api.json
+          path: |
+            packages/communication-react/temp/communication-react.api.json
 
   call_composite_automation_test:
     name: Call Composite automation test


### PR DESCRIPTION
# What
Upload the beta and stable generated api.json files during CI builds

# Why
For easy access to upload to APIView

# How Tested
See artifacts uploaded in test run: https://github.com/Azure/communication-ui-library/runs/5745695409?check_suite_focus=true