### PR TITLE
Support ternary type definitions in conditional compilation

### DIFF
--- a/change/@internal-acs-ui-common-e865738b-2097-4c41-9a5d-c7c5138c826a.json
+++ b/change/@internal-acs-ui-common-e865738b-2097-4c41-9a5d-c7c5138c826a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Support conditional compilation of ternary type",
+  "packageName": "@internal/acs-ui-common",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/scripts/babel-conditional-preprocess.js
+++ b/common/scripts/babel-conditional-preprocess.js
@@ -140,18 +140,13 @@ function Handle(path, featureSet, stabilizedFeatureSet, relaceWith=undefined) {
     comment.value = '';
   })
 
-  switch(path?.container?.type) {
-    case 'JSXExpressionContainer':
-      // We cannot remove Expression in JSXExpressionContainer cause it is not correct for AST
-      // Replacing it with jSXEmptyExpression will get us the same result
-      // There will always be only one expression under JSXExpressionContainer
-      path.replaceWith(t.jSXEmptyExpression());
-      break;
-    case 'TSConditionalType':
-      // TODO add comment
-      // path.replaceWith(path.container.falseType);
-    default:
-      path.remove();
+  // We cannot remove Expression in JSXExpressionContainer cause it is not correct for AST
+  // Replacing it with jSXEmptyExpression will get us the same result
+  // There will always be only one expression under JSXExpressionContainer
+  if (path?.container?.type === 'JSXExpressionContainer') {
+    path.replaceWith(t.jSXEmptyExpression());
+  } else {
+    path.remove();
   }
 }
 

--- a/packages/acs-ui-common/src/conditional-compilation-sample/index.tsx
+++ b/packages/acs-ui-common/src/conditional-compilation-sample/index.tsx
@@ -69,6 +69,7 @@ interface B {
  */
 /* @conditional-compile-remove(demo) */
 import { Dir } from 'fs';
+import { AreEqual } from '../areEqual';
 
 /**
  * Conditionally export from a module.
@@ -111,6 +112,23 @@ export type TypeWithFunctionProperty = {
 export type Unionize = number | /* @conditional-compile-remove(demo) */ boolean;
 export type Impossible = number & /* @conditional-compile-remove(demo) */ boolean;
 
+/**
+ * Conditionally compile a ternary type if.
+ *
+ * Used in selector {@link GetSelector} definitions etc.
+ *
+ * See expanded example below.
+ *
+ * WARNING: Conditional compilation directives must be added in the conditional branch to be removed (not in the condition itself).
+ * When a branch is conditionally compiled out, both the condition and the other branch are removed.
+ */
+export type MyFalseySelector<T> = T extends number ? /* @conditional-compile-remove(demo) */ true : false;
+export type MyTrutySelector<J> = J extends number ? true : /* @conditional-compile-remove(demo) */ false;
+export type MyNestedSelector<Q, R> = Q extends number
+  ? /* @conditional-compile-remove(demo) */ true
+  : R extends number
+  ? /* @conditional-compile-remove(demo) */ true
+  : false;
 /**
  * Add a parameter to an existing function
  *
@@ -269,6 +287,22 @@ export const myExtensibleSelector: MyExtensibleSelector = utils.dummyCreateSelec
     };
   }
 );
+
+/**
+ * When adding a new selector to beta-only API, you need to extend the relevant {@link GetSelector} type.
+ * This example shows how to conditionally add your selector type.
+ *
+ * WARNING: The conditional compilation directive is in the branch to be removed, NOT the condition. (So not before {@link AreEqual}).
+ */
+
+export type GetSelector<Component extends (props: any) => JSX.Element | undefined> = AreEqual<
+  Component,
+  typeof StableComponentWithSelector
+> extends true
+  ? StableSelector
+  : AreEqual<Component, typeof BetaComponentWithSelector> extends true
+  ? /* @conditional-compile-remove(demo) */ BetaSelector
+  : undefined;
 
 /**
  * Adding a new feature conditionally often involves a few operations together:

--- a/packages/acs-ui-common/src/conditional-compilation-sample/index.tsx
+++ b/packages/acs-ui-common/src/conditional-compilation-sample/index.tsx
@@ -69,7 +69,6 @@ interface B {
  */
 /* @conditional-compile-remove(demo) */
 import { Dir } from 'fs';
-import { AreEqual } from '../areEqual';
 
 /**
  * Conditionally export from a module.
@@ -294,14 +293,15 @@ export const myExtensibleSelector: MyExtensibleSelector = utils.dummyCreateSelec
  *
  * WARNING: The conditional compilation directive is in the branch to be removed, NOT the condition. (So not before {@link AreEqual}).
  */
+import { AreEqual } from '../areEqual';
 
-export type GetSelector<Component extends (props: any) => JSX.Element | undefined> = AreEqual<
+export type GetSelector<Component extends (props: unknown) => JSX.Element | undefined> = AreEqual<
   Component,
-  typeof StableComponentWithSelector
+  typeof utils.StableComponentWithSelector
 > extends true
-  ? StableSelector
-  : AreEqual<Component, typeof BetaComponentWithSelector> extends true
-  ? /* @conditional-compile-remove(demo) */ BetaSelector
+  ? utils.StableSelector
+  : AreEqual<Component, typeof utils.BetaComponentWithSelector> extends true
+  ? /* @conditional-compile-remove(demo) */ utils.BetaSelector
   : undefined;
 
 /**

--- a/packages/acs-ui-common/src/conditional-compilation-sample/utils.tsx
+++ b/packages/acs-ui-common/src/conditional-compilation-sample/utils.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import React from 'react';
+
 /*
  * Some helpers needed for conditional compilation examples
  *
@@ -54,3 +56,19 @@ export function dummyCreateSelector(
     );
   };
 }
+
+/** @private */
+export function StableComponentWithSelector(): JSX.Element {
+  return <></>;
+}
+
+/** @private */
+export type StableSelector = number;
+
+/** @private */
+export function BetaComponentWithSelector(): JSX.Element {
+  return <></>;
+}
+
+/** @private */
+export type BetaSelector = number;


### PR DESCRIPTION
# Why

`GetSelector` needs it.

# How Tested

Added examples to live documentation.