### PR TITLE
Remove stabilized feature flag `control-bar-split-buttons`

### DIFF
--- a/change/@internal-calling-component-bindings-b4315fda-dc84-4d8f-9b26-ce98d82f29f3.json
+++ b/change/@internal-calling-component-bindings-b4315fda-dc84-4d8f-9b26-ce98d82f29f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove stabilized feature flag control-bar-split-buttons",
+  "packageName": "@internal/calling-component-bindings",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-components-823865be-6866-4956-88e2-642afe84e137.json
+++ b/change/@internal-react-components-823865be-6866-4956-88e2-642afe84e137.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove stabilized feature flag control-bar-split-buttons",
+  "packageName": "@internal/react-components",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-composites-646778f8-53ed-499f-a646-3eb8649fef64.json
+++ b/change/@internal-react-composites-646778f8-53ed-499f-a646-3eb8649fef64.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove stabilized feature flag control-bar-split-buttons",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/babel/.babelrc.js
+++ b/common/config/babel/.babelrc.js
@@ -32,9 +32,6 @@ process.env['COMMUNICATION_REACT_FLAVOR'] === 'stable' &&
         // Demo feature. Used in live-documentation of conditional compilation.
         // Do not use in production code.
         'stabilizedDemo',
-        // Split buttons in control bar. These are used by `call-with-chat-composite` feature.
-        // Perhaps we should merge this into the `call-with-chat-composite` feature?
-        'control-bar-split-buttons',
         // Camera switcher in the local video preview tile. These are used by `call-with-chat-composite` feature.
         // Perhaps we should merge this into the `call-with-chat-composite` feature?
         'local-camera-switcher',

--- a/docs/references/quick-code-reviews.md
+++ b/docs/references/quick-code-reviews.md
@@ -1,0 +1,34 @@
+# Minimizing turnaround time on code reviews
+
+The best thing you can do to keep code reviews quick is to keep your PRs easy to review.
+
+- Keep the PR functionally focussed - change only a few things not many
+- Keep the code easy to understand for reviewer
+- Add context / screenshots / screencapture in PR description
+
+Turns out, all of these considerations also make for an easy to maintain codebase!
+
+## Code review roles
+
+There are three roles in a code review:
+
+- *Author*: The person submitting the PR.
+- *Reviewer*: Anybody who can approve the PR. We auto-populate this list using GitHub's [CODEOWNERS facility](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+- *Assignee*: Manually added reviewers who are responsible for the review.
+
+We use the assignee role to track which reviewers are responsible for (speedy) code reviews.
+
+As an author, you should
+
+- Add two [assignees](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) for your PRs.
+  - To clearly signal the responsible reviewers, it is best to assign exactly two reviewers (for the two required approvals).
+- Assign new folks if the number of assignees falls below two and you still need two approvals.
+- Feel empowered to ping assignees if you do not have reviews in a reasonable amount of time.
+  It is their responsibility to give you timely reviews (see point below about assignee load-shedding).
+
+As an assignee, you should:
+
+- Review assigned PRs timely. It is safe to say that reviewing assigned PRs should be prioritized over writing new PRs.
+- Load-shed if you have too many reviews assigned to you. Tell the PR author you don't have bandwidth / context / confidence for reviewing the PR and unassign yourself.
+
+Finally, the assignee role is intended to only formalize responsibility. Any of the of the other reviewers can also review and approve a PR.

--- a/packages/calling-component-bindings/src/callControlSelectors.ts
+++ b/packages/calling-component-bindings/src/callControlSelectors.ts
@@ -25,13 +25,9 @@ export type MicrophoneButtonSelector = (
 ) => {
   disabled: boolean;
   checked: boolean;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   microphones: AudioDeviceInfo[];
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   speakers: AudioDeviceInfo[];
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   selectedMicrophone?: AudioDeviceInfo;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   selectedSpeaker?: AudioDeviceInfo;
 };
 
@@ -47,13 +43,9 @@ export const microphoneButtonSelector: MicrophoneButtonSelector = reselect.creat
     return {
       disabled: !callExists || !permission,
       checked: callExists ? !isMuted : false,
-      /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
       microphones: deviceManager.microphones,
-      /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
       speakers: deviceManager.speakers,
-      /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
       selectedMicrophone: deviceManager.selectedMicrophone,
-      /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
       selectedSpeaker: deviceManager.selectedSpeaker
     };
   }
@@ -70,9 +62,7 @@ export type CameraButtonSelector = (
 ) => {
   disabled: boolean;
   checked: boolean;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   cameras: VideoDeviceInfo[];
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   selectedCamera?: VideoDeviceInfo;
 };
 
@@ -91,9 +81,7 @@ export const cameraButtonSelector: CameraButtonSelector = reselect.createSelecto
     return {
       disabled: !deviceManager.selectedCamera || !permission,
       checked: localVideoStreams !== undefined && localVideoStreams.length > 0 ? !!localVideoFromCall : previewOn,
-      /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
       cameras: deviceManager.cameras,
-      /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
       selectedCamera: deviceManager.selectedCamera
     };
   }

--- a/packages/communication-react/src/index.ts
+++ b/packages/communication-react/src/index.ts
@@ -116,8 +116,10 @@ export type {
   ActiveErrorMessage,
   BaseCustomStyles,
   CallParticipantListParticipant,
+  CameraButtonContextualMenuStyles,
   CameraButtonProps,
   CameraButtonStrings,
+  CameraButtonStyles,
   ChatMessage,
   CommunicationParticipant,
   ComponentLocale,
@@ -142,7 +144,6 @@ export type {
   GridLayoutProps,
   GridLayoutStyles,
   HorizontalGalleryStyles,
-  ReadReceiptsBySenderId,
   JumpToNewMessageButtonProps,
   LocalizationProviderProps,
   Message,
@@ -156,8 +157,10 @@ export type {
   MessageThreadProps,
   MessageThreadStrings,
   MessageThreadStyles,
+  MicrophoneButtonContextualMenuStyles,
   MicrophoneButtonProps,
   MicrophoneButtonStrings,
+  MicrophoneButtonStyles,
   OnRenderAvatarCallback,
   OptionsDevice,
   ParticipantAddedSystemMessage,
@@ -174,6 +177,7 @@ export type {
   ParticipantsButtonProps,
   ParticipantsButtonStrings,
   ParticipantsButtonStyles,
+  ReadReceiptsBySenderId,
   ScreenShareButtonProps,
   ScreenShareButtonStrings,
   SendBoxProps,
@@ -186,8 +190,8 @@ export type {
   TypingIndicatorProps,
   TypingIndicatorStrings,
   TypingIndicatorStylesProps,
-  VideoGalleryLocalParticipant,
   VideoGalleryLayout,
+  VideoGalleryLocalParticipant,
   VideoGalleryParticipant,
   VideoGalleryProps,
   VideoGalleryRemoteParticipant,
@@ -210,13 +214,6 @@ export type {
 export type { LocalVideoCameraCycleButtonProps } from '../../react-components/src';
 export * from '../../react-components/src/localization/locales';
 export * from '../../react-components/src/theming';
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
-export type {
-  CameraButtonContextualMenuStyles,
-  CameraButtonStyles,
-  MicrophoneButtonContextualMenuStyles,
-  MicrophoneButtonStyles
-} from '../../react-components/src';
 
 export * from '../../calling-stateful-client/src';
 export * from '../../chat-stateful-client/src';

--- a/packages/react-components/src/components/CameraButton.tsx
+++ b/packages/react-components/src/components/CameraButton.tsx
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IContextualMenuProps } from '@fluentui/react';
 import React, { useCallback, useState } from 'react';
 import { useLocale } from '../localization';
 import { VideoStreamOptions } from '../types';
 import { ControlBarButton, ControlBarButtonProps } from './ControlBarButton';
 import { HighContrastAwareIcon } from './HighContrastAwareIcon';
 
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
 import { IContextualMenuItemStyles, IContextualMenuStyles } from '@fluentui/react';
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
 import { ControlBarButtonStyles } from './ControlBarButton';
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
 import { OptionsDevice, generateDefaultDeviceMenuProps } from './DevicesButton';
 import { Announcer } from './Announcer';
 
@@ -47,17 +43,14 @@ export interface CameraButtonStrings {
    * Tooltip of camera menu
    */
   cameraMenuTooltip: string;
-  /* @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * description of camera button split button role
    */
   cameraButtonSplitRoleDescription?: string;
-  /* @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Camera split button aria label for when button is enabled.
    */
   onSplitButtonAriaLabel?: string;
-  /* @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Camera split button aria label for when button is disabled.
    */
@@ -72,7 +65,6 @@ export interface CameraButtonStrings {
   cameraActionTurnedOffAnnouncement: string;
 }
 
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
 /**
  * Styles for {@link CameraButton}
  *
@@ -85,7 +77,6 @@ export interface CameraButtonStyles extends ControlBarButtonStyles {
   menuStyles?: Partial<CameraButtonContextualMenuStyles>;
 }
 
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
 /**
  * Styles for the {@link CameraButton} menu.
  *
@@ -113,22 +104,18 @@ export interface CameraButtonProps extends ControlBarButtonProps {
    * Options for rendering local video view.
    */
   localVideoViewOptions?: VideoStreamOptions;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Available cameras for selection
    */
   cameras?: OptionsDevice[];
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Camera that is shown as currently selected
    */
   selectedCamera?: OptionsDevice;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Callback when a camera is selected
    */
   onSelectCamera?: (device: OptionsDevice) => Promise<void>;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Whether to use a {@link SplitButton} with a {@link IContextualMenu} for device selection.
    *
@@ -139,7 +126,6 @@ export interface CameraButtonProps extends ControlBarButtonProps {
    * Optional strings to override in component
    */
   strings?: Partial<CameraButtonStrings>;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Styles for {@link CameraButton} and the device selection flyout.
    */
@@ -206,35 +192,16 @@ export const CameraButton = (props: CameraButtonProps): JSX.Element => {
         onRenderOffIcon={props.onRenderOffIcon ?? onRenderCameraOffIcon}
         strings={strings}
         labelKey={props.labelKey ?? 'cameraButtonLabel'}
-        menuProps={props.menuProps ?? generateDefaultDeviceMenuPropsTrampoline(props, strings)}
-        menuIconProps={
-          props.menuIconProps ?? !enableDeviceSelectionMenuTrampoline(props) ? { hidden: true } : undefined
+        menuProps={
+          !!props.menuProps && !!props.enableDeviceSelectionMenu
+            ? generateDefaultDeviceMenuProps({ ...props, styles: props.styles?.menuStyles }, strings)
+            : undefined
         }
-        split={props.split ?? enableDeviceSelectionMenuTrampoline(props)}
-        aria-roledescription={
-          enableDeviceSelectionMenuTrampoline(props) ? strings.cameraButtonSplitRoleDescription : undefined
-        }
-        splitButtonAriaLabel={enableDeviceSelectionMenuTrampoline(props) ? splitButtonAriaString : undefined}
+        menuIconProps={props.menuIconProps ?? !props.enableDeviceSelectionMenu ? { hidden: true } : undefined}
+        split={props.split ?? props.enableDeviceSelectionMenu}
+        aria-roledescription={props.enableDeviceSelectionMenu ? strings.cameraButtonSplitRoleDescription : undefined}
+        splitButtonAriaLabel={props.enableDeviceSelectionMenu ? splitButtonAriaString : undefined}
       />
     </>
   );
-};
-
-const generateDefaultDeviceMenuPropsTrampoline = (
-  props: CameraButtonProps,
-  strings: CameraButtonStrings
-): IContextualMenuProps | undefined => {
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
-  if (props.enableDeviceSelectionMenu) {
-    return generateDefaultDeviceMenuProps({ ...props, styles: props.styles?.menuStyles }, strings);
-  }
-  return undefined;
-};
-
-const enableDeviceSelectionMenuTrampoline = (props: CameraButtonProps): boolean => {
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
-  if (props.enableDeviceSelectionMenu) {
-    return true;
-  }
-  return false;
 };

--- a/packages/react-components/src/components/CameraButton.tsx
+++ b/packages/react-components/src/components/CameraButton.tsx
@@ -193,9 +193,10 @@ export const CameraButton = (props: CameraButtonProps): JSX.Element => {
         strings={strings}
         labelKey={props.labelKey ?? 'cameraButtonLabel'}
         menuProps={
-          !!props.menuProps && !!props.enableDeviceSelectionMenu
+          props.menuProps ??
+          (props.enableDeviceSelectionMenu
             ? generateDefaultDeviceMenuProps({ ...props, styles: props.styles?.menuStyles }, strings)
-            : undefined
+            : undefined)
         }
         menuIconProps={props.menuIconProps ?? !props.enableDeviceSelectionMenu ? { hidden: true } : undefined}
         split={props.split ?? props.enableDeviceSelectionMenu}

--- a/packages/react-components/src/components/MicrophoneButton.tsx
+++ b/packages/react-components/src/components/MicrophoneButton.tsx
@@ -1,17 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IContextualMenuProps } from '@fluentui/react';
 import React, { useState, useCallback } from 'react';
 import { useLocale } from '../localization';
 import { ControlBarButton, ControlBarButtonProps } from './ControlBarButton';
 import { HighContrastAwareIcon } from './HighContrastAwareIcon';
 
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
 import { IContextualMenuItemStyles, IContextualMenuStyles } from '@fluentui/react';
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
 import { ControlBarButtonStyles } from './ControlBarButton';
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
 import { OptionsDevice, generateDefaultDeviceMenuProps } from './DevicesButton';
 import { Announcer } from './Announcer';
 
@@ -31,37 +27,30 @@ export interface MicrophoneButtonStrings {
   tooltipOnContent?: string;
   /** Tooltip content when the button is off. */
   tooltipOffContent?: string;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Title of microphone menu
    */
   microphoneMenuTitle?: string;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Title of speaker menu
    */
   speakerMenuTitle?: string;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Tooltip of microphone menu
    */
   microphoneMenuTooltip?: string;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Tooltip of speaker menu
    */
   speakerMenuTooltip?: string;
-  /* @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Description of microphone button split button role
    */
   microphoneButtonSplitRoleDescription: string;
-  /* @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Microphone split button aria label when mic is enabled.
    */
   onSplitButtonAriaLabel?: string;
-  /* @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Microphone split button aria label when mic is disabled.
    */
@@ -76,7 +65,6 @@ export interface MicrophoneButtonStrings {
   microphoneActionTurnedOffAnnouncement: string;
 }
 
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
 /**
  * Styles for {@link MicrophoneButton}
  *
@@ -89,7 +77,6 @@ export interface MicrophoneButtonStyles extends ControlBarButtonStyles {
   menuStyles?: Partial<MicrophoneButtonContextualMenuStyles>;
 }
 
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
 /**
  * Styles for the {@link MicrophoneButton} menu.
  *
@@ -113,37 +100,30 @@ export interface MicrophoneButtonProps extends ControlBarButtonProps {
    * Maps directly to the `onClick` property.
    */
   onToggleMicrophone?: () => Promise<void>;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Available microphones for selection
    */
   microphones?: OptionsDevice[];
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Available speakers for selection
    */
   speakers?: OptionsDevice[];
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Microphone that is shown as currently selected
    */
   selectedMicrophone?: OptionsDevice;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Speaker that is shown as currently selected
    */
   selectedSpeaker?: OptionsDevice;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Callback when a microphone is selected
    */
   onSelectMicrophone?: (device: OptionsDevice) => Promise<void>;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Speaker when a speaker is selected
    */
   onSelectSpeaker?: (device: OptionsDevice) => Promise<void>;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Whether to use a {@link SplitButton} with a {@link IContextualMenu} for device selection.
    *
@@ -154,7 +134,6 @@ export interface MicrophoneButtonProps extends ControlBarButtonProps {
    * Optional strings to override in component
    */
   strings?: Partial<MicrophoneButtonStrings>;
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
   /**
    * Styles for {@link MicrophoneButton} and the device selection flyout.
    */
@@ -215,35 +194,18 @@ export const MicrophoneButton = (props: MicrophoneButtonProps): JSX.Element => {
         onRenderOffIcon={props.onRenderOffIcon ?? onRenderMicOffIcon}
         strings={strings}
         labelKey={props.labelKey ?? 'microphoneButtonLabel'}
-        menuProps={props.menuProps ?? generateDefaultDeviceMenuPropsTrampoline(props, strings)}
-        menuIconProps={
-          props.menuIconProps ?? !enableDeviceSelectionMenuTrampoline(props) ? { hidden: true } : undefined
+        menuProps={
+          !!props.menuProps && !!props.enableDeviceSelectionMenu
+            ? generateDefaultDeviceMenuProps({ ...props, styles: props.styles?.menuStyles }, strings)
+            : undefined
         }
-        split={props.split ?? enableDeviceSelectionMenuTrampoline(props)}
+        menuIconProps={props.menuIconProps ?? !props.enableDeviceSelectionMenu ? { hidden: true } : undefined}
+        split={props.split ?? props.enableDeviceSelectionMenu}
         aria-roledescription={
-          enableDeviceSelectionMenuTrampoline(props) ? strings.microphoneButtonSplitRoleDescription : undefined
+          props.enableDeviceSelectionMenu ? strings.microphoneButtonSplitRoleDescription : undefined
         }
-        splitButtonAriaLabel={enableDeviceSelectionMenuTrampoline(props) ? splitButtonAriaString : undefined}
+        splitButtonAriaLabel={props.enableDeviceSelectionMenu ? splitButtonAriaString : undefined}
       />
     </>
   );
-};
-
-const generateDefaultDeviceMenuPropsTrampoline = (
-  props: MicrophoneButtonProps,
-  strings: MicrophoneButtonStrings
-): IContextualMenuProps | undefined => {
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
-  if (props.enableDeviceSelectionMenu) {
-    return generateDefaultDeviceMenuProps({ ...props, styles: props.styles?.menuStyles }, strings);
-  }
-  return undefined;
-};
-
-const enableDeviceSelectionMenuTrampoline = (props: MicrophoneButtonProps): boolean => {
-  /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
-  if (props.enableDeviceSelectionMenu) {
-    return true;
-  }
-  return false;
 };

--- a/packages/react-components/src/components/MicrophoneButton.tsx
+++ b/packages/react-components/src/components/MicrophoneButton.tsx
@@ -195,9 +195,10 @@ export const MicrophoneButton = (props: MicrophoneButtonProps): JSX.Element => {
         strings={strings}
         labelKey={props.labelKey ?? 'microphoneButtonLabel'}
         menuProps={
-          !!props.menuProps && !!props.enableDeviceSelectionMenu
+          props.menuProps ??
+          (props.enableDeviceSelectionMenu
             ? generateDefaultDeviceMenuProps({ ...props, styles: props.styles?.menuStyles }, strings)
-            : undefined
+            : undefined)
         }
         menuIconProps={props.menuIconProps ?? !props.enableDeviceSelectionMenu ? { hidden: true } : undefined}
         split={props.split ?? props.enableDeviceSelectionMenu}

--- a/packages/react-components/src/components/index.ts
+++ b/packages/react-components/src/components/index.ts
@@ -50,9 +50,12 @@ export { LocalVideoCameraCycleButton } from './LocalVideoCameraButton';
 export type { LocalVideoCameraCycleButtonProps } from './LocalVideoCameraButton';
 
 export { CameraButton } from './CameraButton';
-export type { CameraButtonProps, CameraButtonStrings } from './CameraButton';
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
-export type { CameraButtonContextualMenuStyles, CameraButtonStyles } from './CameraButton';
+export type {
+  CameraButtonContextualMenuStyles,
+  CameraButtonProps,
+  CameraButtonStrings,
+  CameraButtonStyles
+} from './CameraButton';
 
 export { ControlBar } from './ControlBar';
 export type { ControlBarProps, ControlBarLayout } from './ControlBar';
@@ -64,9 +67,12 @@ export { EndCallButton } from './EndCallButton';
 export type { EndCallButtonProps, EndCallButtonStrings } from './EndCallButton';
 
 export { MicrophoneButton } from './MicrophoneButton';
-export type { MicrophoneButtonProps, MicrophoneButtonStrings } from './MicrophoneButton';
-/* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
-export type { MicrophoneButtonContextualMenuStyles, MicrophoneButtonStyles } from './MicrophoneButton';
+export type {
+  MicrophoneButtonStyles,
+  MicrophoneButtonContextualMenuStyles,
+  MicrophoneButtonProps,
+  MicrophoneButtonStrings
+} from './MicrophoneButton';
 
 export { DevicesButton } from './DevicesButton';
 export type {

--- a/packages/react-composites/src/composites/CallComposite/components/buttons/Camera.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/buttons/Camera.tsx
@@ -23,7 +23,6 @@ export const Camera = (props: {
       {...cameraButtonProps}
       showLabel={props.displayType !== 'compact'}
       styles={styles}
-      /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
       enableDeviceSelectionMenu={props.splitButtonsForDeviceSelection}
     />
   );

--- a/packages/react-composites/src/composites/CallComposite/components/buttons/Microphone.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/buttons/Microphone.tsx
@@ -53,7 +53,6 @@ export const Microphone = (props: {
       showLabel={props.displayType !== 'compact'}
       styles={styles}
       {...microphoneButtonStrings}
-      /* @conditional-compile-remove(call-with-chat-composite) @conditional-compile-remove(control-bar-split-buttons) */
       enableDeviceSelectionMenu={props.splitButtonsForDeviceSelection}
     />
   );


### PR DESCRIPTION
# What

The feature was stabilized in the `1.2.0` release.

This PR removes the feature flags and cleans up any logic that existed specifically to support this feature flag.