### PR TITLE
Storybook: Update references to the correct @azure/communication-calling version

### DIFF
--- a/change/@internal-storybook-06e85c4f-f784-4063-99a3-6f747fa69e1d.json
+++ b/change/@internal-storybook-06e85c4f-f784-4063-99a3-6f747fa69e1d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update references to headless calling version",
+  "packageName": "@internal/storybook",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/README.md
+++ b/packages/communication-react/README.md
@@ -24,7 +24,7 @@ you can most consistently use the API from the core libraries in your applicatio
 
 
 ```bash
-npm i @azure/communication-calling@1.3.2
+npm i @azure/communication-calling@1.4.4
 npm i @azure/communication-chat@1.1.0
 ```
 

--- a/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
@@ -76,7 +76,7 @@ you can most consistently use the API from the core libraries in your applicatio
 
 ```bash
 
-npm install @azure/communication-calling@1.3.2
+npm install @azure/communication-calling@1.4.4
 npm install @azure/communication-chat@1.1.0
 
 ```

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
@@ -81,7 +81,7 @@ you can most consistently use the API from the core libraries in your applicatio
 
 ```bash
 
-npm install @azure/communication-calling@1.3.2
+npm install @azure/communication-calling@1.4.4
 npm install @azure/communication-chat@1.1.0
 
 ```

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulChat.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulChat.stories.mdx
@@ -82,7 +82,7 @@ you can most consistently use the API from the core libraries in your applicatio
 
 ```bash
 
-npm install @azure/communication-calling@1.3.2
+npm install @azure/communication-calling@1.4.4
 npm install @azure/communication-chat@1.1.0
 
 ```

--- a/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
@@ -63,7 +63,7 @@ you can most consistently use the API from the core libraries in your applicatio
 
 ```bash
 
-npm install @azure/communication-calling@1.3.2
+npm install @azure/communication-calling@1.4.4
 npm install @azure/communication-chat@1.1.0
 
 ```

--- a/packages/storybook/stories/Stateful Client/OverviewStateful.stories.mdx
+++ b/packages/storybook/stories/Stateful Client/OverviewStateful.stories.mdx
@@ -35,7 +35,7 @@ you can most consistently use the API from the core libraries in your applicatio
 
 ```bash
 
-npm install @azure/communication-calling@1.3.2
+npm install @azure/communication-calling@1.4.4
 npm install @azure/communication-chat@1.1.0
 
 ```


### PR DESCRIPTION
# Why

Our `peerDependencies` still refer to a specific headless SDK dependency, so our documentation should follow suite.