### PR TITLE
Cancel previous CI runs when newer changes are pushed in a PR

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -4,6 +4,7 @@ on:
   # Allows running workflow manually from the GitHub Actions tab
   workflow_dispatch:
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -4,6 +4,10 @@ on:
   # Allows running workflow manually from the GitHub Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_and_test:
     name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # get matrix for ci-jobs
   get_matrix:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: '24 7 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,7 @@ on:
   schedule:
     - cron: '24 7 * * 0'
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/create-beta-release-branch.yml
+++ b/.github/workflows/create-beta-release-branch.yml
@@ -10,6 +10,10 @@ on:
         required: true
         default: 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   create_beta_release:
     name: Bump versions and create changelog PR

--- a/.github/workflows/create-beta-release-branch.yml
+++ b/.github/workflows/create-beta-release-branch.yml
@@ -10,6 +10,7 @@ on:
         required: true
         default: 'main'
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/create-prerelease-branch.yml
+++ b/.github/workflows/create-prerelease-branch.yml
@@ -17,6 +17,7 @@ on:
           - stable-patch
           - beta
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/create-prerelease-branch.yml
+++ b/.github/workflows/create-prerelease-branch.yml
@@ -17,6 +17,10 @@ on:
           - stable-patch
           - beta
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # create pre-release branch for beta releases
   create_pre-release:

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -9,6 +9,7 @@ on:
         type: string
         required: true
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -9,6 +9,10 @@ on:
         type: string
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   create_release:
     if: ${{ startsWith(github.event.inputs.branch, 'prerelease') }}

--- a/.github/workflows/create-stable-release-branch.yml
+++ b/.github/workflows/create-stable-release-branch.yml
@@ -17,6 +17,7 @@ on:
           - minor
           - patch
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/create-stable-release-branch.yml
+++ b/.github/workflows/create-stable-release-branch.yml
@@ -17,6 +17,10 @@ on:
           - minor
           - patch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   create_stable_release:
     name: Bump versions and create changelog PR

--- a/.github/workflows/deploy-azure-webapps.yml
+++ b/.github/workflows/deploy-azure-webapps.yml
@@ -10,6 +10,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-azure-webapps.yml
+++ b/.github/workflows/deploy-azure-webapps.yml
@@ -10,6 +10,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy-samples:
     name: Build and Deploy samples

--- a/.github/workflows/deploy-release-azure-webapps.yml
+++ b/.github/workflows/deploy-release-azure-webapps.yml
@@ -8,6 +8,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-release-azure-webapps.yml
+++ b/.github/workflows/deploy-release-azure-webapps.yml
@@ -8,6 +8,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy-samples:
     name: Build and Deploy samples

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -4,6 +4,10 @@ on:
   # Trigger via 'Actions' on GitHub
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy-storybook:
     name: Build and Deploy Storybook

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -4,6 +4,7 @@ on:
   # Trigger via 'Actions' on GitHub
   workflow_dispatch:
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/nightly-cd.yml
+++ b/.github/workflows/nightly-cd.yml
@@ -10,6 +10,7 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/nightly-cd.yml
+++ b/.github/workflows/nightly-cd.yml
@@ -10,6 +10,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkForChanges:
     name: Check for new changes

--- a/.github/workflows/npm-release-publish.yml
+++ b/.github/workflows/npm-release-publish.yml
@@ -19,6 +19,7 @@ on:
           - stable
           - beta
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/npm-release-publish.yml
+++ b/.github/workflows/npm-release-publish.yml
@@ -19,6 +19,10 @@ on:
           - stable
           - beta
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     environment:

--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -11,6 +11,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chromatic_deployment:
     name: Publish Chromatic

--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/run-td-build.yml
+++ b/.github/workflows/run-td-build.yml
@@ -17,6 +17,7 @@ on:
         type: boolean
         default: false
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/run-td-build.yml
+++ b/.github/workflows/run-td-build.yml
@@ -17,6 +17,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   runTDBuild:
     name: Run Touchdown build

--- a/.github/workflows/stress-test-ui-tests.yml
+++ b/.github/workflows/stress-test-ui-tests.yml
@@ -3,6 +3,7 @@ name: Stress test UI tests
 on:
   workflow_dispatch:
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/stress-test-ui-tests.yml
+++ b/.github/workflows/stress-test-ui-tests.yml
@@ -3,6 +3,10 @@ name: Stress test UI tests
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stress_test_ui_tests:
     name: Run UI tests 7 times

--- a/.github/workflows/update-api-files.yml
+++ b/.github/workflows/update-api-files.yml
@@ -3,6 +3,7 @@ name: Update API files
 on:
   workflow_dispatch:
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/update-api-files.yml
+++ b/.github/workflows/update-api-files.yml
@@ -3,6 +3,10 @@ name: Update API files
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update_composite_snapshot:
     name: Update all API files

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
+# cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -6,6 +6,10 @@ on:
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # get matrix for ci-jobs
   get_matrix:


### PR DESCRIPTION
# What
Cancel previous CI runs when newer changes are pushed in a PR.

## How does this work

https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre/67939898#67939898

Code snippet being added:
```
concurrency: 
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

This creates a "concurrency grouping" with `cancel-in-progress: true` where if another action is triggered in that concurrency group, it will cancel any in progress ones.

To ensure the correct action is cancelled, it creates a group name using:
* `github.workflow` id to ensure it only cancels runs of the same github action
* `github.ref` to ensure only runs targeting the same branch/PR are cancelled.

Put those together and we cancel runs of the same action on the same branch.

# Why
Currently if you push 5 changes one after another to your PR, our github actions will run all actions for all those changes creating a ton of waste. This change will ensure old actions will be cancelled if newer changes are pushed (or newer actions triggered on the same branch).

This will also cancel old runs if you manually run an action twice on the same branch - for better or worse -- **I added this to all our github actions, please review if any should omit this** (e.g. if we would want to runs of the same action on the same branch)

# How Tested
Action run was successfully cancelled when new `add comments` change was pushed: https://github.com/Azure/communication-ui-library/runs/6456075631.
And successfully cancelled that run when "merge new changes from main" was clicked:
![image](https://user-images.githubusercontent.com/2684369/168640335-f587452d-98b8-4f98-9033-dafaa86255ca.png)
