### PR TITLE
enabling people pane

### DIFF
--- a/samples/Chat/src/app/ChatScreen.tsx
+++ b/samples/Chat/src/app/ChatScreen.tsx
@@ -87,7 +87,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
           <ChatComposite
             adapter={adapter}
             fluentTheme={currentTheme.theme}
-            options={{ autoFocus: 'sendBoxTextField', participantPane: !hideParticipants }}
+            options={{ autoFocus: 'sendBoxTextField', participantPane: true }}
             onFetchAvatarPersonaData={onFetchAvatarPersonaData}
           />
         </Stack.Item>


### PR DESCRIPTION
# What
Enabling the people pane in the chat sample

# Why
Customers were finding our chat sample lacking because it was missing the people pane

# How Tested
ran locally
