### PR TITLE
Support `updateScalingMode` for the local video stream in VideoGallery

### DIFF
--- a/change/@internal-react-components-51d61f5d-5bc8-478a-a806-411ec47dc32f.json
+++ b/change/@internal-react-components-51d61f5d-5bc8-478a-a806-411ec47dc32f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Support updateScalingMode in the VideoGallery to avoid having to destroy and recreate the stream when the localVideoViewOption scaling mode is changed",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/review/react-components.api.md
+++ b/packages/react-components/review/react-components.api.md
@@ -262,6 +262,14 @@ export interface ControlBarProps {
 }
 
 // @public
+export interface CreateVideoStreamViewResult {
+    // (undocumented)
+    view: {
+        updateScalingMode: (scalingMode: ScalingMode) => Promise<void>;
+    };
+}
+
+// @public
 export type CustomAvatarOptions = {
     coinSize?: number;
     hidePersonaDetails?: boolean;
@@ -978,6 +986,9 @@ export type ReadReceiptsBySenderId = {
 };
 
 // @public
+export type ScalingMode = 'Stretch' | 'Crop' | 'Fit';
+
+// @public
 export const ScreenShareButton: (props: ScreenShareButtonProps) => JSX.Element;
 
 // @public
@@ -1134,7 +1145,7 @@ export interface VideoGalleryProps {
     localVideoCameraCycleButtonProps?: LocalVideoCameraCycleButtonProps;
     localVideoViewOptions?: VideoStreamOptions;
     maxRemoteVideoStreams?: number;
-    onCreateLocalStreamView?: (options?: VideoStreamOptions) => Promise<void>;
+    onCreateLocalStreamView?: (options?: VideoStreamOptions) => Promise<void | CreateVideoStreamViewResult>;
     onCreateRemoteStreamView?: (userId: string, options?: VideoStreamOptions) => Promise<void>;
     onDisposeLocalStreamView?: () => void;
     onDisposeRemoteStreamView?: (userId: string) => Promise<void>;
@@ -1183,7 +1194,7 @@ export interface VideoGalleryStyles extends BaseCustomStyles {
 // @public
 export interface VideoStreamOptions {
     isMirrored?: boolean;
-    scalingMode?: 'Stretch' | 'Crop' | 'Fit';
+    scalingMode?: ScalingMode;
 }
 
 // @public

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -13,7 +13,8 @@ import {
   OnRenderAvatarCallback,
   VideoGalleryLocalParticipant,
   VideoGalleryRemoteParticipant,
-  VideoStreamOptions
+  VideoStreamOptions,
+  CreateVideoStreamViewResult
 } from '../types';
 import { GridLayout } from './GridLayout';
 import { HorizontalGalleryStyles } from './HorizontalGallery';
@@ -116,7 +117,7 @@ export interface VideoGalleryProps {
   /** Remote videos view options */
   remoteVideoViewOptions?: VideoStreamOptions;
   /** Callback to create the local video stream view */
-  onCreateLocalStreamView?: (options?: VideoStreamOptions) => Promise<void>;
+  onCreateLocalStreamView?: (options?: VideoStreamOptions) => Promise<void | CreateVideoStreamViewResult>;
   /** Callback to dispose of the local video stream view */
   onDisposeLocalStreamView?: () => void;
   /** Callback to render the local video tile*/

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -15,6 +15,7 @@ export type {
   ChatMessage,
   CommunicationParticipant,
   ContentSystemMessage,
+  CreateVideoStreamViewResult,
   CustomAvatarOptions,
   CustomMessage,
   Message,
@@ -25,6 +26,8 @@ export type {
   ParticipantAddedSystemMessage,
   ParticipantListParticipant,
   ParticipantRemovedSystemMessage,
+  ReadReceiptsBySenderId,
+  ScalingMode,
   SystemMessage,
   SystemMessageCommon,
   TopicUpdatedSystemMessage,
@@ -32,6 +35,5 @@ export type {
   VideoGalleryParticipant,
   VideoGalleryRemoteParticipant,
   VideoGalleryStream,
-  VideoStreamOptions,
-  ReadReceiptsBySenderId
+  VideoStreamOptions
 } from './types';

--- a/packages/react-components/src/types/VideoGalleryParticipant.ts
+++ b/packages/react-components/src/types/VideoGalleryParticipant.ts
@@ -2,6 +2,13 @@
 // Licensed under the MIT license.
 
 /**
+ * Scaling mode of a {@link VideoGalleryStream}.
+ *
+ * @public
+ */
+export type ScalingMode = 'Stretch' | 'Crop' | 'Fit';
+
+/**
  * Options to control how video streams are rendered.
  *
  * @public
@@ -10,7 +17,7 @@ export declare interface VideoStreamOptions {
   /** Whether the video stream is mirrored or not */
   isMirrored?: boolean;
   /** Scaling mode. It can be `Stretch`, `Crop` or `Fit` */
-  scalingMode?: 'Stretch' | 'Crop' | 'Fit';
+  scalingMode?: ScalingMode;
 }
 
 /**
@@ -45,6 +52,18 @@ export interface VideoGalleryStream {
   isMirrored?: boolean;
   /** Render element of the video stream */
   renderElement?: HTMLElement;
+}
+
+/**
+ * Object returned after creating a local or remote VideoStream.
+ * This contains helper functions to manipulate the render of the stream.
+ *
+ * @public
+ */
+export interface CreateVideoStreamViewResult {
+  view: {
+    updateScalingMode: (scalingMode: ScalingMode) => Promise<void>;
+  };
 }
 
 // set the required attribs in selector. (Further simplifying our component logic) For example


### PR DESCRIPTION
# What
Call updateScalingMode instead of recreating the stream in the local video tile

Prev PR in stack:
Next PR in stack:

# Why
This means we do not have to destroy and recreate the stream when the scaling mode has changed.

# How Tested
See next PR in stack for video