### PR TITLE
Update quickstarts to avoid React18 pitfall

### DIFF
--- a/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
@@ -52,7 +52,7 @@ We'll use the create-react-app template for this quickstart. For more informatio
 
 ```bash
 
-npx create-react-app ui-library-quickstart-composites --template typescript
+npx create-react-app ui-library-quickstart-composites --template typescript --scripts-version 4.0.3
 
 cd ui-library-quickstart-composites
 

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
@@ -57,7 +57,7 @@ We'll use the `create-react-app` template for this quickstart. For more informat
 
 ```bash
 
-npx create-react-app ui-library-starting-with-call-stateful --template typescript
+npx create-react-app ui-library-starting-with-call-stateful --template typescript --scripts-version 4.0.3
 
 cd ui-library-starting-with-call-stateful
 

--- a/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
@@ -39,7 +39,7 @@ We'll use the create-react-app template for this quickstart. For more informatio
 
 ```bash
 
-npx create-react-app ui-library-quickstart --template typescript
+npx create-react-app ui-library-quickstart --template typescript --scripts-version 4.0.3
 
 cd ui-library-quickstart
 

--- a/packages/storybook/stories/Troubleshooting.stories.mdx
+++ b/packages/storybook/stories/Troubleshooting.stories.mdx
@@ -55,9 +55,17 @@ specifies an older version of React as a peer dependency than the one installed 
 Since v7, npm automatically install peer dependencies for packages. This fails because of the existence of the
 more recent version of React installed by create-react-app.
 
-**Solution**: We recommend using the `--legacy-peer-deps` flag when adding the @azure/communication-react dependency, as suggested
-by `npm add`.
+**Solution**:
+
+React v18 has breaking changes over React v17 that affect the Fluent UI library we build on.
+Please use React v17 for best experience at this time.
+
+When creating a new app from scratch, you can do this by pinning the `react-scripts` version as follows:
+
+```bash
+
+npx create-react-app your-app --template typescript --scripts-version 4.0.3
 
 ```
-PS C:\tmp\acs\my-react-app> npm add --legacy-peer-deps @azure/communication-react
-```
+
+Support for React v18 is tracked [on this issue](https://github.com/Azure/communication-ui-library/issues/1900).


### PR DESCRIPTION
The default instructions in our storybook currently lead developers to a React v18 application. This is broken because Fluent UI does not support React18 yet.

Pin the `react-scripts` version in the instructions to provide a hassle-free first devX.

Tiny mitigation for #1900 