### PR TITLE
Add custom data model to the chat thread display names

### DIFF
--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -279,6 +279,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
  * that we want to do here to the same level? or is the React useMemo hook enough?
  *
  * So other issue: we can map the ID's into a array, but how do we go about mapping them back?
+ *
  */
 const useRemoteParticipantsWithCustomDisplayNames = (
   messages: (ChatMessage | SystemMessage | CustomMessage)[],

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -50,7 +50,6 @@ import { useSelector } from './hooks/useSelector';
 import { FileDownloadErrorBar } from './FileDownloadErrorBar';
 /* @conditional-compile-remove(file-sharing) */
 import { _FileDownloadCards } from '@internal/react-components';
-import { useCustomAvatarPersonaData } from '../common/CustomDataModelUtils';
 
 /**
  * @private
@@ -141,6 +140,12 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
 
   const messages = messageThreadProps.messages as (ChatMessage | SystemMessage | CustomMessage)[];
 
+  /**
+   * Update Messages and their senders based on the onFetchAvatarPersonaData prop for the chat composite
+   *
+   * Current issue: we aren't using the custom hook like in media gallery that memoizes it. is this something
+   * that we want to do here to the same level? or is the React useMemo hook enough?
+   */
   useMemo(() => {
     if (onFetchAvatarPersonaData) {
       messages.forEach(async (m) => {
@@ -155,7 +160,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
         }
       });
     }
-  }, [messages]);
+  }, [messages, onFetchAvatarPersonaData]);
 
   const onRenderAvatarCallback = useCallback(
     (userId, defaultOptions) => {

--- a/samples/CallWithChat/src/app/views/CallScreen.tsx
+++ b/samples/CallWithChat/src/app/views/CallScreen.tsx
@@ -9,7 +9,8 @@ import {
   CallAndChatLocator,
   CallWithChatAdapterState,
   CallWithChatComposite,
-  CallWithChatAdapter
+  CallWithChatAdapter,
+  AvatarPersonaData
 } from '@azure/communication-react';
 import { Spinner } from '@fluentui/react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -86,6 +87,10 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     return <Spinner label={'Creating adapter'} ariaLive="assertive" labelPosition="top" />;
   }
 
+  const onFetchAvatarPersonaData = async (userId: string): Promise<AvatarPersonaData> => ({
+    text: 'apples'
+  });
+
   return (
     <CallWithChatComposite
       adapter={adapter}
@@ -93,6 +98,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
       rtl={currentRtl}
       joinInvitationURL={window.location.href}
       formFactor={isMobileSession ? 'mobile' : 'desktop'}
+      onFetchAvatarPersonaData={onFetchAvatarPersonaData}
     />
   );
 };

--- a/samples/CallWithChat/src/app/views/CallScreen.tsx
+++ b/samples/CallWithChat/src/app/views/CallScreen.tsx
@@ -87,10 +87,6 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     return <Spinner label={'Creating adapter'} ariaLive="assertive" labelPosition="top" />;
   }
 
-  const onFetchAvatarPersonaData = async (userId: string): Promise<AvatarPersonaData> => ({
-    text: 'apples'
-  });
-
   return (
     <CallWithChatComposite
       adapter={adapter}
@@ -98,7 +94,6 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
       rtl={currentRtl}
       joinInvitationURL={window.location.href}
       formFactor={isMobileSession ? 'mobile' : 'desktop'}
-      onFetchAvatarPersonaData={onFetchAvatarPersonaData}
     />
   );
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Adds to the chat thread overrides for the displayNames associated with messages
![image](https://user-images.githubusercontent.com/94866715/168704197-5e1fe436-29e7-464b-8c9a-25d13039442b.png)

# Why
<!--- What problem does this change solve? -->
Allows more complete coverage of our custom data model feature
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2833447
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran locally with custom data 