### PR TITLE
Ensure resources are cleaned up when disposing of adapter

### DIFF
--- a/change/@internal-react-composites-ba918e00-46e7-49ea-aa1b-09424cfce028.json
+++ b/change/@internal-react-composites-ba918e00-46e7-49ea-aa1b-09424cfce028.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Call call.hangup in adapter dispose method to ensure resources are cleaned up",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -221,6 +221,7 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
 
   public dispose(): void {
     this.resetDiagnosticsForwarder();
+    this.leaveCall();
     this.callClient.offStateChange(this.onClientStateChange);
     this.callAgent.dispose();
   }


### PR DESCRIPTION
# What
Call leaveCall in the dispose method to ensure call.hangup is triggered as well as resource cleanup

# Why

* We want to make sure `call.hangup()` is correctly called anytime we dispose of our adapter per https://docs.microsoft.com/en-us/azure/communication-services/concepts/best-practices#hang-up-the-call-on-onbeforeunload-event.
* Gives a chances for any onHangUp code to execute

Related PR: #1966