### PR TITLE
[CallWithChat][A11y] Set menu role for split buttons in control bar

### DIFF
--- a/change/@internal-react-components-643acc17-d0ce-4f2c-bc52-9caa63bc9f54.json
+++ b/change/@internal-react-components-643acc17-d0ce-4f2c-bc52-9caa63bc9f54.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set menu role for Split Buttons in controlBar",
+  "packageName": "@internal/react-components",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ControlBarButton.tsx
+++ b/packages/react-components/src/components/ControlBarButton.tsx
@@ -139,6 +139,7 @@ export const ControlBarButton = (props: ControlBarButtonProps): JSX.Element => {
     <ControlButtonTooltip content={tooltipContent} id={tooltipId}>
       <DefaultButton
         {...props}
+        role={props.split ? 'menu' : undefined}
         styles={componentStyles}
         onRenderText={props.showLabel && props.onRenderText ? props.onRenderText : undefined}
         onRenderIcon={props.onRenderIcon ?? DefaultRenderIcon}


### PR DESCRIPTION
# What
Set menu role for split buttons in control bar
<img width="30%" src="https://user-images.githubusercontent.com/97130533/162494144-b387c5cf-4eba-49df-b1de-b7533039944d.png"/>
<img width="30%" src="https://user-images.githubusercontent.com/97130533/162494176-09315500-c159-4b78-9395-afe5b8be5d9f.png"/>


# Why
Split buttons were voicing out two roles, split button and button. A11y recommends that only one role should be read.
https://skype.visualstudio.com/SPOOL/_workitems/edit/2790837/
<img width="30%" src="https://user-images.githubusercontent.com/97130533/162494517-375cb9d1-076e-4fee-8f5a-eb5cdaa6c1e0.png"/>
<img width="30%" src="https://user-images.githubusercontent.com/97130533/162494530-292de75f-090c-4b64-bc49-6970d953697a.png"/>



# How Tested
Tested locally on MacOS voiceover.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->