### PR TITLE
[mitigation] Squelch "Not In Thread" Error shown to user

### DIFF
--- a/change/@internal-chat-component-bindings-cdf4f9b9-4292-41f0-b43e-c287b82c2ffd.json
+++ b/change/@internal-chat-component-bindings-cdf4f9b9-4292-41f0-b43e-c287b82c2ffd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Do not show \"Not In Thread\" Error Banner shown to user when a BotContact is a participant in Teams Interop Chats",
+  "packageName": "@internal/chat-component-bindings",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-component-bindings/src/errorBarSelector.ts
+++ b/packages/chat-component-bindings/src/errorBarSelector.ts
@@ -116,7 +116,7 @@ const latestNotInThisThreadError = (latestErrors: ChatErrors): ActiveErrorMessag
     // To the best of our ability we have confirmed this to have no impact on the participantList returned (all valid participants are still returned), nor
     // does it have an impact on the participant list updating on other participants joining/leaving or on individual participant actions like removeParticipant.
     if (isErrorDueToBotContact(error)) {
-      // return false;
+      return false;
     }
 
     // Chat service returns 403 if a user has been removed from a thread.


### PR DESCRIPTION
# What
Filter out a specific rest error from being presented to the user

# Why
Currently we are showing a miscellanous "User no longer has access to this thread" Error Banner shown to user when they do in fact still have access.
This is because of a Chat SDK issue when a BotContact is a participant in Teams Interop Chats

# How Tested
Locally ran and no longer shows the Not In Thread error