### PR TITLE
Revert directly calling updateScalingMode in the VideoGallery VideoTiles

### DIFF
--- a/change/@internal-react-components-b27b5494-8f72-4392-b9b2-532acb5bb66b.json
+++ b/change/@internal-react-components-b27b5494-8f72-4392-b9b2-532acb5bb66b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert directly calling updateScalingMode in the VideoGallery VideoTiles",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/VideoGallery/useVideoStreamLifecycleMaintainer.ts
+++ b/packages/react-components/src/components/VideoGallery/useVideoStreamLifecycleMaintainer.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import React, { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 import { VideoStreamOptions, CreateVideoStreamViewResult, ViewScalingMode } from '../../types';
-import { Cancellable, useCancellableTask } from '../utils/useCancellableTask';
 
-interface VideoStreamLifecycleMaintainerExtendableProps {
+/** @private */
+export interface VideoStreamLifecycleMaintainerExtendableProps {
   isStreamAvailable?: boolean;
   renderElementExists?: boolean;
   isMirrored?: boolean;
@@ -21,7 +21,20 @@ interface VideoStreamLifecycleMaintainerProps extends VideoStreamLifecycleMainta
 /**
  * Helper hook to maintain the video stream lifecycle. This calls onCreateStreamView and onDisposeStreamView
  * appropriately based on react lifecycle events and prop changes.
- * This also handles calls to view.update* appropriately such as view.updateScalingMode().
+ *
+ * @remarks
+ *
+ * Notes on handling changes to scaling mode:
+ *
+ * Ideally we have access to the original StreamRenderView and can call view.updateScalingMode() and do not need to recreate the stream view.
+ * However, to support backwards compat we cannot guarantee this. If we don't have access to the original StreamRenderView we need to dispose
+ * the old view and create a new one.
+ *
+ * Supporting both of these scenarios became too complex and fragile. When we introduce a breaking change this should be update to ensure that
+ * onCreateStreamView _must_ return a view object with updateScalingMode and update logic in this hook to call view.updateScalingMode instead
+ * of recreating the stream.
+ *
+ * @private
  */
 const useVideoStreamLifecycleMaintainer = (props: VideoStreamLifecycleMaintainerProps): void => {
   const {
@@ -34,69 +47,14 @@ const useVideoStreamLifecycleMaintainer = (props: VideoStreamLifecycleMaintainer
     scalingMode
   } = props;
 
-  // HANDLING CHANGES TO VIDEO VIEW OPTIONS
-  //
-  // When VideoViewOptions change two things may happen:
-  //
-  // 1. Just the scaling mode has changed and we have access to the original StreamRenderView
-  //   - In this case we just need to call updateScalingMode on the view and do not need to recreate the stream view
-  // 2. isMirrored has changed, or scalingMode change and we don't have access to the original StreamRenderView
-  //   - In this case we need to dispose the old view and create a new one
-  //
-  // For scenario 1, we hold onto a ref to the scalingMode that persists across renders. When VideoViewOptions.scalingMode
-  // differs from the persistent ref, we know to call updateScalingMode. We then subsequently update the ref to the new value for
-  // future renders.
-  //
-  // For scenario 2, we extract the VideoViewOptions.isMirrored to ensure any change to the isMirrored prop triggers the useEffect
-  // that recreates the stream view. We must also here add an extra check for when the scaling mode changes and we do not have
-  // access to the original StreamView (and hence cannot call updateScalingMode). When this happens we must also trigger the useEffect
-  // that recreates the stream view.
-
-  const [streamRendererResult, setStreamRendererResult] = React.useState<CreateVideoStreamViewResult>();
-  const scalingModeRef = useRef(scalingMode);
-  const hasScalingModeChanged = scalingModeRef.current !== scalingMode;
-  const updatingScalingModeDirectly = hasScalingModeChanged && !!streamRendererResult;
-
-  const [triggerRescale, cancelRescale] = useCancellableTask();
-  const [triggerCreateStreamView, cancelCreateStreamView] = useCancellableTask();
-
-  if (isStreamAvailable && renderElementExists && scalingMode && updatingScalingModeDirectly) {
-    triggerRescale(async (cancellable: Cancellable) => {
-      streamRendererResult && (await streamRendererResult.view.updateScalingMode(scalingMode));
-      if (cancellable.cancelled) {
-        return;
-      }
-      scalingModeRef.current = scalingMode;
-    });
-  }
-
-  // scalingModeForUseEffect will trigger the useEffect to recreate the stream view only if the scaling mode has changed and
-  // we cannot call updateScalingMode on the view object directly. Otherwise it will be null to ensure the useEffect does not trigger
-  // when scaling mode changes.
-  const scalingModeForUseEffect = updatingScalingModeDirectly ? null : scalingMode;
-
   useEffect(() => {
     if (isStreamAvailable && !renderElementExists) {
-      triggerCreateStreamView(async (cancellable: Cancellable): Promise<void> => {
-        const streamViewOptions = {
-          isMirrored: isMirrored,
-          scalingMode: scalingModeForUseEffect === null ? scalingModeRef.current : scalingModeForUseEffect
-        };
-
-        const streamRendererResult = await onCreateStreamView?.(streamViewOptions);
-        // Avoid race condition where onDisposeStreamView is called before onCreateStreamView
-        // and setStreamRendererResult have completed
-        if (cancellable.cancelled) {
-          return;
-        }
-        streamRendererResult && setStreamRendererResult(streamRendererResult);
-      });
+      onCreateStreamView?.({ isMirrored, scalingMode });
     }
+
     // Always clean up element to make tile up to date and be able to dispose correctly
     return () => {
       if (renderElementExists) {
-        cancelRescale();
-        cancelCreateStreamView();
         // TODO: Remove `if isScreenSharingOn` when we isolate dispose behavior for screen share
         if (!isScreenSharingOn) {
           onDisposeStreamView?.();
@@ -104,16 +62,13 @@ const useVideoStreamLifecycleMaintainer = (props: VideoStreamLifecycleMaintainer
       }
     };
   }, [
-    cancelCreateStreamView,
-    cancelRescale,
     isMirrored,
     isScreenSharingOn,
     isStreamAvailable,
     onCreateStreamView,
     onDisposeStreamView,
     renderElementExists,
-    scalingModeForUseEffect,
-    triggerCreateStreamView
+    scalingMode
   ]);
 
   // The execution order for above useEffect is onCreateRemoteStreamView =>(async time gap) RenderElement generated => element disposed => onDisposeRemoteStreamView
@@ -121,14 +76,12 @@ const useVideoStreamLifecycleMaintainer = (props: VideoStreamLifecycleMaintainer
   // Need to do an entire cleanup when remoteTile gets disposed and make sure element gets correctly disposed
   useEffect(() => {
     return () => {
-      cancelRescale();
-      cancelCreateStreamView();
       // TODO: Remove `if isScreenSharingOn` when we isolate dispose behavior for screen share
       if (!isScreenSharingOn) {
         onDisposeStreamView?.();
       }
     };
-  }, [cancelCreateStreamView, cancelRescale, isScreenSharingOn, onDisposeStreamView]);
+  }, [isScreenSharingOn, onDisposeStreamView]);
 };
 
 /** @private */


### PR DESCRIPTION
# What
Revert directly calling updateScalingMode in the VideoGallery VideoTiles

# Why
Causing a bad rendering bug where the remote stream is recreated on first render. Supporting both view.updateScalingMode  and recreation of the tile if view.updateScalingMode does not exist is proving very complex, see abandoned #1955 .

### Will we support `view.updateScalingMode`?
Yes! Either soon if I can carve out more time to implement the complex situation of handling both above scenarios, or when we do a breaking change in this lib.

However this revert is necessary for to unblock beta package check in (#1925) as it will fix the flaky rendering issue.


# How Tested
Locally - remote participants render correctly, also screenshare streams, and changing scaling mode.