### PR TITLE
Update remote video tile to use the `useVideoStreamLifecycleMaintainer`

### DIFF
--- a/packages/react-components/src/components/LocalVideoTile.tsx
+++ b/packages/react-components/src/components/LocalVideoTile.tsx
@@ -7,7 +7,10 @@ import React, { useMemo } from 'react';
 import { OnRenderAvatarCallback, VideoStreamOptions, CreateVideoStreamViewResult } from '../types';
 import { LocalVideoCameraCycleButton, LocalVideoCameraCycleButtonProps } from './LocalVideoCameraButton';
 import { StreamMedia } from './StreamMedia';
-import { useVideoStreamLifecycleMaintainer } from './VideoGallery/useVideoStreamLifecycleMaintainer';
+import {
+  useVideoStreamLifecycleMaintainer,
+  VideoStreamLifecycleMaintainerProps
+} from './VideoGallery/useVideoStreamLifecycleMaintainer';
 import { VideoTile, VideoTileStylesProps } from './VideoTile';
 
 /**
@@ -55,12 +58,12 @@ export const LocalVideoTile = React.memo(
       localVideoSelectedDescription
     } = props;
 
-    const localVideoStreamProps = useMemo(
+    const localVideoStreamProps: VideoStreamLifecycleMaintainerProps = useMemo(
       () => ({
         isMirrored: localVideoViewOptions?.isMirrored,
         isStreamAvailable: isAvailable,
-        onCreateStreamView: onCreateLocalStreamView,
-        onDisposeStreamView: onDisposeLocalStreamView,
+        onCreateLocalStreamView,
+        onDisposeLocalStreamView,
         renderElementExists: !!renderElement,
         scalingMode: localVideoViewOptions?.scalingMode
       }),

--- a/packages/react-components/src/components/RemoteVideoTile.tsx
+++ b/packages/react-components/src/components/RemoteVideoTile.tsx
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { OnRenderAvatarCallback, VideoStreamOptions } from '../types';
 import { StreamMedia } from './StreamMedia';
+import {
+  useVideoStreamLifecycleMaintainer,
+  VideoStreamLifecycleMaintainerProps
+} from './VideoGallery/useVideoStreamLifecycleMaintainer';
 import { VideoTile } from './VideoTile';
 
 /**
@@ -43,39 +47,31 @@ export const RemoteVideoTile = React.memo(
       showMuteIndicator
     } = props;
 
-    useEffect(() => {
-      if (isAvailable && !renderElement) {
-        onCreateRemoteStreamView && onCreateRemoteStreamView(userId, remoteVideoViewOptions);
-      }
-      // Always clean up element to make tile up to date and be able to dispose correctly
-      // TODO: Add an extra param to onDisposeRemoteStreamView(userId, flavor(optional)) after GA
-      // and isolate dispose behavior between screen share and video
-      return () => {
-        if (renderElement && !isScreenSharingOn) {
-          onDisposeRemoteStreamView && onDisposeRemoteStreamView(userId);
-        }
-      };
-    }, [
-      isAvailable,
-      onCreateRemoteStreamView,
-      onDisposeRemoteStreamView,
-      remoteVideoViewOptions,
-      renderElement,
-      userId,
-      isScreenSharingOn
-    ]);
+    const remoteVideoStreamProps: VideoStreamLifecycleMaintainerProps = useMemo(
+      () => ({
+        isMirrored: remoteVideoViewOptions?.isMirrored,
+        isScreenSharingOn,
+        isStreamAvailable: isAvailable,
+        onCreateRemoteStreamView,
+        onDisposeRemoteStreamView,
+        remoteParticipantId: userId,
+        renderElementExists: !!renderElement,
+        scalingMode: remoteVideoViewOptions?.scalingMode
+      }),
+      [
+        isAvailable,
+        isScreenSharingOn,
+        onCreateRemoteStreamView,
+        onDisposeRemoteStreamView,
+        remoteVideoViewOptions?.isMirrored,
+        remoteVideoViewOptions?.scalingMode,
+        renderElement,
+        userId
+      ]
+    );
 
-    // The execution order for above useEffect is onCreateRemoteStreamView =>(async time gap) RenderElement generated => element disposed => onDisposeRemoteStreamView
-    // Element disposed could happen during async time gap, which still cause leaks for unused renderElement.
-    // Need to do an entire cleanup when remoteTile gets disposed and make sure element gets correctly disposed
-    useEffect(() => {
-      return () => {
-        // TODO: Remove if condition when we isolate dispose behavior for screen share
-        if (!isScreenSharingOn) {
-          onDisposeRemoteStreamView && onDisposeRemoteStreamView(userId);
-        }
-      };
-    }, [onDisposeRemoteStreamView, userId, isScreenSharingOn]);
+    // Handle creating, destroying and updating the video stream as necessary
+    useVideoStreamLifecycleMaintainer(remoteVideoStreamProps);
 
     const renderVideoStreamElement = useMemo(() => {
       // Checking if renderElement is well defined or not as calling SDK has a number of video streams limitation which


### PR DESCRIPTION
# What
Update remote video tile to use the `useVideoStreamLifecycleMaintainer` created in #1890
Update `useVideoStreamLifecycleMaintainer` to consider remote streams.

# Why
Reuse logic now contained in a custom hook. Follow up PR will enabled remote tile to make use of `updateScalingMode`

# How Tested
Ran locally and remote videos stopped and started correctly with multiple users in a call, also tested one user turning off and on screensharing