### PR TITLE
[CallWithChat][A11y] Update label and indicate selected camera in LocalVideoCameraButton 

### DIFF
--- a/change/@internal-react-components-3094709f-e16b-4a4e-8fa1-95ea7869f00a.json
+++ b/change/@internal-react-components-3094709f-e16b-4a4e-8fa1-95ea7869f00a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add aria description to indicate selected camera in LocalVideoCameraButton",
+  "packageName": "@internal/react-components",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -1803,6 +1803,7 @@ export type LocalizationProviderProps = {
 // @public (undocumented)
 export interface LocalVideoCameraCycleButtonProps {
     cameras?: OptionsDevice[];
+    description?: string;
     label?: string;
     onSelectCamera?: (device: OptionsDevice) => Promise<void>;
     selectedCamera?: OptionsDevice;
@@ -2545,6 +2546,7 @@ export interface VideoGalleryStrings {
     localVideoCameraSwitcherLabel: string;
     localVideoLabel: string;
     localVideoMovementLabel: string;
+    localVideoSelectedDescription: string;
     screenIsBeingSharedMessage: string;
     screenShareLoadingMessage: string;
 }

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -1804,8 +1804,8 @@ export type LocalizationProviderProps = {
 
 // @public (undocumented)
 export interface LocalVideoCameraCycleButtonProps {
+    ariaDescription?: string;
     cameras?: OptionsDevice[];
-    description?: string;
     label?: string;
     onSelectCamera?: (device: OptionsDevice) => Promise<void>;
     selectedCamera?: OptionsDevice;

--- a/packages/communication-react/stable-review/communication-react.api.md
+++ b/packages/communication-react/stable-review/communication-react.api.md
@@ -1670,6 +1670,7 @@ export type LocalizationProviderProps = {
 // @public (undocumented)
 export interface LocalVideoCameraCycleButtonProps {
     cameras?: OptionsDevice[];
+    description?: string;
     label?: string;
     onSelectCamera?: (device: OptionsDevice) => Promise<void>;
     selectedCamera?: OptionsDevice;
@@ -2398,6 +2399,7 @@ export interface VideoGalleryStrings {
     localVideoCameraSwitcherLabel: string;
     localVideoLabel: string;
     localVideoMovementLabel: string;
+    localVideoSelectedDescription: string;
     screenIsBeingSharedMessage: string;
     screenShareLoadingMessage: string;
 }

--- a/packages/communication-react/stable-review/communication-react.api.md
+++ b/packages/communication-react/stable-review/communication-react.api.md
@@ -1671,8 +1671,8 @@ export type LocalizationProviderProps = {
 
 // @public (undocumented)
 export interface LocalVideoCameraCycleButtonProps {
+    ariaDescription?: string;
     cameras?: OptionsDevice[];
-    description?: string;
     label?: string;
     onSelectCamera?: (device: OptionsDevice) => Promise<void>;
     selectedCamera?: OptionsDevice;

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -588,8 +588,8 @@ export const LocalVideoCameraCycleButton: (props: LocalVideoCameraCycleButtonPro
 
 // @public (undocumented)
 export interface LocalVideoCameraCycleButtonProps {
+    ariaDescription?: string;
     cameras?: OptionsDevice[];
-    description?: string;
     label?: string;
     onSelectCamera?: (device: OptionsDevice) => Promise<void>;
     selectedCamera?: OptionsDevice;

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -587,6 +587,7 @@ export const LocalVideoCameraCycleButton: (props: LocalVideoCameraCycleButtonPro
 // @public (undocumented)
 export interface LocalVideoCameraCycleButtonProps {
     cameras?: OptionsDevice[];
+    description?: string;
     label?: string;
     onSelectCamera?: (device: OptionsDevice) => Promise<void>;
     selectedCamera?: OptionsDevice;
@@ -1118,6 +1119,7 @@ export interface VideoGalleryStrings {
     localVideoCameraSwitcherLabel: string;
     localVideoLabel: string;
     localVideoMovementLabel: string;
+    localVideoSelectedDescription: string;
     screenIsBeingSharedMessage: string;
     screenShareLoadingMessage: string;
 }

--- a/packages/react-components/src/components/LocalVideoCameraButton.tsx
+++ b/packages/react-components/src/components/LocalVideoCameraButton.tsx
@@ -18,6 +18,8 @@ export interface LocalVideoCameraCycleButtonProps {
   onSelectCamera?: (device: OptionsDevice) => Promise<void>;
   /** label for local video camera switcher */
   label?: string;
+  /** description for local video camera switcher */
+  description?: string;
 }
 
 /**
@@ -25,7 +27,7 @@ export interface LocalVideoCameraCycleButtonProps {
  * @internal
  */
 export const LocalVideoCameraCycleButton = (props: LocalVideoCameraCycleButtonProps): JSX.Element => {
-  const { cameras, selectedCamera, onSelectCamera, label } = props;
+  const { cameras, selectedCamera, onSelectCamera, label, description } = props;
   const theme = useTheme();
 
   return (
@@ -34,6 +36,7 @@ export const LocalVideoCameraCycleButton = (props: LocalVideoCameraCycleButtonPr
       styles={localVideoCameraCycleButtonStyles(theme)}
       iconProps={{ iconName: 'LocalCameraSwitch' }}
       ariaLabel={label}
+      ariaDescription={description}
       aria-live={'polite'}
       onClick={() => {
         if (cameras && cameras.length > 1 && selectedCamera !== undefined) {

--- a/packages/react-components/src/components/LocalVideoCameraButton.tsx
+++ b/packages/react-components/src/components/LocalVideoCameraButton.tsx
@@ -19,7 +19,7 @@ export interface LocalVideoCameraCycleButtonProps {
   /** label for local video camera switcher */
   label?: string;
   /** description for local video camera switcher */
-  description?: string;
+  ariaDescription?: string;
 }
 
 /**
@@ -27,7 +27,7 @@ export interface LocalVideoCameraCycleButtonProps {
  * @internal
  */
 export const LocalVideoCameraCycleButton = (props: LocalVideoCameraCycleButtonProps): JSX.Element => {
-  const { cameras, selectedCamera, onSelectCamera, label, description } = props;
+  const { cameras, selectedCamera, onSelectCamera, label, ariaDescription } = props;
   const theme = useTheme();
 
   return (
@@ -36,7 +36,7 @@ export const LocalVideoCameraCycleButton = (props: LocalVideoCameraCycleButtonPr
       styles={localVideoCameraCycleButtonStyles(theme)}
       iconProps={{ iconName: 'LocalCameraSwitch' }}
       ariaLabel={label}
-      ariaDescription={description}
+      ariaDescription={ariaDescription}
       aria-live={'polite'}
       onClick={() => {
         if (cameras && cameras.length > 1 && selectedCamera !== undefined) {

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -67,6 +67,8 @@ export interface VideoGalleryStrings {
   localVideoCameraSwitcherLabel: string;
   /** String for announcing the local video tile can be moved by keyboard controls */
   localVideoMovementLabel: string;
+  /** String for announcing the selected camera */
+  localVideoSelectedDescription: string;
 }
 
 /**
@@ -238,6 +240,9 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
               selectedCamera={localVideoCameraCycleButtonProps.selectedCamera}
               onSelectCamera={localVideoCameraCycleButtonProps.onSelectCamera}
               label={strings.localVideoCameraSwitcherLabel}
+              description={
+                localVideoCameraCycleButtonProps.selectedCamera.name + ' ' + strings.localVideoSelectedDescription
+              }
             />
           )}
       </Stack>

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -44,6 +44,7 @@ import { LocalVideoCameraCycleButton, LocalVideoCameraCycleButtonProps } from '.
 /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(local-camera-switcher) */
 import { localVideoTileWithControlsContainerStyle, LOCAL_VIDEO_TILE_ZINDEX } from './styles/VideoGallery.styles';
 import { _ModalClone } from './ModalClone/ModalClone';
+import { _formatString } from '@internal/acs-ui-common';
 
 // Currently the Calling JS SDK supports up to 4 remote video streams
 const DEFAULT_MAX_REMOTE_VIDEO_STREAMS = 4;
@@ -229,6 +230,10 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
 
   /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(local-camera-switcher) */
   const localCameraCycleButton = (localVideoCameraCycleButtonProps): JSX.Element => {
+    const ariaDescription = _formatString('{selectedCameraName} {localVideoSelectedDescription}', {
+      selectedCameraName: localVideoCameraCycleButtonProps.selectedCamera.name,
+      localVideoSelectedDescription: strings.localVideoSelectedDescription
+    });
     return (
       <Stack horizontalAlign="end">
         {showCameraSwitcherInLocalPreview &&
@@ -240,9 +245,7 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
               selectedCamera={localVideoCameraCycleButtonProps.selectedCamera}
               onSelectCamera={localVideoCameraCycleButtonProps.onSelectCamera}
               label={strings.localVideoCameraSwitcherLabel}
-              description={
-                localVideoCameraCycleButtonProps.selectedCamera.name + ' ' + strings.localVideoSelectedDescription
-              }
+              ariaDescription={ariaDescription}
             />
           )}
       </Stack>

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -230,9 +230,8 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
 
   /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(local-camera-switcher) */
   const localCameraCycleButton = (localVideoCameraCycleButtonProps): JSX.Element => {
-    const ariaDescription = _formatString('{selectedCameraName} {localVideoSelectedDescription}', {
-      selectedCameraName: localVideoCameraCycleButtonProps.selectedCamera.name,
-      localVideoSelectedDescription: strings.localVideoSelectedDescription
+    const ariaDescription = _formatString(strings.localVideoSelectedDescription, {
+      cameraName: localVideoCameraCycleButtonProps.selectedCamera.name
     });
     return (
       <Stack horizontalAlign="end">

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -141,7 +141,7 @@
     "screenIsBeingSharedMessage": "You are sharing your screen",
     "screenShareLoadingMessage": "Loading {participant}'s screen",
     "localVideoLabel": "You",
-    "localVideoCameraSwitcherLabel": "Cycle camera",
+    "localVideoCameraSwitcherLabel": "Switch camera",
     "localVideoMovementLabel": "Movable Local Video Tile",
     "localVideoSelectedDescription": "selected"
   }

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -143,6 +143,6 @@
     "localVideoLabel": "You",
     "localVideoCameraSwitcherLabel": "Switch camera",
     "localVideoMovementLabel": "Movable Local Video Tile",
-    "localVideoSelectedDescription": "selected"
+    "localVideoSelectedDescription": "{cameraName} selected"
   }
 }

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -140,6 +140,7 @@
     "screenShareLoadingMessage": "Loading {participant}'s screen",
     "localVideoLabel": "You",
     "localVideoCameraSwitcherLabel": "Cycle camera",
-    "localVideoMovementLabel": "Movable Local Video Tile"
+    "localVideoMovementLabel": "Movable Local Video Tile",
+    "localVideoSelectedDescription": "selected"
   }
 }

--- a/packages/react-components/stable-review/react-components.api.md
+++ b/packages/react-components/stable-review/react-components.api.md
@@ -578,6 +578,7 @@ export const LocalVideoCameraCycleButton: (props: LocalVideoCameraCycleButtonPro
 // @public (undocumented)
 export interface LocalVideoCameraCycleButtonProps {
     cameras?: OptionsDevice[];
+    description?: string;
     label?: string;
     onSelectCamera?: (device: OptionsDevice) => Promise<void>;
     selectedCamera?: OptionsDevice;
@@ -1095,6 +1096,7 @@ export interface VideoGalleryStrings {
     localVideoCameraSwitcherLabel: string;
     localVideoLabel: string;
     localVideoMovementLabel: string;
+    localVideoSelectedDescription: string;
     screenIsBeingSharedMessage: string;
     screenShareLoadingMessage: string;
 }

--- a/packages/react-components/stable-review/react-components.api.md
+++ b/packages/react-components/stable-review/react-components.api.md
@@ -579,8 +579,8 @@ export const LocalVideoCameraCycleButton: (props: LocalVideoCameraCycleButtonPro
 
 // @public (undocumented)
 export interface LocalVideoCameraCycleButtonProps {
+    ariaDescription?: string;
     cameras?: OptionsDevice[];
-    description?: string;
     label?: string;
     onSelectCamera?: (device: OptionsDevice) => Promise<void>;
     selectedCamera?: OptionsDevice;


### PR DESCRIPTION
# What
Indicate which camera is currently selected in LocalVideoCameraButton using ariaDescription.
Update "Cycle camera" string to "Switch camera" as indicated by A11y bug.
<img width="50%" src="https://user-images.githubusercontent.com/97130533/163013667-d12767d4-04e8-47b7-8a09-c19d69489002.png"/>
<img width="50%" src="https://user-images.githubusercontent.com/97130533/163012593-ae96d6df-a44f-498d-94d6-f6f25c680577.png"/>


# Why
<img width="50%" src="https://user-images.githubusercontent.com/97130533/163012548-f3b3efa6-d717-42d4-9dcf-cbf045141a6c.png"/>
<img width="50%" src="https://user-images.githubusercontent.com/97130533/163013122-80d120fa-62eb-4e64-b5a9-bfa6fd39e5d7.png"/>
https://skype.visualstudio.com/SPOOL/_workitems/edit/2791846/

# How Tested
Test locally on MacOS using VoiceOver

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->