### PR TITLE
[DraftPR][Do not review] Custom Button Injection into Call and CallWithChat composite

### DIFF
--- a/packages/communication-react/review/communication-react.api.md
+++ b/packages/communication-react/review/communication-react.api.md
@@ -810,6 +810,8 @@ export interface CallWithChatControlOptions {
     displayType?: CallControlDisplayType;
     endCallButton?: boolean;
     microphoneButton?: boolean;
+    // @beta
+    onFetchCustomButtonProps?: CustomCallControlButtonCallback[];
     peopleButton?: boolean;
     screenShareButton?: boolean | {
         disabled: boolean;
@@ -1343,7 +1345,7 @@ export interface CustomCallControlButtonCallbackArgs {
 }
 
 // @beta
-export type CustomCallControlButtonPlacement = 'first' | 'last' | 'afterCameraButton' | 'afterEndCallButton' | 'afterMicrophoneButton' | 'afterDevicesButton' | 'afterParticipantsButton' | 'afterScreenShareButton';
+export type CustomCallControlButtonPlacement = 'sideBar' | 'mainBar' | 'overflowBar';
 
 // @beta
 export interface CustomCallControlButtonProps extends ControlBarButtonProps {

--- a/packages/react-composites/review/react-composites.api.md
+++ b/packages/react-composites/review/react-composites.api.md
@@ -603,6 +603,8 @@ export interface CallWithChatControlOptions {
     displayType?: CallControlDisplayType;
     endCallButton?: boolean;
     microphoneButton?: boolean;
+    // @beta
+    onFetchCustomButtonProps?: CustomCallControlButtonCallback[];
     peopleButton?: boolean;
     screenShareButton?: boolean | {
         disabled: boolean;
@@ -796,7 +798,7 @@ export interface CustomCallControlButtonCallbackArgs {
 }
 
 // @beta
-export type CustomCallControlButtonPlacement = 'first' | 'last' | 'afterCameraButton' | 'afterEndCallButton' | 'afterMicrophoneButton' | 'afterDevicesButton' | 'afterParticipantsButton' | 'afterScreenShareButton';
+export type CustomCallControlButtonPlacement = 'sideBar' | 'mainBar' | 'overflowBar';
 
 // @beta
 export interface CustomCallControlButtonProps extends ControlBarButtonProps {

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -55,15 +55,11 @@ export const CallControls = (props: CallControlsProps & ContainerRectProps): JSX
             occluding some of its content.
          */}
         <ControlBar layout="horizontal">
-          {customButtons['first']}
           {isEnabled(options?.microphoneButton) && <Microphone displayType={options?.displayType} />}
-          {customButtons['afterMicrophoneButton']}
           {isEnabled(options?.cameraButton) && <Camera displayType={options?.displayType} />}
-          {customButtons['afterCameraButton']}
           {isEnabled(options?.screenShareButton) && (
             <ScreenShare option={options?.screenShareButton} displayType={options?.displayType} />
           )}
-          {customButtons['afterScreenShareButton']}
           {isEnabled(options?.participantsButton) && (
             <Participants
               option={options?.participantsButton}
@@ -73,14 +69,11 @@ export const CallControls = (props: CallControlsProps & ContainerRectProps): JSX
               increaseFlyoutItemSize={props.increaseFlyoutItemSize}
             />
           )}
-          {customButtons['afterParticipantsButton']}
           {isEnabled(options?.devicesButton) && (
             <Devices displayType={options?.displayType} increaseFlyoutItemSize={props.increaseFlyoutItemSize} />
           )}
-          {customButtons['afterDevicesButton']}
+          {customButtons['mainBar']}
           {isEnabled(options?.endCallButton) && <EndCall displayType={options?.displayType} />}
-          {customButtons['afterEndCallButton']}
-          {customButtons['last']}
         </ControlBar>
       </Stack.Item>
     </Stack>

--- a/packages/react-composites/src/composites/CallComposite/components/buttons/Custom.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/buttons/Custom.tsx
@@ -18,14 +18,9 @@ export const generateCustomButtons = (
   displayType?: CallControlDisplayType
 ): CustomButtons => {
   const response = {
-    first: undefined,
-    afterCameraButton: undefined,
-    afterEndCallButton: undefined,
-    afterMicrophoneButton: undefined,
-    afterDevicesButton: undefined,
-    afterParticipantsButton: undefined,
-    afterScreenShareButton: undefined,
-    last: undefined
+    sideBar: undefined,
+    mainBar: undefined,
+    overflowBar: undefined
   };
   if (!onFetchCustomButtonProps) {
     return response;
@@ -40,6 +35,33 @@ export const generateCustomButtons = (
           .map((buttonProps, i) => (
             <ControlBarButton {...buttonProps} key={`${buttonProps.placement}_${i}`} />
           ))}
+      </>
+    );
+  }
+  return response;
+};
+
+/** @private */
+export const generateCustomDrawerButtons = (
+  onFetchCustomButtonProps?: CustomCallControlButtonCallback[],
+  displayType?: CallControlDisplayType
+): CustomButtons => {
+  const response = {
+    sideBar: undefined,
+    mainBar: undefined,
+    overflowBar: undefined
+  };
+  if (!onFetchCustomButtonProps) {
+    return response;
+  }
+
+  const allButtonProps = onFetchCustomButtonProps.map((f) => f({ displayType }));
+  for (const key in response) {
+    response[key] = (
+      <>
+        {allButtonProps
+          .filter((buttonProps) => buttonProps.placement === key)
+          .map((buttonProps, i) => ({ ...buttonProps, key: `${buttonProps.placement}_${i}` }))}
       </>
     );
   }

--- a/packages/react-composites/src/composites/CallComposite/types/CallControlOptions.ts
+++ b/packages/react-composites/src/composites/CallComposite/types/CallControlOptions.ts
@@ -81,15 +81,7 @@ export type CallControlOptions = {
  *
  * @beta
  */
-export type CustomCallControlButtonPlacement =
-  | 'first'
-  | 'last'
-  | 'afterCameraButton'
-  | 'afterEndCallButton'
-  | 'afterMicrophoneButton'
-  | 'afterDevicesButton'
-  | 'afterParticipantsButton'
-  | 'afterScreenShareButton';
+export type CustomCallControlButtonPlacement = 'sideBar' | 'mainBar' | 'overflowBar';
 
 /**
  * A callback that returns the props to render a custom {@link ControlBarButton}.

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -4,6 +4,8 @@
 import React, { useCallback, useState, useMemo, useEffect, useRef } from 'react';
 import { LayerHost, mergeStyles, PartialTheme, Stack, Theme } from '@fluentui/react';
 import { CallComposite, CallCompositePage, CallControlDisplayType } from '../CallComposite';
+/* @conditional-compile-remove(control-bar-button-injection) */
+import { CustomCallControlButtonCallback } from '../CallComposite';
 import { CallAdapterProvider } from '../CallComposite/adapter/CallAdapterProvider';
 import { CallWithChatControlBar } from './CallWithChatControlBar';
 import { CallState } from '@azure/communication-calling';
@@ -127,6 +129,13 @@ export interface CallWithChatControlOptions {
    * @defaultValue true
    */
   peopleButton?: boolean;
+  /* @conditional-compile-remove(control-bar-button-injection) */
+  /**
+   * Inject custom buttons in the call controls.
+   *
+   * @beta
+   */
+  onFetchCustomButtonProps?: CustomCallControlButtonCallback[];
 }
 
 type CallWithChatScreenProps = {

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatControlBar.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatControlBar.tsx
@@ -4,6 +4,8 @@
 import React, { useMemo } from 'react';
 import { CallAdapterProvider } from '../CallComposite/adapter/CallAdapterProvider';
 import { CallAdapter } from '../CallComposite';
+/* @conditional-compile-remove(control-bar-button-injection) */
+import { CustomCallControlButtonCallback } from '../CallComposite';
 import { PeopleButton } from './PeopleButton';
 import { concatStyleSets, IStyle, ITheme, mergeStyles, Stack, useTheme } from '@fluentui/react';
 import { controlBarContainerStyles } from '../CallComposite/styles/CallControls.styles';
@@ -20,6 +22,8 @@ import { EndCall } from '../CallComposite/components/buttons/EndCall';
 import { MoreButton } from './MoreButton';
 import { CallWithChatControlOptions } from './CallWithChatComposite';
 import { ContainerRectProps } from '../common/ContainerRectProps';
+/* @conditional-compile-remove(control-bar-button-injection) */
+import { generateCustomButtons } from '../CallComposite/components/buttons/Custom';
 
 /**
  * @private
@@ -105,6 +109,15 @@ export const CallWithChatControlBar = (props: CallWithChatControlBarProps & Cont
     () => (!props.mobileView ? getDesktopEndCallButtonStyles(theme) : undefined),
     [props.mobileView, theme]
   );
+  /* @conditional-compile-remove(control-bar-button-injection) */
+  const customButtons = useMemo(
+    () =>
+      generateCustomButtons(
+        onFetchCustomButtonPropsTrampoline(options != false ? options : undefined),
+        options !== false ? options?.displayType : undefined
+      ),
+    [options]
+  );
 
   // when options is false then we want to hide the whole control bar.
   if (options === false) {
@@ -161,6 +174,20 @@ export const CallWithChatControlBar = (props: CallWithChatControlBarProps & Cont
                     styles={screenShareButtonStyles}
                   />
                 )}
+                {
+                  /* @conditional-compile-remove(control-bar-button-injection) */
+                  props.mobileView
+                    ? customButtons['mainBar']?.props.children.slice(0, 1)
+                    : customButtons['mainBar']?.props.children.slice(0, 3).map((element) => {
+                        return (
+                          <element.type
+                            {...element.props}
+                            styles={commonButtonStyles}
+                            displayType={options.displayType}
+                          />
+                        );
+                      })
+                }
                 {props.mobileView && (
                   <MoreButton
                     data-ui-id="call-with-chat-composite-more-button"
@@ -176,6 +203,12 @@ export const CallWithChatControlBar = (props: CallWithChatControlBarProps & Cont
       </Stack.Item>
       {!props.mobileView && (
         <Stack horizontal className={!props.mobileView ? mergeStyles(desktopButtonContainerStyle) : undefined}>
+          {
+            /* @conditional-compile-remove(control-bar-button-injection) */
+            customButtons['sideBar']?.props.children.slice(0, 2).map((element) => {
+              return <element.type {...element.props} styles={commonButtonStyles} />;
+            })
+          }
           {isEnabled(options?.peopleButton) && (
             <PeopleButton
               checked={props.peopleButtonChecked}
@@ -275,3 +308,13 @@ const getDesktopEndCallButtonStyles = (theme: ITheme): ControlBarButtonStyles =>
 };
 
 const isEnabled = (option: unknown): boolean => option !== false;
+
+/* @conditional-compile-remove(control-bar-button-injection) */
+const onFetchCustomButtonPropsTrampoline = (
+  options?: CallWithChatControlOptions
+): CustomCallControlButtonCallback[] | undefined => {
+  let response: CustomCallControlButtonCallback[] | undefined = undefined;
+  /* @conditional-compile-remove(control-bar-button-injection) */
+  response = options?.onFetchCustomButtonProps;
+  return response;
+};

--- a/packages/react-composites/src/composites/CallWithChatComposite/components/MoreDrawer.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/components/MoreDrawer.tsx
@@ -2,13 +2,20 @@
 // Licensed under the MIT license.
 
 import React, { useCallback } from 'react';
+/* @conditional-compile-remove(control-bar-button-injection) */
+import { useMemo } from 'react';
 import {
   OptionsDevice,
   _DrawerMenu as DrawerMenu,
-  _DrawerMenuItemProps as DrawerMenuItemProps
+  _DrawerMenuItemProps as DrawerMenuItemProps,
+  _DrawerMenuItemProps
 } from '@internal/react-components';
 import { AudioDeviceInfo } from '@azure/communication-calling';
 import { CallWithChatControlOptions } from '../CallWithChatComposite';
+/* @conditional-compile-remove(control-bar-button-injection) */
+import { generateCustomDrawerButtons } from '../../CallComposite/components/buttons/Custom';
+/* @conditional-compile-remove(control-bar-button-injection) */
+import { CustomCallControlButtonCallback } from '../../CallComposite';
 
 /** @private */
 export interface MoreDrawerStrings {
@@ -143,6 +150,46 @@ export const MoreDrawer = (props: MoreDrawerProps): JSX.Element => {
       onItemClick: props.onPeopleButtonClicked
     });
   }
+  /* @conditional-compile-remove(control-bar-button-injection) */
+  const customDrawerButtons = useMemo(
+    () =>
+      generateCustomDrawerButtons(
+        onFetchCustomButtonPropsTrampoline(drawerSelectionOptions != false ? drawerSelectionOptions : undefined),
+        drawerSelectionOptions !== false ? drawerSelectionOptions?.displayType : undefined
+      ),
+    [drawerSelectionOptions]
+  );
+
+  /* @conditional-compile-remove(control-bar-button-injection) */
+  customDrawerButtons['overflowBar']?.props.children.forEach((element) => {
+    drawerMenuItems.push({
+      itemKey: element.key,
+      text: element.strings.label,
+      onItemClick: element.onClick,
+      iconProps: { iconName: element.onRenderOnIcon().props.iconName },
+      subMenuProps: element.menuProps ? makeSubMenuItems(element) : undefined
+    });
+  });
+  /* @conditional-compile-remove(control-bar-button-injection) */
+  customDrawerButtons['mainBar']?.props.children.slice(1).forEach((element) => {
+    drawerMenuItems.push({
+      itemKey: element.key,
+      text: element.strings.label,
+      onItemClick: element.onClick,
+      iconProps: { iconName: element.onRenderOnIcon().props.iconName },
+      subMenuProps: element.menuProps ? makeSubMenuItems(element) : undefined
+    });
+  });
+  /* @conditional-compile-remove(control-bar-button-injection) */
+  customDrawerButtons['sideBar']?.props.children.forEach((element) => {
+    drawerMenuItems.push({
+      itemKey: element.key,
+      text: element.strings.label,
+      onItemClick: element.onClick,
+      iconProps: { iconName: element.onRenderOnIcon().props.iconName },
+      subMenuProps: element.menuProps ? makeSubMenuItems(element) : undefined
+    });
+  });
 
   return <DrawerMenu items={drawerMenuItems} onLightDismiss={props.onLightDismiss} />;
 };
@@ -151,3 +198,28 @@ const isDeviceSelected = (speaker: OptionsDevice, selectedSpeaker?: OptionsDevic
   !!selectedSpeaker && speaker.id === selectedSpeaker.id;
 
 const isEnabled = (option: unknown): boolean => option !== false;
+
+/* @conditional-compile-remove(control-bar-button-injection) */
+/** @private */
+const onFetchCustomButtonPropsTrampoline = (
+  options?: CallWithChatControlOptions
+): CustomCallControlButtonCallback[] | undefined => {
+  let response: CustomCallControlButtonCallback[] | undefined = undefined;
+  response = options?.onFetchCustomButtonProps;
+  return response;
+};
+
+/* @conditional-compile-remove(control-bar-button-injection) */
+/** @private */
+const makeSubMenuItems = (element): _DrawerMenuItemProps[] => {
+  const subMenuProps: _DrawerMenuItemProps[] = [];
+  if (element.menuProps) {
+    element.menuProps?.items.forEach((subMenuElement) => {
+      subMenuProps.push({
+        itemKey: subMenuElement.key,
+        text: subMenuElement.text
+      });
+    });
+  }
+  return subMenuProps;
+};


### PR DESCRIPTION
# What
A Draft PR for Custom Button Injection API using Proposal 4 from [Link](https://microsoft-my.sharepoint.com/:w:/p/edwardlee/EQtMhJj_7dVAm7zOtUwzI7cB37l1kmrKhUVYKZnJ7vYxYA?e=DqLWSw)
Feature definition can be found here [Link](https://microsoft.sharepoint-df.com/:w:/t/IC3SDK/EQDJoDZ4_lhBo6ze9KGzV9ABN41uzbQhIZmmYNfd-2HlLg?e=wHDw5B)

# Why
Allow Customers to inject Custom buttons into Call and callWithChat composite. 

Create an array of custom buttons:
<img src="https://user-images.githubusercontent.com/97130533/170387755-fd222bb7-353f-4dbd-b152-b3111854661f.png" width="75%"/>

<img src="https://user-images.githubusercontent.com/97130533/170387815-ad6614e1-15fd-44b3-8b91-357443586409.png" width="75%" />


Pass in custom buttons as options into the CallScreen:
<img src="https://user-images.githubusercontent.com/97130533/170387901-f1e458d5-a44c-4b9f-9393-10222f83287f.png" width="50%" />



# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->