### PR TITLE
Stub css classnames in storybook snapshot tests

### DIFF
--- a/packages/storybook/stories/CallComposite/__snapshots__/BasicExample.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/BasicExample.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite/Basic Example Basic Example 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Basic Exam
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/CallComposite/__snapshots__/CustomDataModelExample.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/CustomDataModelExample.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite/Custom Data Model Example Custom Data Model Example 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Custom Dat
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/CallComposite/__snapshots__/JoinExistingCall.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/JoinExistingCall.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite/Join Existing Call Join Existing Call 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Join Exist
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/CallComposite/__snapshots__/ThemeExample.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/ThemeExample.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite/Theme Example Theme Example 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Theme Exam
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/CallWithChatComposite/__snapshots__/BasicExample.stories.storyshot
+++ b/packages/storybook/stories/CallWithChatComposite/__snapshots__/BasicExample.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallWithChatComposite/Basic Example Basic Example 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallWithChatComposite/Ba
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <div>

--- a/packages/storybook/stories/CallWithChatComposite/__snapshots__/JoinExample.stories.storyshot
+++ b/packages/storybook/stories/CallWithChatComposite/__snapshots__/JoinExample.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallWithChatComposite/Join Teams Meeting Join Teams Meeting 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallWithChatComposite/Jo
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/BasicExample.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/BasicExample.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Basic Example Basic Example 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Basic Exam
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <div>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/CustomBehavior.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/CustomBehavior.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Behavior Example Custom Behavior Example 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Beh
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <div>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/CustomDataModelExample.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/CustomDataModelExample.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Data Model Example Custom Data Model Example 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Dat
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <div>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/CustomDateTimeFormat.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/CustomDateTimeFormat.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Date Time Format Example Custom Date Time Format Example 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,16 +21,16 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Dat
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <div
-          className="ms-Stack css-4"
+          className="ms-Stack css-stub-classname"
         >
           <div
-            className="ms-StackItem css-5"
+            className="ms-StackItem css-stub-classname"
           >
             <div
-              className="ms-Stack css-6"
+              className="ms-Stack css-stub-classname"
               style={
                 Object {
                   "display": "inline-block",
@@ -69,13 +69,13 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Dat
               </span>
                
               <span
-                className="css-7"
+                className="css-stub-classname"
               >
                 Important
               </span>
                - 
               <div
-                className="ms-Stack css-6"
+                className="ms-Stack css-stub-classname"
                 style={
                   Object {
                     "display": "inline-block",
@@ -83,12 +83,12 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Dat
                 }
               >
                 <span
-                  className="css-8"
+                  className="css-stub-classname"
                 >
                   This feature is currently in public preview and not recommended for production use. 
                 </span>
                 <a
-                  className="ms-Link root-9"
+                  className="ms-Link css-stub-classname"
                   href="https://azure.microsoft.com/support/legal/preview-supplemental-terms/"
                   onClick={[Function]}
                   target="_blank"

--- a/packages/storybook/stories/ChatComposite/__snapshots__/JoinExistingChatThread.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/JoinExistingChatThread.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Join Existing Chat Thread Join Existing Chat Thread 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Join Exist
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/ThemesExample.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/ThemesExample.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Theme Example Theme Example 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Theme Exam
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <span>
           <div>

--- a/packages/storybook/stories/ControlBar/Buttons/ControlBarButton/__snapshots__/ControlBarButton.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/ControlBarButton/__snapshots__/ControlBarButton.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/Default Default 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
       }
     >
       <div
-        className="ms-TooltipHost root-1"
+        className="ms-TooltipHost root-94"
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
         onKeyDown={[Function]}
@@ -30,7 +30,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
       >
         <button
           aria-label="airplane"
-          className="ms-Button ms-Button--default root-2"
+          className="ms-Button ms-Button--default css-stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -41,7 +41,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-3"
+            className="ms-Button-flexContainer css-stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <span

--- a/packages/storybook/stories/ControlBar/Buttons/Devices/__snapshots__/Devices.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Devices/__snapshots__/Devices.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/Devices Devices 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
       }
     >
       <div
-        className="ms-TooltipHost root-1"
+        className="ms-TooltipHost root-94"
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
         onKeyDown={[Function]}
@@ -33,7 +33,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
           aria-expanded={false}
           aria-haspopup={true}
           aria-label="Manage devices"
-          className="ms-Button ms-Button--default ms-Button--hasMenu root-2"
+          className="ms-Button ms-Button--default ms-Button--hasMenu css-stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -44,12 +44,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-3"
+            className="ms-Button-flexContainer css-stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="root-94 root-11"
+              className="css-stub-classname"
               data-icon-name="ControlButtonOptions"
             >
               <span
@@ -72,7 +72,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
             </i>
             <i
               aria-hidden={true}
-              className="ms-Icon root-94 css-13 ms-Button-menuIcon menuIcon-7"
+              className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
               data-icon-name="ChevronDown"
               hidden={true}
               style={

--- a/packages/storybook/stories/ControlBar/Buttons/EndCall/__snapshots__/EndCall.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/EndCall/__snapshots__/EndCall.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/End Call End Call 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/E
       }
     >
       <div
-        className="ms-TooltipHost root-1"
+        className="ms-TooltipHost root-94"
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
         onKeyDown={[Function]}
@@ -30,7 +30,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/E
       >
         <button
           aria-label="Leave Call"
-          className="ms-Button ms-Button--default root-2"
+          className="ms-Button ms-Button--default css-stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -41,7 +41,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/E
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-3"
+            className="ms-Button-flexContainer css-stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <i

--- a/packages/storybook/stories/ControlBar/Buttons/Microphone/__snapshots__/Microphone.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Microphone/__snapshots__/Microphone.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/Microphone Microphone 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -22,10 +22,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/M
     >
       <div
         aria-live="polite"
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       />
       <div
-        className="ms-TooltipHost root-2"
+        className="ms-TooltipHost root-94"
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
         onKeyDown={[Function]}
@@ -34,7 +34,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/M
       >
         <button
           aria-label="Unmute microphone"
-          className="ms-Button ms-Button--default root-3"
+          className="ms-Button ms-Button--default css-stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -45,12 +45,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/M
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-4"
+            className="ms-Button-flexContainer css-stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="root-94 root-12"
+              className="css-stub-classname"
               data-icon-name="ControlButtonMicOff"
             >
               <span
@@ -79,7 +79,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/M
             </i>
             <i
               aria-hidden={true}
-              className="ms-Icon root-94 css-13 ms-Button-menuIcon menuIcon-8"
+              className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
               data-icon-name="ChevronDown"
               hidden={true}
               style={

--- a/packages/storybook/stories/ControlBar/Buttons/Participants/__snapshots__/Participants.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Participants/__snapshots__/Participants.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/Participants Participants 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/P
       }
     >
       <div
-        className="ms-TooltipHost root-1"
+        className="ms-TooltipHost root-94"
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
         onKeyDown={[Function]}
@@ -33,7 +33,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/P
           aria-expanded={false}
           aria-haspopup={true}
           aria-label="Show Participants"
-          className="ms-Button ms-Button--default ms-Button--hasMenu root-2"
+          className="ms-Button ms-Button--default ms-Button--hasMenu css-stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -44,12 +44,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/P
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-3"
+            className="ms-Button-flexContainer css-stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="root-94 root-11"
+              className="css-stub-classname"
               data-icon-name="ControlButtonParticipants"
             >
               <span
@@ -72,7 +72,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/P
             </i>
             <i
               aria-hidden={true}
-              className="ms-Icon root-94 css-12 ms-Button-menuIcon menuIcon-7"
+              className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
               data-icon-name="ChevronDown"
               hidden={true}
               style={

--- a/packages/storybook/stories/ControlBar/Buttons/ScreenShare/__snapshots__/ScreenShare.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/ScreenShare/__snapshots__/ScreenShare.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/Screen Share Screen Share 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/S
       }
     >
       <div
-        className="ms-TooltipHost root-2"
+        className="ms-TooltipHost root-94"
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
         onKeyDown={[Function]}
@@ -30,7 +30,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/S
       >
         <button
           aria-label="Present your screen"
-          className="ms-Button ms-Button--default root-3"
+          className="ms-Button ms-Button--default css-stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -41,12 +41,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/S
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-4"
+            className="ms-Button-flexContainer css-stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="root-94 root-12"
+              className="css-stub-classname"
               data-icon-name="ControlButtonScreenShareStart"
             >
               <span

--- a/packages/storybook/stories/ControlBar/__snapshots__/ControlBar.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/__snapshots__/ControlBar.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control Bar 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -33,17 +33,17 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
         }
       >
         <div
-          className="css-2"
+          className="css-stub-classname"
         >
           <div
-            className="ms-Stack css-3"
+            className="ms-Stack css-stub-classname"
           >
             <div
               aria-live="polite"
-              className="ms-Stack css-4"
+              className="ms-Stack css-stub-classname"
             />
             <div
-              className="ms-TooltipHost root-5"
+              className="ms-TooltipHost root-94"
               onBlurCapture={[Function]}
               onFocusCapture={[Function]}
               onKeyDown={[Function]}
@@ -52,7 +52,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             >
               <button
                 aria-label="Turn on camera"
-                className="ms-Button ms-Button--default root-6"
+                className="ms-Button ms-Button--default css-stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -63,12 +63,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-7"
+                  className="ms-Button-flexContainer css-stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="root-94 root-15"
+                    className="css-stub-classname"
                     data-icon-name="ControlButtonCameraOff"
                   >
                     <span
@@ -97,7 +97,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                   </i>
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-16 ms-Button-menuIcon menuIcon-11"
+                    className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                     data-icon-name="ChevronDown"
                     hidden={true}
                     style={
@@ -113,10 +113,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             </div>
             <div
               aria-live="polite"
-              className="ms-Stack css-4"
+              className="ms-Stack css-stub-classname"
             />
             <div
-              className="ms-TooltipHost root-5"
+              className="ms-TooltipHost root-94"
               onBlurCapture={[Function]}
               onFocusCapture={[Function]}
               onKeyDown={[Function]}
@@ -125,7 +125,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             >
               <button
                 aria-label="Unmute microphone"
-                className="ms-Button ms-Button--default root-6"
+                className="ms-Button ms-Button--default css-stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -136,12 +136,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-7"
+                  className="ms-Button-flexContainer css-stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="root-94 root-15"
+                    className="css-stub-classname"
                     data-icon-name="ControlButtonMicOff"
                   >
                     <span
@@ -170,7 +170,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                   </i>
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-16 ms-Button-menuIcon menuIcon-11"
+                    className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                     data-icon-name="ChevronDown"
                     hidden={true}
                     style={
@@ -185,7 +185,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
               </button>
             </div>
             <div
-              className="ms-TooltipHost root-5"
+              className="ms-TooltipHost root-94"
               onBlurCapture={[Function]}
               onFocusCapture={[Function]}
               onKeyDown={[Function]}
@@ -194,7 +194,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             >
               <button
                 aria-label="Present your screen"
-                className="ms-Button ms-Button--default root-18"
+                className="ms-Button ms-Button--default css-stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -205,12 +205,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-7"
+                  className="ms-Button-flexContainer css-stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="root-94 root-15"
+                    className="css-stub-classname"
                     data-icon-name="ControlButtonScreenShareStart"
                   >
                     <span
@@ -235,7 +235,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
               </button>
             </div>
             <div
-              className="ms-TooltipHost root-5"
+              className="ms-TooltipHost root-94"
               onBlurCapture={[Function]}
               onFocusCapture={[Function]}
               onKeyDown={[Function]}
@@ -247,7 +247,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 aria-expanded={false}
                 aria-haspopup={true}
                 aria-label="Show Participants"
-                className="ms-Button ms-Button--default ms-Button--hasMenu root-6"
+                className="ms-Button ms-Button--default ms-Button--hasMenu css-stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -258,12 +258,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-7"
+                  className="ms-Button-flexContainer css-stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="root-94 root-15"
+                    className="css-stub-classname"
                     data-icon-name="ControlButtonParticipants"
                   >
                     <span
@@ -286,7 +286,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                   </i>
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-16 ms-Button-menuIcon menuIcon-11"
+                    className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                     data-icon-name="ChevronDown"
                     hidden={true}
                     style={
@@ -301,7 +301,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
               </button>
             </div>
             <div
-              className="ms-TooltipHost root-5"
+              className="ms-TooltipHost root-94"
               onBlurCapture={[Function]}
               onFocusCapture={[Function]}
               onKeyDown={[Function]}
@@ -313,7 +313,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 aria-expanded={false}
                 aria-haspopup={true}
                 aria-label="Manage devices"
-                className="ms-Button ms-Button--default ms-Button--hasMenu root-6"
+                className="ms-Button ms-Button--default ms-Button--hasMenu css-stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -324,12 +324,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-7"
+                  className="ms-Button-flexContainer css-stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="root-94 root-15"
+                    className="css-stub-classname"
                     data-icon-name="ControlButtonOptions"
                   >
                     <span
@@ -352,7 +352,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                   </i>
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-16 ms-Button-menuIcon menuIcon-11"
+                    className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                     data-icon-name="ChevronDown"
                     hidden={true}
                     style={
@@ -367,7 +367,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
               </button>
             </div>
             <div
-              className="ms-TooltipHost root-5"
+              className="ms-TooltipHost root-94"
               onBlurCapture={[Function]}
               onFocusCapture={[Function]}
               onKeyDown={[Function]}
@@ -376,7 +376,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             >
               <button
                 aria-label="Leave Call"
-                className="ms-Button ms-Button--default root-19"
+                className="ms-Button ms-Button--default css-stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -387,7 +387,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-7"
+                  className="ms-Button-flexContainer css-stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i

--- a/packages/storybook/stories/ErrorBar/__snapshots__/ErrorBar.stories.storyshot
+++ b/packages/storybook/stories/ErrorBar/__snapshots__/ErrorBar.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Error Bar Error Bar 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,27 +21,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Error Bar Error Bar 1
       }
     >
       <div
-        className="css-1"
+        className="css-stub-classname"
       >
         <div
-          className="ms-Stack css-2"
+          className="ms-Stack css-stub-classname"
           data-ui-id="error-bar-stack"
         >
           <div
-            aria-describedby="MessageBar1"
-            className="ms-MessageBar ms-MessageBar--error ms-MessageBar-multiline root-3"
+            aria-describedby="MessageBar69"
+            className="ms-MessageBar ms-MessageBar--error ms-MessageBar-multiline css-stub-classname"
             role="region"
           >
             <div
-              className="ms-MessageBar-content content-4"
+              className="ms-MessageBar-content css-stub-classname"
             >
               <div
                 aria-hidden={true}
-                className="ms-MessageBar-icon iconContainer-5"
+                className="ms-MessageBar-icon css-stub-classname"
               >
                 <i
                   aria-hidden={true}
-                  className="root-94 icon-14"
+                  className="css-stub-classname"
                   data-icon-name="ErrorBadge"
                 >
                   
@@ -49,17 +49,17 @@ exports[`storybook snapshot tests Storyshots UI Components/Error Bar Error Bar 1
               </div>
               <div
                 aria-live="assertive"
-                className="ms-MessageBar-text text-7"
-                id="MessageBar1"
+                className="ms-MessageBar-text css-stub-classname"
+                id="MessageBar69"
                 role="alert"
               >
                 <span
-                  className="ms-MessageBar-innerText innerText-8"
+                  className="ms-MessageBar-innerText css-stub-classname"
                 />
               </div>
               <button
                 aria-label="Close"
-                className="ms-Button ms-Button--icon ms-MessageBar-dismissal dismissal-15"
+                className="ms-Button ms-Button--icon ms-MessageBar-dismissal css-stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -71,12 +71,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Error Bar Error Bar 1
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-16"
+                  className="ms-Button-flexContainer css-stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-23 ms-Button-icon icon-18"
+                    className="ms-Icon root-94 css-stub-classname ms-Button-icon css-stub-classname"
                     data-icon-name="Clear"
                     style={
                       Object {

--- a/packages/storybook/stories/Examples/DevicesDropdown/__snapshots__/DeviceSettingsDropDown.stories.storyshot
+++ b/packages/storybook/stories/Examples/DevicesDropdown/__snapshots__/DeviceSettingsDropDown.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Device Settings Device Settings 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,10 +21,10 @@ exports[`storybook snapshot tests Storyshots Examples/Device Settings Device Set
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <div
-          className="css-118 body-0"
+          className="css-118 css-stub-classname"
           dir="ltr"
         >
           <div
@@ -37,10 +37,10 @@ exports[`storybook snapshot tests Storyshots Examples/Device Settings Device Set
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                className="ms-Dropdown dropdown-2"
+                className="ms-Dropdown css-stub-classname"
                 data-is-focusable={true}
                 data-ktp-target={true}
-                id="Dropdown2"
+                id="Dropdown75"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onClick={[Function]}
@@ -61,17 +61,17 @@ exports[`storybook snapshot tests Storyshots Examples/Device Settings Device Set
                   aria-atomic={true}
                   aria-invalid={false}
                   aria-live="polite"
-                  className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-3"
-                  id="Dropdown2-option"
+                  className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder css-stub-classname"
+                  id="Dropdown75-option"
                 >
                   Select an option
                 </span>
                 <span
-                  className="ms-Dropdown-caretDownWrapper caretDownWrapper-4"
+                  className="ms-Dropdown-caretDownWrapper css-stub-classname"
                 >
                   <i
                     aria-hidden={true}
-                    className="root-94 ms-Dropdown-caretDown caretDown-19"
+                    className="ms-Dropdown-caretDown css-stub-classname"
                     data-icon-name="ChevronDown"
                   >
                     

--- a/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallModal.stories.storyshot
+++ b/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallModal.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incoming Call Modal Incoming Call Modal 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -24,7 +24,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
         className="ms-layer"
       >
         <div
-          className="ms-Fabric ms-Layer-content content-10"
+          className="ms-Fabric ms-Layer-content css-stub-classname"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
@@ -57,7 +57,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
           onTouchStart={[Function]}
         >
           <div
-            aria-labelledby="Dialog1-title"
+            aria-labelledby="Dialog77-title"
             aria-modal={true}
             onKeyDown={[Function]}
             role="alertdialog"
@@ -69,16 +69,16 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
             }
           >
             <div
-              className="ms-Modal is-open ms-Dialog root-3"
+              className="ms-Modal is-open ms-Dialog css-stub-classname"
               role="document"
             >
               <div
                 aria-hidden={true}
-                className="ms-Overlay ms-Overlay--dark root-12"
+                className="ms-Overlay ms-Overlay--dark css-stub-classname"
               />
               <div
-                className="ms-Dialog-main main-4"
-                id="ModalFocusTrapZone2"
+                className="ms-Dialog-main css-stub-classname"
+                id="ModalFocusTrapZone78"
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
               >
@@ -94,29 +94,29 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                   tabIndex={0}
                 />
                 <div
-                  className="ms-Modal-scrollableContent scrollableContent-5"
+                  className="ms-Modal-scrollableContent css-stub-classname"
                   data-is-scrollable={true}
                 >
                   <div
-                    className="content-13"
+                    className="css-stub-classname"
                   >
                     <div
-                      className="ms-Dialog-header header-15"
+                      className="ms-Dialog-header css-stub-classname"
                     >
                       <div
                         aria-level={1}
-                        className="ms-Dialog-title title-18"
-                        id="Dialog1-title"
+                        className="ms-Dialog-title css-stub-classname"
+                        id="Dialog77-title"
                         role="heading"
                       >
                         Incoming Video Call
                       </div>
                       <div
-                        className="topButton-19"
+                        className="css-stub-classname"
                       >
                         <button
                           aria-label="Close"
-                          className="ms-Button ms-Button--icon ms-Dialog-button ms-Dialog-button--close root-20"
+                          className="ms-Button ms-Button--icon ms-Dialog-button ms-Dialog-button--close css-stub-classname"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -128,12 +128,12 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                           type="button"
                         >
                           <span
-                            className="ms-Button-flexContainer flexContainer-21"
+                            className="ms-Button-flexContainer css-stub-classname"
                             data-automationid="splitbuttonprimary"
                           >
                             <i
                               aria-hidden={true}
-                              className="ms-Icon root-94 css-28 ms-Button-icon icon-23"
+                              className="ms-Icon root-94 css-stub-classname ms-Button-icon css-stub-classname"
                               data-icon-name="Cancel"
                               style={
                                 Object {
@@ -148,16 +148,16 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                       </div>
                     </div>
                     <div
-                      className="ms-Dialog-inner inner-16"
+                      className="ms-Dialog-inner css-stub-classname"
                     >
                       <div
-                        className="ms-Dialog-content innerContent-17"
+                        className="ms-Dialog-content css-stub-classname"
                       >
                         <div
-                          className="ms-Stack css-29"
+                          className="ms-Stack css-stub-classname"
                         >
                           <div
-                            className="ms-Stack css-30"
+                            className="ms-Stack css-stub-classname"
                             style={
                               Object {
                                 "marginRight": "0.5rem",
@@ -166,19 +166,19 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                           >
                             <div
                               aria-label="Maximus Aurelius"
-                              className="ms-Persona ms-Persona--size40 root-31"
+                              className="ms-Persona ms-Persona--size40 css-stub-classname"
                             >
                               <div
-                                className="ms-Persona-coin ms-Persona--size40 coin-38"
+                                className="ms-Persona-coin ms-Persona--size40 css-stub-classname"
                                 role="presentation"
                               >
                                 <div
-                                  className="ms-Persona-imageArea imageArea-40"
+                                  className="ms-Persona-imageArea css-stub-classname"
                                   role="presentation"
                                 >
                                   <div
                                     aria-hidden="true"
-                                    className="ms-Persona-initials initials-43"
+                                    className="ms-Persona-initials css-stub-classname"
                                   >
                                     <span>
                                       MA
@@ -189,7 +189,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                             </div>
                           </div>
                           <div
-                            className="ms-Stack css-46"
+                            className="ms-Stack css-stub-classname"
                             style={
                               Object {
                                 "alignItems": "flex-start",
@@ -197,7 +197,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                             }
                           >
                             <div
-                              className="ms-Stack css-47"
+                              className="ms-Stack css-stub-classname"
                               style={
                                 Object {
                                   "color": "#000000",
@@ -222,7 +222,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                               </span>
                             </div>
                             <div
-                              className="ms-Stack css-47"
+                              className="ms-Stack css-stub-classname"
                               style={
                                 Object {
                                   "color": "#201f1e",
@@ -238,16 +238,16 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                         </div>
                       </div>
                       <div
-                        className="ms-Dialog-actions actions-48"
+                        className="ms-Dialog-actions css-stub-classname"
                       >
                         <div
-                          className="ms-Dialog-actionsRight actionsRight-50"
+                          className="ms-Dialog-actionsRight css-stub-classname"
                         >
                           <span
-                            className="ms-Dialog-action action-49"
+                            className="ms-Dialog-action css-stub-classname"
                           >
                             <button
-                              className="ms-Button ms-Button--default root-51"
+                              className="ms-Button ms-Button--default css-stub-classname"
                               data-is-focusable={true}
                               onClick={[Function]}
                               onKeyDown={[Function]}
@@ -264,7 +264,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                               type="button"
                             >
                               <span
-                                className="ms-Button-flexContainer flexContainer-21"
+                                className="ms-Button-flexContainer css-stub-classname"
                                 data-automationid="splitbuttonprimary"
                               >
                                 <span
@@ -294,10 +294,10 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                             </button>
                           </span>
                           <span
-                            className="ms-Dialog-action action-49"
+                            className="ms-Dialog-action css-stub-classname"
                           >
                             <button
-                              className="ms-Button ms-Button--default root-51"
+                              className="ms-Button ms-Button--default css-stub-classname"
                               data-is-focusable={true}
                               onClick={[Function]}
                               onKeyDown={[Function]}
@@ -314,15 +314,15 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                               type="button"
                             >
                               <span
-                                className="ms-Button-flexContainer flexContainer-21"
+                                className="ms-Button-flexContainer css-stub-classname"
                                 data-automationid="splitbuttonprimary"
                               >
                                 <span
-                                  className="ms-Button-textContainer textContainer-22"
+                                  className="ms-Button-textContainer css-stub-classname"
                                 >
                                   <span
-                                    className="ms-Button-label label-52"
-                                    id="id__9"
+                                    className="ms-Button-label css-stub-classname"
+                                    id="id__85"
                                   >
                                     Accept
                                   </span>
@@ -331,10 +331,10 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                             </button>
                           </span>
                           <span
-                            className="ms-Dialog-action action-49"
+                            className="ms-Dialog-action css-stub-classname"
                           >
                             <button
-                              className="ms-Button ms-Button--default root-51"
+                              className="ms-Button ms-Button--default css-stub-classname"
                               data-is-focusable={true}
                               onClick={[Function]}
                               onKeyDown={[Function]}
@@ -351,15 +351,15 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                               type="button"
                             >
                               <span
-                                className="ms-Button-flexContainer flexContainer-21"
+                                className="ms-Button-flexContainer css-stub-classname"
                                 data-automationid="splitbuttonprimary"
                               >
                                 <span
-                                  className="ms-Button-textContainer textContainer-22"
+                                  className="ms-Button-textContainer css-stub-classname"
                                 >
                                   <span
-                                    className="ms-Button-label label-52"
-                                    id="id__12"
+                                    className="ms-Button-label css-stub-classname"
+                                    id="id__88"
                                   >
                                     Decline
                                   </span>

--- a/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallToast.stories.storyshot
+++ b/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallToast.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incoming Call Toast Incoming Call Toast 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,29 +21,29 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <div
-          className="ms-Stack css-177 css-2"
+          className="ms-Stack css-stub-classname"
         >
           <div
-            className="ms-Stack css-178 css-3"
+            className="ms-Stack css-stub-classname"
           >
             <div
               aria-label="Maximus Aurelius"
-              className="ms-Persona ms-Persona--size40 root-4"
+              className="ms-Persona ms-Persona--size40 css-stub-classname"
             >
               <div
-                className="ms-Persona-coin ms-Persona--size40 coin-11"
+                className="ms-Persona-coin ms-Persona--size40 css-stub-classname"
                 role="presentation"
               >
                 <div
-                  className="ms-Persona-imageArea imageArea-13"
+                  className="ms-Persona-imageArea css-stub-classname"
                   role="presentation"
                 >
                   <div
                     aria-hidden="true"
-                    className="ms-Persona-initials initials-16"
+                    className="ms-Persona-initials css-stub-classname"
                   >
                     <span>
                       MA
@@ -54,7 +54,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
             </div>
           </div>
           <div
-            className="ms-Stack css-19"
+            className="ms-Stack css-stub-classname"
             style={
               Object {
                 "alignItems": "flex-start",
@@ -63,7 +63,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
             }
           >
             <div
-              className="ms-Stack css-1"
+              className="ms-Stack css-stub-classname"
               style={
                 Object {
                   "fontSize": "0.875rem",
@@ -75,7 +75,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
               </b>
             </div>
             <div
-              className="ms-Stack css-1"
+              className="ms-Stack css-stub-classname"
               style={
                 Object {
                   "fontSize": "0.75rem",
@@ -88,10 +88,10 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
             </div>
           </div>
           <div
-            className="ms-Stack css-20"
+            className="ms-Stack css-stub-classname"
           >
             <button
-              className="ms-Button ms-Button--default css-180 root-21"
+              className="ms-Button ms-Button--default css-stub-classname"
               data-is-focusable={true}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -102,7 +102,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
               type="button"
             >
               <span
-                className="ms-Button-flexContainer flexContainer-22"
+                className="ms-Button-flexContainer css-stub-classname"
                 data-automationid="splitbuttonprimary"
               >
                 <span
@@ -125,7 +125,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
               </span>
             </button>
             <button
-              className="ms-Button ms-Button--default css-179 root-21"
+              className="ms-Button ms-Button--default css-stub-classname"
               data-is-focusable={true}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -136,7 +136,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
               type="button"
             >
               <span
-                className="ms-Button-flexContainer flexContainer-22"
+                className="ms-Button-flexContainer css-stub-classname"
                 data-automationid="splitbuttonprimary"
               >
                 <span

--- a/packages/storybook/stories/Examples/LocalPreview/__snapshots__/LocalPreview.stories.storyshot
+++ b/packages/storybook/stories/Examples/LocalPreview/__snapshots__/LocalPreview.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Preview 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
       }
     >
       <div
-        className="css-118 body-0"
+        className="css-118 css-stub-classname"
         dir="ltr"
       >
         <div
@@ -29,7 +29,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
           data-uses-unhanded-props={true}
         >
           <div
-            className="ms-Stack css-3"
+            className="ms-Stack css-stub-classname"
             style={
               Object {
                 "height": "100%",
@@ -38,40 +38,40 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
             }
           >
             <div
-              className="ms-StackItem css-4"
+              className="ms-StackItem css-stub-classname"
             >
               <div
-                className="ms-Stack css-5"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-12"
+                  className="ms-Stack css-stub-classname"
                   data-ui-id="video-tile"
                 >
                   <div
-                    className="css-9"
+                    className="css-stub-classname"
                   />
                   <div
-                    className="ms-Stack css-13"
+                    className="ms-Stack css-stub-classname"
                   >
                     <div
-                      className="css-14"
+                      className="css-stub-classname"
                     />
                   </div>
                   <div
-                    className="ms-Stack css-15"
+                    className="ms-Stack css-stub-classname"
                   >
                     <div
-                      className="css-17"
+                      className="css-stub-classname"
                     >
                       <div
-                        className="ms-Stack css-18"
+                        className="ms-Stack css-stub-classname"
                       >
                         <div
                           aria-live="polite"
-                          className="ms-Stack css-19"
+                          className="ms-Stack css-stub-classname"
                         />
                         <div
-                          className="ms-TooltipHost root-20"
+                          className="ms-TooltipHost root-94"
                           onBlurCapture={[Function]}
                           onFocusCapture={[Function]}
                           onKeyDown={[Function]}
@@ -80,7 +80,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                         >
                           <button
                             aria-label="Turn off camera"
-                            className="ms-Button ms-Button--default is-checked root-21"
+                            className="ms-Button ms-Button--default is-checked css-stub-classname"
                             data-is-focusable={true}
                             onClick={[Function]}
                             onKeyDown={[Function]}
@@ -91,12 +91,12 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                             type="button"
                           >
                             <span
-                              className="ms-Button-flexContainer flexContainer-22"
+                              className="ms-Button-flexContainer css-stub-classname"
                               data-automationid="splitbuttonprimary"
                             >
                               <i
                                 aria-hidden={true}
-                                className="root-94 root-30"
+                                className="css-stub-classname"
                                 data-icon-name="ControlButtonCameraOn"
                               >
                                 <span
@@ -122,7 +122,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                               </i>
                               <i
                                 aria-hidden={true}
-                                className="ms-Icon root-94 css-31 ms-Button-menuIcon menuIcon-26"
+                                className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                                 data-icon-name="ChevronDown"
                                 hidden={true}
                                 style={
@@ -138,10 +138,10 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                         </div>
                         <div
                           aria-live="polite"
-                          className="ms-Stack css-19"
+                          className="ms-Stack css-stub-classname"
                         />
                         <div
-                          className="ms-TooltipHost root-20"
+                          className="ms-TooltipHost root-94"
                           onBlurCapture={[Function]}
                           onFocusCapture={[Function]}
                           onKeyDown={[Function]}
@@ -150,7 +150,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                         >
                           <button
                             aria-label="Mute microphone"
-                            className="ms-Button ms-Button--default is-checked root-21"
+                            className="ms-Button ms-Button--default is-checked css-stub-classname"
                             data-is-focusable={true}
                             onClick={[Function]}
                             onKeyDown={[Function]}
@@ -161,12 +161,12 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                             type="button"
                           >
                             <span
-                              className="ms-Button-flexContainer flexContainer-22"
+                              className="ms-Button-flexContainer css-stub-classname"
                               data-automationid="splitbuttonprimary"
                             >
                               <i
                                 aria-hidden={true}
-                                className="root-94 root-30"
+                                className="css-stub-classname"
                                 data-icon-name="ControlButtonMicOn"
                               >
                                 <span
@@ -192,7 +192,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                               </i>
                               <i
                                 aria-hidden={true}
-                                className="ms-Icon root-94 css-31 ms-Button-menuIcon menuIcon-26"
+                                className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                                 data-icon-name="ChevronDown"
                                 hidden={true}
                                 style={

--- a/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/ComplianceBanner.stories.storyshot
+++ b/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/ComplianceBanner.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance Banner Compliance Banner 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance B
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
         style={
           Object {
             "minHeight": "50%",
@@ -30,10 +30,10 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance B
         }
       >
         <div
-          className="ms-Stack css-2"
+          className="ms-Stack css-stub-classname"
         >
           <button
-            className="ms-Button ms-Button--primary root-3"
+            className="ms-Button ms-Button--primary css-stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -44,15 +44,15 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance B
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-4"
+              className="ms-Button-flexContainer css-stub-classname"
               data-automationid="splitbuttonprimary"
             >
               <span
-                className="ms-Button-textContainer textContainer-5"
+                className="ms-Button-textContainer css-stub-classname"
               >
                 <span
-                  className="ms-Button-label label-7"
-                  id="id__1"
+                  className="ms-Button-label css-stub-classname"
+                  id="id__109"
                 >
                   Toggle Recording
                 </span>
@@ -60,7 +60,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance B
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--primary root-3"
+            className="ms-Button ms-Button--primary css-stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -71,15 +71,15 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance B
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-4"
+              className="ms-Button-flexContainer css-stub-classname"
               data-automationid="splitbuttonprimary"
             >
               <span
-                className="ms-Button-textContainer textContainer-5"
+                className="ms-Button-textContainer css-stub-classname"
               >
                 <span
-                  className="ms-Button-label label-7"
-                  id="id__4"
+                  className="ms-Button-label css-stub-classname"
+                  id="id__112"
                 >
                   Toggle Transcription
                 </span>

--- a/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/Lobby.stories.storyshot
+++ b/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/Lobby.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,17 +21,17 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
       }
     >
       <div
-        className="ms-Stack css-7"
+        className="ms-Stack css-stub-classname"
         data-ui-id="video-tile"
       >
         <div
-          className="css-4"
+          className="css-stub-classname"
         />
         <div
-          className="ms-Stack css-8"
+          className="ms-Stack css-stub-classname"
         />
         <div
-          className="ms-Stack css-9"
+          className="ms-Stack css-stub-classname"
         >
           <div
             style={
@@ -86,17 +86,17 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
             </p>
           </div>
           <div
-            className="css-11"
+            className="css-stub-classname"
           >
             <div
-              className="ms-Stack css-12"
+              className="ms-Stack css-stub-classname"
             >
               <div
                 aria-live="polite"
-                className="ms-Stack css-13"
+                className="ms-Stack css-stub-classname"
               />
               <div
-                className="ms-TooltipHost root-14"
+                className="ms-TooltipHost root-94"
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
                 onKeyDown={[Function]}
@@ -105,7 +105,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
               >
                 <button
                   aria-label="Turn off camera"
-                  className="ms-Button ms-Button--default is-checked root-15"
+                  className="ms-Button ms-Button--default is-checked css-stub-classname"
                   data-is-focusable={true}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -116,12 +116,12 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   type="button"
                 >
                   <span
-                    className="ms-Button-flexContainer flexContainer-16"
+                    className="ms-Button-flexContainer css-stub-classname"
                     data-automationid="splitbuttonprimary"
                   >
                     <i
                       aria-hidden={true}
-                      className="root-94 root-24"
+                      className="css-stub-classname"
                       data-icon-name="ControlButtonCameraOn"
                     >
                       <span
@@ -146,18 +146,18 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                       </span>
                     </i>
                     <span
-                      className="ms-Button-textContainer textContainer-17"
+                      className="ms-Button-textContainer css-stub-classname"
                     >
                       <span
-                        className="ms-Button-label label-19"
-                        id="id__2"
+                        className="ms-Button-label css-stub-classname"
+                        id="id__117"
                       >
                         Turn off
                       </span>
                     </span>
                     <i
                       aria-hidden={true}
-                      className="ms-Icon root-94 css-25 ms-Button-menuIcon menuIcon-20"
+                      className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                       data-icon-name="ChevronDown"
                       hidden={true}
                       style={
@@ -173,10 +173,10 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
               </div>
               <div
                 aria-live="polite"
-                className="ms-Stack css-13"
+                className="ms-Stack css-stub-classname"
               />
               <div
-                className="ms-TooltipHost root-14"
+                className="ms-TooltipHost root-94"
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
                 onKeyDown={[Function]}
@@ -185,7 +185,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
               >
                 <button
                   aria-label="Mute microphone"
-                  className="ms-Button ms-Button--default is-checked root-15"
+                  className="ms-Button ms-Button--default is-checked css-stub-classname"
                   data-is-focusable={true}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -196,12 +196,12 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   type="button"
                 >
                   <span
-                    className="ms-Button-flexContainer flexContainer-16"
+                    className="ms-Button-flexContainer css-stub-classname"
                     data-automationid="splitbuttonprimary"
                   >
                     <i
                       aria-hidden={true}
-                      className="root-94 root-24"
+                      className="css-stub-classname"
                       data-icon-name="ControlButtonMicOn"
                     >
                       <span
@@ -226,18 +226,18 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                       </span>
                     </i>
                     <span
-                      className="ms-Button-textContainer textContainer-17"
+                      className="ms-Button-textContainer css-stub-classname"
                     >
                       <span
-                        className="ms-Button-label label-19"
-                        id="id__6"
+                        className="ms-Button-label css-stub-classname"
+                        id="id__121"
                       >
                         Mute
                       </span>
                     </span>
                     <i
                       aria-hidden={true}
-                      className="ms-Icon root-94 css-25 ms-Button-menuIcon menuIcon-20"
+                      className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                       data-icon-name="ChevronDown"
                       hidden={true}
                       style={
@@ -252,7 +252,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                 </button>
               </div>
               <div
-                className="ms-TooltipHost root-14"
+                className="ms-TooltipHost root-94"
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
                 onKeyDown={[Function]}
@@ -261,7 +261,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
               >
                 <button
                   aria-label="Manage devices"
-                  className="ms-Button ms-Button--default root-26"
+                  className="ms-Button ms-Button--default css-stub-classname"
                   data-is-focusable={true}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -272,12 +272,12 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   type="button"
                 >
                   <span
-                    className="ms-Button-flexContainer flexContainer-16"
+                    className="ms-Button-flexContainer css-stub-classname"
                     data-automationid="splitbuttonprimary"
                   >
                     <i
                       aria-hidden={true}
-                      className="root-94 root-24"
+                      className="css-stub-classname"
                       data-icon-name="ControlButtonOptions"
                     >
                       <span
@@ -299,18 +299,18 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                       </span>
                     </i>
                     <span
-                      className="ms-Button-textContainer textContainer-17"
+                      className="ms-Button-textContainer css-stub-classname"
                     >
                       <span
-                        className="ms-Button-label label-19"
-                        id="id__10"
+                        className="ms-Button-label css-stub-classname"
+                        id="id__125"
                       >
                         Devices
                       </span>
                     </span>
                     <i
                       aria-hidden={true}
-                      className="ms-Icon root-94 css-25 ms-Button-menuIcon menuIcon-27"
+                      className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                       data-icon-name="ChevronDown"
                       hidden={true}
                       style={
@@ -325,7 +325,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                 </button>
               </div>
               <div
-                className="ms-TooltipHost root-14"
+                className="ms-TooltipHost root-94"
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
                 onKeyDown={[Function]}
@@ -334,7 +334,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
               >
                 <button
                   aria-label="Leave Call"
-                  className="ms-Button ms-Button--default root-28"
+                  className="ms-Button ms-Button--default css-stub-classname"
                   data-is-focusable={true}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -351,7 +351,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   type="button"
                 >
                   <span
-                    className="ms-Button-flexContainer flexContainer-16"
+                    className="ms-Button-flexContainer css-stub-classname"
                     data-automationid="splitbuttonprimary"
                   >
                     <i
@@ -378,11 +378,11 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                       </span>
                     </i>
                     <span
-                      className="ms-Button-textContainer textContainer-17"
+                      className="ms-Button-textContainer css-stub-classname"
                     >
                       <span
-                        className="ms-Button-label label-29"
-                        id="id__14"
+                        className="ms-Button-label css-stub-classname"
+                        id="id__129"
                       >
                         Leave
                       </span>

--- a/packages/storybook/stories/Examples/Themes/__snapshots__/TeamsTheme.stories.storyshot
+++ b/packages/storybook/stories/Examples/Themes/__snapshots__/TeamsTheme.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -31,7 +31,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
         }
       >
         <div
-          className="css-118 body-1"
+          className="css-118 css-stub-classname"
           dir="ltr"
         >
           <div
@@ -39,7 +39,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
             data-uses-unhanded-props={true}
           >
             <div
-              className="ms-Stack css-3"
+              className="ms-Stack css-stub-classname"
               style={
                 Object {
                   "background": "#1a1a1a",
@@ -49,23 +49,23 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
               }
             >
               <div
-                className="ms-Stack css-4"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-StackItem css-5"
+                  className="ms-StackItem css-stub-classname"
                 >
                   <div
-                    className="css-7"
+                    className="css-stub-classname"
                   >
                     <div
-                      className="ms-Stack css-8"
+                      className="ms-Stack css-stub-classname"
                     >
                       <div
                         aria-live="polite"
-                        className="ms-Stack css-9"
+                        className="ms-Stack css-stub-classname"
                       />
                       <div
-                        className="ms-TooltipHost root-10"
+                        className="ms-TooltipHost root-94"
                         onBlurCapture={[Function]}
                         onFocusCapture={[Function]}
                         onKeyDown={[Function]}
@@ -74,7 +74,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       >
                         <button
                           aria-label="Turn on camera"
-                          className="ms-Button ms-Button--default root-11"
+                          className="ms-Button ms-Button--default css-stub-classname"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -85,12 +85,12 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           type="button"
                         >
                           <span
-                            className="ms-Button-flexContainer flexContainer-12"
+                            className="ms-Button-flexContainer css-stub-classname"
                             data-automationid="splitbuttonprimary"
                           >
                             <i
                               aria-hidden={true}
-                              className="root-94 root-20"
+                              className="css-stub-classname"
                               data-icon-name="ControlButtonCameraOff"
                             >
                               <span
@@ -119,7 +119,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                             </i>
                             <i
                               aria-hidden={true}
-                              className="ms-Icon root-94 css-21 ms-Button-menuIcon menuIcon-16"
+                              className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                               data-icon-name="ChevronDown"
                               hidden={true}
                               style={
@@ -135,10 +135,10 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       </div>
                       <div
                         aria-live="polite"
-                        className="ms-Stack css-9"
+                        className="ms-Stack css-stub-classname"
                       />
                       <div
-                        className="ms-TooltipHost root-10"
+                        className="ms-TooltipHost root-94"
                         onBlurCapture={[Function]}
                         onFocusCapture={[Function]}
                         onKeyDown={[Function]}
@@ -147,7 +147,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       >
                         <button
                           aria-label="Unmute microphone"
-                          className="ms-Button ms-Button--default root-11"
+                          className="ms-Button ms-Button--default css-stub-classname"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -158,12 +158,12 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           type="button"
                         >
                           <span
-                            className="ms-Button-flexContainer flexContainer-12"
+                            className="ms-Button-flexContainer css-stub-classname"
                             data-automationid="splitbuttonprimary"
                           >
                             <i
                               aria-hidden={true}
-                              className="root-94 root-20"
+                              className="css-stub-classname"
                               data-icon-name="ControlButtonMicOff"
                             >
                               <span
@@ -192,7 +192,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                             </i>
                             <i
                               aria-hidden={true}
-                              className="ms-Icon root-94 css-21 ms-Button-menuIcon menuIcon-16"
+                              className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
                               data-icon-name="ChevronDown"
                               hidden={true}
                               style={
@@ -207,7 +207,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                         </button>
                       </div>
                       <div
-                        className="ms-TooltipHost root-10"
+                        className="ms-TooltipHost root-94"
                         onBlurCapture={[Function]}
                         onFocusCapture={[Function]}
                         onKeyDown={[Function]}
@@ -216,7 +216,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       >
                         <button
                           aria-label="Present your screen"
-                          className="ms-Button ms-Button--default root-23"
+                          className="ms-Button ms-Button--default css-stub-classname"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -227,12 +227,12 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           type="button"
                         >
                           <span
-                            className="ms-Button-flexContainer flexContainer-12"
+                            className="ms-Button-flexContainer css-stub-classname"
                             data-automationid="splitbuttonprimary"
                           >
                             <i
                               aria-hidden={true}
-                              className="root-94 root-20"
+                              className="css-stub-classname"
                               data-icon-name="ControlButtonScreenShareStart"
                             >
                               <span
@@ -257,7 +257,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                         </button>
                       </div>
                       <div
-                        className="ms-TooltipHost root-10"
+                        className="ms-TooltipHost root-94"
                         onBlurCapture={[Function]}
                         onFocusCapture={[Function]}
                         onKeyDown={[Function]}
@@ -266,7 +266,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       >
                         <button
                           aria-label="Leave Call"
-                          className="ms-Button ms-Button--default root-24"
+                          className="ms-Button ms-Button--default css-stub-classname"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -277,7 +277,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           type="button"
                         >
                           <span
-                            className="ms-Button-flexContainer flexContainer-12"
+                            className="ms-Button-flexContainer css-stub-classname"
                             data-automationid="splitbuttonprimary"
                           >
                             <i
@@ -304,7 +304,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                               </span>
                             </i>
                             <span
-                              className="ms-Button-textContainer textContainer-13"
+                              className="ms-Button-textContainer css-stub-classname"
                             >
                               <span
                                 style={
@@ -324,24 +324,24 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                 </div>
               </div>
               <div
-                className="css-111 css-26"
+                className="css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-33"
+                  className="ms-Stack css-stub-classname"
                   data-ui-id="video-tile"
                 >
                   <div
-                    className="css-30"
+                    className="css-stub-classname"
                   />
                   <div
-                    className="ms-Stack css-34"
+                    className="ms-Stack css-stub-classname"
                   >
                     <div
-                      className="ms-Stack css-36"
+                      className="ms-Stack css-stub-classname"
                     >
                       <div
                         aria-label=""
-                        className="ms-Persona ms-Persona--size48 root-37"
+                        className="ms-Persona ms-Persona--size48 css-stub-classname"
                         style={
                           Object {
                             "height": 100,
@@ -350,11 +350,11 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                         }
                       >
                         <div
-                          className="ms-Persona-coin ms-Persona--size48 coin-44"
+                          className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                           role="presentation"
                         >
                           <div
-                            className="ms-Persona-imageArea imageArea-46"
+                            className="ms-Persona-imageArea css-stub-classname"
                             role="presentation"
                             style={
                               Object {
@@ -365,7 +365,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           >
                             <div
                               aria-hidden="true"
-                              className="ms-Persona-initials initials-49"
+                              className="ms-Persona-initials css-stub-classname"
                               style={
                                 Object {
                                   "height": 100,
@@ -383,13 +383,13 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-140 css-52"
+                    className="ms-Stack css-stub-classname"
                   >
                     <div
-                      className="ms-Stack css-141 css-53"
+                      className="ms-Stack css-stub-classname"
                     >
                       <span
-                        className="css-54"
+                        className="css-stub-classname"
                         title="Michael"
                       >
                         Michael

--- a/packages/storybook/stories/GridLayout/__snapshots__/GridLayout.stories.storyshot
+++ b/packages/storybook/stories/GridLayout/__snapshots__/GridLayout.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layout 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -29,24 +29,24 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
         }
       >
         <div
-          className="css-111 css-1"
+          className="css-stub-classname"
         >
           <div
-            className="ms-Stack css-8"
+            className="ms-Stack css-stub-classname"
             data-ui-id="video-tile"
           >
             <div
-              className="css-5"
+              className="css-stub-classname"
             />
             <div
-              className="ms-Stack css-9"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Stack css-11"
+                className="ms-Stack css-stub-classname"
               >
                 <div
                   aria-label=""
-                  className="ms-Persona ms-Persona--size48 root-12"
+                  className="ms-Persona ms-Persona--size48 css-stub-classname"
                   style={
                     Object {
                       "height": 100,
@@ -55,11 +55,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                   }
                 >
                   <div
-                    className="ms-Persona-coin ms-Persona--size48 coin-19"
+                    className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                     role="presentation"
                   >
                     <div
-                      className="ms-Persona-imageArea imageArea-21"
+                      className="ms-Persona-imageArea css-stub-classname"
                       role="presentation"
                       style={
                         Object {
@@ -70,7 +70,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                     >
                       <div
                         aria-hidden="true"
-                        className="ms-Persona-initials initials-24"
+                        className="ms-Persona-initials css-stub-classname"
                         style={
                           Object {
                             "height": 100,
@@ -88,13 +88,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-140 css-27"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Stack css-141 css-28"
+                className="ms-Stack css-stub-classname"
               >
                 <span
-                  className="css-29"
+                  className="css-stub-classname"
                   title="Michael"
                 >
                   Michael
@@ -103,21 +103,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
             </div>
           </div>
           <div
-            className="ms-Stack css-8"
+            className="ms-Stack css-stub-classname"
             data-ui-id="video-tile"
           >
             <div
-              className="css-5"
+              className="css-stub-classname"
             />
             <div
-              className="ms-Stack css-9"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Stack css-11"
+                className="ms-Stack css-stub-classname"
               >
                 <div
                   aria-label=""
-                  className="ms-Persona ms-Persona--size48 root-12"
+                  className="ms-Persona ms-Persona--size48 css-stub-classname"
                   style={
                     Object {
                       "height": 100,
@@ -126,11 +126,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                   }
                 >
                   <div
-                    className="ms-Persona-coin ms-Persona--size48 coin-19"
+                    className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                     role="presentation"
                   >
                     <div
-                      className="ms-Persona-imageArea imageArea-21"
+                      className="ms-Persona-imageArea css-stub-classname"
                       role="presentation"
                       style={
                         Object {
@@ -141,7 +141,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                     >
                       <div
                         aria-hidden="true"
-                        className="ms-Persona-initials initials-30"
+                        className="ms-Persona-initials css-stub-classname"
                         style={
                           Object {
                             "height": 100,
@@ -159,13 +159,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-140 css-27"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Stack css-141 css-28"
+                className="ms-Stack css-stub-classname"
               >
                 <span
-                  className="css-29"
+                  className="css-stub-classname"
                   title="Jim"
                 >
                   Jim
@@ -174,21 +174,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
             </div>
           </div>
           <div
-            className="ms-Stack css-8"
+            className="ms-Stack css-stub-classname"
             data-ui-id="video-tile"
           >
             <div
-              className="css-5"
+              className="css-stub-classname"
             />
             <div
-              className="ms-Stack css-9"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Stack css-11"
+                className="ms-Stack css-stub-classname"
               >
                 <div
                   aria-label=""
-                  className="ms-Persona ms-Persona--size48 root-12"
+                  className="ms-Persona ms-Persona--size48 css-stub-classname"
                   style={
                     Object {
                       "height": 100,
@@ -197,11 +197,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                   }
                 >
                   <div
-                    className="ms-Persona-coin ms-Persona--size48 coin-19"
+                    className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                     role="presentation"
                   >
                     <div
-                      className="ms-Persona-imageArea imageArea-21"
+                      className="ms-Persona-imageArea css-stub-classname"
                       role="presentation"
                       style={
                         Object {
@@ -212,7 +212,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                     >
                       <div
                         aria-hidden="true"
-                        className="ms-Persona-initials initials-31"
+                        className="ms-Persona-initials css-stub-classname"
                         style={
                           Object {
                             "height": 100,
@@ -230,13 +230,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-140 css-27"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Stack css-141 css-28"
+                className="ms-Stack css-stub-classname"
               >
                 <span
-                  className="css-29"
+                  className="css-stub-classname"
                   title="Pam"
                 >
                   Pam
@@ -245,21 +245,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
             </div>
           </div>
           <div
-            className="ms-Stack css-8"
+            className="ms-Stack css-stub-classname"
             data-ui-id="video-tile"
           >
             <div
-              className="css-5"
+              className="css-stub-classname"
             />
             <div
-              className="ms-Stack css-9"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Stack css-11"
+                className="ms-Stack css-stub-classname"
               >
                 <div
                   aria-label=""
-                  className="ms-Persona ms-Persona--size48 root-12"
+                  className="ms-Persona ms-Persona--size48 css-stub-classname"
                   style={
                     Object {
                       "height": 100,
@@ -268,11 +268,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                   }
                 >
                   <div
-                    className="ms-Persona-coin ms-Persona--size48 coin-19"
+                    className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                     role="presentation"
                   >
                     <div
-                      className="ms-Persona-imageArea imageArea-21"
+                      className="ms-Persona-imageArea css-stub-classname"
                       role="presentation"
                       style={
                         Object {
@@ -283,7 +283,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                     >
                       <div
                         aria-hidden="true"
-                        className="ms-Persona-initials initials-32"
+                        className="ms-Persona-initials css-stub-classname"
                         style={
                           Object {
                             "height": 100,
@@ -301,13 +301,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-140 css-27"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Stack css-141 css-28"
+                className="ms-Stack css-stub-classname"
               >
                 <span
-                  className="css-29"
+                  className="css-stub-classname"
                   title="Dwight"
                 >
                   Dwight

--- a/packages/storybook/stories/MessageStatusIndicator/__snapshots__/MessageStatusIndicator.stories.storyshot
+++ b/packages/storybook/stories/MessageStatusIndicator/__snapshots__/MessageStatusIndicator.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Message Status Indicator Message Status Indicator 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Message Status Indica
       }
     >
       <div
-        className="ms-TooltipHost root-2"
+        className="ms-TooltipHost css-stub-classname"
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
         onKeyDown={[Function]}
@@ -30,7 +30,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Message Status Indica
       >
         <i
           aria-label="Message sent"
-          className="root-94 css-126 root-3"
+          className="css-stub-classname"
           data-icon-name="MessageDelivered"
           data-ui-id="chat-composite-message-status-icon"
           role="status"

--- a/packages/storybook/stories/ParticipantItem/__snapshots__/ParticipantItem.stories.storyshot
+++ b/packages/storybook/stories/ParticipantItem/__snapshots__/ParticipantItem.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Participant Item Participant Item 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -28,7 +28,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
         }
       >
         <div
-          className="css-7"
+          className="css-stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onMouseEnter={[Function]}
@@ -36,22 +36,22 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
           role="menuitem"
         >
           <div
-            className="ms-Stack css-9"
+            className="ms-Stack css-stub-classname"
           >
             <div
-              className="ms-Persona ms-Persona--size32 root-10"
+              className="ms-Persona ms-Persona--size32 css-stub-classname"
             >
               <div
-                className="ms-Persona-coin ms-Persona--size32 coin-17"
+                className="ms-Persona-coin ms-Persona--size32 css-stub-classname"
                 role="presentation"
               >
                 <div
-                  className="ms-Persona-imageArea imageArea-19"
+                  className="ms-Persona-imageArea css-stub-classname"
                   role="presentation"
                 >
                   <div
                     aria-hidden="true"
-                    className="ms-Persona-initials initials-22"
+                    className="ms-Persona-initials css-stub-classname"
                   >
                     <span>
                       AM
@@ -60,14 +60,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                 </div>
               </div>
               <div
-                className="ms-Persona-details details-11"
+                className="ms-Persona-details css-stub-classname"
               >
                 <div
-                  className="ms-Persona-primaryText primaryText-12"
+                  className="ms-Persona-primaryText css-stub-classname"
                   dir="auto"
                 >
                   <div
-                    className="ms-TooltipHost root-25"
+                    className="ms-TooltipHost css-stub-classname"
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
                     onKeyDown={[Function]}
@@ -78,28 +78,28 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                   </div>
                 </div>
                 <div
-                  className="ms-Persona-secondaryText secondaryText-13"
+                  className="ms-Persona-secondaryText css-stub-classname"
                   dir="auto"
                 />
                 <div
-                  className="ms-Persona-tertiaryText tertiaryText-14"
+                  className="ms-Persona-tertiaryText css-stub-classname"
                   dir="auto"
                 />
                 <div
-                  className="ms-Persona-optionalText optionalText-15"
+                  className="ms-Persona-optionalText css-stub-classname"
                   dir="auto"
                 />
               </div>
             </div>
             <div
-              className="ms-Stack css-26"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Stack css-27"
+                className="ms-Stack css-stub-classname"
               >
                 <span
                   aria-hidden={true}
-                  className="root-span css-1"
+                  className="root-span css-stub-classname"
                 >
                   <svg
                     className="svg"
@@ -116,7 +116,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                 </span>
                 <span
                   aria-hidden={true}
-                  className="root-span css-1"
+                  className="root-span css-stub-classname"
                 >
                   <svg
                     className="svg"
@@ -141,13 +141,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
             </div>
           </div>
           <div
-            className="ms-Stack css-28"
+            className="ms-Stack css-stub-classname"
             data-ui-id="participant-item-menu-button"
             title="More Options"
           >
             <i
               aria-hidden={true}
-              className="root-94 css-138"
+              className="css-stub-classname"
               data-icon-name="ParticipantItemOptions"
             >
               <span
@@ -179,7 +179,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
             className="ms-layer"
           >
             <div
-              className="ms-Fabric ms-Layer-content content-52"
+              className="ms-Fabric ms-Layer-content css-stub-classname"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
@@ -212,7 +212,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
               onTouchStart={[Function]}
             >
               <div
-                className="ms-Callout-container container-54"
+                className="ms-Callout-container css-stub-classname"
                 style={
                   Object {
                     "visibility": "hidden",
@@ -220,7 +220,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                 }
               >
                 <div
-                  className="ms-Callout ms-ContextualMenu-Callout root-55"
+                  className="ms-Callout ms-ContextualMenu-Callout css-stub-classname"
                   hidden={true}
                   onScroll={[Function]}
                   style={
@@ -233,7 +233,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                   tabIndex={-1}
                 >
                   <div
-                    className="ms-Callout-main calloutMain-58"
+                    className="ms-Callout-main css-stub-classname"
                     onKeyDown={[Function]}
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
@@ -247,7 +247,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                     }
                   >
                     <div
-                      className="ms-ContextualMenu-container container-30"
+                      className="ms-ContextualMenu-container css-stub-classname"
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
                       onKeyUp={[Function]}
@@ -255,27 +255,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                       tabIndex={-1}
                     >
                       <div
-                        className="ms-FocusZone css-59 ms-ContextualMenu is-open root-29"
-                        data-focuszone-id="FocusZone4"
+                        className="ms-FocusZone css-stub-classname ms-ContextualMenu is-open css-stub-classname"
+                        data-focuszone-id="FocusZone157"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
                       >
                         <ul
-                          className="ms-ContextualMenu-list is-open list-31"
+                          className="ms-ContextualMenu-list is-open css-stub-classname"
                           onKeyDown={[Function]}
                           onKeyUp={[Function]}
                           role="presentation"
                         >
                           <li
-                            className="ms-ContextualMenu-item item-34"
+                            className="ms-ContextualMenu-item css-stub-classname"
                             role="presentation"
                           >
                             <button
                               aria-disabled={false}
                               aria-posinset={1}
                               aria-setsize={2}
-                              className="ms-ContextualMenu-link root-36"
+                              className="ms-ContextualMenu-link css-stub-classname"
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseEnter={[Function]}
@@ -284,10 +284,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                               role="menuitem"
                             >
                               <div
-                                className="ms-ContextualMenu-linkContent linkContent-40"
+                                className="ms-ContextualMenu-linkContent css-stub-classname"
                               >
                                 <span
-                                  className="ms-ContextualMenu-itemText label-46"
+                                  className="ms-ContextualMenu-itemText css-stub-classname"
                                 >
                                   Mute
                                 </span>
@@ -295,14 +295,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                             </button>
                           </li>
                           <li
-                            className="ms-ContextualMenu-item item-34"
+                            className="ms-ContextualMenu-item css-stub-classname"
                             role="presentation"
                           >
                             <button
                               aria-disabled={false}
                               aria-posinset={2}
                               aria-setsize={2}
-                              className="ms-ContextualMenu-link root-36"
+                              className="ms-ContextualMenu-link css-stub-classname"
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseEnter={[Function]}
@@ -311,10 +311,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                               role="menuitem"
                             >
                               <div
-                                className="ms-ContextualMenu-linkContent linkContent-40"
+                                className="ms-ContextualMenu-linkContent css-stub-classname"
                               >
                                 <span
-                                  className="ms-ContextualMenu-itemText label-46"
+                                  className="ms-ContextualMenu-itemText css-stub-classname"
                                 >
                                   Remove
                                 </span>

--- a/packages/storybook/stories/ParticipantList/__snapshots__/ParticipantList.stories.storyshot
+++ b/packages/storybook/stories/ParticipantList/__snapshots__/ParticipantList.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Participant List Participant List 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,14 +21,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
       }
     >
       <div
-        className="ms-Stack css-1"
+        className="ms-Stack css-stub-classname"
       >
         <div
-          className="ms-Stack css-139 css-1"
+          className="ms-Stack css-stub-classname"
           data-ui-id="participant-list"
         >
           <div
-            className="css-7"
+            className="css-stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -36,22 +36,22 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             role="menuitem"
           >
             <div
-              className="ms-Stack css-9"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Persona ms-Persona--size32 root-10"
+                className="ms-Persona ms-Persona--size32 css-stub-classname"
               >
                 <div
-                  className="ms-Persona-coin ms-Persona--size32 coin-17"
+                  className="ms-Persona-coin ms-Persona--size32 css-stub-classname"
                   role="presentation"
                 >
                   <div
-                    className="ms-Persona-imageArea imageArea-19"
+                    className="ms-Persona-imageArea css-stub-classname"
                     role="presentation"
                   >
                     <div
                       aria-hidden="true"
-                      className="ms-Persona-initials initials-22"
+                      className="ms-Persona-initials css-stub-classname"
                     >
                       <span>
                         R
@@ -60,14 +60,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                   </div>
                 </div>
                 <div
-                  className="ms-Persona-details details-11"
+                  className="ms-Persona-details css-stub-classname"
                 >
                   <div
-                    className="ms-Persona-primaryText primaryText-12"
+                    className="ms-Persona-primaryText css-stub-classname"
                     dir="auto"
                   >
                     <div
-                      className="ms-TooltipHost root-25"
+                      className="ms-TooltipHost css-stub-classname"
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
@@ -78,31 +78,31 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     </div>
                   </div>
                   <div
-                    className="ms-Persona-secondaryText secondaryText-13"
+                    className="ms-Persona-secondaryText css-stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-tertiaryText tertiaryText-14"
+                    className="ms-Persona-tertiaryText css-stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-optionalText optionalText-15"
+                    className="ms-Persona-optionalText css-stub-classname"
                     dir="auto"
                   />
                 </div>
               </div>
               <div
-                className="ms-Stack css-26"
+                className="ms-Stack css-stub-classname"
               />
             </div>
             <div
-              className="ms-Stack css-27"
+              className="ms-Stack css-stub-classname"
               data-ui-id="participant-item-menu-button"
               title="More Options"
             >
               <i
                 aria-hidden={true}
-                className="root-94 css-138"
+                className="css-stub-classname"
                 data-icon-name="ParticipantItemOptions"
               >
                 <span
@@ -134,7 +134,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
               className="ms-layer"
             >
               <div
-                className="ms-Fabric ms-Layer-content content-58"
+                className="ms-Fabric ms-Layer-content css-stub-classname"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onClick={[Function]}
@@ -167,7 +167,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                 onTouchStart={[Function]}
               >
                 <div
-                  className="ms-Callout-container container-60"
+                  className="ms-Callout-container css-stub-classname"
                   style={
                     Object {
                       "visibility": "hidden",
@@ -175,7 +175,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                   }
                 >
                   <div
-                    className="ms-Callout ms-ContextualMenu-Callout root-61"
+                    className="ms-Callout ms-ContextualMenu-Callout css-stub-classname"
                     hidden={true}
                     onScroll={[Function]}
                     style={
@@ -188,7 +188,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     tabIndex={-1}
                   >
                     <div
-                      className="ms-Callout-main calloutMain-64"
+                      className="ms-Callout-main css-stub-classname"
                       onKeyDown={[Function]}
                       onMouseDown={[Function]}
                       onMouseUp={[Function]}
@@ -202,7 +202,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                       }
                     >
                       <div
-                        className="ms-ContextualMenu-container container-29"
+                        className="ms-ContextualMenu-container css-stub-classname"
                         onFocusCapture={[Function]}
                         onKeyDown={[Function]}
                         onKeyUp={[Function]}
@@ -210,27 +210,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                         tabIndex={-1}
                       >
                         <div
-                          className="ms-FocusZone css-59 ms-ContextualMenu is-open root-28"
-                          data-focuszone-id="FocusZone11"
+                          className="ms-FocusZone css-stub-classname ms-ContextualMenu is-open css-stub-classname"
+                          data-focuszone-id="FocusZone169"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
                         >
                           <ul
-                            className="ms-ContextualMenu-list is-open list-30"
+                            className="ms-ContextualMenu-list is-open css-stub-classname"
                             onKeyDown={[Function]}
                             onKeyUp={[Function]}
                             role="presentation"
                           >
                             <li
-                              className="ms-ContextualMenu-item item-33"
+                              className="ms-ContextualMenu-item css-stub-classname"
                               role="presentation"
                             >
                               <button
                                 aria-disabled={false}
                                 aria-posinset={1}
                                 aria-setsize={1}
-                                className="ms-ContextualMenu-link root-35"
+                                className="ms-ContextualMenu-link css-stub-classname"
                                 data-ui-id="participant-list-remove-participant-button"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -240,10 +240,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                                 role="menuitem"
                               >
                                 <div
-                                  className="ms-ContextualMenu-linkContent linkContent-39"
+                                  className="ms-ContextualMenu-linkContent css-stub-classname"
                                 >
                                   <span
-                                    className="ms-ContextualMenu-itemText label-45"
+                                    className="ms-ContextualMenu-itemText css-stub-classname"
                                   >
                                     Remove
                                   </span>
@@ -260,7 +260,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             </span>
           </div>
           <div
-            className="css-7"
+            className="css-stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -268,22 +268,22 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             role="menuitem"
           >
             <div
-              className="ms-Stack css-9"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Persona ms-Persona--size32 root-10"
+                className="ms-Persona ms-Persona--size32 css-stub-classname"
               >
                 <div
-                  className="ms-Persona-coin ms-Persona--size32 coin-17"
+                  className="ms-Persona-coin ms-Persona--size32 css-stub-classname"
                   role="presentation"
                 >
                   <div
-                    className="ms-Persona-imageArea imageArea-19"
+                    className="ms-Persona-imageArea css-stub-classname"
                     role="presentation"
                   >
                     <div
                       aria-hidden="true"
-                      className="ms-Persona-initials initials-51"
+                      className="ms-Persona-initials css-stub-classname"
                     >
                       <span>
                         D
@@ -292,14 +292,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                   </div>
                 </div>
                 <div
-                  className="ms-Persona-details details-11"
+                  className="ms-Persona-details css-stub-classname"
                 >
                   <div
-                    className="ms-Persona-primaryText primaryText-12"
+                    className="ms-Persona-primaryText css-stub-classname"
                     dir="auto"
                   >
                     <div
-                      className="ms-TooltipHost root-25"
+                      className="ms-TooltipHost css-stub-classname"
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
@@ -310,31 +310,31 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     </div>
                   </div>
                   <div
-                    className="ms-Persona-secondaryText secondaryText-13"
+                    className="ms-Persona-secondaryText css-stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-tertiaryText tertiaryText-14"
+                    className="ms-Persona-tertiaryText css-stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-optionalText optionalText-15"
+                    className="ms-Persona-optionalText css-stub-classname"
                     dir="auto"
                   />
                 </div>
               </div>
               <div
-                className="ms-Stack css-26"
+                className="ms-Stack css-stub-classname"
               />
             </div>
             <div
-              className="ms-Stack css-27"
+              className="ms-Stack css-stub-classname"
               data-ui-id="participant-item-menu-button"
               title="More Options"
             >
               <i
                 aria-hidden={true}
-                className="root-94 css-138"
+                className="css-stub-classname"
                 data-icon-name="ParticipantItemOptions"
               >
                 <span
@@ -366,7 +366,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
               className="ms-layer"
             >
               <div
-                className="ms-Fabric ms-Layer-content content-58"
+                className="ms-Fabric ms-Layer-content css-stub-classname"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onClick={[Function]}
@@ -399,7 +399,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                 onTouchStart={[Function]}
               >
                 <div
-                  className="ms-Callout-container container-60"
+                  className="ms-Callout-container css-stub-classname"
                   style={
                     Object {
                       "visibility": "hidden",
@@ -407,7 +407,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                   }
                 >
                   <div
-                    className="ms-Callout ms-ContextualMenu-Callout root-61"
+                    className="ms-Callout ms-ContextualMenu-Callout css-stub-classname"
                     hidden={true}
                     onScroll={[Function]}
                     style={
@@ -420,7 +420,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     tabIndex={-1}
                   >
                     <div
-                      className="ms-Callout-main calloutMain-64"
+                      className="ms-Callout-main css-stub-classname"
                       onKeyDown={[Function]}
                       onMouseDown={[Function]}
                       onMouseUp={[Function]}
@@ -434,7 +434,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                       }
                     >
                       <div
-                        className="ms-ContextualMenu-container container-29"
+                        className="ms-ContextualMenu-container css-stub-classname"
                         onFocusCapture={[Function]}
                         onKeyDown={[Function]}
                         onKeyUp={[Function]}
@@ -442,27 +442,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                         tabIndex={-1}
                       >
                         <div
-                          className="ms-FocusZone css-59 ms-ContextualMenu is-open root-28"
-                          data-focuszone-id="FocusZone12"
+                          className="ms-FocusZone css-stub-classname ms-ContextualMenu is-open css-stub-classname"
+                          data-focuszone-id="FocusZone170"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
                         >
                           <ul
-                            className="ms-ContextualMenu-list is-open list-30"
+                            className="ms-ContextualMenu-list is-open css-stub-classname"
                             onKeyDown={[Function]}
                             onKeyUp={[Function]}
                             role="presentation"
                           >
                             <li
-                              className="ms-ContextualMenu-item item-33"
+                              className="ms-ContextualMenu-item css-stub-classname"
                               role="presentation"
                             >
                               <button
                                 aria-disabled={false}
                                 aria-posinset={1}
                                 aria-setsize={1}
-                                className="ms-ContextualMenu-link root-35"
+                                className="ms-ContextualMenu-link css-stub-classname"
                                 data-ui-id="participant-list-remove-participant-button"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -472,10 +472,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                                 role="menuitem"
                               >
                                 <div
-                                  className="ms-ContextualMenu-linkContent linkContent-39"
+                                  className="ms-ContextualMenu-linkContent css-stub-classname"
                                 >
                                   <span
-                                    className="ms-ContextualMenu-itemText label-45"
+                                    className="ms-ContextualMenu-itemText css-stub-classname"
                                   >
                                     Remove
                                   </span>
@@ -492,7 +492,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             </span>
           </div>
           <div
-            className="css-7"
+            className="css-stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -500,42 +500,42 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             role="menuitem"
           >
             <div
-              className="ms-Stack css-9"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Persona ms-Persona--size32 ms-Persona--away root-10"
+                className="ms-Persona ms-Persona--size32 ms-Persona--away css-stub-classname"
               >
                 <div
-                  className="ms-Persona-coin ms-Persona--size32 coin-17"
+                  className="ms-Persona-coin ms-Persona--size32 css-stub-classname"
                   role="presentation"
                 >
                   <div
-                    className="ms-Persona-imageArea imageArea-19"
+                    className="ms-Persona-imageArea css-stub-classname"
                     role="presentation"
                   >
                     <div
                       aria-hidden="true"
-                      className="ms-Persona-initials initials-52"
+                      className="ms-Persona-initials css-stub-classname"
                     >
                       <span>
                         M
                       </span>
                     </div>
                     <div
-                      className="ms-Persona-presence presence-53"
+                      className="ms-Persona-presence css-stub-classname"
                       role="presentation"
                     />
                   </div>
                 </div>
                 <div
-                  className="ms-Persona-details details-11"
+                  className="ms-Persona-details css-stub-classname"
                 >
                   <div
-                    className="ms-Persona-primaryText primaryText-12"
+                    className="ms-Persona-primaryText css-stub-classname"
                     dir="auto"
                   >
                     <div
-                      className="ms-TooltipHost root-25"
+                      className="ms-TooltipHost css-stub-classname"
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
@@ -546,31 +546,31 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     </div>
                   </div>
                   <div
-                    className="ms-Persona-secondaryText secondaryText-13"
+                    className="ms-Persona-secondaryText css-stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-tertiaryText tertiaryText-14"
+                    className="ms-Persona-tertiaryText css-stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-optionalText optionalText-15"
+                    className="ms-Persona-optionalText css-stub-classname"
                     dir="auto"
                   />
                 </div>
               </div>
               <div
-                className="ms-Stack css-26"
+                className="ms-Stack css-stub-classname"
               />
             </div>
             <div
-              className="ms-Stack css-27"
+              className="ms-Stack css-stub-classname"
               data-ui-id="participant-item-menu-button"
               title="More Options"
             >
               <i
                 aria-hidden={true}
-                className="root-94 css-138"
+                className="css-stub-classname"
                 data-icon-name="ParticipantItemOptions"
               >
                 <span
@@ -602,7 +602,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
               className="ms-layer"
             >
               <div
-                className="ms-Fabric ms-Layer-content content-58"
+                className="ms-Fabric ms-Layer-content css-stub-classname"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onClick={[Function]}
@@ -635,7 +635,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                 onTouchStart={[Function]}
               >
                 <div
-                  className="ms-Callout-container container-60"
+                  className="ms-Callout-container css-stub-classname"
                   style={
                     Object {
                       "visibility": "hidden",
@@ -643,7 +643,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                   }
                 >
                   <div
-                    className="ms-Callout ms-ContextualMenu-Callout root-61"
+                    className="ms-Callout ms-ContextualMenu-Callout css-stub-classname"
                     hidden={true}
                     onScroll={[Function]}
                     style={
@@ -656,7 +656,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     tabIndex={-1}
                   >
                     <div
-                      className="ms-Callout-main calloutMain-64"
+                      className="ms-Callout-main css-stub-classname"
                       onKeyDown={[Function]}
                       onMouseDown={[Function]}
                       onMouseUp={[Function]}
@@ -670,7 +670,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                       }
                     >
                       <div
-                        className="ms-ContextualMenu-container container-29"
+                        className="ms-ContextualMenu-container css-stub-classname"
                         onFocusCapture={[Function]}
                         onKeyDown={[Function]}
                         onKeyUp={[Function]}
@@ -678,27 +678,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                         tabIndex={-1}
                       >
                         <div
-                          className="ms-FocusZone css-59 ms-ContextualMenu is-open root-28"
-                          data-focuszone-id="FocusZone13"
+                          className="ms-FocusZone css-stub-classname ms-ContextualMenu is-open css-stub-classname"
+                          data-focuszone-id="FocusZone171"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
                         >
                           <ul
-                            className="ms-ContextualMenu-list is-open list-30"
+                            className="ms-ContextualMenu-list is-open css-stub-classname"
                             onKeyDown={[Function]}
                             onKeyUp={[Function]}
                             role="presentation"
                           >
                             <li
-                              className="ms-ContextualMenu-item item-33"
+                              className="ms-ContextualMenu-item css-stub-classname"
                               role="presentation"
                             >
                               <button
                                 aria-disabled={false}
                                 aria-posinset={1}
                                 aria-setsize={1}
-                                className="ms-ContextualMenu-link root-35"
+                                className="ms-ContextualMenu-link css-stub-classname"
                                 data-ui-id="participant-list-remove-participant-button"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -708,10 +708,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                                 role="menuitem"
                               >
                                 <div
-                                  className="ms-ContextualMenu-linkContent linkContent-39"
+                                  className="ms-ContextualMenu-linkContent css-stub-classname"
                                 >
                                   <span
-                                    className="ms-ContextualMenu-itemText label-45"
+                                    className="ms-ContextualMenu-itemText css-stub-classname"
                                   >
                                     Remove
                                   </span>
@@ -728,7 +728,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             </span>
           </div>
           <div
-            className="css-55"
+            className="css-stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -736,42 +736,42 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             role="menuitem"
           >
             <div
-              className="ms-Stack css-9"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="ms-Persona ms-Persona--size32 ms-Persona--online root-10"
+                className="ms-Persona ms-Persona--size32 ms-Persona--online css-stub-classname"
               >
                 <div
-                  className="ms-Persona-coin ms-Persona--size32 coin-17"
+                  className="ms-Persona-coin ms-Persona--size32 css-stub-classname"
                   role="presentation"
                 >
                   <div
-                    className="ms-Persona-imageArea imageArea-19"
+                    className="ms-Persona-imageArea css-stub-classname"
                     role="presentation"
                   >
                     <div
                       aria-hidden="true"
-                      className="ms-Persona-initials initials-22"
+                      className="ms-Persona-initials css-stub-classname"
                     >
                       <span>
                         Y
                       </span>
                     </div>
                     <div
-                      className="ms-Persona-presence presence-56"
+                      className="ms-Persona-presence css-stub-classname"
                       role="presentation"
                     />
                   </div>
                 </div>
                 <div
-                  className="ms-Persona-details details-11"
+                  className="ms-Persona-details css-stub-classname"
                 >
                   <div
-                    className="ms-Persona-primaryText primaryText-12"
+                    className="ms-Persona-primaryText css-stub-classname"
                     dir="auto"
                   >
                     <div
-                      className="ms-TooltipHost root-25"
+                      className="ms-TooltipHost css-stub-classname"
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
@@ -782,26 +782,26 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     </div>
                   </div>
                   <div
-                    className="ms-Persona-secondaryText secondaryText-13"
+                    className="ms-Persona-secondaryText css-stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-tertiaryText tertiaryText-14"
+                    className="ms-Persona-tertiaryText css-stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-optionalText optionalText-15"
+                    className="ms-Persona-optionalText css-stub-classname"
                     dir="auto"
                   />
                 </div>
               </div>
               <span
-                className="css-57"
+                className="css-stub-classname"
               >
                 (you)
               </span>
               <div
-                className="ms-Stack css-26"
+                className="ms-Stack css-stub-classname"
               />
             </div>
           </div>

--- a/packages/storybook/stories/SendBox/__snapshots__/SendBox.stories.storyshot
+++ b/packages/storybook/stories/SendBox/__snapshots__/SendBox.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -28,30 +28,30 @@ exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`]
         }
       >
         <div
-          className="ms-Stack css-112 css-3"
+          className="ms-Stack css-stub-classname"
         >
           <div
-            className="ms-Stack css-4"
+            className="ms-Stack css-stub-classname"
           >
             <div
-              className="ms-Stack css-119 css-3"
+              className="ms-Stack css-stub-classname"
             >
               <div
-                className="css-5"
+                className="css-stub-classname"
               >
                 <div
-                  className="ms-TextField ms-TextField--multiline root-8"
+                  className="ms-TextField ms-TextField--multiline css-stub-classname"
                 >
                   <div
-                    className="ms-TextField-wrapper wrapper-9"
+                    className="ms-TextField-wrapper css-stub-classname"
                   >
                     <div
-                      className="ms-TextField-fieldGroup fieldGroup-10"
+                      className="ms-TextField-fieldGroup css-stub-classname"
                     >
                       <textarea
                         aria-invalid={false}
                         autoFocus={false}
-                        className="ms-TextField-field ms-TextField--unresizable css-120 css-113 field-11"
+                        className="ms-TextField-field ms-TextField--unresizable css-stub-classname"
                         data-ui-id="sendbox-textfield"
                         disabled={false}
                         id="sendbox"
@@ -67,10 +67,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`]
                   </div>
                 </div>
                 <div
-                  className="ms-Stack css-20"
+                  className="ms-Stack css-stub-classname"
                 >
                   <div
-                    className="ms-TooltipHost css-122 root-21"
+                    className="ms-TooltipHost css-stub-classname"
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
                     onKeyDown={[Function]}
@@ -79,7 +79,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`]
                   >
                     <button
                       aria-label="Send message"
-                      className="ms-Button ms-Button--icon css-121 css-114 root-22"
+                      className="ms-Button ms-Button--icon css-stub-classname"
                       data-is-focusable={true}
                       id="sendIconWrapper"
                       onClick={[Function]}
@@ -93,12 +93,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`]
                       type="button"
                     >
                       <span
-                        className="ms-Button-flexContainer flexContainer-23"
+                        className="ms-Button-flexContainer css-stub-classname"
                         data-automationid="splitbuttonprimary"
                       >
                         <i
                           aria-hidden={true}
-                          className="root-94 css-115 root-30"
+                          className="css-stub-classname"
                           data-icon-name="SendBoxSend"
                         >
                           <span

--- a/packages/storybook/stories/TypingIndicator/__snapshots__/TypingIndicator.stories.storyshot
+++ b/packages/storybook/stories/TypingIndicator/__snapshots__/TypingIndicator.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Typing Indicator Typing Indicator 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Typing Indicator Typi
       }
     >
       <div
-        className="ms-Stack css-109 css-1"
+        className="ms-Stack css-stub-classname"
       >
         <div
           aria-label="User1, User2 are typing ..."
@@ -30,26 +30,26 @@ exports[`storybook snapshot tests Storyshots UI Components/Typing Indicator Typi
           role="status"
         >
           <span
-            className="css-2"
+            className="css-stub-classname"
           >
             <span
-              className="css-2"
+              className="css-stub-classname"
             >
               User1
             </span>
             <span
-              className="css-2"
+              className="css-stub-classname"
             >
               , 
             </span>
             <span
-              className="css-2"
+              className="css-stub-classname"
             >
               User2
             </span>
           </span>
           <span
-            className="css-2"
+            className="css-stub-classname"
           >
              are typing ...
           </span>

--- a/packages/storybook/stories/VideoGallery/__snapshots__/VideoGallery.stories.storyshot
+++ b/packages/storybook/stories/VideoGallery/__snapshots__/VideoGallery.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video Gallery 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -25,30 +25,30 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
         data-ui-id="video-gallery"
       >
         <div
-          className="ms-Stack css-3"
+          className="ms-Stack css-stub-classname"
         >
           <div
             aria-label="Movable Local Video Tile"
-            className="ms-Stack css-4"
+            className="ms-Stack css-stub-classname"
             role="dialog"
             tabIndex={0}
           >
             <div
-              className="ms-Stack css-12"
+              className="ms-Stack css-stub-classname"
               data-ui-id="video-tile"
             >
               <div
-                className="css-8"
+                className="css-stub-classname"
               />
               <div
-                className="ms-Stack css-13"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-15"
+                  className="ms-Stack css-stub-classname"
                 >
                   <div
                     aria-label=""
-                    className="ms-Persona ms-Persona--size48 root-16"
+                    className="ms-Persona ms-Persona--size48 css-stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -57,11 +57,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                     }
                   >
                     <div
-                      className="ms-Persona-coin ms-Persona--size48 coin-23"
+                      className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                       role="presentation"
                     >
                       <div
-                        className="ms-Persona-imageArea imageArea-25"
+                        className="ms-Persona-imageArea css-stub-classname"
                         role="presentation"
                         style={
                           Object {
@@ -72,7 +72,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                       >
                         <div
                           aria-hidden="true"
-                          className="ms-Persona-initials initials-28"
+                          className="ms-Persona-initials css-stub-classname"
                           style={
                             Object {
                               "height": 100,
@@ -90,19 +90,19 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 </div>
               </div>
               <div
-                className="ms-Stack css-140 css-31"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-141 css-32"
+                  className="ms-Stack css-stub-classname"
                 >
                   <span
-                    className="css-33"
+                    className="css-stub-classname"
                     title="You"
                   >
                     You
                   </span>
                   <div
-                    className="ms-Stack css-34"
+                    className="ms-Stack css-stub-classname"
                   >
                     <i
                       aria-hidden={true}
@@ -140,27 +140,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
           </div>
         </div>
         <div
-          className="ms-Stack css-35"
+          className="ms-Stack css-stub-classname"
         >
           <div
-            className="css-111 css-36"
+            className="css-stub-classname"
           >
             <div
-              className="ms-Stack css-38"
+              className="ms-Stack css-stub-classname"
               data-ui-id="video-tile"
             >
               <div
-                className="css-8"
+                className="css-stub-classname"
               />
               <div
-                className="ms-Stack css-13"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-15"
+                  className="ms-Stack css-stub-classname"
                 >
                   <div
                     aria-label=""
-                    className="ms-Persona ms-Persona--size48 root-16"
+                    className="ms-Persona ms-Persona--size48 css-stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -169,11 +169,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                     }
                   >
                     <div
-                      className="ms-Persona-coin ms-Persona--size48 coin-23"
+                      className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                       role="presentation"
                     >
                       <div
-                        className="ms-Persona-imageArea imageArea-25"
+                        className="ms-Persona-imageArea css-stub-classname"
                         role="presentation"
                         style={
                           Object {
@@ -184,7 +184,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                       >
                         <div
                           aria-hidden="true"
-                          className="ms-Persona-initials initials-28"
+                          className="ms-Persona-initials css-stub-classname"
                           style={
                             Object {
                               "height": 100,
@@ -202,13 +202,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 </div>
               </div>
               <div
-                className="ms-Stack css-140 css-31"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-141 css-32"
+                  className="ms-Stack css-stub-classname"
                 >
                   <span
-                    className="css-33"
+                    className="css-stub-classname"
                     title="Rick"
                   >
                     Rick
@@ -217,21 +217,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
               </div>
             </div>
             <div
-              className="ms-Stack css-38"
+              className="ms-Stack css-stub-classname"
               data-ui-id="video-tile"
             >
               <div
-                className="css-8"
+                className="css-stub-classname"
               />
               <div
-                className="ms-Stack css-13"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-15"
+                  className="ms-Stack css-stub-classname"
                 >
                   <div
                     aria-label=""
-                    className="ms-Persona ms-Persona--size48 root-16"
+                    className="ms-Persona ms-Persona--size48 css-stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -240,11 +240,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                     }
                   >
                     <div
-                      className="ms-Persona-coin ms-Persona--size48 coin-23"
+                      className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                       role="presentation"
                     >
                       <div
-                        className="ms-Persona-imageArea imageArea-25"
+                        className="ms-Persona-imageArea css-stub-classname"
                         role="presentation"
                         style={
                           Object {
@@ -255,7 +255,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                       >
                         <div
                           aria-hidden="true"
-                          className="ms-Persona-initials initials-39"
+                          className="ms-Persona-initials css-stub-classname"
                           style={
                             Object {
                               "height": 100,
@@ -273,13 +273,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 </div>
               </div>
               <div
-                className="ms-Stack css-140 css-31"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-141 css-32"
+                  className="ms-Stack css-stub-classname"
                 >
                   <span
-                    className="css-33"
+                    className="css-stub-classname"
                     title="Daryl"
                   >
                     Daryl
@@ -288,21 +288,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
               </div>
             </div>
             <div
-              className="ms-Stack css-38"
+              className="ms-Stack css-stub-classname"
               data-ui-id="video-tile"
             >
               <div
-                className="css-8"
+                className="css-stub-classname"
               />
               <div
-                className="ms-Stack css-13"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-15"
+                  className="ms-Stack css-stub-classname"
                 >
                   <div
                     aria-label=""
-                    className="ms-Persona ms-Persona--size48 root-16"
+                    className="ms-Persona ms-Persona--size48 css-stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -311,11 +311,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                     }
                   >
                     <div
-                      className="ms-Persona-coin ms-Persona--size48 coin-23"
+                      className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                       role="presentation"
                     >
                       <div
-                        className="ms-Persona-imageArea imageArea-25"
+                        className="ms-Persona-imageArea css-stub-classname"
                         role="presentation"
                         style={
                           Object {
@@ -326,7 +326,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                       >
                         <div
                           aria-hidden="true"
-                          className="ms-Persona-initials initials-40"
+                          className="ms-Persona-initials css-stub-classname"
                           style={
                             Object {
                               "height": 100,
@@ -344,13 +344,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 </div>
               </div>
               <div
-                className="ms-Stack css-140 css-31"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-141 css-32"
+                  className="ms-Stack css-stub-classname"
                 >
                   <span
-                    className="css-33"
+                    className="css-stub-classname"
                     title="Michonne"
                   >
                     Michonne
@@ -359,21 +359,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
               </div>
             </div>
             <div
-              className="ms-Stack css-38"
+              className="ms-Stack css-stub-classname"
               data-ui-id="video-tile"
             >
               <div
-                className="css-8"
+                className="css-stub-classname"
               />
               <div
-                className="ms-Stack css-13"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-15"
+                  className="ms-Stack css-stub-classname"
                 >
                   <div
                     aria-label=""
-                    className="ms-Persona ms-Persona--size48 root-16"
+                    className="ms-Persona ms-Persona--size48 css-stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -382,11 +382,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                     }
                   >
                     <div
-                      className="ms-Persona-coin ms-Persona--size48 coin-23"
+                      className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                       role="presentation"
                     >
                       <div
-                        className="ms-Persona-imageArea imageArea-25"
+                        className="ms-Persona-imageArea css-stub-classname"
                         role="presentation"
                         style={
                           Object {
@@ -397,7 +397,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                       >
                         <div
                           aria-hidden="true"
-                          className="ms-Persona-initials initials-41"
+                          className="ms-Persona-initials css-stub-classname"
                           style={
                             Object {
                               "height": 100,
@@ -415,13 +415,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 </div>
               </div>
               <div
-                className="ms-Stack css-140 css-31"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-141 css-32"
+                  className="ms-Stack css-stub-classname"
                 >
                   <span
-                    className="css-33"
+                    className="css-stub-classname"
                     title="Dwight"
                   >
                     Dwight
@@ -438,20 +438,20 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
             }
           >
             <div
-              className="css-42"
+              className="css-stub-classname"
             >
               <div
-                className="ms-Stack css-45"
+                className="ms-Stack css-stub-classname"
               >
                 <div
-                  className="ms-Stack css-46"
+                  className="ms-Stack css-stub-classname"
                 />
               </div>
             </div>
           </div>
           <div
-            className="ms-LayerHost css-2"
-            id="layerhost1"
+            className="ms-LayerHost css-stub-classname"
+            id="layerhost182"
           />
         </div>
       </div>

--- a/packages/storybook/stories/VideoTile/__snapshots__/VideoTile.stories.storyshot
+++ b/packages/storybook/stories/VideoTile/__snapshots__/VideoTile.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile 1`] = `
 <div
-  className="css-118 body-0"
+  className="css-118 css-stub-classname"
   dir="ltr"
 >
   <div
@@ -21,21 +21,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
       }
     >
       <div
-        className="ms-Stack css-7"
+        className="ms-Stack css-stub-classname"
         data-ui-id="video-tile"
       >
         <div
-          className="css-4"
+          className="css-stub-classname"
         />
         <div
-          className="ms-Stack css-8"
+          className="ms-Stack css-stub-classname"
         >
           <div
-            className="ms-Stack css-10"
+            className="ms-Stack css-stub-classname"
           >
             <div
               aria-label=""
-              className="ms-Persona ms-Persona--size48 root-11"
+              className="ms-Persona ms-Persona--size48 css-stub-classname"
               style={
                 Object {
                   "height": 100,
@@ -44,11 +44,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
               }
             >
               <div
-                className="ms-Persona-coin ms-Persona--size48 coin-18"
+                className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
                 role="presentation"
               >
                 <div
-                  className="ms-Persona-imageArea imageArea-20"
+                  className="ms-Persona-imageArea css-stub-classname"
                   role="presentation"
                   style={
                     Object {
@@ -59,7 +59,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
                 >
                   <div
                     aria-hidden="true"
-                    className="ms-Persona-initials initials-23"
+                    className="ms-Persona-initials css-stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -77,13 +77,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
           </div>
         </div>
         <div
-          className="ms-Stack css-140 css-26"
+          className="ms-Stack css-stub-classname"
         >
           <div
-            className="ms-Stack css-141 css-27"
+            className="ms-Stack css-stub-classname"
           >
             <span
-              className="css-28"
+              className="css-stub-classname"
               title="John Smith"
             >
               John Smith

--- a/packages/storybook/stories/storybook.test.ts
+++ b/packages/storybook/stories/storybook.test.ts
@@ -15,18 +15,15 @@ jest.mock('@azure/communication-calling', () => {
 
 ReactDom.createPortal = (node: any) => node;
 
-// Reset the stylesheet classname generator for the snapshot tests.
-// Classnames are of the format css-#, where # is an integer that is
-// incremented with each new classname generated. (css- is the default prefix
-// but it can also use the display name of the component). For more information
-// see: https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/Stylesheet.ts#L171
-// As class names are generated from the Stylesheet, which is a global singleton, any
-// tests that have run before this test suite will have incremented the classname count.
-// Here we reset the count to ensure classname generation begins at 0.
-// Currently unsure if tests running in parallel will cause these snapshots to fail again, if that
-// happens we should replace the classname generator with our own deterministic classname generator.
+// Classnames in fluent are of the format css-#, where # is an integer that is incremented by a global singleton
+// when each new classname is generated.
+// Here we mock the classname generation for two reasons:
+//   1. Unblocks parallel tests - if the order in which the tests run changes the generated css classnames
+//      will differ across different runs
+//   2. Prevents unnecessary PR friction - often PRs with small changes to styles would require snapshots to be updated
+//      simply to change a couple of css-# numbered classes. This caused a lot of developer friction.
 beforeEach(() => {
-  Stylesheet.getInstance().reset();
+  Stylesheet.getInstance().getClassName = () => 'css-stub-classname';
 });
 
 // Storyshots do not fail on warnings or errors thrown by components, this is a quick fix to ensure we have tests fail when warning are outputted.


### PR DESCRIPTION
# What
Stub css classnames in storybook snapshot tests. class names go from `css-#` to `css-stub-classsname`

# Why
Prevents unnecessary PR friction - often PRs with small changes to styles would require snapshots to be updated simply to change a couple of css-# numbered classes. This caused a lot of developer friction.

# How Tested
See updated snapshots in PR