### PR TITLE
Add a more reliable method to avoid flaky tooltips in e2e snapshots

### DIFF
--- a/packages/react-composites/tests/browser/call/UserFacingDiagnostics.test.ts
+++ b/packages/react-composites/tests/browser/call/UserFacingDiagnostics.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { expect } from '@playwright/test';
-import { dataUiId, clickOutsideOfPage, waitForPageFontsLoaded, waitForSelector } from '../common/utils';
+import { dataUiId, waitForSelector, stableScreenshot } from '../common/utils';
 import { test } from './fixture';
 import { buildUrlWithMockAdapter } from './utils';
 import { DiagnosticQuality } from './TestCallingState';
@@ -15,11 +15,8 @@ test.describe('User Facing Diagnostics tests', async () => {
         diagnostics: { media: { speakingWhileMicrophoneIsMuted: { value: true, valueType: 'DiagnosticFlag' } } }
       })
     );
-    // Click outside of screen to turn away initial aria label
-    await clickOutsideOfPage(page);
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
-    await waitForPageFontsLoaded(page);
-    expect(await page.screenshot()).toMatchSnapshot('banner-when-speaking-while-muted.png');
+    expect(await stableScreenshot(page)).toMatchSnapshot('banner-when-speaking-while-muted.png');
   });
 
   test('Tile should be showing when network reconnect is bad ', async ({ pages, serverUrl }) => {
@@ -29,11 +26,8 @@ test.describe('User Facing Diagnostics tests', async () => {
         diagnostics: { network: { networkReconnect: { value: DiagnosticQuality.Bad, valueType: 'DiagnosticQuality' } } }
       })
     );
-    // Click outside of screen to turn away initial aria label
-    await clickOutsideOfPage(page);
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
-    await waitForPageFontsLoaded(page);
-    expect(await page.screenshot()).toMatchSnapshot('tile-when-ufd-network-reconnect-is-bad.png');
+    expect(await stableScreenshot(page)).toMatchSnapshot('tile-when-ufd-network-reconnect-is-bad.png');
   });
 
   test('Error bar should be showing when camera freezes ', async ({ pages, serverUrl }) => {
@@ -43,10 +37,7 @@ test.describe('User Facing Diagnostics tests', async () => {
         diagnostics: { media: { cameraFreeze: { value: true, valueType: 'DiagnosticFlag' } } }
       })
     );
-    // Click outside of screen to turn away initial aria label
-    await clickOutsideOfPage(page);
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
-    await waitForPageFontsLoaded(page);
-    expect(await page.screenshot()).toMatchSnapshot('error-bar-when-camera-freezes.png');
+    expect(await stableScreenshot(page)).toMatchSnapshot('error-bar-when-camera-freezes.png');
   });
 });

--- a/packages/react-composites/tests/browser/common/utils.ts
+++ b/packages/react-composites/tests/browser/common/utils.ts
@@ -333,7 +333,7 @@ export async function stableScreenshot(
     await disableTooltips(page);
   }
   try {
-    return page.screenshot(screenshotOptions);
+    return await page.screenshot(screenshotOptions);
   } finally {
     if (stubOptions?.tooltips != false) {
       await enableTooltips(page);

--- a/packages/react-composites/tests/browser/common/utils.ts
+++ b/packages/react-composites/tests/browser/common/utils.ts
@@ -34,9 +34,7 @@ async function screenshotOnFailure<T>(page: Page, fn: () => Promise<T>): Promise
 export const pageClick = async (page: Page, selector: string): Promise<void> => {
   await page.bringToFront();
   await screenshotOnFailure(page, async () => await page.click(selector, { timeout: PER_STEP_TIMEOUT_MS }));
-
-  // Move the mouse off the screen
-  await page.mouse.move(-1, -1);
+  clickOutsideOfPage(page);
 };
 
 /**


### PR DESCRIPTION
The UFD tests were already dismissing tooltips by clicking off screen, but we still saw a small rate of flakiness in the screenshots.

This PR introduces an alternative method, suggested by @anjulgarg, in #1851 that is likely to work better - it disables the tooltips via CSS. We know that the new styles have been loaded by the browser when the function returns.

The plan is to merge this PR and observe for a week or so, if the UFD tests are found to be stable, we can start replacing other uses of the now deprecated `clickOutsideOfPage` function with the new `stableSnapshot` helper.