### PR TITLE
Add util method for hiding and enabling tooltips during tests

### DIFF
--- a/packages/react-components/src/components/FileDownloadCards.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.tsx
@@ -4,6 +4,7 @@ import { Icon, Spinner, SpinnerSize } from '@fluentui/react';
 import React, { useCallback, useState } from 'react';
 import { _FileCard } from './FileCard';
 import { _FileCardGroup } from './FileCardGroup';
+import { extension } from './utils';
 
 /**
  * Meta Data containing information about the uploaded file.

--- a/packages/react-components/src/components/FileDownloadCards.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.tsx
@@ -4,7 +4,6 @@ import { Icon, Spinner, SpinnerSize } from '@fluentui/react';
 import React, { useCallback, useState } from 'react';
 import { _FileCard } from './FileCard';
 import { _FileCardGroup } from './FileCardGroup';
-import { extension } from './utils';
 
 /**
  * Meta Data containing information about the uploaded file.

--- a/packages/react-composites/tests/browser/call/CallComposite.test.ts
+++ b/packages/react-composites/tests/browser/call/CallComposite.test.ts
@@ -10,7 +10,9 @@ import {
   isTestProfileStableFlavor,
   waitForCallCompositeToLoad,
   waitForFunction,
-  waitForSelector
+  waitForSelector,
+  disableTooltips,
+  enableTooltips
 } from '../common/utils';
 import { test } from './fixture';
 import { expect, Page } from '@playwright/test';
@@ -51,7 +53,9 @@ test.describe('Call Composite E2E Configuration Screen Tests', () => {
   test('composite pages load completely', async ({ pages }) => {
     const page = pages[0];
     await stubLocalCameraName(page);
+    await disableTooltips(page);
     expect(await page.screenshot()).toMatchSnapshot(`call-configuration-page.png`);
+    await enableTooltips(page);
   });
 
   test('local device settings can toggle camera & audio', async ({ pages }) => {
@@ -63,7 +67,9 @@ test.describe('Call Composite E2E Configuration Screen Tests', () => {
       return !!videoNode && videoNode.readyState === 4 && !videoNode.paused && videoNode;
     });
     await stubLocalCameraName(page);
+    await disableTooltips(page);
     expect(await page.screenshot()).toMatchSnapshot(`call-configuration-page-camera-enabled.png`);
+    await enableTooltips(page);
   });
 
   test('local device buttons should show tooltips on hover', async ({ pages }) => {

--- a/packages/react-composites/tests/browser/common/utils.ts
+++ b/packages/react-composites/tests/browser/common/utils.ts
@@ -302,3 +302,20 @@ export const isTestProfileStableFlavor = (): boolean => {
     throw 'Faled to find Communication React Flavor env variable';
   }
 };
+
+/**
+ * Helper function for disabling all the tooltips on the page.
+ * Tooltips are idnetified via the `ms-Callout-container` class name.
+ * Note: For tooltips to work again, please call `enableTooltips(page)` after the test.
+ */
+export const disableTooltips = async (page: Page): Promise<void> => {
+  await page.addStyleTag({ content: '.ms-Callout-container{display: none}' });
+};
+
+/**
+ * Helper function for enabling all the tooltips on the page.
+ * Tooltips are idnetified via the `ms-Callout-container` class name.
+ */
+export const enableTooltips = async (page: Page): Promise<void> => {
+  await page.addStyleTag({ content: '.ms-Callout-container{display: block}' });
+};


### PR DESCRIPTION
# What
Adding util method for hiding and enabling tooltips.
This helps us fix the following bug
**https://skype.visualstudio.com/SPOOL/_sprints/taskboard/ACS%20Web%20UI/SPOOL/CY2022-Q2/Sprint%2062%20(Ends%20May%2015)?workitem=2826640**

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->