### PR TITLE
Add callIdHistory to context + internal context

### DIFF
--- a/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
@@ -214,7 +214,7 @@ describe('declarative call agent', () => {
     mockCallAgent.calls = [];
     callAgentDeclaratify(mockCallAgent, context, internalContext);
     expect(Object.keys(context.getState().calls).length).toBe(0);
-    expect(internalContext.getRemoteRenderInfos().size).toBe(0);
+    expect(Array.from(internalContext.getCallIds()).length).toBe(0);
   });
 
   test('should update state with new call when startCall is invoked', () => {

--- a/packages/calling-stateful-client/src/CallIdHistory.ts
+++ b/packages/calling-stateful-client/src/CallIdHistory.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @private
+ * Call Id will change during the call for at least 1 time
+ * This is to avoid async bug that call id has been changed during an async-await function
+ * but the function still uses stale call id to access state
+ */
+export class CallIdHistory {
+  private _callIdHistory = new Map<string, string>();
+
+  public updateCallIdHistory(newCallId: string, oldCallId: string): void {
+    // callId for a call can fluctuate between some set of values.
+    // But if a newCallId already exists, and maps to different call, we're in trouble.
+    // This can only happen if a callId is reused across two distinct calls.
+    const existing = this._callIdHistory.get(newCallId);
+    if (existing !== undefined && this.latestCallId(newCallId) !== oldCallId) {
+      console.trace(`${newCallId} alredy exists and maps to ${existing}, which is not the same as ${oldCallId}`);
+    }
+
+    // The latest callId never maps to another callId.
+    this._callIdHistory.delete(newCallId);
+    this._callIdHistory.set(oldCallId, newCallId);
+  }
+
+  public latestCallId(callId: string): string {
+    let latest = callId;
+    /* eslint no-constant-condition: ["error", { "checkLoops": false }] */
+    while (true) {
+      const newer = this._callIdHistory.get(latest);
+      if (newer === undefined) {
+        break;
+      }
+      latest = newer;
+    }
+    return latest;
+  }
+}

--- a/packages/calling-stateful-client/src/StreamUtils.ts
+++ b/packages/calling-stateful-client/src/StreamUtils.ts
@@ -451,8 +451,8 @@ export function disposeAllViewsFromCall(
  * @private
  */
 export function disposeAllViews(context: CallContext, internalContext: InternalCallContext): void {
-  const remoteStreamAndRenderers = internalContext.getRemoteRenderInfos();
-  for (const [callId] of remoteStreamAndRenderers.entries()) {
+  const callIds = internalContext.getCallIds();
+  for (const callId of callIds) {
     disposeAllViewsFromCall(context, internalContext, callId);
   }
 }


### PR DESCRIPTION
- Update all visit to callId using latestCallId
- Encapsule the access to internalMap directly to ensure no leaks

This is a PR based on https://github.com/Azure/communication-ui-library/pull/1693, and added more fixes into context as well, this is fully tested on a simulate call id change during remote stream rendering - https://github.com/Azure/communication-ui-library/tree/jinan/simulate-call-id-change

# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->