### PR TITLE
Build only storybook when deploying

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install Dependencies
         run: rush install
 
-      - name: Build Storybook dependencies
-        run: rush build -v -T storybook
+      - name: Build Storybook
+        run: rush build -v -o storybook
 
       - name: Run Storybook tests
         run: rush test -o storybook


### PR DESCRIPTION
# Why

On stable release branches, we test that storybook builds, but *do not test that the other packlets build in beta flavored build*.
When deploying, we can not be sure the other packages build.

# How Tested

Deployed storybook for `1.2.0`.