### PR TITLE
Fix styling of some custom button examples in storybook

### DIFF
--- a/change/@internal-storybook-4d997d45-9308-47af-a0af-cce5ff7bb33d.json
+++ b/change/@internal-storybook-4d997d45-9308-47af-a0af-cce5ff7bb33d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix styling in custom button stories",
+  "packageName": "@internal/storybook",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/ControlBar/Buttons/Participants/snippets/WithCustomRender.snippet.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/Participants/snippets/WithCustomRender.snippet.tsx
@@ -1,4 +1,9 @@
-import { CallParticipantListParticipant, FluentThemeProvider, ParticipantsButton } from '@azure/communication-react';
+import {
+  CallParticipantListParticipant,
+  ControlBarButtonStyles,
+  FluentThemeProvider,
+  ParticipantsButton
+} from '@azure/communication-react';
 import { Icon, Label, Persona, PersonaSize } from '@fluentui/react';
 import React from 'react';
 
@@ -66,6 +71,17 @@ const onMuteAll = (): void => {
   // your implementation to mute all participants
 };
 
+// Remove default height constraints to accomodate
+// our more elaborate content.
+const buttonStyles: ControlBarButtonStyles = {
+  root: {
+    height: 'none'
+  },
+  rootChecked: {
+    height: 'none'
+  }
+};
+
 export const ParticipantsButtonWithCustomRenderExample: () => JSX.Element = () => {
   const customOnRenderIcon = (): JSX.Element => {
     return <Icon key={'participantsCustomIconKey'} iconName={'Group'} style={{ color: 'orange', fontSize: '20px' }} />;
@@ -89,6 +105,7 @@ export const ParticipantsButtonWithCustomRenderExample: () => JSX.Element = () =
         onRenderIcon={customOnRenderIcon}
         onRenderText={customOnRenderText}
         onRenderAvatar={(userId?, options?) => customOnRenderAvatar(userId, options)}
+        styles={buttonStyles}
       />
     </FluentThemeProvider>
   );

--- a/packages/storybook/stories/ControlBar/Buttons/ScreenShare/snippets/Custom.snippet.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/ScreenShare/snippets/Custom.snippet.tsx
@@ -1,6 +1,17 @@
-import { ScreenShareButton } from '@azure/communication-react';
+import { ControlBarButtonStyles, ScreenShareButton } from '@azure/communication-react';
 import { IButtonProps, Icon, Label } from '@fluentui/react';
 import React from 'react';
+
+// Remove default height constraints to accomodate
+// our more elaborate content.
+const buttonStyles: ControlBarButtonStyles = {
+  root: {
+    height: 'none'
+  },
+  rootChecked: {
+    height: 'none'
+  }
+};
 
 export const CustomScreenShareButtonExample: () => JSX.Element = () => {
   const customOnRenderIcon = (props?: IButtonProps): JSX.Element => {
@@ -36,8 +47,14 @@ export const CustomScreenShareButtonExample: () => JSX.Element = () => {
         showLabel={true}
         onRenderIcon={customOnRenderIcon}
         onRenderText={customOnRenderText}
+        styles={buttonStyles}
       />
-      <ScreenShareButton showLabel={true} onRenderIcon={customOnRenderIcon} onRenderText={customOnRenderText} />
+      <ScreenShareButton
+        showLabel={true}
+        onRenderIcon={customOnRenderIcon}
+        onRenderText={customOnRenderText}
+        styles={buttonStyles}
+      />
     </>
   );
 };


### PR DESCRIPTION

Remarks | Before | After
:-- | ---       | ---
Notice highlight on hover | ![image](https://user-images.githubusercontent.com/82062616/164556821-e2a408ab-5aa0-49d4-a492-c4b6a58e59fe.png) | ![image](https://user-images.githubusercontent.com/82062616/164556900-36de58ad-713e-40e4-a31c-2134447cac00.png)
Notice the scrollbar | ![image](https://user-images.githubusercontent.com/82062616/164557028-70a76c4f-d83a-4f90-8160-fb33b2237083.png) | ![image](https://user-images.githubusercontent.com/82062616/164557051-9ff62c0a-5031-4486-bb6f-7e00dfc7dfc6.png)



