### PR TITLE
Add new prop to dialpad to grab textfield values and button clicked info

### DIFF
--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -443,11 +443,13 @@ export interface DialpadButtonProps {
 // @beta
 export interface DialpadProps {
     // (undocumented)
-    onClickDialpadButton?: () => void;
+    onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
     // (undocumented)
     onDisplayDialpadInput?: (input: string) => string;
     // (undocumented)
     onSendDtmfTone?: (dtmfTone: DtmfTone) => Promise<void>;
+    // (undocumented)
+    onTextFieldChange?: (input: string) => void;
     // (undocumented)
     strings?: DialpadStrings;
     // (undocumented)

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -99,9 +99,11 @@ export interface DialpadProps {
   // function to send dtmf tones on button click
   onSendDtmfTone?: (dtmfTone: DtmfTone) => Promise<void>;
   // Callback for dialpad button behavior
-  onClickDialpadButton?: () => void;
+  onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
   // customize dialpad input formatting
   onDisplayDialpadInput?: (input: string) => string;
+  // on change function for text field
+  onTextFieldChange?: (input: string) => void;
   styles?: DialpadStyles;
 }
 
@@ -177,15 +179,17 @@ const DialpadContainer = (props: {
   // dialpadButtons?: DialpadButtonProps[][];
   onSendDtmfTone?: (dtmfTone: DtmfTone) => Promise<void>;
   // Callback for dialpad button behavior
-  onClickDialpadButton?: () => void;
+  onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
   // customize dialpad input formatting
   onDisplayDialpadInput?: (input: string) => string;
+  // on change function for text field
+  onTextFieldChange?: (input: string) => void;
   styles?: DialpadStyles;
 }): JSX.Element => {
   const theme = useTheme();
   const [textValue, setTextValue] = useState('');
 
-  const { onSendDtmfTone, onClickDialpadButton, onDisplayDialpadInput } = props;
+  const { onSendDtmfTone, onClickDialpadButton, onDisplayDialpadInput, onTextFieldChange } = props;
 
   const onClickDialpad = (input: string, index: number): void => {
     setTextValue(textValue + input);
@@ -193,7 +197,12 @@ const DialpadContainer = (props: {
       onSendDtmfTone(DtmfTones[index]);
     }
     if (onClickDialpadButton) {
-      onClickDialpadButton();
+      onClickDialpadButton(input, index);
+    }
+    if (onTextFieldChange) {
+      onTextFieldChange(
+        onDisplayDialpadInput ? onDisplayDialpadInput(textValue + input) : formatPhoneNumber(textValue + input)
+      );
     }
   };
 
@@ -210,7 +219,15 @@ const DialpadContainer = (props: {
       <TextField
         styles={concatStyleSets(textFieldStyles(theme), props.styles?.textField)}
         value={onDisplayDialpadInput ? onDisplayDialpadInput(textValue) : formatPhoneNumber(textValue)}
-        onChange={setText}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onChange={(e: any) => {
+          setText(e);
+          if (onTextFieldChange) {
+            onTextFieldChange(
+              onDisplayDialpadInput ? onDisplayDialpadInput(e.target.value) : formatPhoneNumber(e.target.value)
+            );
+          }
+        }}
         placeholder={props.placeholderText}
         data-test-id="dialpad-input"
       />

--- a/packages/storybook/stories/Dialpad/Dialpad.stories.tsx
+++ b/packages/storybook/stories/Dialpad/Dialpad.stories.tsx
@@ -31,8 +31,10 @@ const getDocs: () => JSX.Element = () => {
       </Canvas>
       <Heading>Example Dialpad with custom content</Heading>
       <Description>
-        On Dialpad button click, the corresponding dtmf tone will be logged on the console. This example showcases how
-        to customize the format for dialpad input.
+        On Dialpad button click, the corresponding dtmf tone, the index and value of the button clicked will be shown on
+        the screen. On Keyboard click, the corresponding keyboard input will be shown on the screen as well. This
+        example showcases how to customize the format for dialpad input, and how to add custom functions to textfield to
+        listen to keyboard changes and how to add extra functionality to dialpad buttons.
       </Description>
       <Canvas mdxSource={CustomDialpadText}>
         <CustomDialpadExample />

--- a/packages/storybook/stories/Dialpad/snippets/CustomDialpad.snippet.tsx
+++ b/packages/storybook/stories/Dialpad/snippets/CustomDialpad.snippet.tsx
@@ -3,12 +3,8 @@
 
 import { DtmfTone } from '@azure/communication-calling';
 import { Dialpad } from '@azure/communication-react';
-import React from 'react';
+import React, { useState } from 'react';
 
-const onSendDtmfTone = (dtmfTone: DtmfTone): Promise<void> => {
-  console.log(dtmfTone);
-  return Promise.resolve();
-};
 const onDisplayDialpadInput = (value: string): string => {
   // if input value is falsy eg if the user deletes the input, then just return
   if (!value) {
@@ -24,6 +20,40 @@ const onDisplayDialpadInput = (value: string): string => {
     return `(${phoneNumber.slice(0, 4)}) ${phoneNumber.slice(4, phoneNumber.length)}`;
   }
 };
+
 export const CustomDialpadExample: () => JSX.Element = () => {
-  return <Dialpad onSendDtmfTone={onSendDtmfTone} onDisplayDialpadInput={onDisplayDialpadInput} />;
+  const [dtmftone, setDtmftone] = useState('');
+  const [buttonValue, setButtonValue] = useState('');
+  const [buttonIndex, setButtonIndex] = useState('');
+  const [textfieldInput, setTextfieldInput] = useState('');
+
+  const onSendDtmfTone = (dtmfTone: DtmfTone): Promise<void> => {
+    setDtmftone(dtmfTone);
+    return Promise.resolve();
+  };
+
+  const onClickDialpadButton = (buttonValue: string, buttonIndex: number): void => {
+    setButtonValue(buttonValue);
+    setButtonIndex(buttonIndex.toString());
+  };
+
+  const onTextFieldChange = (input: string): void => {
+    setTextfieldInput(input);
+  };
+
+  return (
+    <>
+      <div>DTMF Tone: {dtmftone}</div>
+      <div>
+        Button Clicked: {buttonValue} index at {buttonIndex}
+      </div>
+      <div>Textfield Input from keyboard: {textfieldInput}</div>
+      <Dialpad
+        onSendDtmfTone={onSendDtmfTone}
+        onDisplayDialpadInput={onDisplayDialpadInput}
+        onClickDialpadButton={onClickDialpadButton}
+        onTextFieldChange={onTextFieldChange}
+      />{' '}
+    </>
+  );
 };


### PR DESCRIPTION
# What
Add new prop to dialpad to grab textfield values and button clicked info

# Why
In this way contosso can 
1. do something with the button clicked 
2. do something with the value in textfield

# How Tested
storybook
<img width="1081" alt="Screen Shot 2022-06-13 at 5 16 30 PM" src="https://user-images.githubusercontent.com/96077406/173469247-87563f42-48a4-4c5d-bd45-86a05d60e8a6.png">


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->