### PR TITLE
Stub MORE css classnames in storybook snapshot tests

### DIFF
--- a/packages/storybook/stories/CallComposite/__snapshots__/BasicExample.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/BasicExample.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite/Basic Example Basic Example 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Basic Exam
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/CallComposite/__snapshots__/CustomDataModelExample.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/CustomDataModelExample.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite/Custom Data Model Example Custom Data Model Example 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Custom Dat
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/CallComposite/__snapshots__/JoinExistingCall.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/JoinExistingCall.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite/Join Existing Call Join Existing Call 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Join Exist
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/CallComposite/__snapshots__/ThemeExample.stories.storyshot
+++ b/packages/storybook/stories/CallComposite/__snapshots__/ThemeExample.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallComposite/Theme Example Theme Example 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallComposite/Theme Exam
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/CallWithChatComposite/__snapshots__/BasicExample.stories.storyshot
+++ b/packages/storybook/stories/CallWithChatComposite/__snapshots__/BasicExample.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallWithChatComposite/Basic Example Basic Example 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallWithChatComposite/Ba
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <div>

--- a/packages/storybook/stories/CallWithChatComposite/__snapshots__/JoinExample.stories.storyshot
+++ b/packages/storybook/stories/CallWithChatComposite/__snapshots__/JoinExample.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/CallWithChatComposite/Join Teams Meeting Join Teams Meeting 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/CallWithChatComposite/Jo
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/BasicExample.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/BasicExample.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Basic Example Basic Example 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Basic Exam
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <div>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/CustomBehavior.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/CustomBehavior.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Behavior Example Custom Behavior Example 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Beh
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <div>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/CustomDataModelExample.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/CustomDataModelExample.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Data Model Example Custom Data Model Example 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Dat
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <div>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/CustomDateTimeFormat.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/CustomDateTimeFormat.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Date Time Format Example Custom Date Time Format Example 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,16 +21,16 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Dat
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
         >
           <div
-            className="ms-StackItem css-stub-classname"
+            className="ms-StackItem stub-classname"
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               style={
                 Object {
                   "display": "inline-block",
@@ -69,13 +69,13 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Dat
               </span>
                
               <span
-                className="css-stub-classname"
+                className="stub-classname"
               >
                 Important
               </span>
                - 
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
                 style={
                   Object {
                     "display": "inline-block",
@@ -83,12 +83,12 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Custom Dat
                 }
               >
                 <span
-                  className="css-stub-classname"
+                  className="stub-classname"
                 >
                   This feature is currently in public preview and not recommended for production use. 
                 </span>
                 <a
-                  className="ms-Link css-stub-classname"
+                  className="ms-Link stub-classname"
                   href="https://azure.microsoft.com/support/legal/preview-supplemental-terms/"
                   onClick={[Function]}
                   target="_blank"

--- a/packages/storybook/stories/ChatComposite/__snapshots__/JoinExistingChatThread.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/JoinExistingChatThread.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Join Existing Chat Thread Join Existing Chat Thread 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Join Exist
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <p>

--- a/packages/storybook/stories/ChatComposite/__snapshots__/ThemesExample.stories.storyshot
+++ b/packages/storybook/stories/ChatComposite/__snapshots__/ThemesExample.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Theme Example Theme Example 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Composites/ChatComposite/Theme Exam
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <span>
           <div>

--- a/packages/storybook/stories/ControlBar/Buttons/ControlBarButton/__snapshots__/ControlBarButton.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/ControlBarButton/__snapshots__/ControlBarButton.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/Default Default 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -30,7 +30,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
       >
         <button
           aria-label="airplane"
-          className="ms-Button ms-Button--default css-stub-classname"
+          className="ms-Button ms-Button--default stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -41,7 +41,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
           type="button"
         >
           <span
-            className="ms-Button-flexContainer css-stub-classname"
+            className="ms-Button-flexContainer stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <span

--- a/packages/storybook/stories/ControlBar/Buttons/Devices/__snapshots__/Devices.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Devices/__snapshots__/Devices.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/Devices Devices 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -33,7 +33,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
           aria-expanded={false}
           aria-haspopup={true}
           aria-label="Manage devices"
-          className="ms-Button ms-Button--default ms-Button--hasMenu css-stub-classname"
+          className="ms-Button ms-Button--default ms-Button--hasMenu stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -44,12 +44,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
           type="button"
         >
           <span
-            className="ms-Button-flexContainer css-stub-classname"
+            className="ms-Button-flexContainer stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="css-stub-classname"
+              className="stub-classname"
               data-icon-name="ControlButtonOptions"
             >
               <span
@@ -72,7 +72,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/D
             </i>
             <i
               aria-hidden={true}
-              className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+              className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
               data-icon-name="ChevronDown"
               hidden={true}
               style={

--- a/packages/storybook/stories/ControlBar/Buttons/EndCall/__snapshots__/EndCall.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/EndCall/__snapshots__/EndCall.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/End Call End Call 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -30,7 +30,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/E
       >
         <button
           aria-label="Leave Call"
-          className="ms-Button ms-Button--default css-stub-classname"
+          className="ms-Button ms-Button--default stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -41,7 +41,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/E
           type="button"
         >
           <span
-            className="ms-Button-flexContainer css-stub-classname"
+            className="ms-Button-flexContainer stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <i

--- a/packages/storybook/stories/ControlBar/Buttons/Microphone/__snapshots__/Microphone.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Microphone/__snapshots__/Microphone.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/Microphone Microphone 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -22,7 +22,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/M
     >
       <div
         aria-live="polite"
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       />
       <div
         className="ms-TooltipHost root-94"
@@ -34,7 +34,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/M
       >
         <button
           aria-label="Unmute microphone"
-          className="ms-Button ms-Button--default css-stub-classname"
+          className="ms-Button ms-Button--default stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -45,12 +45,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/M
           type="button"
         >
           <span
-            className="ms-Button-flexContainer css-stub-classname"
+            className="ms-Button-flexContainer stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="css-stub-classname"
+              className="stub-classname"
               data-icon-name="ControlButtonMicOff"
             >
               <span
@@ -79,7 +79,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/M
             </i>
             <i
               aria-hidden={true}
-              className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+              className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
               data-icon-name="ChevronDown"
               hidden={true}
               style={

--- a/packages/storybook/stories/ControlBar/Buttons/Participants/__snapshots__/Participants.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/Participants/__snapshots__/Participants.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/Participants Participants 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -33,7 +33,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/P
           aria-expanded={false}
           aria-haspopup={true}
           aria-label="Show Participants"
-          className="ms-Button ms-Button--default ms-Button--hasMenu css-stub-classname"
+          className="ms-Button ms-Button--default ms-Button--hasMenu stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -44,12 +44,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/P
           type="button"
         >
           <span
-            className="ms-Button-flexContainer css-stub-classname"
+            className="ms-Button-flexContainer stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="css-stub-classname"
+              className="stub-classname"
               data-icon-name="ControlButtonParticipants"
             >
               <span
@@ -72,7 +72,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/P
             </i>
             <i
               aria-hidden={true}
-              className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+              className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
               data-icon-name="ChevronDown"
               hidden={true}
               style={

--- a/packages/storybook/stories/ControlBar/Buttons/ScreenShare/__snapshots__/ScreenShare.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/Buttons/ScreenShare/__snapshots__/ScreenShare.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/Screen Share Screen Share 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -30,7 +30,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/S
       >
         <button
           aria-label="Present your screen"
-          className="ms-Button ms-Button--default css-stub-classname"
+          className="ms-Button ms-Button--default stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -41,12 +41,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar/Buttons/S
           type="button"
         >
           <span
-            className="ms-Button-flexContainer css-stub-classname"
+            className="ms-Button-flexContainer stub-classname"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="css-stub-classname"
+              className="stub-classname"
               data-icon-name="ControlButtonScreenShareStart"
             >
               <span

--- a/packages/storybook/stories/ControlBar/__snapshots__/ControlBar.stories.storyshot
+++ b/packages/storybook/stories/ControlBar/__snapshots__/ControlBar.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control Bar 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -33,14 +33,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
         }
       >
         <div
-          className="css-stub-classname"
+          className="stub-classname"
         >
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
           >
             <div
               aria-live="polite"
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             />
             <div
               className="ms-TooltipHost root-94"
@@ -52,7 +52,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             >
               <button
                 aria-label="Turn on camera"
-                className="ms-Button ms-Button--default css-stub-classname"
+                className="ms-Button ms-Button--default stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -63,12 +63,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer css-stub-classname"
+                  className="ms-Button-flexContainer stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="css-stub-classname"
+                    className="stub-classname"
                     data-icon-name="ControlButtonCameraOff"
                   >
                     <span
@@ -97,7 +97,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                   </i>
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                    className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                     data-icon-name="ChevronDown"
                     hidden={true}
                     style={
@@ -113,7 +113,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             </div>
             <div
               aria-live="polite"
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             />
             <div
               className="ms-TooltipHost root-94"
@@ -125,7 +125,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             >
               <button
                 aria-label="Unmute microphone"
-                className="ms-Button ms-Button--default css-stub-classname"
+                className="ms-Button ms-Button--default stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -136,12 +136,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer css-stub-classname"
+                  className="ms-Button-flexContainer stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="css-stub-classname"
+                    className="stub-classname"
                     data-icon-name="ControlButtonMicOff"
                   >
                     <span
@@ -170,7 +170,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                   </i>
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                    className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                     data-icon-name="ChevronDown"
                     hidden={true}
                     style={
@@ -194,7 +194,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             >
               <button
                 aria-label="Present your screen"
-                className="ms-Button ms-Button--default css-stub-classname"
+                className="ms-Button ms-Button--default stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -205,12 +205,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer css-stub-classname"
+                  className="ms-Button-flexContainer stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="css-stub-classname"
+                    className="stub-classname"
                     data-icon-name="ControlButtonScreenShareStart"
                   >
                     <span
@@ -247,7 +247,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 aria-expanded={false}
                 aria-haspopup={true}
                 aria-label="Show Participants"
-                className="ms-Button ms-Button--default ms-Button--hasMenu css-stub-classname"
+                className="ms-Button ms-Button--default ms-Button--hasMenu stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -258,12 +258,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer css-stub-classname"
+                  className="ms-Button-flexContainer stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="css-stub-classname"
+                    className="stub-classname"
                     data-icon-name="ControlButtonParticipants"
                   >
                     <span
@@ -286,7 +286,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                   </i>
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                    className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                     data-icon-name="ChevronDown"
                     hidden={true}
                     style={
@@ -313,7 +313,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 aria-expanded={false}
                 aria-haspopup={true}
                 aria-label="Manage devices"
-                className="ms-Button ms-Button--default ms-Button--hasMenu css-stub-classname"
+                className="ms-Button ms-Button--default ms-Button--hasMenu stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -324,12 +324,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer css-stub-classname"
+                  className="ms-Button-flexContainer stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="css-stub-classname"
+                    className="stub-classname"
                     data-icon-name="ControlButtonOptions"
                   >
                     <span
@@ -352,7 +352,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                   </i>
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                    className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                     data-icon-name="ChevronDown"
                     hidden={true}
                     style={
@@ -376,7 +376,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
             >
               <button
                 aria-label="Leave Call"
-                className="ms-Button ms-Button--default css-stub-classname"
+                className="ms-Button ms-Button--default stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -387,7 +387,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Control Bar Control B
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer css-stub-classname"
+                  className="ms-Button-flexContainer stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i

--- a/packages/storybook/stories/ErrorBar/__snapshots__/ErrorBar.stories.storyshot
+++ b/packages/storybook/stories/ErrorBar/__snapshots__/ErrorBar.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Error Bar Error Bar 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,27 +21,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Error Bar Error Bar 1
       }
     >
       <div
-        className="css-stub-classname"
+        className="stub-classname"
       >
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
           data-ui-id="error-bar-stack"
         >
           <div
-            aria-describedby="MessageBar69"
-            className="ms-MessageBar ms-MessageBar--error ms-MessageBar-multiline css-stub-classname"
+            aria-describedby="MessageBar1"
+            className="ms-MessageBar ms-MessageBar--error ms-MessageBar-multiline stub-classname"
             role="region"
           >
             <div
-              className="ms-MessageBar-content css-stub-classname"
+              className="ms-MessageBar-content stub-classname"
             >
               <div
                 aria-hidden={true}
-                className="ms-MessageBar-icon css-stub-classname"
+                className="ms-MessageBar-icon stub-classname"
               >
                 <i
                   aria-hidden={true}
-                  className="css-stub-classname"
+                  className="stub-classname"
                   data-icon-name="ErrorBadge"
                 >
                   
@@ -49,17 +49,17 @@ exports[`storybook snapshot tests Storyshots UI Components/Error Bar Error Bar 1
               </div>
               <div
                 aria-live="assertive"
-                className="ms-MessageBar-text css-stub-classname"
-                id="MessageBar69"
+                className="ms-MessageBar-text stub-classname"
+                id="MessageBar1"
                 role="alert"
               >
                 <span
-                  className="ms-MessageBar-innerText css-stub-classname"
+                  className="ms-MessageBar-innerText stub-classname"
                 />
               </div>
               <button
                 aria-label="Close"
-                className="ms-Button ms-Button--icon ms-MessageBar-dismissal css-stub-classname"
+                className="ms-Button ms-Button--icon ms-MessageBar-dismissal stub-classname"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -71,12 +71,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Error Bar Error Bar 1
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer css-stub-classname"
+                  className="ms-Button-flexContainer stub-classname"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-94 css-stub-classname ms-Button-icon css-stub-classname"
+                    className="ms-Icon root-94 stub-classname ms-Button-icon stub-classname"
                     data-icon-name="Clear"
                     style={
                       Object {

--- a/packages/storybook/stories/Examples/DevicesDropdown/__snapshots__/DeviceSettingsDropDown.stories.storyshot
+++ b/packages/storybook/stories/Examples/DevicesDropdown/__snapshots__/DeviceSettingsDropDown.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Device Settings Device Settings 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,14 +21,14 @@ exports[`storybook snapshot tests Storyshots Examples/Device Settings Device Set
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <div
-          className="css-118 css-stub-classname"
+          className="stub-classname stub-classname"
           dir="ltr"
         >
           <div
-            className="css-118"
+            className="stub-classname"
             data-uses-unhanded-props={true}
           >
             <div
@@ -37,10 +37,10 @@ exports[`storybook snapshot tests Storyshots Examples/Device Settings Device Set
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                className="ms-Dropdown css-stub-classname"
+                className="ms-Dropdown stub-classname"
                 data-is-focusable={true}
                 data-ktp-target={true}
-                id="Dropdown75"
+                id="Dropdown2"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onClick={[Function]}
@@ -61,17 +61,17 @@ exports[`storybook snapshot tests Storyshots Examples/Device Settings Device Set
                   aria-atomic={true}
                   aria-invalid={false}
                   aria-live="polite"
-                  className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder css-stub-classname"
-                  id="Dropdown75-option"
+                  className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder stub-classname"
+                  id="Dropdown2-option"
                 >
                   Select an option
                 </span>
                 <span
-                  className="ms-Dropdown-caretDownWrapper css-stub-classname"
+                  className="ms-Dropdown-caretDownWrapper stub-classname"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Dropdown-caretDown css-stub-classname"
+                    className="ms-Dropdown-caretDown stub-classname"
                     data-icon-name="ChevronDown"
                   >
                     

--- a/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallModal.stories.storyshot
+++ b/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallModal.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incoming Call Modal Incoming Call Modal 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -24,7 +24,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
         className="ms-layer"
       >
         <div
-          className="ms-Fabric ms-Layer-content css-stub-classname"
+          className="ms-Fabric ms-Layer-content stub-classname"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
@@ -57,7 +57,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
           onTouchStart={[Function]}
         >
           <div
-            aria-labelledby="Dialog77-title"
+            aria-labelledby="Dialog1-title"
             aria-modal={true}
             onKeyDown={[Function]}
             role="alertdialog"
@@ -69,16 +69,16 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
             }
           >
             <div
-              className="ms-Modal is-open ms-Dialog css-stub-classname"
+              className="ms-Modal is-open ms-Dialog stub-classname"
               role="document"
             >
               <div
                 aria-hidden={true}
-                className="ms-Overlay ms-Overlay--dark css-stub-classname"
+                className="ms-Overlay ms-Overlay--dark stub-classname"
               />
               <div
-                className="ms-Dialog-main css-stub-classname"
-                id="ModalFocusTrapZone78"
+                className="ms-Dialog-main stub-classname"
+                id="ModalFocusTrapZone2"
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
               >
@@ -94,29 +94,29 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                   tabIndex={0}
                 />
                 <div
-                  className="ms-Modal-scrollableContent css-stub-classname"
+                  className="ms-Modal-scrollableContent stub-classname"
                   data-is-scrollable={true}
                 >
                   <div
-                    className="css-stub-classname"
+                    className="stub-classname"
                   >
                     <div
-                      className="ms-Dialog-header css-stub-classname"
+                      className="ms-Dialog-header stub-classname"
                     >
                       <div
                         aria-level={1}
-                        className="ms-Dialog-title css-stub-classname"
-                        id="Dialog77-title"
+                        className="ms-Dialog-title stub-classname"
+                        id="Dialog1-title"
                         role="heading"
                       >
                         Incoming Video Call
                       </div>
                       <div
-                        className="css-stub-classname"
+                        className="stub-classname"
                       >
                         <button
                           aria-label="Close"
-                          className="ms-Button ms-Button--icon ms-Dialog-button ms-Dialog-button--close css-stub-classname"
+                          className="ms-Button ms-Button--icon ms-Dialog-button ms-Dialog-button--close stub-classname"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -128,12 +128,12 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                           type="button"
                         >
                           <span
-                            className="ms-Button-flexContainer css-stub-classname"
+                            className="ms-Button-flexContainer stub-classname"
                             data-automationid="splitbuttonprimary"
                           >
                             <i
                               aria-hidden={true}
-                              className="ms-Icon root-94 css-stub-classname ms-Button-icon css-stub-classname"
+                              className="ms-Icon root-94 stub-classname ms-Button-icon stub-classname"
                               data-icon-name="Cancel"
                               style={
                                 Object {
@@ -148,16 +148,16 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                       </div>
                     </div>
                     <div
-                      className="ms-Dialog-inner css-stub-classname"
+                      className="ms-Dialog-inner stub-classname"
                     >
                       <div
-                        className="ms-Dialog-content css-stub-classname"
+                        className="ms-Dialog-content stub-classname"
                       >
                         <div
-                          className="ms-Stack css-stub-classname"
+                          className="ms-Stack stub-classname"
                         >
                           <div
-                            className="ms-Stack css-stub-classname"
+                            className="ms-Stack stub-classname"
                             style={
                               Object {
                                 "marginRight": "0.5rem",
@@ -166,19 +166,19 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                           >
                             <div
                               aria-label="Maximus Aurelius"
-                              className="ms-Persona ms-Persona--size40 css-stub-classname"
+                              className="ms-Persona ms-Persona--size40 stub-classname"
                             >
                               <div
-                                className="ms-Persona-coin ms-Persona--size40 css-stub-classname"
+                                className="ms-Persona-coin ms-Persona--size40 stub-classname"
                                 role="presentation"
                               >
                                 <div
-                                  className="ms-Persona-imageArea css-stub-classname"
+                                  className="ms-Persona-imageArea stub-classname"
                                   role="presentation"
                                 >
                                   <div
                                     aria-hidden="true"
-                                    className="ms-Persona-initials css-stub-classname"
+                                    className="ms-Persona-initials stub-classname"
                                   >
                                     <span>
                                       MA
@@ -189,7 +189,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                             </div>
                           </div>
                           <div
-                            className="ms-Stack css-stub-classname"
+                            className="ms-Stack stub-classname"
                             style={
                               Object {
                                 "alignItems": "flex-start",
@@ -197,7 +197,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                             }
                           >
                             <div
-                              className="ms-Stack css-stub-classname"
+                              className="ms-Stack stub-classname"
                               style={
                                 Object {
                                   "color": "#000000",
@@ -222,7 +222,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                               </span>
                             </div>
                             <div
-                              className="ms-Stack css-stub-classname"
+                              className="ms-Stack stub-classname"
                               style={
                                 Object {
                                   "color": "#201f1e",
@@ -238,16 +238,16 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                         </div>
                       </div>
                       <div
-                        className="ms-Dialog-actions css-stub-classname"
+                        className="ms-Dialog-actions stub-classname"
                       >
                         <div
-                          className="ms-Dialog-actionsRight css-stub-classname"
+                          className="ms-Dialog-actionsRight stub-classname"
                         >
                           <span
-                            className="ms-Dialog-action css-stub-classname"
+                            className="ms-Dialog-action stub-classname"
                           >
                             <button
-                              className="ms-Button ms-Button--default css-stub-classname"
+                              className="ms-Button ms-Button--default stub-classname"
                               data-is-focusable={true}
                               onClick={[Function]}
                               onKeyDown={[Function]}
@@ -264,7 +264,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                               type="button"
                             >
                               <span
-                                className="ms-Button-flexContainer css-stub-classname"
+                                className="ms-Button-flexContainer stub-classname"
                                 data-automationid="splitbuttonprimary"
                               >
                                 <span
@@ -294,10 +294,10 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                             </button>
                           </span>
                           <span
-                            className="ms-Dialog-action css-stub-classname"
+                            className="ms-Dialog-action stub-classname"
                           >
                             <button
-                              className="ms-Button ms-Button--default css-stub-classname"
+                              className="ms-Button ms-Button--default stub-classname"
                               data-is-focusable={true}
                               onClick={[Function]}
                               onKeyDown={[Function]}
@@ -314,15 +314,15 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                               type="button"
                             >
                               <span
-                                className="ms-Button-flexContainer css-stub-classname"
+                                className="ms-Button-flexContainer stub-classname"
                                 data-automationid="splitbuttonprimary"
                               >
                                 <span
-                                  className="ms-Button-textContainer css-stub-classname"
+                                  className="ms-Button-textContainer stub-classname"
                                 >
                                   <span
-                                    className="ms-Button-label css-stub-classname"
-                                    id="id__85"
+                                    className="ms-Button-label stub-classname"
+                                    id="id__9"
                                   >
                                     Accept
                                   </span>
@@ -331,10 +331,10 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                             </button>
                           </span>
                           <span
-                            className="ms-Dialog-action css-stub-classname"
+                            className="ms-Dialog-action stub-classname"
                           >
                             <button
-                              className="ms-Button ms-Button--default css-stub-classname"
+                              className="ms-Button ms-Button--default stub-classname"
                               data-is-focusable={true}
                               onClick={[Function]}
                               onKeyDown={[Function]}
@@ -351,15 +351,15 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
                               type="button"
                             >
                               <span
-                                className="ms-Button-flexContainer css-stub-classname"
+                                className="ms-Button-flexContainer stub-classname"
                                 data-automationid="splitbuttonprimary"
                               >
                                 <span
-                                  className="ms-Button-textContainer css-stub-classname"
+                                  className="ms-Button-textContainer stub-classname"
                                 >
                                   <span
-                                    className="ms-Button-label css-stub-classname"
-                                    id="id__88"
+                                    className="ms-Button-label stub-classname"
+                                    id="id__12"
                                   >
                                     Decline
                                   </span>

--- a/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallToast.stories.storyshot
+++ b/packages/storybook/stories/Examples/IncomingCallAlerts/__snapshots__/IncomingCallToast.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incoming Call Toast Incoming Call Toast 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,29 +21,29 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
         >
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
           >
             <div
               aria-label="Maximus Aurelius"
-              className="ms-Persona ms-Persona--size40 css-stub-classname"
+              className="ms-Persona ms-Persona--size40 stub-classname"
             >
               <div
-                className="ms-Persona-coin ms-Persona--size40 css-stub-classname"
+                className="ms-Persona-coin ms-Persona--size40 stub-classname"
                 role="presentation"
               >
                 <div
-                  className="ms-Persona-imageArea css-stub-classname"
+                  className="ms-Persona-imageArea stub-classname"
                   role="presentation"
                 >
                   <div
                     aria-hidden="true"
-                    className="ms-Persona-initials css-stub-classname"
+                    className="ms-Persona-initials stub-classname"
                   >
                     <span>
                       MA
@@ -54,7 +54,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
             </div>
           </div>
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
             style={
               Object {
                 "alignItems": "flex-start",
@@ -63,7 +63,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
             }
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               style={
                 Object {
                   "fontSize": "0.875rem",
@@ -75,7 +75,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
               </b>
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               style={
                 Object {
                   "fontSize": "0.75rem",
@@ -88,10 +88,10 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
             </div>
           </div>
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
           >
             <button
-              className="ms-Button ms-Button--default css-stub-classname"
+              className="ms-Button ms-Button--default stub-classname"
               data-is-focusable={true}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -102,7 +102,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
               type="button"
             >
               <span
-                className="ms-Button-flexContainer css-stub-classname"
+                className="ms-Button-flexContainer stub-classname"
                 data-automationid="splitbuttonprimary"
               >
                 <span
@@ -125,7 +125,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
               </span>
             </button>
             <button
-              className="ms-Button ms-Button--default css-stub-classname"
+              className="ms-Button ms-Button--default stub-classname"
               data-is-focusable={true}
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -136,7 +136,7 @@ exports[`storybook snapshot tests Storyshots Examples/Incoming Call Alerts/Incom
               type="button"
             >
               <span
-                className="ms-Button-flexContainer css-stub-classname"
+                className="ms-Button-flexContainer stub-classname"
                 data-automationid="splitbuttonprimary"
               >
                 <span

--- a/packages/storybook/stories/Examples/LocalPreview/__snapshots__/LocalPreview.stories.storyshot
+++ b/packages/storybook/stories/Examples/LocalPreview/__snapshots__/LocalPreview.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Preview 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,15 +21,15 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
       }
     >
       <div
-        className="css-118 css-stub-classname"
+        className="stub-classname stub-classname"
         dir="ltr"
       >
         <div
-          className="css-118"
+          className="stub-classname"
           data-uses-unhanded-props={true}
         >
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
             style={
               Object {
                 "height": "100%",
@@ -38,37 +38,37 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
             }
           >
             <div
-              className="ms-StackItem css-stub-classname"
+              className="ms-StackItem stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                   data-ui-id="video-tile"
                 >
                   <div
-                    className="css-stub-classname"
+                    className="stub-classname"
                   />
                   <div
-                    className="ms-Stack css-stub-classname"
+                    className="ms-Stack stub-classname"
                   >
                     <div
-                      className="css-stub-classname"
+                      className="stub-classname"
                     />
                   </div>
                   <div
-                    className="ms-Stack css-stub-classname"
+                    className="ms-Stack stub-classname"
                   >
                     <div
-                      className="css-stub-classname"
+                      className="stub-classname"
                     >
                       <div
-                        className="ms-Stack css-stub-classname"
+                        className="ms-Stack stub-classname"
                       >
                         <div
                           aria-live="polite"
-                          className="ms-Stack css-stub-classname"
+                          className="ms-Stack stub-classname"
                         />
                         <div
                           className="ms-TooltipHost root-94"
@@ -80,7 +80,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                         >
                           <button
                             aria-label="Turn off camera"
-                            className="ms-Button ms-Button--default is-checked css-stub-classname"
+                            className="ms-Button ms-Button--default is-checked stub-classname"
                             data-is-focusable={true}
                             onClick={[Function]}
                             onKeyDown={[Function]}
@@ -91,12 +91,12 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                             type="button"
                           >
                             <span
-                              className="ms-Button-flexContainer css-stub-classname"
+                              className="ms-Button-flexContainer stub-classname"
                               data-automationid="splitbuttonprimary"
                             >
                               <i
                                 aria-hidden={true}
-                                className="css-stub-classname"
+                                className="stub-classname"
                                 data-icon-name="ControlButtonCameraOn"
                               >
                                 <span
@@ -122,7 +122,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                               </i>
                               <i
                                 aria-hidden={true}
-                                className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                                className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                                 data-icon-name="ChevronDown"
                                 hidden={true}
                                 style={
@@ -138,7 +138,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                         </div>
                         <div
                           aria-live="polite"
-                          className="ms-Stack css-stub-classname"
+                          className="ms-Stack stub-classname"
                         />
                         <div
                           className="ms-TooltipHost root-94"
@@ -150,7 +150,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                         >
                           <button
                             aria-label="Mute microphone"
-                            className="ms-Button ms-Button--default is-checked css-stub-classname"
+                            className="ms-Button ms-Button--default is-checked stub-classname"
                             data-is-focusable={true}
                             onClick={[Function]}
                             onKeyDown={[Function]}
@@ -161,12 +161,12 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                             type="button"
                           >
                             <span
-                              className="ms-Button-flexContainer css-stub-classname"
+                              className="ms-Button-flexContainer stub-classname"
                               data-automationid="splitbuttonprimary"
                             >
                               <i
                                 aria-hidden={true}
-                                className="css-stub-classname"
+                                className="stub-classname"
                                 data-icon-name="ControlButtonMicOn"
                               >
                                 <span
@@ -192,7 +192,7 @@ exports[`storybook snapshot tests Storyshots Examples/Local Preview Local Previe
                               </i>
                               <i
                                 aria-hidden={true}
-                                className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                                className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                                 data-icon-name="ChevronDown"
                                 hidden={true}
                                 style={

--- a/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/ComplianceBanner.stories.storyshot
+++ b/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/ComplianceBanner.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance Banner Compliance Banner 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance B
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
         style={
           Object {
             "minHeight": "50%",
@@ -30,10 +30,10 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance B
         }
       >
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
         >
           <button
-            className="ms-Button ms-Button--primary css-stub-classname"
+            className="ms-Button ms-Button--primary stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -44,15 +44,15 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance B
             type="button"
           >
             <span
-              className="ms-Button-flexContainer css-stub-classname"
+              className="ms-Button-flexContainer stub-classname"
               data-automationid="splitbuttonprimary"
             >
               <span
-                className="ms-Button-textContainer css-stub-classname"
+                className="ms-Button-textContainer stub-classname"
               >
                 <span
-                  className="ms-Button-label css-stub-classname"
-                  id="id__109"
+                  className="ms-Button-label stub-classname"
+                  id="id__1"
                 >
                   Toggle Recording
                 </span>
@@ -60,7 +60,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance B
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--primary css-stub-classname"
+            className="ms-Button ms-Button--primary stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -71,15 +71,15 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Compliance B
             type="button"
           >
             <span
-              className="ms-Button-flexContainer css-stub-classname"
+              className="ms-Button-flexContainer stub-classname"
               data-automationid="splitbuttonprimary"
             >
               <span
-                className="ms-Button-textContainer css-stub-classname"
+                className="ms-Button-textContainer stub-classname"
               >
                 <span
-                  className="ms-Button-label css-stub-classname"
-                  id="id__112"
+                  className="ms-Button-label stub-classname"
+                  id="id__4"
                 >
                   Toggle Transcription
                 </span>

--- a/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/Lobby.stories.storyshot
+++ b/packages/storybook/stories/Examples/TeamsInterop/__snapshots__/Lobby.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,17 +21,17 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
         data-ui-id="video-tile"
       >
         <div
-          className="css-stub-classname"
+          className="stub-classname"
         />
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
         />
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
         >
           <div
             style={
@@ -86,14 +86,14 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
             </p>
           </div>
           <div
-            className="css-stub-classname"
+            className="stub-classname"
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
                 aria-live="polite"
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               />
               <div
                 className="ms-TooltipHost root-94"
@@ -105,7 +105,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
               >
                 <button
                   aria-label="Turn off camera"
-                  className="ms-Button ms-Button--default is-checked css-stub-classname"
+                  className="ms-Button ms-Button--default is-checked stub-classname"
                   data-is-focusable={true}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -116,12 +116,12 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   type="button"
                 >
                   <span
-                    className="ms-Button-flexContainer css-stub-classname"
+                    className="ms-Button-flexContainer stub-classname"
                     data-automationid="splitbuttonprimary"
                   >
                     <i
                       aria-hidden={true}
-                      className="css-stub-classname"
+                      className="stub-classname"
                       data-icon-name="ControlButtonCameraOn"
                     >
                       <span
@@ -146,18 +146,18 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                       </span>
                     </i>
                     <span
-                      className="ms-Button-textContainer css-stub-classname"
+                      className="ms-Button-textContainer stub-classname"
                     >
                       <span
-                        className="ms-Button-label css-stub-classname"
-                        id="id__117"
+                        className="ms-Button-label stub-classname"
+                        id="id__2"
                       >
                         Turn off
                       </span>
                     </span>
                     <i
                       aria-hidden={true}
-                      className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                      className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                       data-icon-name="ChevronDown"
                       hidden={true}
                       style={
@@ -173,7 +173,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
               </div>
               <div
                 aria-live="polite"
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               />
               <div
                 className="ms-TooltipHost root-94"
@@ -185,7 +185,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
               >
                 <button
                   aria-label="Mute microphone"
-                  className="ms-Button ms-Button--default is-checked css-stub-classname"
+                  className="ms-Button ms-Button--default is-checked stub-classname"
                   data-is-focusable={true}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -196,12 +196,12 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   type="button"
                 >
                   <span
-                    className="ms-Button-flexContainer css-stub-classname"
+                    className="ms-Button-flexContainer stub-classname"
                     data-automationid="splitbuttonprimary"
                   >
                     <i
                       aria-hidden={true}
-                      className="css-stub-classname"
+                      className="stub-classname"
                       data-icon-name="ControlButtonMicOn"
                     >
                       <span
@@ -226,18 +226,18 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                       </span>
                     </i>
                     <span
-                      className="ms-Button-textContainer css-stub-classname"
+                      className="ms-Button-textContainer stub-classname"
                     >
                       <span
-                        className="ms-Button-label css-stub-classname"
-                        id="id__121"
+                        className="ms-Button-label stub-classname"
+                        id="id__6"
                       >
                         Mute
                       </span>
                     </span>
                     <i
                       aria-hidden={true}
-                      className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                      className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                       data-icon-name="ChevronDown"
                       hidden={true}
                       style={
@@ -261,7 +261,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
               >
                 <button
                   aria-label="Manage devices"
-                  className="ms-Button ms-Button--default css-stub-classname"
+                  className="ms-Button ms-Button--default stub-classname"
                   data-is-focusable={true}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -272,12 +272,12 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   type="button"
                 >
                   <span
-                    className="ms-Button-flexContainer css-stub-classname"
+                    className="ms-Button-flexContainer stub-classname"
                     data-automationid="splitbuttonprimary"
                   >
                     <i
                       aria-hidden={true}
-                      className="css-stub-classname"
+                      className="stub-classname"
                       data-icon-name="ControlButtonOptions"
                     >
                       <span
@@ -299,18 +299,18 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                       </span>
                     </i>
                     <span
-                      className="ms-Button-textContainer css-stub-classname"
+                      className="ms-Button-textContainer stub-classname"
                     >
                       <span
-                        className="ms-Button-label css-stub-classname"
-                        id="id__125"
+                        className="ms-Button-label stub-classname"
+                        id="id__10"
                       >
                         Devices
                       </span>
                     </span>
                     <i
                       aria-hidden={true}
-                      className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                      className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                       data-icon-name="ChevronDown"
                       hidden={true}
                       style={
@@ -334,7 +334,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
               >
                 <button
                   aria-label="Leave Call"
-                  className="ms-Button ms-Button--default css-stub-classname"
+                  className="ms-Button ms-Button--default stub-classname"
                   data-is-focusable={true}
                   onClick={[Function]}
                   onKeyDown={[Function]}
@@ -351,7 +351,7 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                   type="button"
                 >
                   <span
-                    className="ms-Button-flexContainer css-stub-classname"
+                    className="ms-Button-flexContainer stub-classname"
                     data-automationid="splitbuttonprimary"
                   >
                     <i
@@ -378,11 +378,11 @@ exports[`storybook snapshot tests Storyshots Examples/Teams Interop/Lobby Lobby 
                       </span>
                     </i>
                     <span
-                      className="ms-Button-textContainer css-stub-classname"
+                      className="ms-Button-textContainer stub-classname"
                     >
                       <span
-                        className="ms-Button-label css-stub-classname"
-                        id="id__129"
+                        className="ms-Button-label stub-classname"
+                        id="id__14"
                       >
                         Leave
                       </span>

--- a/packages/storybook/stories/Examples/Themes/__snapshots__/TeamsTheme.stories.storyshot
+++ b/packages/storybook/stories/Examples/Themes/__snapshots__/TeamsTheme.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -31,15 +31,15 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
         }
       >
         <div
-          className="css-118 css-stub-classname"
+          className="stub-classname stub-classname"
           dir="ltr"
         >
           <div
-            className="css-118"
+            className="stub-classname"
             data-uses-unhanded-props={true}
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               style={
                 Object {
                   "background": "#1a1a1a",
@@ -49,20 +49,20 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
               }
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-StackItem css-stub-classname"
+                  className="ms-StackItem stub-classname"
                 >
                   <div
-                    className="css-stub-classname"
+                    className="stub-classname"
                   >
                     <div
-                      className="ms-Stack css-stub-classname"
+                      className="ms-Stack stub-classname"
                     >
                       <div
                         aria-live="polite"
-                        className="ms-Stack css-stub-classname"
+                        className="ms-Stack stub-classname"
                       />
                       <div
                         className="ms-TooltipHost root-94"
@@ -74,7 +74,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       >
                         <button
                           aria-label="Turn on camera"
-                          className="ms-Button ms-Button--default css-stub-classname"
+                          className="ms-Button ms-Button--default stub-classname"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -85,12 +85,12 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           type="button"
                         >
                           <span
-                            className="ms-Button-flexContainer css-stub-classname"
+                            className="ms-Button-flexContainer stub-classname"
                             data-automationid="splitbuttonprimary"
                           >
                             <i
                               aria-hidden={true}
-                              className="css-stub-classname"
+                              className="stub-classname"
                               data-icon-name="ControlButtonCameraOff"
                             >
                               <span
@@ -119,7 +119,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                             </i>
                             <i
                               aria-hidden={true}
-                              className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                              className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                               data-icon-name="ChevronDown"
                               hidden={true}
                               style={
@@ -135,7 +135,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       </div>
                       <div
                         aria-live="polite"
-                        className="ms-Stack css-stub-classname"
+                        className="ms-Stack stub-classname"
                       />
                       <div
                         className="ms-TooltipHost root-94"
@@ -147,7 +147,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       >
                         <button
                           aria-label="Unmute microphone"
-                          className="ms-Button ms-Button--default css-stub-classname"
+                          className="ms-Button ms-Button--default stub-classname"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -158,12 +158,12 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           type="button"
                         >
                           <span
-                            className="ms-Button-flexContainer css-stub-classname"
+                            className="ms-Button-flexContainer stub-classname"
                             data-automationid="splitbuttonprimary"
                           >
                             <i
                               aria-hidden={true}
-                              className="css-stub-classname"
+                              className="stub-classname"
                               data-icon-name="ControlButtonMicOff"
                             >
                               <span
@@ -192,7 +192,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                             </i>
                             <i
                               aria-hidden={true}
-                              className="ms-Icon root-94 css-stub-classname ms-Button-menuIcon css-stub-classname"
+                              className="ms-Icon root-94 stub-classname ms-Button-menuIcon stub-classname"
                               data-icon-name="ChevronDown"
                               hidden={true}
                               style={
@@ -216,7 +216,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       >
                         <button
                           aria-label="Present your screen"
-                          className="ms-Button ms-Button--default css-stub-classname"
+                          className="ms-Button ms-Button--default stub-classname"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -227,12 +227,12 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           type="button"
                         >
                           <span
-                            className="ms-Button-flexContainer css-stub-classname"
+                            className="ms-Button-flexContainer stub-classname"
                             data-automationid="splitbuttonprimary"
                           >
                             <i
                               aria-hidden={true}
-                              className="css-stub-classname"
+                              className="stub-classname"
                               data-icon-name="ControlButtonScreenShareStart"
                             >
                               <span
@@ -266,7 +266,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                       >
                         <button
                           aria-label="Leave Call"
-                          className="ms-Button ms-Button--default css-stub-classname"
+                          className="ms-Button ms-Button--default stub-classname"
                           data-is-focusable={true}
                           onClick={[Function]}
                           onKeyDown={[Function]}
@@ -277,7 +277,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           type="button"
                         >
                           <span
-                            className="ms-Button-flexContainer css-stub-classname"
+                            className="ms-Button-flexContainer stub-classname"
                             data-automationid="splitbuttonprimary"
                           >
                             <i
@@ -304,7 +304,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                               </span>
                             </i>
                             <span
-                              className="ms-Button-textContainer css-stub-classname"
+                              className="ms-Button-textContainer stub-classname"
                             >
                               <span
                                 style={
@@ -324,24 +324,24 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                 </div>
               </div>
               <div
-                className="css-stub-classname"
+                className="stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                   data-ui-id="video-tile"
                 >
                   <div
-                    className="css-stub-classname"
+                    className="stub-classname"
                   />
                   <div
-                    className="ms-Stack css-stub-classname"
+                    className="ms-Stack stub-classname"
                   >
                     <div
-                      className="ms-Stack css-stub-classname"
+                      className="ms-Stack stub-classname"
                     >
                       <div
                         aria-label=""
-                        className="ms-Persona ms-Persona--size48 css-stub-classname"
+                        className="ms-Persona ms-Persona--size48 stub-classname"
                         style={
                           Object {
                             "height": 100,
@@ -350,11 +350,11 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                         }
                       >
                         <div
-                          className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                          className="ms-Persona-coin ms-Persona--size48 stub-classname"
                           role="presentation"
                         >
                           <div
-                            className="ms-Persona-imageArea css-stub-classname"
+                            className="ms-Persona-imageArea stub-classname"
                             role="presentation"
                             style={
                               Object {
@@ -365,7 +365,7 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                           >
                             <div
                               aria-hidden="true"
-                              className="ms-Persona-initials css-stub-classname"
+                              className="ms-Persona-initials stub-classname"
                               style={
                                 Object {
                                   "height": 100,
@@ -383,13 +383,13 @@ exports[`storybook snapshot tests Storyshots Examples/Themes/Teams Teams 1`] = `
                     </div>
                   </div>
                   <div
-                    className="ms-Stack css-stub-classname"
+                    className="ms-Stack stub-classname"
                   >
                     <div
-                      className="ms-Stack css-stub-classname"
+                      className="ms-Stack stub-classname"
                     >
                       <span
-                        className="css-stub-classname"
+                        className="stub-classname"
                         title="Michael"
                       >
                         Michael

--- a/packages/storybook/stories/GridLayout/__snapshots__/GridLayout.stories.storyshot
+++ b/packages/storybook/stories/GridLayout/__snapshots__/GridLayout.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layout 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -29,24 +29,24 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
         }
       >
         <div
-          className="css-stub-classname"
+          className="stub-classname"
         >
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
             data-ui-id="video-tile"
           >
             <div
-              className="css-stub-classname"
+              className="stub-classname"
             />
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
                   aria-label=""
-                  className="ms-Persona ms-Persona--size48 css-stub-classname"
+                  className="ms-Persona ms-Persona--size48 stub-classname"
                   style={
                     Object {
                       "height": 100,
@@ -55,11 +55,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                   }
                 >
                   <div
-                    className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                    className="ms-Persona-coin ms-Persona--size48 stub-classname"
                     role="presentation"
                   >
                     <div
-                      className="ms-Persona-imageArea css-stub-classname"
+                      className="ms-Persona-imageArea stub-classname"
                       role="presentation"
                       style={
                         Object {
@@ -70,7 +70,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                     >
                       <div
                         aria-hidden="true"
-                        className="ms-Persona-initials css-stub-classname"
+                        className="ms-Persona-initials stub-classname"
                         style={
                           Object {
                             "height": 100,
@@ -88,13 +88,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <span
-                  className="css-stub-classname"
+                  className="stub-classname"
                   title="Michael"
                 >
                   Michael
@@ -103,21 +103,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
             </div>
           </div>
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
             data-ui-id="video-tile"
           >
             <div
-              className="css-stub-classname"
+              className="stub-classname"
             />
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
                   aria-label=""
-                  className="ms-Persona ms-Persona--size48 css-stub-classname"
+                  className="ms-Persona ms-Persona--size48 stub-classname"
                   style={
                     Object {
                       "height": 100,
@@ -126,11 +126,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                   }
                 >
                   <div
-                    className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                    className="ms-Persona-coin ms-Persona--size48 stub-classname"
                     role="presentation"
                   >
                     <div
-                      className="ms-Persona-imageArea css-stub-classname"
+                      className="ms-Persona-imageArea stub-classname"
                       role="presentation"
                       style={
                         Object {
@@ -141,7 +141,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                     >
                       <div
                         aria-hidden="true"
-                        className="ms-Persona-initials css-stub-classname"
+                        className="ms-Persona-initials stub-classname"
                         style={
                           Object {
                             "height": 100,
@@ -159,13 +159,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <span
-                  className="css-stub-classname"
+                  className="stub-classname"
                   title="Jim"
                 >
                   Jim
@@ -174,21 +174,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
             </div>
           </div>
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
             data-ui-id="video-tile"
           >
             <div
-              className="css-stub-classname"
+              className="stub-classname"
             />
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
                   aria-label=""
-                  className="ms-Persona ms-Persona--size48 css-stub-classname"
+                  className="ms-Persona ms-Persona--size48 stub-classname"
                   style={
                     Object {
                       "height": 100,
@@ -197,11 +197,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                   }
                 >
                   <div
-                    className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                    className="ms-Persona-coin ms-Persona--size48 stub-classname"
                     role="presentation"
                   >
                     <div
-                      className="ms-Persona-imageArea css-stub-classname"
+                      className="ms-Persona-imageArea stub-classname"
                       role="presentation"
                       style={
                         Object {
@@ -212,7 +212,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                     >
                       <div
                         aria-hidden="true"
-                        className="ms-Persona-initials css-stub-classname"
+                        className="ms-Persona-initials stub-classname"
                         style={
                           Object {
                             "height": 100,
@@ -230,13 +230,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <span
-                  className="css-stub-classname"
+                  className="stub-classname"
                   title="Pam"
                 >
                   Pam
@@ -245,21 +245,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
             </div>
           </div>
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
             data-ui-id="video-tile"
           >
             <div
-              className="css-stub-classname"
+              className="stub-classname"
             />
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
                   aria-label=""
-                  className="ms-Persona ms-Persona--size48 css-stub-classname"
+                  className="ms-Persona ms-Persona--size48 stub-classname"
                   style={
                     Object {
                       "height": 100,
@@ -268,11 +268,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                   }
                 >
                   <div
-                    className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                    className="ms-Persona-coin ms-Persona--size48 stub-classname"
                     role="presentation"
                   >
                     <div
-                      className="ms-Persona-imageArea css-stub-classname"
+                      className="ms-Persona-imageArea stub-classname"
                       role="presentation"
                       style={
                         Object {
@@ -283,7 +283,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
                     >
                       <div
                         aria-hidden="true"
-                        className="ms-Persona-initials css-stub-classname"
+                        className="ms-Persona-initials stub-classname"
                         style={
                           Object {
                             "height": 100,
@@ -301,13 +301,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Grid Layout Grid Layo
               </div>
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <span
-                  className="css-stub-classname"
+                  className="stub-classname"
                   title="Dwight"
                 >
                   Dwight

--- a/packages/storybook/stories/MessageStatusIndicator/__snapshots__/MessageStatusIndicator.stories.storyshot
+++ b/packages/storybook/stories/MessageStatusIndicator/__snapshots__/MessageStatusIndicator.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Message Status Indicator Message Status Indicator 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,7 +21,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Message Status Indica
       }
     >
       <div
-        className="ms-TooltipHost css-stub-classname"
+        className="ms-TooltipHost stub-classname"
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
         onKeyDown={[Function]}
@@ -30,7 +30,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Message Status Indica
       >
         <i
           aria-label="Message sent"
-          className="css-stub-classname"
+          className="stub-classname"
           data-icon-name="MessageDelivered"
           data-ui-id="chat-composite-message-status-icon"
           role="status"

--- a/packages/storybook/stories/ParticipantItem/__snapshots__/ParticipantItem.stories.storyshot
+++ b/packages/storybook/stories/ParticipantItem/__snapshots__/ParticipantItem.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Participant Item Participant Item 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -28,7 +28,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
         }
       >
         <div
-          className="css-stub-classname"
+          className="stub-classname"
           data-is-focusable={true}
           onClick={[Function]}
           onMouseEnter={[Function]}
@@ -36,22 +36,22 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
           role="menuitem"
         >
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
           >
             <div
-              className="ms-Persona ms-Persona--size32 css-stub-classname"
+              className="ms-Persona ms-Persona--size32 stub-classname"
             >
               <div
-                className="ms-Persona-coin ms-Persona--size32 css-stub-classname"
+                className="ms-Persona-coin ms-Persona--size32 stub-classname"
                 role="presentation"
               >
                 <div
-                  className="ms-Persona-imageArea css-stub-classname"
+                  className="ms-Persona-imageArea stub-classname"
                   role="presentation"
                 >
                   <div
                     aria-hidden="true"
-                    className="ms-Persona-initials css-stub-classname"
+                    className="ms-Persona-initials stub-classname"
                   >
                     <span>
                       AM
@@ -60,14 +60,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                 </div>
               </div>
               <div
-                className="ms-Persona-details css-stub-classname"
+                className="ms-Persona-details stub-classname"
               >
                 <div
-                  className="ms-Persona-primaryText css-stub-classname"
+                  className="ms-Persona-primaryText stub-classname"
                   dir="auto"
                 >
                   <div
-                    className="ms-TooltipHost css-stub-classname"
+                    className="ms-TooltipHost stub-classname"
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
                     onKeyDown={[Function]}
@@ -78,28 +78,28 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                   </div>
                 </div>
                 <div
-                  className="ms-Persona-secondaryText css-stub-classname"
+                  className="ms-Persona-secondaryText stub-classname"
                   dir="auto"
                 />
                 <div
-                  className="ms-Persona-tertiaryText css-stub-classname"
+                  className="ms-Persona-tertiaryText stub-classname"
                   dir="auto"
                 />
                 <div
-                  className="ms-Persona-optionalText css-stub-classname"
+                  className="ms-Persona-optionalText stub-classname"
                   dir="auto"
                 />
               </div>
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <span
                   aria-hidden={true}
-                  className="root-span css-stub-classname"
+                  className="root-span stub-classname"
                 >
                   <svg
                     className="svg"
@@ -116,7 +116,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                 </span>
                 <span
                   aria-hidden={true}
-                  className="root-span css-stub-classname"
+                  className="root-span stub-classname"
                 >
                   <svg
                     className="svg"
@@ -141,13 +141,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
             </div>
           </div>
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
             data-ui-id="participant-item-menu-button"
             title="More Options"
           >
             <i
               aria-hidden={true}
-              className="css-stub-classname"
+              className="stub-classname"
               data-icon-name="ParticipantItemOptions"
             >
               <span
@@ -179,7 +179,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
             className="ms-layer"
           >
             <div
-              className="ms-Fabric ms-Layer-content css-stub-classname"
+              className="ms-Fabric ms-Layer-content stub-classname"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
@@ -212,7 +212,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
               onTouchStart={[Function]}
             >
               <div
-                className="ms-Callout-container css-stub-classname"
+                className="ms-Callout-container stub-classname"
                 style={
                   Object {
                     "visibility": "hidden",
@@ -220,7 +220,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                 }
               >
                 <div
-                  className="ms-Callout ms-ContextualMenu-Callout css-stub-classname"
+                  className="ms-Callout ms-ContextualMenu-Callout stub-classname"
                   hidden={true}
                   onScroll={[Function]}
                   style={
@@ -233,7 +233,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                   tabIndex={-1}
                 >
                   <div
-                    className="ms-Callout-main css-stub-classname"
+                    className="ms-Callout-main stub-classname"
                     onKeyDown={[Function]}
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
@@ -247,7 +247,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                     }
                   >
                     <div
-                      className="ms-ContextualMenu-container css-stub-classname"
+                      className="ms-ContextualMenu-container stub-classname"
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
                       onKeyUp={[Function]}
@@ -255,27 +255,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                       tabIndex={-1}
                     >
                       <div
-                        className="ms-FocusZone css-stub-classname ms-ContextualMenu is-open css-stub-classname"
-                        data-focuszone-id="FocusZone157"
+                        className="ms-FocusZone stub-classname ms-ContextualMenu is-open stub-classname"
+                        data-focuszone-id="FocusZone4"
                         onFocus={[Function]}
                         onKeyDown={[Function]}
                         onMouseDownCapture={[Function]}
                       >
                         <ul
-                          className="ms-ContextualMenu-list is-open css-stub-classname"
+                          className="ms-ContextualMenu-list is-open stub-classname"
                           onKeyDown={[Function]}
                           onKeyUp={[Function]}
                           role="presentation"
                         >
                           <li
-                            className="ms-ContextualMenu-item css-stub-classname"
+                            className="ms-ContextualMenu-item stub-classname"
                             role="presentation"
                           >
                             <button
                               aria-disabled={false}
                               aria-posinset={1}
                               aria-setsize={2}
-                              className="ms-ContextualMenu-link css-stub-classname"
+                              className="ms-ContextualMenu-link stub-classname"
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseEnter={[Function]}
@@ -284,10 +284,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                               role="menuitem"
                             >
                               <div
-                                className="ms-ContextualMenu-linkContent css-stub-classname"
+                                className="ms-ContextualMenu-linkContent stub-classname"
                               >
                                 <span
-                                  className="ms-ContextualMenu-itemText css-stub-classname"
+                                  className="ms-ContextualMenu-itemText stub-classname"
                                 >
                                   Mute
                                 </span>
@@ -295,14 +295,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                             </button>
                           </li>
                           <li
-                            className="ms-ContextualMenu-item css-stub-classname"
+                            className="ms-ContextualMenu-item stub-classname"
                             role="presentation"
                           >
                             <button
                               aria-disabled={false}
                               aria-posinset={2}
                               aria-setsize={2}
-                              className="ms-ContextualMenu-link css-stub-classname"
+                              className="ms-ContextualMenu-link stub-classname"
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseEnter={[Function]}
@@ -311,10 +311,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant Item Part
                               role="menuitem"
                             >
                               <div
-                                className="ms-ContextualMenu-linkContent css-stub-classname"
+                                className="ms-ContextualMenu-linkContent stub-classname"
                               >
                                 <span
-                                  className="ms-ContextualMenu-itemText css-stub-classname"
+                                  className="ms-ContextualMenu-itemText stub-classname"
                                 >
                                   Remove
                                 </span>

--- a/packages/storybook/stories/ParticipantList/__snapshots__/ParticipantList.stories.storyshot
+++ b/packages/storybook/stories/ParticipantList/__snapshots__/ParticipantList.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Participant List Participant List 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,14 +21,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
           data-ui-id="participant-list"
         >
           <div
-            className="css-stub-classname"
+            className="stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -36,22 +36,22 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             role="menuitem"
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Persona ms-Persona--size32 css-stub-classname"
+                className="ms-Persona ms-Persona--size32 stub-classname"
               >
                 <div
-                  className="ms-Persona-coin ms-Persona--size32 css-stub-classname"
+                  className="ms-Persona-coin ms-Persona--size32 stub-classname"
                   role="presentation"
                 >
                   <div
-                    className="ms-Persona-imageArea css-stub-classname"
+                    className="ms-Persona-imageArea stub-classname"
                     role="presentation"
                   >
                     <div
                       aria-hidden="true"
-                      className="ms-Persona-initials css-stub-classname"
+                      className="ms-Persona-initials stub-classname"
                     >
                       <span>
                         R
@@ -60,14 +60,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                   </div>
                 </div>
                 <div
-                  className="ms-Persona-details css-stub-classname"
+                  className="ms-Persona-details stub-classname"
                 >
                   <div
-                    className="ms-Persona-primaryText css-stub-classname"
+                    className="ms-Persona-primaryText stub-classname"
                     dir="auto"
                   >
                     <div
-                      className="ms-TooltipHost css-stub-classname"
+                      className="ms-TooltipHost stub-classname"
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
@@ -78,31 +78,31 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     </div>
                   </div>
                   <div
-                    className="ms-Persona-secondaryText css-stub-classname"
+                    className="ms-Persona-secondaryText stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-tertiaryText css-stub-classname"
+                    className="ms-Persona-tertiaryText stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-optionalText css-stub-classname"
+                    className="ms-Persona-optionalText stub-classname"
                     dir="auto"
                   />
                 </div>
               </div>
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               />
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               data-ui-id="participant-item-menu-button"
               title="More Options"
             >
               <i
                 aria-hidden={true}
-                className="css-stub-classname"
+                className="stub-classname"
                 data-icon-name="ParticipantItemOptions"
               >
                 <span
@@ -134,7 +134,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
               className="ms-layer"
             >
               <div
-                className="ms-Fabric ms-Layer-content css-stub-classname"
+                className="ms-Fabric ms-Layer-content stub-classname"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onClick={[Function]}
@@ -167,7 +167,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                 onTouchStart={[Function]}
               >
                 <div
-                  className="ms-Callout-container css-stub-classname"
+                  className="ms-Callout-container stub-classname"
                   style={
                     Object {
                       "visibility": "hidden",
@@ -175,7 +175,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                   }
                 >
                   <div
-                    className="ms-Callout ms-ContextualMenu-Callout css-stub-classname"
+                    className="ms-Callout ms-ContextualMenu-Callout stub-classname"
                     hidden={true}
                     onScroll={[Function]}
                     style={
@@ -188,7 +188,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     tabIndex={-1}
                   >
                     <div
-                      className="ms-Callout-main css-stub-classname"
+                      className="ms-Callout-main stub-classname"
                       onKeyDown={[Function]}
                       onMouseDown={[Function]}
                       onMouseUp={[Function]}
@@ -202,7 +202,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                       }
                     >
                       <div
-                        className="ms-ContextualMenu-container css-stub-classname"
+                        className="ms-ContextualMenu-container stub-classname"
                         onFocusCapture={[Function]}
                         onKeyDown={[Function]}
                         onKeyUp={[Function]}
@@ -210,27 +210,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                         tabIndex={-1}
                       >
                         <div
-                          className="ms-FocusZone css-stub-classname ms-ContextualMenu is-open css-stub-classname"
-                          data-focuszone-id="FocusZone169"
+                          className="ms-FocusZone stub-classname ms-ContextualMenu is-open stub-classname"
+                          data-focuszone-id="FocusZone11"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
                         >
                           <ul
-                            className="ms-ContextualMenu-list is-open css-stub-classname"
+                            className="ms-ContextualMenu-list is-open stub-classname"
                             onKeyDown={[Function]}
                             onKeyUp={[Function]}
                             role="presentation"
                           >
                             <li
-                              className="ms-ContextualMenu-item css-stub-classname"
+                              className="ms-ContextualMenu-item stub-classname"
                               role="presentation"
                             >
                               <button
                                 aria-disabled={false}
                                 aria-posinset={1}
                                 aria-setsize={1}
-                                className="ms-ContextualMenu-link css-stub-classname"
+                                className="ms-ContextualMenu-link stub-classname"
                                 data-ui-id="participant-list-remove-participant-button"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -240,10 +240,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                                 role="menuitem"
                               >
                                 <div
-                                  className="ms-ContextualMenu-linkContent css-stub-classname"
+                                  className="ms-ContextualMenu-linkContent stub-classname"
                                 >
                                   <span
-                                    className="ms-ContextualMenu-itemText css-stub-classname"
+                                    className="ms-ContextualMenu-itemText stub-classname"
                                   >
                                     Remove
                                   </span>
@@ -260,7 +260,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             </span>
           </div>
           <div
-            className="css-stub-classname"
+            className="stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -268,22 +268,22 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             role="menuitem"
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Persona ms-Persona--size32 css-stub-classname"
+                className="ms-Persona ms-Persona--size32 stub-classname"
               >
                 <div
-                  className="ms-Persona-coin ms-Persona--size32 css-stub-classname"
+                  className="ms-Persona-coin ms-Persona--size32 stub-classname"
                   role="presentation"
                 >
                   <div
-                    className="ms-Persona-imageArea css-stub-classname"
+                    className="ms-Persona-imageArea stub-classname"
                     role="presentation"
                   >
                     <div
                       aria-hidden="true"
-                      className="ms-Persona-initials css-stub-classname"
+                      className="ms-Persona-initials stub-classname"
                     >
                       <span>
                         D
@@ -292,14 +292,14 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                   </div>
                 </div>
                 <div
-                  className="ms-Persona-details css-stub-classname"
+                  className="ms-Persona-details stub-classname"
                 >
                   <div
-                    className="ms-Persona-primaryText css-stub-classname"
+                    className="ms-Persona-primaryText stub-classname"
                     dir="auto"
                   >
                     <div
-                      className="ms-TooltipHost css-stub-classname"
+                      className="ms-TooltipHost stub-classname"
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
@@ -310,31 +310,31 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     </div>
                   </div>
                   <div
-                    className="ms-Persona-secondaryText css-stub-classname"
+                    className="ms-Persona-secondaryText stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-tertiaryText css-stub-classname"
+                    className="ms-Persona-tertiaryText stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-optionalText css-stub-classname"
+                    className="ms-Persona-optionalText stub-classname"
                     dir="auto"
                   />
                 </div>
               </div>
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               />
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               data-ui-id="participant-item-menu-button"
               title="More Options"
             >
               <i
                 aria-hidden={true}
-                className="css-stub-classname"
+                className="stub-classname"
                 data-icon-name="ParticipantItemOptions"
               >
                 <span
@@ -366,7 +366,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
               className="ms-layer"
             >
               <div
-                className="ms-Fabric ms-Layer-content css-stub-classname"
+                className="ms-Fabric ms-Layer-content stub-classname"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onClick={[Function]}
@@ -399,7 +399,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                 onTouchStart={[Function]}
               >
                 <div
-                  className="ms-Callout-container css-stub-classname"
+                  className="ms-Callout-container stub-classname"
                   style={
                     Object {
                       "visibility": "hidden",
@@ -407,7 +407,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                   }
                 >
                   <div
-                    className="ms-Callout ms-ContextualMenu-Callout css-stub-classname"
+                    className="ms-Callout ms-ContextualMenu-Callout stub-classname"
                     hidden={true}
                     onScroll={[Function]}
                     style={
@@ -420,7 +420,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     tabIndex={-1}
                   >
                     <div
-                      className="ms-Callout-main css-stub-classname"
+                      className="ms-Callout-main stub-classname"
                       onKeyDown={[Function]}
                       onMouseDown={[Function]}
                       onMouseUp={[Function]}
@@ -434,7 +434,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                       }
                     >
                       <div
-                        className="ms-ContextualMenu-container css-stub-classname"
+                        className="ms-ContextualMenu-container stub-classname"
                         onFocusCapture={[Function]}
                         onKeyDown={[Function]}
                         onKeyUp={[Function]}
@@ -442,27 +442,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                         tabIndex={-1}
                       >
                         <div
-                          className="ms-FocusZone css-stub-classname ms-ContextualMenu is-open css-stub-classname"
-                          data-focuszone-id="FocusZone170"
+                          className="ms-FocusZone stub-classname ms-ContextualMenu is-open stub-classname"
+                          data-focuszone-id="FocusZone12"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
                         >
                           <ul
-                            className="ms-ContextualMenu-list is-open css-stub-classname"
+                            className="ms-ContextualMenu-list is-open stub-classname"
                             onKeyDown={[Function]}
                             onKeyUp={[Function]}
                             role="presentation"
                           >
                             <li
-                              className="ms-ContextualMenu-item css-stub-classname"
+                              className="ms-ContextualMenu-item stub-classname"
                               role="presentation"
                             >
                               <button
                                 aria-disabled={false}
                                 aria-posinset={1}
                                 aria-setsize={1}
-                                className="ms-ContextualMenu-link css-stub-classname"
+                                className="ms-ContextualMenu-link stub-classname"
                                 data-ui-id="participant-list-remove-participant-button"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -472,10 +472,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                                 role="menuitem"
                               >
                                 <div
-                                  className="ms-ContextualMenu-linkContent css-stub-classname"
+                                  className="ms-ContextualMenu-linkContent stub-classname"
                                 >
                                   <span
-                                    className="ms-ContextualMenu-itemText css-stub-classname"
+                                    className="ms-ContextualMenu-itemText stub-classname"
                                   >
                                     Remove
                                   </span>
@@ -492,7 +492,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             </span>
           </div>
           <div
-            className="css-stub-classname"
+            className="stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -500,42 +500,42 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             role="menuitem"
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Persona ms-Persona--size32 ms-Persona--away css-stub-classname"
+                className="ms-Persona ms-Persona--size32 ms-Persona--away stub-classname"
               >
                 <div
-                  className="ms-Persona-coin ms-Persona--size32 css-stub-classname"
+                  className="ms-Persona-coin ms-Persona--size32 stub-classname"
                   role="presentation"
                 >
                   <div
-                    className="ms-Persona-imageArea css-stub-classname"
+                    className="ms-Persona-imageArea stub-classname"
                     role="presentation"
                   >
                     <div
                       aria-hidden="true"
-                      className="ms-Persona-initials css-stub-classname"
+                      className="ms-Persona-initials stub-classname"
                     >
                       <span>
                         M
                       </span>
                     </div>
                     <div
-                      className="ms-Persona-presence css-stub-classname"
+                      className="ms-Persona-presence stub-classname"
                       role="presentation"
                     />
                   </div>
                 </div>
                 <div
-                  className="ms-Persona-details css-stub-classname"
+                  className="ms-Persona-details stub-classname"
                 >
                   <div
-                    className="ms-Persona-primaryText css-stub-classname"
+                    className="ms-Persona-primaryText stub-classname"
                     dir="auto"
                   >
                     <div
-                      className="ms-TooltipHost css-stub-classname"
+                      className="ms-TooltipHost stub-classname"
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
@@ -546,31 +546,31 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     </div>
                   </div>
                   <div
-                    className="ms-Persona-secondaryText css-stub-classname"
+                    className="ms-Persona-secondaryText stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-tertiaryText css-stub-classname"
+                    className="ms-Persona-tertiaryText stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-optionalText css-stub-classname"
+                    className="ms-Persona-optionalText stub-classname"
                     dir="auto"
                   />
                 </div>
               </div>
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               />
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               data-ui-id="participant-item-menu-button"
               title="More Options"
             >
               <i
                 aria-hidden={true}
-                className="css-stub-classname"
+                className="stub-classname"
                 data-icon-name="ParticipantItemOptions"
               >
                 <span
@@ -602,7 +602,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
               className="ms-layer"
             >
               <div
-                className="ms-Fabric ms-Layer-content css-stub-classname"
+                className="ms-Fabric ms-Layer-content stub-classname"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onClick={[Function]}
@@ -635,7 +635,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                 onTouchStart={[Function]}
               >
                 <div
-                  className="ms-Callout-container css-stub-classname"
+                  className="ms-Callout-container stub-classname"
                   style={
                     Object {
                       "visibility": "hidden",
@@ -643,7 +643,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                   }
                 >
                   <div
-                    className="ms-Callout ms-ContextualMenu-Callout css-stub-classname"
+                    className="ms-Callout ms-ContextualMenu-Callout stub-classname"
                     hidden={true}
                     onScroll={[Function]}
                     style={
@@ -656,7 +656,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     tabIndex={-1}
                   >
                     <div
-                      className="ms-Callout-main css-stub-classname"
+                      className="ms-Callout-main stub-classname"
                       onKeyDown={[Function]}
                       onMouseDown={[Function]}
                       onMouseUp={[Function]}
@@ -670,7 +670,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                       }
                     >
                       <div
-                        className="ms-ContextualMenu-container css-stub-classname"
+                        className="ms-ContextualMenu-container stub-classname"
                         onFocusCapture={[Function]}
                         onKeyDown={[Function]}
                         onKeyUp={[Function]}
@@ -678,27 +678,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                         tabIndex={-1}
                       >
                         <div
-                          className="ms-FocusZone css-stub-classname ms-ContextualMenu is-open css-stub-classname"
-                          data-focuszone-id="FocusZone171"
+                          className="ms-FocusZone stub-classname ms-ContextualMenu is-open stub-classname"
+                          data-focuszone-id="FocusZone13"
                           onFocus={[Function]}
                           onKeyDown={[Function]}
                           onMouseDownCapture={[Function]}
                         >
                           <ul
-                            className="ms-ContextualMenu-list is-open css-stub-classname"
+                            className="ms-ContextualMenu-list is-open stub-classname"
                             onKeyDown={[Function]}
                             onKeyUp={[Function]}
                             role="presentation"
                           >
                             <li
-                              className="ms-ContextualMenu-item css-stub-classname"
+                              className="ms-ContextualMenu-item stub-classname"
                               role="presentation"
                             >
                               <button
                                 aria-disabled={false}
                                 aria-posinset={1}
                                 aria-setsize={1}
-                                className="ms-ContextualMenu-link css-stub-classname"
+                                className="ms-ContextualMenu-link stub-classname"
                                 data-ui-id="participant-list-remove-participant-button"
                                 onClick={[Function]}
                                 onMouseDown={[Function]}
@@ -708,10 +708,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                                 role="menuitem"
                               >
                                 <div
-                                  className="ms-ContextualMenu-linkContent css-stub-classname"
+                                  className="ms-ContextualMenu-linkContent stub-classname"
                                 >
                                   <span
-                                    className="ms-ContextualMenu-itemText css-stub-classname"
+                                    className="ms-ContextualMenu-itemText stub-classname"
                                   >
                                     Remove
                                   </span>
@@ -728,7 +728,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             </span>
           </div>
           <div
-            className="css-stub-classname"
+            className="stub-classname"
             data-is-focusable={true}
             onClick={[Function]}
             onMouseEnter={[Function]}
@@ -736,42 +736,42 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
             role="menuitem"
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="ms-Persona ms-Persona--size32 ms-Persona--online css-stub-classname"
+                className="ms-Persona ms-Persona--size32 ms-Persona--online stub-classname"
               >
                 <div
-                  className="ms-Persona-coin ms-Persona--size32 css-stub-classname"
+                  className="ms-Persona-coin ms-Persona--size32 stub-classname"
                   role="presentation"
                 >
                   <div
-                    className="ms-Persona-imageArea css-stub-classname"
+                    className="ms-Persona-imageArea stub-classname"
                     role="presentation"
                   >
                     <div
                       aria-hidden="true"
-                      className="ms-Persona-initials css-stub-classname"
+                      className="ms-Persona-initials stub-classname"
                     >
                       <span>
                         Y
                       </span>
                     </div>
                     <div
-                      className="ms-Persona-presence css-stub-classname"
+                      className="ms-Persona-presence stub-classname"
                       role="presentation"
                     />
                   </div>
                 </div>
                 <div
-                  className="ms-Persona-details css-stub-classname"
+                  className="ms-Persona-details stub-classname"
                 >
                   <div
-                    className="ms-Persona-primaryText css-stub-classname"
+                    className="ms-Persona-primaryText stub-classname"
                     dir="auto"
                   >
                     <div
-                      className="ms-TooltipHost css-stub-classname"
+                      className="ms-TooltipHost stub-classname"
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
                       onKeyDown={[Function]}
@@ -782,26 +782,26 @@ exports[`storybook snapshot tests Storyshots UI Components/Participant List Part
                     </div>
                   </div>
                   <div
-                    className="ms-Persona-secondaryText css-stub-classname"
+                    className="ms-Persona-secondaryText stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-tertiaryText css-stub-classname"
+                    className="ms-Persona-tertiaryText stub-classname"
                     dir="auto"
                   />
                   <div
-                    className="ms-Persona-optionalText css-stub-classname"
+                    className="ms-Persona-optionalText stub-classname"
                     dir="auto"
                   />
                 </div>
               </div>
               <span
-                className="css-stub-classname"
+                className="stub-classname"
               >
                 (you)
               </span>
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               />
             </div>
           </div>

--- a/packages/storybook/stories/SendBox/__snapshots__/SendBox.stories.storyshot
+++ b/packages/storybook/stories/SendBox/__snapshots__/SendBox.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -28,30 +28,30 @@ exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`]
         }
       >
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
         >
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
             >
               <div
-                className="css-stub-classname"
+                className="stub-classname"
               >
                 <div
-                  className="ms-TextField ms-TextField--multiline css-stub-classname"
+                  className="ms-TextField ms-TextField--multiline stub-classname"
                 >
                   <div
-                    className="ms-TextField-wrapper css-stub-classname"
+                    className="ms-TextField-wrapper stub-classname"
                   >
                     <div
-                      className="ms-TextField-fieldGroup css-stub-classname"
+                      className="ms-TextField-fieldGroup stub-classname"
                     >
                       <textarea
                         aria-invalid={false}
                         autoFocus={false}
-                        className="ms-TextField-field ms-TextField--unresizable css-stub-classname"
+                        className="ms-TextField-field ms-TextField--unresizable stub-classname"
                         data-ui-id="sendbox-textfield"
                         disabled={false}
                         id="sendbox"
@@ -67,10 +67,10 @@ exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`]
                   </div>
                 </div>
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <div
-                    className="ms-TooltipHost css-stub-classname"
+                    className="ms-TooltipHost stub-classname"
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
                     onKeyDown={[Function]}
@@ -79,7 +79,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`]
                   >
                     <button
                       aria-label="Send message"
-                      className="ms-Button ms-Button--icon css-stub-classname"
+                      className="ms-Button ms-Button--icon stub-classname"
                       data-is-focusable={true}
                       id="sendIconWrapper"
                       onClick={[Function]}
@@ -93,12 +93,12 @@ exports[`storybook snapshot tests Storyshots UI Components/Send Box Send Box 1`]
                       type="button"
                     >
                       <span
-                        className="ms-Button-flexContainer css-stub-classname"
+                        className="ms-Button-flexContainer stub-classname"
                         data-automationid="splitbuttonprimary"
                       >
                         <i
                           aria-hidden={true}
-                          className="css-stub-classname"
+                          className="stub-classname"
                           data-icon-name="SendBoxSend"
                         >
                           <span

--- a/packages/storybook/stories/TypingIndicator/__snapshots__/TypingIndicator.stories.storyshot
+++ b/packages/storybook/stories/TypingIndicator/__snapshots__/TypingIndicator.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Typing Indicator Typing Indicator 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,35 +21,35 @@ exports[`storybook snapshot tests Storyshots UI Components/Typing Indicator Typi
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
       >
         <div
           aria-label="User1, User2 are typing ..."
-          className="css-110"
+          className="stub-classname"
           data-ui-id="typing-indicator"
           role="status"
         >
           <span
-            className="css-stub-classname"
+            className="stub-classname"
           >
             <span
-              className="css-stub-classname"
+              className="stub-classname"
             >
               User1
             </span>
             <span
-              className="css-stub-classname"
+              className="stub-classname"
             >
               , 
             </span>
             <span
-              className="css-stub-classname"
+              className="stub-classname"
             >
               User2
             </span>
           </span>
           <span
-            className="css-stub-classname"
+            className="stub-classname"
           >
              are typing ...
           </span>

--- a/packages/storybook/stories/VideoGallery/__snapshots__/VideoGallery.stories.storyshot
+++ b/packages/storybook/stories/VideoGallery/__snapshots__/VideoGallery.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video Gallery 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,34 +21,34 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
       }
     >
       <div
-        className="css-143"
+        className="stub-classname"
         data-ui-id="video-gallery"
       >
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
         >
           <div
             aria-label="Movable Local Video Tile"
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
             role="dialog"
             tabIndex={0}
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               data-ui-id="video-tile"
             >
               <div
-                className="css-stub-classname"
+                className="stub-classname"
               />
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <div
                     aria-label=""
-                    className="ms-Persona ms-Persona--size48 css-stub-classname"
+                    className="ms-Persona ms-Persona--size48 stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -57,11 +57,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                     }
                   >
                     <div
-                      className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                      className="ms-Persona-coin ms-Persona--size48 stub-classname"
                       role="presentation"
                     >
                       <div
-                        className="ms-Persona-imageArea css-stub-classname"
+                        className="ms-Persona-imageArea stub-classname"
                         role="presentation"
                         style={
                           Object {
@@ -72,7 +72,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                       >
                         <div
                           aria-hidden="true"
-                          className="ms-Persona-initials css-stub-classname"
+                          className="ms-Persona-initials stub-classname"
                           style={
                             Object {
                               "height": 100,
@@ -90,19 +90,19 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 </div>
               </div>
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <span
-                    className="css-stub-classname"
+                    className="stub-classname"
                     title="You"
                   >
                     You
                   </span>
                   <div
-                    className="ms-Stack css-stub-classname"
+                    className="ms-Stack stub-classname"
                   >
                     <i
                       aria-hidden={true}
@@ -140,27 +140,27 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
           </div>
         </div>
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
         >
           <div
-            className="css-stub-classname"
+            className="stub-classname"
           >
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               data-ui-id="video-tile"
             >
               <div
-                className="css-stub-classname"
+                className="stub-classname"
               />
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <div
                     aria-label=""
-                    className="ms-Persona ms-Persona--size48 css-stub-classname"
+                    className="ms-Persona ms-Persona--size48 stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -169,11 +169,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                     }
                   >
                     <div
-                      className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                      className="ms-Persona-coin ms-Persona--size48 stub-classname"
                       role="presentation"
                     >
                       <div
-                        className="ms-Persona-imageArea css-stub-classname"
+                        className="ms-Persona-imageArea stub-classname"
                         role="presentation"
                         style={
                           Object {
@@ -184,7 +184,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                       >
                         <div
                           aria-hidden="true"
-                          className="ms-Persona-initials css-stub-classname"
+                          className="ms-Persona-initials stub-classname"
                           style={
                             Object {
                               "height": 100,
@@ -202,13 +202,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 </div>
               </div>
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <span
-                    className="css-stub-classname"
+                    className="stub-classname"
                     title="Rick"
                   >
                     Rick
@@ -217,21 +217,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
               </div>
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               data-ui-id="video-tile"
             >
               <div
-                className="css-stub-classname"
+                className="stub-classname"
               />
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <div
                     aria-label=""
-                    className="ms-Persona ms-Persona--size48 css-stub-classname"
+                    className="ms-Persona ms-Persona--size48 stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -240,11 +240,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                     }
                   >
                     <div
-                      className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                      className="ms-Persona-coin ms-Persona--size48 stub-classname"
                       role="presentation"
                     >
                       <div
-                        className="ms-Persona-imageArea css-stub-classname"
+                        className="ms-Persona-imageArea stub-classname"
                         role="presentation"
                         style={
                           Object {
@@ -255,7 +255,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                       >
                         <div
                           aria-hidden="true"
-                          className="ms-Persona-initials css-stub-classname"
+                          className="ms-Persona-initials stub-classname"
                           style={
                             Object {
                               "height": 100,
@@ -273,13 +273,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 </div>
               </div>
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <span
-                    className="css-stub-classname"
+                    className="stub-classname"
                     title="Daryl"
                   >
                     Daryl
@@ -288,21 +288,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
               </div>
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               data-ui-id="video-tile"
             >
               <div
-                className="css-stub-classname"
+                className="stub-classname"
               />
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <div
                     aria-label=""
-                    className="ms-Persona ms-Persona--size48 css-stub-classname"
+                    className="ms-Persona ms-Persona--size48 stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -311,11 +311,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                     }
                   >
                     <div
-                      className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                      className="ms-Persona-coin ms-Persona--size48 stub-classname"
                       role="presentation"
                     >
                       <div
-                        className="ms-Persona-imageArea css-stub-classname"
+                        className="ms-Persona-imageArea stub-classname"
                         role="presentation"
                         style={
                           Object {
@@ -326,7 +326,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                       >
                         <div
                           aria-hidden="true"
-                          className="ms-Persona-initials css-stub-classname"
+                          className="ms-Persona-initials stub-classname"
                           style={
                             Object {
                               "height": 100,
@@ -344,13 +344,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 </div>
               </div>
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <span
-                    className="css-stub-classname"
+                    className="stub-classname"
                     title="Michonne"
                   >
                     Michonne
@@ -359,21 +359,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
               </div>
             </div>
             <div
-              className="ms-Stack css-stub-classname"
+              className="ms-Stack stub-classname"
               data-ui-id="video-tile"
             >
               <div
-                className="css-stub-classname"
+                className="stub-classname"
               />
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <div
                     aria-label=""
-                    className="ms-Persona ms-Persona--size48 css-stub-classname"
+                    className="ms-Persona ms-Persona--size48 stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -382,11 +382,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                     }
                   >
                     <div
-                      className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                      className="ms-Persona-coin ms-Persona--size48 stub-classname"
                       role="presentation"
                     >
                       <div
-                        className="ms-Persona-imageArea css-stub-classname"
+                        className="ms-Persona-imageArea stub-classname"
                         role="presentation"
                         style={
                           Object {
@@ -397,7 +397,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                       >
                         <div
                           aria-hidden="true"
-                          className="ms-Persona-initials css-stub-classname"
+                          className="ms-Persona-initials stub-classname"
                           style={
                             Object {
                               "height": 100,
@@ -415,13 +415,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
                 </div>
               </div>
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 >
                   <span
-                    className="css-stub-classname"
+                    className="stub-classname"
                     title="Dwight"
                   >
                     Dwight
@@ -438,20 +438,20 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Gallery Video G
             }
           >
             <div
-              className="css-stub-classname"
+              className="stub-classname"
             >
               <div
-                className="ms-Stack css-stub-classname"
+                className="ms-Stack stub-classname"
               >
                 <div
-                  className="ms-Stack css-stub-classname"
+                  className="ms-Stack stub-classname"
                 />
               </div>
             </div>
           </div>
           <div
-            className="ms-LayerHost css-stub-classname"
-            id="layerhost182"
+            className="ms-LayerHost stub-classname"
+            id="layerhost1"
           />
         </div>
       </div>

--- a/packages/storybook/stories/VideoTile/__snapshots__/VideoTile.stories.storyshot
+++ b/packages/storybook/stories/VideoTile/__snapshots__/VideoTile.stories.storyshot
@@ -2,11 +2,11 @@
 
 exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile 1`] = `
 <div
-  className="css-118 css-stub-classname"
+  className="stub-classname stub-classname"
   dir="ltr"
 >
   <div
-    className="css-118"
+    className="stub-classname"
     data-uses-unhanded-props={true}
     dir="ltr"
   >
@@ -21,21 +21,21 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
       }
     >
       <div
-        className="ms-Stack css-stub-classname"
+        className="ms-Stack stub-classname"
         data-ui-id="video-tile"
       >
         <div
-          className="css-stub-classname"
+          className="stub-classname"
         />
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
         >
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
           >
             <div
               aria-label=""
-              className="ms-Persona ms-Persona--size48 css-stub-classname"
+              className="ms-Persona ms-Persona--size48 stub-classname"
               style={
                 Object {
                   "height": 100,
@@ -44,11 +44,11 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
               }
             >
               <div
-                className="ms-Persona-coin ms-Persona--size48 css-stub-classname"
+                className="ms-Persona-coin ms-Persona--size48 stub-classname"
                 role="presentation"
               >
                 <div
-                  className="ms-Persona-imageArea css-stub-classname"
+                  className="ms-Persona-imageArea stub-classname"
                   role="presentation"
                   style={
                     Object {
@@ -59,7 +59,7 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
                 >
                   <div
                     aria-hidden="true"
-                    className="ms-Persona-initials css-stub-classname"
+                    className="ms-Persona-initials stub-classname"
                     style={
                       Object {
                         "height": 100,
@@ -77,13 +77,13 @@ exports[`storybook snapshot tests Storyshots UI Components/Video Tile Video Tile
           </div>
         </div>
         <div
-          className="ms-Stack css-stub-classname"
+          className="ms-Stack stub-classname"
         >
           <div
-            className="ms-Stack css-stub-classname"
+            className="ms-Stack stub-classname"
           >
             <span
-              className="css-stub-classname"
+              className="stub-classname"
               title="John Smith"
             >
               John Smith

--- a/packages/storybook/stories/storybook.test.ts
+++ b/packages/storybook/stories/storybook.test.ts
@@ -15,13 +15,13 @@ jest.mock('@azure/communication-calling', () => {
 
 ReactDom.createPortal = (node: any) => node;
 
-// Classnames in fluent are of the format <display name>-#, where # is an integer that is incremented by a global singleton
-// when each new classname is generated.
+// Classnames in fluent are of the format <classname-prefix>-# (e.g. css-42), where # is an integer that is incremented by a
+// global singleton when each new classname is generated.
 // Here we mock the classname generation for two reasons:
 //   1. Unblocks parallel tests - if the order in which the tests run changes the generated css classnames
 //      will differ across different runs
 //   2. Prevents unnecessary PR friction - often PRs with small changes to styles would require snapshots to be updated
-//      simply to change the number of a couple of <display name>-# numbered classes. This caused a lot of developer friction.
+//      simply to change the number of a couple of <classname-prefix>-# numbered classes. This caused a lot of developer friction.
 Stylesheet.getInstance().getClassName = () => 'stub-classname';
 beforeEach(() => {
   // Ideally we could stub out the getId in the same way we can stub out getClassName, but currently this is not

--- a/packages/storybook/stories/storybook.test.ts
+++ b/packages/storybook/stories/storybook.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Stylesheet } from '@fluentui/react';
+import { resetIds, Stylesheet } from '@fluentui/react';
 import initStoryshots, { multiSnapshotWithOptions } from '@storybook/addon-storyshots';
 import ReactDom from 'react-dom';
 
@@ -15,15 +15,18 @@ jest.mock('@azure/communication-calling', () => {
 
 ReactDom.createPortal = (node: any) => node;
 
-// Classnames in fluent are of the format css-#, where # is an integer that is incremented by a global singleton
+// Classnames in fluent are of the format <display name>-#, where # is an integer that is incremented by a global singleton
 // when each new classname is generated.
 // Here we mock the classname generation for two reasons:
 //   1. Unblocks parallel tests - if the order in which the tests run changes the generated css classnames
 //      will differ across different runs
 //   2. Prevents unnecessary PR friction - often PRs with small changes to styles would require snapshots to be updated
-//      simply to change a couple of css-# numbered classes. This caused a lot of developer friction.
+//      simply to change the number of a couple of <display name>-# numbered classes. This caused a lot of developer friction.
+Stylesheet.getInstance().getClassName = () => 'stub-classname';
 beforeEach(() => {
-  Stylesheet.getInstance().getClassName = () => 'css-stub-classname';
+  // Ideally we could stub out the getId in the same way we can stub out getClassName, but currently this is not
+  // possible: https://github.com/microsoft/fluentui/blob/master/packages/utilities/src/getId.ts#L5
+  resetIds(0);
 });
 
 // Storyshots do not fail on warnings or errors thrown by components, this is a quick fix to ensure we have tests fail when warning are outputted.


### PR DESCRIPTION
# What
* Overriding getClassName was running in the beforeEach and not at global scope.
* Adding resetIds also (typically its just the classnames that are causing issues, we can monitor this one but it doesn't have a good way to override it)

# Why
Previous PR #1963 completed a little early - found some more when looking at the snapshots in the PR.