### PR TITLE
fix static html sample config

### DIFF
--- a/samples/StaticHtmlComposites/webpack.config.js
+++ b/samples/StaticHtmlComposites/webpack.config.js
@@ -22,7 +22,7 @@ const config = {
     port: 3000,
     client: false,
     open: true,
-    static: { directory: path.resolve(__dirname, 'public') },
+    static: { directory: path.resolve(__dirname, 'dist') },
     proxy: [
       {
         path: '/token',


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fixed the dev server path (oops!)
# Why
<!--- What problem does this change solve? -->
dev-server for static html composites is pointed at the right folder.
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran locally with all other samples as well to verify fix.