### PR TITLE
Correctly set readBy count when `mobileView` is set

### DIFF
--- a/change/@internal-react-components-973a8fae-95c5-4409-8eee-91ba9ac3b00d.json
+++ b/change/@internal-react-components-973a8fae-95c5-4409-8eee-91ba9ac3b00d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "bugfix: Update readBy count for messages when `mobileView` is set",
+  "packageName": "@internal/react-components",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
@@ -148,8 +148,13 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
             if (!wasInteractionByTouch) {
               return;
             }
-            props.onActionButtonClick(message, setMessageReadBy);
+            // If the message was touched via touch we immediately open the menu
+            // flyout (when using mouse the 3-dot menu that appears on hover
+            // must be clicked to open the flyout).
+            // In doing so here we set the target of the flyout to be the message and
+            // not the 3-dot menu button to position the flyout correctly.
             setChatMessageActionFlyoutTarget(messageRef);
+            props.onActionButtonClick(message, setMessageReadBy);
           }}
         />
       </div>

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
@@ -144,7 +144,13 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
           onTouchStart={() => setWasInteractionByTouch(true)}
           onPointerDown={() => setWasInteractionByTouch(false)}
           onKeyDown={() => setWasInteractionByTouch(false)}
-          onClick={() => wasInteractionByTouch && setChatMessageActionFlyoutTarget(messageRef)}
+          onClick={() => {
+            if (!wasInteractionByTouch) {
+              return;
+            }
+            props.onActionButtonClick(message, setMessageReadBy);
+            setChatMessageActionFlyoutTarget(messageRef);
+          }}
         />
       </div>
       {chatActionsEnabled && (


### PR DESCRIPTION
# What
![image](https://user-images.githubusercontent.com/82062616/161167900-ddcf2941-caa5-4772-8cf3-069654109042.png)


# Why

Fixes a bug where we always showed that 0 remote participants have read a message.

# How Tested
Local `CallWithChat` sample.
