### PR TITLE
Add rush command to build just npm package for both flavors for updating api files

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -68,9 +68,17 @@
     {
       "commandKind": "global",
       "name": "build:all-flavors",
-      "summary": "Build all flavor in one command (mainly for api update)",
-      "description": "Build all flavor in one command (mainly for api update). This command will switch current flavor to beta.",
+      "summary": "Build all packages for all flavors in one command",
+      "description": "Build all packages for all flavors in one command. This command will switch current flavor to beta.",
       "shellCommand": "(rush switch-flavor:stable && rush rebuild) || rush switch-flavor:beta && rush rebuild",
+      "safeForSimultaneousRushProcesses": true
+    },
+    {
+      "commandKind": "global",
+      "name": "build:npm-all-flavors",
+      "summary": "Build all packages in all flavors, excluding samples and storybook (this is mainly for api update)",
+      "description": "Build all packages in all flavors in one command, excluding samples and storybook (this is mainly for api update). This command will switch current flavor to beta.",
+      "shellCommand": "(rush switch-flavor:stable && rush rebuild -t @azure/communication-react) || rush switch-flavor:beta && rush rebuild -t @azure/communication-react",
       "safeForSimultaneousRushProcesses": true
     },
     {


### PR DESCRIPTION
# What
Add rush command to build just npm package for both flavors, i.e. build all excluding storybook and samples

# Why
I'm lazy and to update the api files locally currently we have to do:
```
rush switch-flavor:stable
rush build -t @azure/communication-react
rush switch-flavor:beta
rush build -t @azure/communication-react
```

which is laborsome. Currently we can do `rush build:all-flavors` but that builds storybook and samples which take a long time to build and often not necessary to build locally.

# How Tested
Test rush command on my machine and worked.