### PR TITLE
Fix metapackage preprocess tsconfig file -- do not transpile files not used by the meta package

### DIFF
--- a/packages/communication-react/tsconfig.preprocess.json
+++ b/packages/communication-react/tsconfig.preprocess.json
@@ -19,6 +19,6 @@
     ]
   },
   "typeRoots": ["./node_modules/@types"],
-  "include": ["preprocess-dist/**/*"],
+  "include": ["preprocess-dist/communication-react/src/**/*"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
# What
Update the tsconfig for the preprocessed builds to only compile the meta package code and its dependencies.
This change updates the tsconfig to point to the meta package's src/ directly -- matching the non-preprocess tsconfig file.

# Why
Currently we compile every ts file in the preprocess dir, this includes files that should not be included such as chat-stateful-client test.ts files.
Instead we should be mimic-ing the ordinary tsconfig that points to the meta package src/ directory.

# How Tested
Successfully compiles all metapackage src/ and any other packlet src files used by the metapackage (which is 99% of our codebase) but successfully does not compile other packlet files that are not used in the meta package (such as test files)