### PR TITLE
One liner: use `useId`

### DIFF
--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -179,7 +179,7 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
   }, [setActivePane]);
 
   /** Constant setting of id for the parent stack of the composite */
-  const compositeParentDivId = 'callWithChatCompositeParentDiv-internal';
+  const compositeParentDivId = useId('callWithChatCompositeParentDiv-internal');
 
   const toggleChat = useCallback(() => {
     if (activePane === 'chat') {


### PR DESCRIPTION
# What
* Use fluent useId hook when creating a referential ID

# Why
If there are ever two composites they will have unique ids

# How Tested
Manual regression test: Chat sendbox still gets focus when chat pane opened