### PR TITLE
Use pageClick so that we get screenshot on timeout

### DIFF
--- a/packages/react-composites/tests/browser/chat/ErrorBar.test.ts
+++ b/packages/react-composites/tests/browser/chat/ErrorBar.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { stubMessageTimestamps, waitForChatCompositeToLoad, buildUrl, dataUiId } from '../common/utils';
+import { stubMessageTimestamps, waitForChatCompositeToLoad, buildUrl, dataUiId, pageClick } from '../common/utils';
 import { test } from './fixture';
 import { expect } from '@playwright/test';
 import {
@@ -41,8 +41,8 @@ test.describe('ErrorBar is shown correctly', async () => {
     await stubMessageTimestamps(page);
     expect(await page.screenshot()).toMatchSnapshot('error-bar-send-message-with-wrong-thread-id.png');
     // test resend button in contextual menu
-    await page.click(dataUiId('chat-composite-message'));
-    await page.click(dataUiId('chat-composite-message-action-icon'));
+    await pageClick(page, dataUiId('chat-composite-message'));
+    await pageClick(page, dataUiId('chat-composite-message-action-icon'));
     await page.waitForSelector('[id="chat-composite-message-contextual-menu"]');
 
     expect(await page.screenshot()).toMatchSnapshot(


### PR DESCRIPTION
Noticed an unsafe use of `page.click` while working on e2e tests. FIXIT.