### PR TITLE
API fix: Hide FileSharing API from stable build

### DIFF
--- a/change/@internal-react-components-d08c2e65-2c24-49f0-8bba-f2e2fdf1ac9a.json
+++ b/change/@internal-react-components-d08c2e65-2c24-49f0-8bba-f2e2fdf1ac9a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "API fix: Hide FileSharing API from stable build",
+  "packageName": "@internal/react-components",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/stable-review/communication-react.api.md
+++ b/packages/communication-react/stable-review/communication-react.api.md
@@ -1787,7 +1787,6 @@ export type MessageThreadProps = {
     onRenderJumpToNewMessageButton?: (newMessageButtonProps: JumpToNewMessageButtonProps) => JSX.Element;
     onLoadPreviousChatMessages?: (messagesToLoad: number) => Promise<boolean>;
     onRenderMessage?: (messageProps: MessageProps, messageRenderer?: MessageRenderer) => JSX.Element;
-    onRenderFileDownloads?: (userId: string, message: ChatMessage) => JSX.Element;
     onUpdateMessage?: (messageId: string, content: string) => Promise<void>;
     onDeleteMessage?: (messageId: string) => Promise<void>;
     onSendMessage?: (messageId: string) => Promise<void>;

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -525,6 +525,7 @@ export type MessageThreadProps = {
    * `messageRenderer` is not provided for `CustomMessage` and thus only available for `ChatMessage` and `SystemMessage`.
    */
   onRenderMessage?: (messageProps: MessageProps, messageRenderer?: MessageRenderer) => JSX.Element;
+  /* @conditional-compile-remove(file-sharing) */
   /**
    * Optional callback to render uploaded files in the message component.
    * @beta
@@ -663,6 +664,8 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
     onDeleteMessage,
     onSendMessage
   } = props;
+
+  const onRenderFileDownloads = onRenderFileDownloadsTrampoline(props);
 
   const [messages, setMessages] = useState<(ChatMessage | SystemMessage | CustomMessage)[]>([]);
   // We need this state to wait for one tick and scroll to bottom after messages have been initialized.
@@ -923,7 +926,7 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
         return (
           <ChatMessageComponent
             {...messageProps}
-            onRenderFileDownloads={props.onRenderFileDownloads}
+            onRenderFileDownloads={onRenderFileDownloads}
             message={messageProps.message}
             userId={props.userId}
             remoteParticipantsCount={participantCount ? participantCount - 1 : 0}
@@ -944,7 +947,7 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
       participantCount,
       onRenderAvatar,
       onActionButtonClickMemo,
-      props.onRenderFileDownloads,
+      onRenderFileDownloads,
       props.userId,
       showMessageStatus
     ]
@@ -1081,4 +1084,12 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
       </Stack>
     </Ref>
   );
+};
+
+const onRenderFileDownloadsTrampoline = (
+  props: MessageThreadProps
+): ((userId: string, message: ChatMessage) => JSX.Element) | undefined => {
+  /* @conditional-compile-remove(file-sharing) */
+  return props.onRenderFileDownloads;
+  return undefined;
 };

--- a/packages/react-components/stable-review/react-components.api.md
+++ b/packages/react-components/stable-review/react-components.api.md
@@ -646,7 +646,6 @@ export type MessageThreadProps = {
     onRenderJumpToNewMessageButton?: (newMessageButtonProps: JumpToNewMessageButtonProps) => JSX.Element;
     onLoadPreviousChatMessages?: (messagesToLoad: number) => Promise<boolean>;
     onRenderMessage?: (messageProps: MessageProps, messageRenderer?: MessageRenderer) => JSX.Element;
-    onRenderFileDownloads?: (userId: string, message: ChatMessage) => JSX.Element;
     onUpdateMessage?: (messageId: string, content: string) => Promise<void>;
     onDeleteMessage?: (messageId: string) => Promise<void>;
     onSendMessage?: (messageId: string) => Promise<void>;


### PR DESCRIPTION
# Why
API leaked into stable build. Fix it before `1.2.0`.