### PR TITLE
Fix PiPiP being dragged outside the window bounds after container resize

### DIFF
--- a/change/@internal-react-components-a6c127ee-d965-43d5-9c30-3977b9f4822b.json
+++ b/change/@internal-react-components-a6c127ee-d965-43d5-9c30-3977b9f4822b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Make useContainerHeight/Width an internal fn for use in react-composites",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-composites-caac35d4-c319-4bde-884a-85db2c432a24.json
+++ b/change/@internal-react-composites-caac35d4-c319-4bde-884a-85db2c432a24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Picture-In-Picture component in mobile composites going outside the screen when the mobile device is rotated from portrait to landscape",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -26,6 +26,7 @@ import { PersonaPresence } from '@fluentui/react';
 import { PersonaSize } from '@fluentui/react';
 import { default as React_2 } from 'react';
 import * as React_3 from 'react';
+import { RefObject } from 'react';
 import { Theme } from '@fluentui/react';
 
 // @public
@@ -1057,6 +1058,12 @@ export interface TypingIndicatorStylesProps extends BaseCustomStyles {
     typingString?: IStyle;
     typingUserDisplayName?: IStyle;
 }
+
+// @internal
+export const _useContainerHeight: (containerRef: RefObject<HTMLElement>) => number | undefined;
+
+// @internal
+export const _useContainerWidth: (containerRef: RefObject<HTMLElement>) => number | undefined;
 
 // @public
 export const useTheme: () => Theme;

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -40,7 +40,7 @@ import { memoizeFnAll, MessageStatus } from '@internal/acs-ui-common';
 import { SystemMessage as SystemMessageComponent, SystemMessageIconTypes } from './SystemMessage';
 import { ChatMessageComponent } from './ChatMessage/ChatMessageComponent';
 import { useLocale } from '../localization/LocalizationProvider';
-import { isNarrowWidth, useContainerWidth } from './utils/responsive';
+import { isNarrowWidth, _useContainerWidth } from './utils/responsive';
 import { getParticipantsWhoHaveReadMessage } from './utils/getParticipantsWhoHaveReadMessage';
 
 const isMessageSame = (first: ChatMessage, second: ChatMessage): boolean => {
@@ -702,7 +702,7 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
   // When the chat thread is narrow, we perform space optimizations such as overlapping
   // the avatar on top of the chat message and moving the chat accept/reject edit buttons
   // to a new line
-  const chatThreadWidth = useContainerWidth(chatThreadRef);
+  const chatThreadWidth = _useContainerWidth(chatThreadRef);
   const isNarrow = chatThreadWidth ? isNarrowWidth(chatThreadWidth) : false;
 
   const messagesRef = useRef(messages);

--- a/packages/react-components/src/components/ResponsiveHorizontalGallery.tsx
+++ b/packages/react-components/src/components/ResponsiveHorizontalGallery.tsx
@@ -5,7 +5,7 @@ import { IStyle, mergeStyles } from '@fluentui/react';
 import React, { useRef } from 'react';
 import { HorizontalGallery, HorizontalGalleryStyles } from './HorizontalGallery';
 import { convertRemToPx } from './utils/common';
-import { useContainerWidth } from './utils/responsive';
+import { _useContainerWidth } from './utils/responsive';
 
 /**
  * Wrapped HorizontalGallery that adjusts the number of items per page based on the
@@ -21,7 +21,7 @@ export const ResponsiveHorizontalGallery = (props: {
 }): JSX.Element => {
   const { childWidthRem, gapWidthRem, buttonWidthRem = 0 } = props;
   const containerRef = useRef<HTMLDivElement>(null);
-  const containerWidth = useContainerWidth(containerRef);
+  const containerWidth = _useContainerWidth(containerRef);
 
   const leftPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingLeft) : 0;
   const rightPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingRight) : 0;

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -36,7 +36,7 @@ import {
   SMALL_FLOATING_MODAL_SIZE_PX,
   LARGE_FLOATING_MODAL_SIZE_PX
 } from './styles/VideoGallery.styles';
-import { isNarrowWidth, useContainerHeight, useContainerWidth } from './utils/responsive';
+import { isNarrowWidth, _useContainerHeight, _useContainerWidth } from './utils/responsive';
 import { LocalScreenShare } from './VideoGallery/LocalScreenShare';
 import { RemoteScreenShare } from './VideoGallery/RemoteScreenShare';
 import { VideoTile } from './VideoTile';
@@ -209,8 +209,8 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
   const shouldFloatNonDraggableLocalVideo = !!(showCameraSwitcherInLocalPreview && shouldFloatLocalVideo);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const containerWidth = useContainerWidth(containerRef);
-  const containerHeight = useContainerHeight(containerRef);
+  const containerWidth = _useContainerWidth(containerRef);
+  const containerHeight = _useContainerHeight(containerRef);
   const isNarrow = containerWidth ? isNarrowWidth(containerWidth) : false;
   const visibleVideoParticipants = useRef<VideoGalleryRemoteParticipant[]>([]);
   const visibleAudioParticipants = useRef<VideoGalleryRemoteParticipant[]>([]);

--- a/packages/react-components/src/components/index.ts
+++ b/packages/react-components/src/components/index.ts
@@ -107,3 +107,5 @@ export type { SendBoxErrorBarError } from './SendBoxErrorBar';
 export * from './FileCard';
 export * from './FileCardGroup';
 export * from './ModalClone/ModalClone';
+
+export { _useContainerHeight, _useContainerWidth } from './utils/responsive';

--- a/packages/react-components/src/components/utils/responsive.ts
+++ b/packages/react-components/src/components/utils/responsive.ts
@@ -8,9 +8,9 @@ import { convertRemToPx } from './common';
  * A utility hook for providing the width of a parent element.
  * Returns updated width if parent/window resizes.
  * @param containerRef - Ref of a parent element whose width will be returned.
- * @private
+ * @internal
  */
-export const useContainerWidth = (containerRef: RefObject<HTMLElement>): number | undefined => {
+export const _useContainerWidth = (containerRef: RefObject<HTMLElement>): number | undefined => {
   const [width, setWidth] = useState<number | undefined>(undefined);
 
   const observer = useRef(
@@ -38,9 +38,9 @@ export const useContainerWidth = (containerRef: RefObject<HTMLElement>): number 
  * A utility hook for providing the height of a parent element.
  * Returns updated height if parent/window resizes.
  * @param containerRef - Ref of a parent element whose height will be returned.
- * @private
+ * @internal
  */
-export const useContainerHeight = (containerRef: RefObject<HTMLElement>): number | undefined => {
+export const _useContainerHeight = (containerRef: RefObject<HTMLElement>): number | undefined => {
   const [height, setHeight] = useState<number | undefined>(undefined);
 
   const observer = useRef(

--- a/packages/react-components/stable-review/react-components.api.md
+++ b/packages/react-components/stable-review/react-components.api.md
@@ -26,6 +26,7 @@ import { PersonaPresence } from '@fluentui/react';
 import { PersonaSize } from '@fluentui/react';
 import { default as React_2 } from 'react';
 import * as React_3 from 'react';
+import { RefObject } from 'react';
 import { Theme } from '@fluentui/react';
 
 // @public
@@ -1034,6 +1035,12 @@ export interface TypingIndicatorStylesProps extends BaseCustomStyles {
     typingString?: IStyle;
     typingUserDisplayName?: IStyle;
 }
+
+// @internal
+export const _useContainerHeight: (containerRef: RefObject<HTMLElement>) => number | undefined;
+
+// @internal
+export const _useContainerWidth: (containerRef: RefObject<HTMLElement>) => number | undefined;
 
 // @public
 export const useTheme: () => Theme;

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
@@ -123,10 +123,6 @@ export const CallWithChatPane = (props: {
     [modalHostHeight, modalHostWidth, props.rtl]
   );
 
-  console.log('modalHostRef: ', modalHostRef);
-  console.log('minDragPosition: ', minDragPosition);
-  console.log('maxDragPosition: ', maxDragPosition);
-
   const pipStyles = useMemo(() => getPipStyles(theme), [theme]);
 
   const dataUiId =

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
@@ -1,8 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { IStackStyles, IStackTokens, ITheme, Stack } from '@fluentui/react';
-import { ParticipantMenuItemsCallback, useTheme, _DrawerMenu, _DrawerMenuItemProps } from '@internal/react-components';
-import React, { useMemo, useState } from 'react';
+import {
+  _DrawerMenu,
+  _DrawerMenuItemProps,
+  _useContainerHeight,
+  _useContainerWidth,
+  ParticipantMenuItemsCallback,
+  useTheme
+} from '@internal/react-components';
+import React, { useMemo, useRef, useState } from 'react';
 import { CallAdapter } from '../CallComposite';
 import { CallAdapterProvider } from '../CallComposite/adapter/CallAdapterProvider';
 import { ChatAdapter, ChatComposite, ChatCompositeProps } from '../ChatComposite';
@@ -90,7 +97,36 @@ export const CallWithChatPane = (props: {
     </CallAdapterProvider>
   );
 
-  const modalLayerHost = document.getElementById(props.modalLayerHostId);
+  // Use document.getElementById until Fluent's Stack supports componentRef property: https://github.com/microsoft/fluentui/issues/20410
+  const modalLayerHostElement = document.getElementById(props.modalLayerHostId);
+  const modalHostRef = useRef<HTMLElement>(modalLayerHostElement);
+  const modalHostWidth = _useContainerWidth(modalHostRef);
+  const modalHostHeight = _useContainerHeight(modalHostRef);
+  const minDragPosition: _ICoordinates | undefined = useMemo(
+    () =>
+      modalHostWidth === undefined
+        ? undefined
+        : {
+            x: props.rtl ? -1 * modalPipRightPositionPx : modalPipRightPositionPx - modalHostWidth + modalPipWidthPx,
+            y: -1 * modalPipTopPositionPx
+          },
+    [modalHostWidth, props.rtl]
+  );
+  const maxDragPosition: _ICoordinates | undefined = useMemo(
+    () =>
+      modalHostWidth === undefined || modalHostHeight === undefined
+        ? undefined
+        : {
+            x: props.rtl ? modalHostWidth - modalPipRightPositionPx - modalPipWidthPx : modalPipRightPositionPx,
+            y: modalHostHeight - modalPipTopPositionPx - modalPipHeightPx
+          },
+    [modalHostHeight, modalHostWidth, props.rtl]
+  );
+
+  console.log('modalHostRef: ', modalHostRef);
+  console.log('minDragPosition: ', minDragPosition);
+  console.log('maxDragPosition: ', maxDragPosition);
+
   const pipStyles = useMemo(() => getPipStyles(theme), [theme]);
 
   const dataUiId =
@@ -111,24 +147,14 @@ export const CallWithChatPane = (props: {
           </Stack.Item>
         </Stack>
       </Stack.Item>
-      {props.mobileView && modalLayerHost && (
+      {props.mobileView && (
         <ModalLocalAndRemotePIP
           callAdapter={props.callAdapter}
           modalLayerHostId={props.modalLayerHostId}
           hidden={hidden}
           styles={pipStyles}
-          minDragPosition={{
-            x: props.rtl
-              ? -1 * modalPipRightPositionPx
-              : modalPipRightPositionPx - modalLayerHost.getBoundingClientRect().width + modalPipWidthPx,
-            y: -1 * modalPipTopPositionPx
-          }}
-          maxDragPosition={{
-            x: props.rtl
-              ? modalLayerHost.getBoundingClientRect().width - modalPipRightPositionPx - modalPipWidthPx
-              : modalPipRightPositionPx,
-            y: modalLayerHost.getBoundingClientRect().height - modalPipTopPositionPx - modalPipHeightPx
-          }}
+          minDragPosition={minDragPosition}
+          maxDragPosition={maxDragPosition}
         />
       )}
       {drawerMenuItems.length > 0 && (


### PR DESCRIPTION
# What
On container resize, recalculate the min and max bounds
**note: ** no change to the bounds calculations (just pulled out into a useMemo)

# Why
After resize (e.g. rotate portrait to landscape) the min and max bounds were incorrect:

https://user-images.githubusercontent.com/2684369/163233356-d647009a-81ea-46cf-a62f-bf58d0f4a3ff.mp4

# How Tested

https://user-images.githubusercontent.com/2684369/163233343-e20be12a-e15b-4be6-bc40-44604e6d6b96.mp4