### PR TITLE
Fix flaky tooltips in calling UI tests

### DIFF
--- a/packages/react-composites/tests/browser/call/CallComposite.test.ts
+++ b/packages/react-composites/tests/browser/call/CallComposite.test.ts
@@ -11,7 +11,7 @@ import {
   waitForCallCompositeToLoad,
   waitForFunction,
   waitForSelector,
-  clickOutsideOfPage
+  stableScreenshot
 } from '../common/utils';
 import { test } from './fixture';
 import { expect, Page } from '@playwright/test';
@@ -52,8 +52,7 @@ test.describe('Call Composite E2E Configuration Screen Tests', () => {
   test('composite pages load completely', async ({ pages }) => {
     const page = pages[0];
     await stubLocalCameraName(page);
-    await clickOutsideOfPage(page);
-    expect(await page.screenshot()).toMatchSnapshot(`call-configuration-page.png`);
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(`call-configuration-page.png`);
   });
 
   test('local device settings can toggle camera & audio', async ({ pages }) => {
@@ -65,8 +64,9 @@ test.describe('Call Composite E2E Configuration Screen Tests', () => {
       return !!videoNode && videoNode.readyState === 4 && !videoNode.paused && videoNode;
     });
     await stubLocalCameraName(page);
-    await clickOutsideOfPage(page);
-    expect(await page.screenshot()).toMatchSnapshot(`call-configuration-page-camera-enabled.png`);
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
+      `call-configuration-page-camera-enabled.png`
+    );
   });
 
   test('local device buttons should show tooltips on hover', async ({ pages }) => {
@@ -94,8 +94,9 @@ test.describe('Call Composite E2E Configuration Screen Tests', () => {
       })
     );
     await waitForCallCompositeToLoad(page);
-    await clickOutsideOfPage(page);
-    expect(await page.screenshot()).toMatchSnapshot('call-configuration-page-with-call-details.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
+      'call-configuration-page-with-call-details.png'
+    );
   });
 });
 
@@ -113,8 +114,6 @@ test.describe('Call Composite E2E CallPage Tests', () => {
 
       await page.goto(buildUrl(serverUrl, user));
       await waitForCallCompositeToLoad(page);
-      // Move the mouse off-screen to avoid tooltips / delayed focus from introducing flake in the snapshots
-      await page.mouse.move(0, 0);
     }
 
     await loadCallPageWithParticipantVideos(pages);
@@ -124,8 +123,7 @@ test.describe('Call Composite E2E CallPage Tests', () => {
     for (const idx in pages) {
       const page = pages[idx];
       await page.bringToFront();
-      await clickOutsideOfPage(page);
-      expect(await page.screenshot()).toMatchSnapshot(`video-gallery-page-${idx}.png`);
+      expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(`video-gallery-page-${idx}.png`);
     }
   });
 
@@ -146,8 +144,9 @@ test.describe('Call Composite E2E CallPage Tests', () => {
     await waitForFunction(page, () => {
       return document.querySelectorAll('video').length === 1;
     });
-    await clickOutsideOfPage(page);
-    expect(await page.screenshot()).toMatchSnapshot(`video-gallery-page-camera-toggled.png`);
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
+      `video-gallery-page-camera-toggled.png`
+    );
   });
 });
 

--- a/packages/react-composites/tests/browser/call/ErrorBar.test.ts
+++ b/packages/react-composites/tests/browser/call/ErrorBar.test.ts
@@ -4,7 +4,7 @@
 import { test } from './fixture';
 import { expect, Page } from '@playwright/test';
 import { buildUrlWithMockAdapter } from './utils';
-import { dataUiId, clickOutsideOfPage, waitForPageFontsLoaded, waitForSelector } from '../common/utils';
+import { dataUiId, stableScreenshot, waitForSelector } from '../common/utils';
 import { IDS } from '../common/constants';
 
 test.describe('Error bar tests', async () => {
@@ -23,11 +23,10 @@ test.describe('Error bar tests', async () => {
         }
       })
     );
-    // Click off page to turn away initial aria label
-    await clickOutsideOfPage(page);
     await waitForSelector(page, dataUiId(IDS.videoGallery));
-    await waitForPageFontsLoaded(page);
-    expect(await page.screenshot()).toMatchSnapshot('failure-to-start-video-on-error-bar.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
+      'failure-to-start-video-on-error-bar.png'
+    );
   });
 
   test('Multiple errors should be shown on error bar', async ({ pages, serverUrl }) => {
@@ -52,11 +51,8 @@ test.describe('Error bar tests', async () => {
         }
       })
     );
-    // Click off page to turn away initial aria label
-    await clickOutsideOfPage(page);
     await waitForSelector(page, dataUiId(IDS.videoGallery));
-    await waitForPageFontsLoaded(page);
-    expect(await page.screenshot()).toMatchSnapshot('multiple-errors-on-error-bar.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('multiple-errors-on-error-bar.png');
     await dismissFirstErrorOnErrorBar(page);
     expect(await page.screenshot()).toMatchSnapshot('one-error-dismissed-on-error-bar.png');
     await dismissFirstErrorOnErrorBar(page);

--- a/packages/react-composites/tests/browser/call/HorizontalGallery.test.ts
+++ b/packages/react-composites/tests/browser/call/HorizontalGallery.test.ts
@@ -4,7 +4,7 @@
 import { test } from './fixture';
 import { expect } from '@playwright/test';
 import { buildUrlWithMockAdapter } from './utils';
-import { dataUiId, pageClick, clickOutsideOfPage, waitForPageFontsLoaded, waitForSelector } from '../common/utils';
+import { dataUiId, pageClick, waitForSelector, stableScreenshot } from '../common/utils';
 import { IDS } from '../common/constants';
 
 test.describe('HorizontalGallery tests', async () => {
@@ -29,11 +29,10 @@ test.describe('HorizontalGallery tests', async () => {
         remoteParticipants: testRemoteParticipants
       })
     );
-    // Click outside of screen to turn away initial aria label
-    await clickOutsideOfPage(page);
     await waitForSelector(page, dataUiId(IDS.videoGallery));
-    await waitForPageFontsLoaded(page);
-    expect(await page.screenshot()).toMatchSnapshot('horizontal-gallery-with-1-audio-participant.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
+      'horizontal-gallery-with-1-audio-participant.png'
+    );
   });
 
   test('HorizontalGallery should have multiple audio participants spanning multiple pages. Navigation buttons should work.', async ({
@@ -80,11 +79,10 @@ test.describe('HorizontalGallery tests', async () => {
         remoteParticipants: testRemoteParticipants
       })
     );
-    // Click outside of screen to turn away initial aria label
-    await clickOutsideOfPage(page);
     await waitForSelector(page, dataUiId(IDS.videoGallery));
-    await waitForPageFontsLoaded(page);
-    expect(await page.screenshot()).toMatchSnapshot('horizontal-gallery-with-many-audio-participants-on-page-1.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
+      'horizontal-gallery-with-many-audio-participants-on-page-1.png'
+    );
     await waitForSelector(page, dataUiId(IDS.horizontalGalleryRightNavButton));
     await pageClick(page, dataUiId(IDS.horizontalGalleryRightNavButton));
     expect(await page.screenshot()).toMatchSnapshot('horizontal-gallery-with-many-audio-participants-on-page-2.png');

--- a/packages/react-composites/tests/browser/call/PageState.test.ts
+++ b/packages/react-composites/tests/browser/call/PageState.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { expect } from '@playwright/test';
-import { clickOutsideOfPage, waitForPageFontsLoaded, waitForSelector, dataUiId } from '../common/utils';
+import { stableScreenshot, waitForPageFontsLoaded, waitForSelector, dataUiId } from '../common/utils';
 import { test } from './fixture';
 import { buildUrlWithMockAdapter } from './utils';
 
@@ -14,11 +14,8 @@ test.describe('Page state tests', async () => {
         page: 'lobby'
       })
     );
-    // Click outside of page to turn away initial aria label
-    await clickOutsideOfPage(page);
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
-    await waitForPageFontsLoaded(page);
-    expect(await page.screenshot()).toMatchSnapshot('lobby-page.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('lobby-page.png');
   });
   test('Page when access is denied', async ({ pages, serverUrl }) => {
     const page = pages[0];
@@ -27,9 +24,8 @@ test.describe('Page state tests', async () => {
         page: 'accessDeniedTeamsMeeting'
       })
     );
-    await waitForPageFontsLoaded(page);
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
-    expect(await page.screenshot()).toMatchSnapshot('access-denied-page.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('access-denied-page.png');
   });
   test('Page when join call failed due to network', async ({ pages, serverUrl }) => {
     const page = pages[0];
@@ -38,9 +34,10 @@ test.describe('Page state tests', async () => {
         page: 'joinCallFailedDueToNoNetwork'
       })
     );
-    await waitForPageFontsLoaded(page);
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
-    expect(await page.screenshot()).toMatchSnapshot('call-failed-due-to-network-page.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
+      'call-failed-due-to-network-page.png'
+    );
   });
   test('Page when local participant left call', async ({ pages, serverUrl }) => {
     const page = pages[0];
@@ -49,9 +46,8 @@ test.describe('Page state tests', async () => {
         page: 'leftCall'
       })
     );
-    await waitForPageFontsLoaded(page);
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
-    expect(await page.screenshot()).toMatchSnapshot('left-call-page.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('left-call-page.png');
   });
   test('Page when local participant is removed from call', async ({ pages, serverUrl }) => {
     const page = pages[0];
@@ -62,6 +58,6 @@ test.describe('Page state tests', async () => {
     );
     await waitForPageFontsLoaded(page);
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
-    expect(await page.screenshot()).toMatchSnapshot('removed-from-call-page.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('removed-from-call-page.png');
   });
 });

--- a/packages/react-composites/tests/browser/call/Screenshare.test.ts
+++ b/packages/react-composites/tests/browser/call/Screenshare.test.ts
@@ -4,7 +4,7 @@
 import { test } from './fixture';
 import { expect } from '@playwright/test';
 import { buildUrlWithMockAdapter } from './utils';
-import { dataUiId, pageClick, clickOutsideOfPage, waitForPageFontsLoaded, waitForSelector } from '../common/utils';
+import { dataUiId, pageClick, stableScreenshot, waitForSelector } from '../common/utils';
 import { IDS } from '../common/constants';
 
 test.describe('Screenshare tests', async () => {
@@ -53,11 +53,8 @@ test.describe('Screenshare tests', async () => {
         remoteParticipants: testRemoteParticipants
       })
     );
-    // Click off page to turn away initial aria label
-    await clickOutsideOfPage(page);
     await waitForSelector(page, dataUiId(IDS.videoGallery));
-    await waitForPageFontsLoaded(page);
-    expect(await page.screenshot()).toMatchSnapshot('local-screenshare.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('local-screenshare.png');
   });
 
   test('Remote screen share stream should be displayed in grid area of VideoGallery.', async ({ pages, serverUrl }) => {
@@ -105,11 +102,10 @@ test.describe('Screenshare tests', async () => {
         remoteParticipants: testRemoteParticipants
       })
     );
-    // Click off page to turn away initial aria label
-    await clickOutsideOfPage(page);
     await waitForSelector(page, dataUiId(IDS.videoGallery));
-    await waitForPageFontsLoaded(page);
-    expect(await page.screenshot()).toMatchSnapshot('remote-screenshare-horizontal-gallery-page-1.png');
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
+      'remote-screenshare-horizontal-gallery-page-1.png'
+    );
     await waitForSelector(page, dataUiId(IDS.horizontalGalleryRightNavButton));
     await pageClick(page, dataUiId(IDS.horizontalGalleryRightNavButton));
     expect(await page.screenshot()).toMatchSnapshot('remote-screenshare-horizontal-gallery-page-2.png');

--- a/packages/react-composites/tests/browser/callwithchat/CallWithChatComposite.test.ts
+++ b/packages/react-composites/tests/browser/callwithchat/CallWithChatComposite.test.ts
@@ -4,11 +4,11 @@
 import { IDS, TEST_PARTICIPANTS } from '../common/constants';
 import {
   buildUrl,
-  clickOutsideOfPage,
   dataUiId,
   isTestProfileDesktop,
   loadCallPageWithParticipantVideos,
   pageClick,
+  stableScreenshot,
   stubMessageTimestamps,
   waitForCallWithChatCompositeToLoad,
   waitForPiPiPToHaveLoaded,
@@ -33,8 +33,9 @@ test.describe('CallWithChat Composite Pre-Join Tests', () => {
 
   test('Pre-join screen loads correctly', async ({ pages }) => {
     const page = pages[0];
-    await clickOutsideOfPage(page);
-    expect(await page.screenshot()).toMatchSnapshot(`call-with-chat-pre-join-screen.png`);
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
+      `call-with-chat-pre-join-screen.png`
+    );
   });
 });
 
@@ -46,8 +47,9 @@ test.describe('CallWithChat Composite CallWithChat Page Tests', () => {
 
   test('CallWithChat gallery screen loads correctly', async ({ pages }) => {
     const page = pages[0];
-    await clickOutsideOfPage(page);
-    expect(await page.screenshot()).toMatchSnapshot(`call-with-chat-gallery-screen.png`);
+    expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
+      `call-with-chat-gallery-screen.png`
+    );
   });
 
   test('Chat messages are displayed correctly', async ({ pages }, testInfo) => {

--- a/packages/react-composites/tests/browser/common/utils.ts
+++ b/packages/react-composites/tests/browser/common/utils.ts
@@ -141,21 +141,6 @@ export const loadCallPage = async (pages: Page[]): Promise<void> => {
       { participantTileSelector: dataUiId('video-tile'), expectedTileCount: pages.length }
     );
   }
-
-  // Dismiss any tooltips (such as the microphone tooltip as we autofocus the microphone button on page load)
-  for (const page of pages) {
-    await clickOutsideOfPage(page);
-  }
-};
-
-/**
- * Click outside of the Composite page
- *
- * @deprecated This method of dismissing tooltips has been shown to be flaky.
- *     Use {@link stableScreenshot} instead.
- */
-export const clickOutsideOfPage = async (page: Page): Promise<void> => {
-  await page.mouse.click(-1, -1);
 };
 
 /**
@@ -190,11 +175,6 @@ export const loadCallPageWithParticipantVideos = async (pages: Page[]): Promise<
         expectedVideoCount: pages.length
       }
     );
-  }
-
-  // Dismiss any tooltips (such as the microphone tooltip as we autofocus the microphone button on page load)
-  for (const page of pages) {
-    await clickOutsideOfPage(page);
   }
 };
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Using the new `stableSnapshot` util function to ensure tooltips are not showing before snapshots are taken in calling UI tests.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Our PR's are failing miserably on UI tests :(

# How Tested
<!--- How did you test your change. What tests have you added. -->
Testing against CI

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->