### PR TITLE
Fix tab ordering of the new messages button in chat composite

### DIFF
--- a/change/@internal-react-components-7891fe1d-c0a9-4de7-986a-815fe42fa3e1.json
+++ b/change/@internal-react-components-7891fe1d-c0a9-4de7-986a-815fe42fa3e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix tab ordering of the New Messages button in the Chat Composite",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -1136,7 +1136,8 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
     <Ref innerRef={chatThreadRef}>
       <Stack className={mergeStyles(messageThreadContainerStyle, styles?.root)} grow>
         {/* Always ensure New Messages button is above the chat body element in the DOM tree. This is to ensure correct
-            tab ordering. Users should be able to tab navigate to the new messages button _before_ tab focus is taken to the chat body.*/}
+            tab ordering. Because the New Messages button floats on top of the chat body it is in a higher z-index and
+            thus Users should be able to tab navigate to the new messages button _before_ tab focus is taken to the chat body.*/}
         {existsNewChatMessage && !disableJumpToNewMessageButton && (
           <div className={mergeStyles(newMessageButtonContainerStyle, styles?.newMessageButtonContainer)}>
             {onRenderJumpToNewMessageButton ? (

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -1135,7 +1135,8 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
   return (
     <Ref innerRef={chatThreadRef}>
       <Stack className={mergeStyles(messageThreadContainerStyle, styles?.root)} grow>
-        <Ref innerRef={chatScrollDivRef}>{chatBody}</Ref>
+        {/* Always ensure New Messages button is above the chat body element in the DOM tree. This is to ensure correct
+            tab ordering. Users should be able to tab navigate to the new messages button _before_ tab focus is taken to the chat body.*/}
         {existsNewChatMessage && !disableJumpToNewMessageButton && (
           <div className={mergeStyles(newMessageButtonContainerStyle, styles?.newMessageButtonContainer)}>
             {onRenderJumpToNewMessageButton ? (
@@ -1145,6 +1146,8 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
             )}
           </div>
         )}
+
+        <Ref innerRef={chatScrollDivRef}>{chatBody}</Ref>
       </Stack>
     </Ref>
   );


### PR DESCRIPTION
# What
Ensure New Messages button is tab navigated to before the chat body

# Why
New Messages floats on top of the chat body (so is in a higher zindex) and thus should be tabbed to before the chat body

# How Tested
tested in callwithchat and tab behavior has updated: now goes chat pane header -> new messages -> message body