### PR TITLE
File download cards to use fileSharingMetadata file extension

### DIFF
--- a/change/@internal-react-components-eb226ab8-dad0-4116-b8b9-12e6dd4692e0.json
+++ b/change/@internal-react-components-eb226ab8-dad0-4116-b8b9-12e6dd4692e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "File download cards to use fileMetadata extension instead of parsing it from filename",
+  "packageName": "@internal/react-components",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/docs/references/quick-code-reviews.md
+++ b/docs/references/quick-code-reviews.md
@@ -1,0 +1,34 @@
+# Minimizing turnaround time on code reviews
+
+The best thing you can do to keep code reviews quick is to keep your PRs easy to review.
+
+- Keep the PR functionally focussed - change only a few things not many
+- Keep the code easy to understand for reviewer
+- Add context / screenshots / screencapture in PR description
+
+Turns out, all of these considerations also make for an easy to maintain codebase!
+
+## Code review roles
+
+There are three roles in a code review:
+
+- *Author*: The person submitting the PR.
+- *Reviewer*: Anybody who can approve the PR. We auto-populate this list using GitHub's [CODEOWNERS facility](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+- *Assignee*: Manually added reviewers who are responsible for the review.
+
+We use the assignee role to track which reviewers are responsible for (speedy) code reviews.
+
+As an author, you should
+
+- Add two [assignees](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) for your PRs.
+  - To clearly signal the responsible reviewers, it is best to assign exactly two reviewers (for the two required approvals).
+- Assign new folks if the number of assignees falls below two and you still need two approvals.
+- Feel empowered to ping assignees if you do not have reviews in a reasonable amount of time.
+  It is their responsibility to give you timely reviews (see point below about assignee load-shedding).
+
+As an assignee, you should:
+
+- Review assigned PRs timely. It is safe to say that reviewing assigned PRs should be prioritized over writing new PRs.
+- Load-shed if you have too many reviews assigned to you. Tell the PR author you don't have bandwidth / context / confidence for reviewing the PR and unassign yourself.
+
+Finally, the assignee role is intended to only formalize responsibility. Any of the of the other reviewers can also review and approve a PR.

--- a/packages/react-components/src/components/FileDownloadCards.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.tsx
@@ -4,7 +4,6 @@ import { Icon, Spinner, SpinnerSize } from '@fluentui/react';
 import React, { useCallback, useState } from 'react';
 import { _FileCard } from './FileCard';
 import { _FileCardGroup } from './FileCardGroup';
-import { extension } from './utils';
 
 /**
  * Meta Data containing information about the uploaded file.

--- a/packages/react-components/src/components/FileDownloadCards.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.tsx
@@ -139,7 +139,7 @@ export const _FileDownloadCards = (props: _FileDownloadCards): JSX.Element => {
             <_FileCard
               fileName={file.name}
               key={file.name}
-              fileExtension={extension(file.name)}
+              fileExtension={file.extension}
               actionIcon={
                 showSpinner ? <Spinner size={SpinnerSize.medium} aria-live={'assertive'} /> : <DownloadIconTrampoline />
               }


### PR DESCRIPTION
# What
File download cards to use `fileSharingMetadata` file extension instead of parsing the extension from name.
This allows contoso to explicitly specify an extension for an uploaded file in case they want to render different icons.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->