### PR TITLE
Prevent CallWithChat reload when toggling side panes

### DIFF
--- a/change/@internal-react-composites-b9a6780a-3131-4e9f-b1f2-671b9db680b5.json
+++ b/change/@internal-react-composites-b9a6780a-3131-4e9f-b1f2-671b9db680b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Performance improvement by preventing CallWithChat composite reloads when toggling side panes on mobile devices",
+  "packageName": "@internal/react-composites",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -248,6 +248,10 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
     togglePeople();
   }, [togglePeople]);
 
+  const callCompositeContainerCSS = useMemo(() => {
+    return { display: isMobileWithActivePane ? 'none' : 'flex' };
+  }, [isMobileWithActivePane]);
+
   return (
     <div ref={containerRef} className={mergeStyles(containerDivStyles)}>
       <Stack verticalFill grow styles={compositeOuterContainerStyles} id={compositeParentDivId}>
@@ -256,7 +260,7 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
             grow
             styles={callCompositeContainerStyles}
             // Perf: Instead of removing the video gallery from DOM, we hide it to prevent re-renders.
-            style={{ display: isMobileWithActivePane ? 'none' : 'flex' }}
+            style={callCompositeContainerCSS}
           >
             <CallComposite
               {...props}

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -252,7 +252,12 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
     <div ref={containerRef} className={mergeStyles(containerDivStyles)}>
       <Stack verticalFill grow styles={compositeOuterContainerStyles} id={compositeParentDivId}>
         <Stack horizontal grow>
-          <Stack.Item grow styles={callCompositeContainerStyles}>
+          <Stack.Item
+            grow
+            styles={callCompositeContainerStyles}
+            // Perf: Instead of removing the video gallery from DOM, we hide it to prevent re-renders.
+            style={{ display: isMobileWithActivePane ? 'none' : 'flex' }}
+          >
             <CallComposite
               {...props}
               formFactor={formFactor}

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -252,17 +252,16 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
     <div ref={containerRef} className={mergeStyles(containerDivStyles)}>
       <Stack verticalFill grow styles={compositeOuterContainerStyles} id={compositeParentDivId}>
         <Stack horizontal grow>
-          {!isMobileWithActivePane && (
-            <Stack.Item grow styles={callCompositeContainerStyles}>
-              <CallComposite
-                {...props}
-                formFactor={formFactor}
-                options={{ callControls: false }}
-                adapter={callAdapter}
-                fluentTheme={fluentTheme}
-              />
-            </Stack.Item>
-          )}
+          <Stack.Item grow styles={callCompositeContainerStyles}>
+            <CallComposite
+              {...props}
+              formFactor={formFactor}
+              options={{ callControls: false }}
+              adapter={callAdapter}
+              fluentTheme={fluentTheme}
+            />
+          </Stack.Item>
+
           {chatProps.adapter && callAdapter && hasJoinedCall && (
             <CallWithChatPane
               chatCompositeProps={chatProps}

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
@@ -31,6 +31,13 @@ import { _ICoordinates } from '@internal/react-components';
 import { _pxToRem } from '@internal/acs-ui-common';
 
 /**
+ * @private
+ * `zIndex` to ensure that the `absolute` positioned chat pane is rendered
+ * above the video gallery; and below the PiPiP modal.
+ */
+export const CHAT_PANE_Z_INDEX = 1;
+
+/**
  * Pane that is used to store chat and people for CallWithChat composite
  * @private
  */
@@ -55,7 +62,8 @@ export const CallWithChatPane = (props: {
 
   const theme = useTheme();
   const hidden = props.activePane === 'none';
-  const paneStyles = hidden ? hiddenStyles : props.mobileView ? availableSpaceStyles(theme) : sidePaneStyles;
+  const availableSpaceStylesMemo = useMemo(() => availableSpaceStyles(theme), [theme]);
+  const paneStyles = hidden ? hiddenStyles : props.mobileView ? availableSpaceStylesMemo : sidePaneStyles;
 
   const callWithChatStrings = useCallWithChatCompositeStrings();
 
@@ -138,10 +146,8 @@ export const CallWithChatPane = (props: {
       <Stack.Item verticalFill grow styles={paneBodyContainer}>
         <Stack horizontal styles={scrollableContainer}>
           <Stack.Item verticalFill styles={scrollableContainerContents}>
-            <Stack styles={props.activePane === 'chat' ? availableSpaceStyles(theme) : hiddenStyles}>
-              {chatContent}
-            </Stack>
-            <Stack styles={props.activePane === 'people' ? availableSpaceStyles(theme) : hiddenStyles}>
+            <Stack styles={props.activePane === 'chat' ? availableSpaceStylesMemo : hiddenStyles}>{chatContent}</Stack>
+            <Stack styles={props.activePane === 'people' ? availableSpaceStylesMemo : hiddenStyles}>
               {peopleContent}
             </Stack>
           </Stack.Item>
@@ -187,7 +193,13 @@ const sidePaneStyles: IStackStyles = {
 };
 
 const availableSpaceStyles = (theme: Theme): IStackStyles => ({
-  root: { width: '100%', height: '100%', position: 'absolute', zIndex: 1, background: theme.palette.white }
+  root: {
+    width: '100%',
+    height: '100%',
+    position: 'absolute',
+    zIndex: CHAT_PANE_Z_INDEX,
+    background: theme.palette.white
+  }
 });
 
 const sidePaneTokens: IStackTokens = {

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { IStackStyles, IStackTokens, ITheme, Stack, Theme } from '@fluentui/react';
+import { IStackStyles, IStackTokens, ITheme, Stack } from '@fluentui/react';
 import {
   _DrawerMenu,
   _DrawerMenuItemProps,
@@ -31,13 +31,6 @@ import { _ICoordinates } from '@internal/react-components';
 import { _pxToRem } from '@internal/acs-ui-common';
 
 /**
- * @private
- * `zIndex` to ensure that the `absolute` positioned chat pane is rendered
- * above the video gallery; and below the PiPiP modal.
- */
-export const CHAT_PANE_Z_INDEX = 1;
-
-/**
  * Pane that is used to store chat and people for CallWithChat composite
  * @private
  */
@@ -60,12 +53,11 @@ export const CallWithChatPane = (props: {
 }): JSX.Element => {
   const [drawerMenuItems, setDrawerMenuItems] = useState<_DrawerMenuItemProps[]>([]);
 
-  const theme = useTheme();
   const hidden = props.activePane === 'none';
-  const availableSpaceStylesMemo = useMemo(() => availableSpaceStyles(theme), [theme]);
-  const paneStyles = hidden ? hiddenStyles : props.mobileView ? availableSpaceStylesMemo : sidePaneStyles;
+  const paneStyles = hidden ? hiddenStyles : props.mobileView ? availableSpaceStyles : sidePaneStyles;
 
   const callWithChatStrings = useCallWithChatCompositeStrings();
+  const theme = useTheme();
 
   const header =
     props.activePane === 'none' ? null : props.mobileView ? (
@@ -146,10 +138,8 @@ export const CallWithChatPane = (props: {
       <Stack.Item verticalFill grow styles={paneBodyContainer}>
         <Stack horizontal styles={scrollableContainer}>
           <Stack.Item verticalFill styles={scrollableContainerContents}>
-            <Stack styles={props.activePane === 'chat' ? availableSpaceStylesMemo : hiddenStyles}>{chatContent}</Stack>
-            <Stack styles={props.activePane === 'people' ? availableSpaceStylesMemo : hiddenStyles}>
-              {peopleContent}
-            </Stack>
+            <Stack styles={props.activePane === 'chat' ? availableSpaceStyles : hiddenStyles}>{chatContent}</Stack>
+            <Stack styles={props.activePane === 'people' ? availableSpaceStyles : hiddenStyles}>{peopleContent}</Stack>
           </Stack.Item>
         </Stack>
       </Stack.Item>
@@ -192,15 +182,7 @@ const sidePaneStyles: IStackStyles = {
   }
 };
 
-const availableSpaceStyles = (theme: Theme): IStackStyles => ({
-  root: {
-    width: '100%',
-    height: '100%',
-    position: 'absolute',
-    zIndex: CHAT_PANE_Z_INDEX,
-    background: theme.palette.white
-  }
-});
+const availableSpaceStyles: IStackStyles = { root: { width: '100%', height: '100%' } };
 
 const sidePaneTokens: IStackTokens = {
   childrenGap: '0.5rem'

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { IStackStyles, IStackTokens, ITheme, Stack } from '@fluentui/react';
+import { IStackStyles, IStackTokens, ITheme, Stack, Theme } from '@fluentui/react';
 import {
   _DrawerMenu,
   _DrawerMenuItemProps,
@@ -53,11 +53,11 @@ export const CallWithChatPane = (props: {
 }): JSX.Element => {
   const [drawerMenuItems, setDrawerMenuItems] = useState<_DrawerMenuItemProps[]>([]);
 
+  const theme = useTheme();
   const hidden = props.activePane === 'none';
-  const paneStyles = hidden ? hiddenStyles : props.mobileView ? availableSpaceStyles : sidePaneStyles;
+  const paneStyles = hidden ? hiddenStyles : props.mobileView ? availableSpaceStyles(theme) : sidePaneStyles;
 
   const callWithChatStrings = useCallWithChatCompositeStrings();
-  const theme = useTheme();
 
   const header =
     props.activePane === 'none' ? null : props.mobileView ? (
@@ -138,8 +138,12 @@ export const CallWithChatPane = (props: {
       <Stack.Item verticalFill grow styles={paneBodyContainer}>
         <Stack horizontal styles={scrollableContainer}>
           <Stack.Item verticalFill styles={scrollableContainerContents}>
-            <Stack styles={props.activePane === 'chat' ? availableSpaceStyles : hiddenStyles}>{chatContent}</Stack>
-            <Stack styles={props.activePane === 'people' ? availableSpaceStyles : hiddenStyles}>{peopleContent}</Stack>
+            <Stack styles={props.activePane === 'chat' ? availableSpaceStyles(theme) : hiddenStyles}>
+              {chatContent}
+            </Stack>
+            <Stack styles={props.activePane === 'people' ? availableSpaceStyles(theme) : hiddenStyles}>
+              {peopleContent}
+            </Stack>
           </Stack.Item>
         </Stack>
       </Stack.Item>
@@ -182,7 +186,9 @@ const sidePaneStyles: IStackStyles = {
   }
 };
 
-const availableSpaceStyles: IStackStyles = { root: { width: '100%', height: '100%' } };
+const availableSpaceStyles = (theme: Theme): IStackStyles => ({
+  root: { width: '100%', height: '100%', position: 'absolute', zIndex: 1, background: theme.palette.white }
+});
 
 const sidePaneTokens: IStackTokens = {
   childrenGap: '0.5rem'


### PR DESCRIPTION
# What
Bugfix that prevents CallWithChat Composite from reloading whenever Chat/Participant pane is toggled.
Should greatly improve perf on mobile devices since it doesn't recreate the entire call arrangement when side pane is toggled

# Why
Fixes the following bug
https://skype.visualstudio.com/SPOOL/_workitems/edit/2835161

Improves performance of callwithchat

# How Tested
Manually

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->