### PR TITLE
Cherry pick split button fix into release/1.2.2.beta.1

### DIFF
--- a/change/@internal-react-components-0f7a218c-6127-44ec-99fa-3ad1059951e0.json
+++ b/change/@internal-react-components-0f7a218c-6127-44ec-99fa-3ad1059951e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add split button aria labels to the microphone and camera buttons. Remove the aria-role of menu from the split buttons.",
+  "packageName": "@internal/react-components",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -855,7 +855,9 @@ export interface CameraButtonStrings {
     cameraMenuTitle: string;
     cameraMenuTooltip: string;
     offLabel: string;
+    offSplitButtonAriaLabel?: string;
     onLabel: string;
+    onSplitButtonAriaLabel?: string;
     tooltipDisabledContent?: string;
     tooltipOffContent?: string;
     tooltipOnContent?: string;
@@ -2026,11 +2028,13 @@ export type MicrophoneButtonSelector = (state: CallClientState, props: CallingBa
 export interface MicrophoneButtonStrings {
     microphoneActionTurnedOffAnnouncement: string;
     microphoneActionTurnedOnAnnouncement: string;
-    microphoneButtonSplitRoleDescription?: string;
+    microphoneButtonSplitRoleDescription: string;
     microphoneMenuTitle?: string;
     microphoneMenuTooltip?: string;
     offLabel: string;
+    offSplitButtonAriaLabel?: string;
     onLabel: string;
+    onSplitButtonAriaLabel?: string;
     speakerMenuTitle?: string;
     speakerMenuTooltip?: string;
     tooltipDisabledContent?: string;

--- a/packages/communication-react/stable-review/communication-react.api.md
+++ b/packages/communication-react/stable-review/communication-react.api.md
@@ -820,7 +820,9 @@ export interface CameraButtonStrings {
     cameraMenuTitle: string;
     cameraMenuTooltip: string;
     offLabel: string;
+    offSplitButtonAriaLabel?: string;
     onLabel: string;
+    onSplitButtonAriaLabel?: string;
     tooltipDisabledContent?: string;
     tooltipOffContent?: string;
     tooltipOnContent?: string;
@@ -1889,11 +1891,13 @@ export type MicrophoneButtonSelector = (state: CallClientState, props: CallingBa
 export interface MicrophoneButtonStrings {
     microphoneActionTurnedOffAnnouncement: string;
     microphoneActionTurnedOnAnnouncement: string;
-    microphoneButtonSplitRoleDescription?: string;
+    microphoneButtonSplitRoleDescription: string;
     microphoneMenuTitle?: string;
     microphoneMenuTooltip?: string;
     offLabel: string;
+    offSplitButtonAriaLabel?: string;
     onLabel: string;
+    onSplitButtonAriaLabel?: string;
     speakerMenuTitle?: string;
     speakerMenuTooltip?: string;
     tooltipDisabledContent?: string;

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -96,7 +96,9 @@ export interface CameraButtonStrings {
     cameraMenuTitle: string;
     cameraMenuTooltip: string;
     offLabel: string;
+    offSplitButtonAriaLabel?: string;
     onLabel: string;
+    onSplitButtonAriaLabel?: string;
     tooltipDisabledContent?: string;
     tooltipOffContent?: string;
     tooltipOnContent?: string;
@@ -785,11 +787,13 @@ export interface MicrophoneButtonProps extends ControlBarButtonProps {
 export interface MicrophoneButtonStrings {
     microphoneActionTurnedOffAnnouncement: string;
     microphoneActionTurnedOnAnnouncement: string;
-    microphoneButtonSplitRoleDescription?: string;
+    microphoneButtonSplitRoleDescription: string;
     microphoneMenuTitle?: string;
     microphoneMenuTooltip?: string;
     offLabel: string;
+    offSplitButtonAriaLabel?: string;
     onLabel: string;
+    onSplitButtonAriaLabel?: string;
     speakerMenuTitle?: string;
     speakerMenuTooltip?: string;
     tooltipDisabledContent?: string;

--- a/packages/react-components/src/components/CameraButton.tsx
+++ b/packages/react-components/src/components/CameraButton.tsx
@@ -52,6 +52,16 @@ export interface CameraButtonStrings {
    * description of camera button split button role
    */
   cameraButtonSplitRoleDescription?: string;
+  /* @conditional-compile-remove(control-bar-split-buttons) */
+  /**
+   * Camera split button aria label for when button is enabled.
+   */
+  onSplitButtonAriaLabel?: string;
+  /* @conditional-compile-remove(control-bar-split-buttons) */
+  /**
+   * Camera split button aria label for when button is disabled.
+   */
+  offSplitButtonAriaLabel?: string;
   /**
    * Camera action turned on string for announcer
    */
@@ -160,6 +170,7 @@ export const CameraButton = (props: CameraButtonProps): JSX.Element => {
   }
 
   const cameraOn = props.checked;
+  const splitButtonAriaString = cameraOn ? strings.onSplitButtonAriaLabel : strings.offSplitButtonAriaLabel;
 
   const toggleAnnouncerString = useCallback(
     (isCameraOn: boolean) => {
@@ -200,9 +211,10 @@ export const CameraButton = (props: CameraButtonProps): JSX.Element => {
           props.menuIconProps ?? !enableDeviceSelectionMenuTrampoline(props) ? { hidden: true } : undefined
         }
         split={props.split ?? enableDeviceSelectionMenuTrampoline(props)}
-        ariaDescription={
+        aria-roledescription={
           enableDeviceSelectionMenuTrampoline(props) ? strings.cameraButtonSplitRoleDescription : undefined
         }
+        splitButtonAriaLabel={enableDeviceSelectionMenuTrampoline(props) ? splitButtonAriaString : undefined}
       />
     </>
   );

--- a/packages/react-components/src/components/ControlBarButton.tsx
+++ b/packages/react-components/src/components/ControlBarButton.tsx
@@ -139,13 +139,11 @@ export const ControlBarButton = (props: ControlBarButtonProps): JSX.Element => {
     <ControlButtonTooltip content={tooltipContent} id={tooltipId}>
       <DefaultButton
         {...props}
-        role={props.split ? 'menu' : undefined}
         styles={componentStyles}
         onRenderText={props.showLabel && props.onRenderText ? props.onRenderText : undefined}
         onRenderIcon={props.onRenderIcon ?? DefaultRenderIcon}
-        ariaLabel={props.ariaLabel ?? tooltipContent ?? labelText}
+        ariaLabel={props.splitButtonAriaLabel ?? props.ariaLabel ?? tooltipContent ?? labelText}
         allowDisabledFocus={props.allowDisabledFocus ?? true}
-        aria-roledescription={props.ariaDescription}
         menuTriggerKeyCode={KeyCodes.down} // explicitly sets the keypress to activiate the split button drop down.
       >
         {props.showLabel ? labelText : <></>}

--- a/packages/react-components/src/components/MicrophoneButton.tsx
+++ b/packages/react-components/src/components/MicrophoneButton.tsx
@@ -53,9 +53,19 @@ export interface MicrophoneButtonStrings {
   speakerMenuTooltip?: string;
   /* @conditional-compile-remove(control-bar-split-buttons) */
   /**
-   * description of microphone button split button role
+   * Description of microphone button split button role
    */
-  microphoneButtonSplitRoleDescription?: string;
+  microphoneButtonSplitRoleDescription: string;
+  /* @conditional-compile-remove(control-bar-split-buttons) */
+  /**
+   * Microphone split button aria label when mic is enabled.
+   */
+  onSplitButtonAriaLabel?: string;
+  /* @conditional-compile-remove(control-bar-split-buttons) */
+  /**
+   * Microphone split button aria label when mic is disabled.
+   */
+  offSplitButtonAriaLabel?: string;
   /**
    * Microphone action turned on string for announcer
    */
@@ -172,6 +182,8 @@ export const MicrophoneButton = (props: MicrophoneButtonProps): JSX.Element => {
 
   const isMicOn = props.checked;
 
+  const splitButtonAriaString = isMicOn ? strings.onSplitButtonAriaLabel : strings.offSplitButtonAriaLabel;
+
   const toggleAnnouncerString = useCallback(
     (isMicOn: boolean) => {
       setAnnouncerString(
@@ -208,9 +220,10 @@ export const MicrophoneButton = (props: MicrophoneButtonProps): JSX.Element => {
           props.menuIconProps ?? !enableDeviceSelectionMenuTrampoline(props) ? { hidden: true } : undefined
         }
         split={props.split ?? enableDeviceSelectionMenuTrampoline(props)}
-        ariaDescription={
+        aria-roledescription={
           enableDeviceSelectionMenuTrampoline(props) ? strings.microphoneButtonSplitRoleDescription : undefined
         }
+        splitButtonAriaLabel={enableDeviceSelectionMenuTrampoline(props) ? splitButtonAriaString : undefined}
       />
     </>
   );

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -44,6 +44,8 @@
     "cameraMenuTitle": "Camera",
     "cameraMenuTooltip": "Choose Camera",
     "cameraButtonSplitRoleDescription": "Split button",
+    "onSplitButtonAriaLabel": "Turn off camera and camera options",
+    "offSplitButtonAriaLabel": "Turn on camera and camera options",
     "cameraActionTurnedOnAnnouncement": "Your camera has been turned on",
     "cameraActionTurnedOffAnnouncement": "Your camera has been turned off"
   },
@@ -58,6 +60,8 @@
     "speakerMenuTitle": "Speaker",
     "speakerMenuTooltip": "Choose Speaker",
     "microphoneButtonSplitRoleDescription": "Split button",
+    "onSplitButtonAriaLabel": "Mute microphone and audio options",
+    "offSplitButtonAriaLabel": "Unmute microphone and audio options",
     "microphoneActionTurnedOnAnnouncement": "Your microphone has been turned on",
     "microphoneActionTurnedOffAnnouncement": "Your microphone has been turned off"
   },

--- a/packages/react-components/stable-review/react-components.api.md
+++ b/packages/react-components/stable-review/react-components.api.md
@@ -87,7 +87,9 @@ export interface CameraButtonStrings {
     cameraMenuTitle: string;
     cameraMenuTooltip: string;
     offLabel: string;
+    offSplitButtonAriaLabel?: string;
     onLabel: string;
+    onSplitButtonAriaLabel?: string;
     tooltipDisabledContent?: string;
     tooltipOffContent?: string;
     tooltipOnContent?: string;
@@ -770,11 +772,13 @@ export interface MicrophoneButtonProps extends ControlBarButtonProps {
 export interface MicrophoneButtonStrings {
     microphoneActionTurnedOffAnnouncement: string;
     microphoneActionTurnedOnAnnouncement: string;
-    microphoneButtonSplitRoleDescription?: string;
+    microphoneButtonSplitRoleDescription: string;
     microphoneMenuTitle?: string;
     microphoneMenuTooltip?: string;
     offLabel: string;
+    offSplitButtonAriaLabel?: string;
     onLabel: string;
+    onSplitButtonAriaLabel?: string;
     speakerMenuTitle?: string;
     speakerMenuTooltip?: string;
     tooltipDisabledContent?: string;


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add split button aria fix to release
# Why
<!--- What problem does this change solve? -->
fixes issue where windows narrator can't interact with camera and mic buttons. Also adds split button aria labels for camera and mic buttons to have labels indicating there is a menu in the button.
<!--- Provide a link if you are addressing an open issue. -->
https://github.com/Azure/communication-ui-library/pull/1829
