### PR TITLE
Try see if createAdapter retries help e2e live test flakiness

### DIFF
--- a/packages/react-composites/tests/browser/call/app/index.tsx
+++ b/packages/react-composites/tests/browser/call/app/index.tsx
@@ -166,14 +166,14 @@ const createCallAdapterWithCredentials = async (): Promise<CallAdapter> => {
   const groupId = verifyParamExists(params.groupId, 'groupId');
   const userId = verifyParamExists(params.userId, 'userId');
 
-  const args = {
-    userId: fromFlatCommunicationIdentifier(userId) as CommunicationUserIdentifier,
-    displayName,
-    credential: new AzureCommunicationTokenCredential(token),
-    locator: { groupId: groupId }
-  };
-
   const createAdapter = async (): Promise<CallAdapter> => {
+    const args = {
+      userId: fromFlatCommunicationIdentifier(userId) as CommunicationUserIdentifier,
+      displayName,
+      credential: new AzureCommunicationTokenCredential(token),
+      locator: { groupId: groupId }
+    };
+
     return await createAzureCommunicationCallAdapter(args);
   };
   return await createAdapterWithRetries(createAdapter);

--- a/packages/react-composites/tests/browser/call/app/index.tsx
+++ b/packages/react-composites/tests/browser/call/app/index.tsx
@@ -18,7 +18,12 @@ import {
   CustomCallControlButtonCallbackArgs
 } from '../../../../src';
 import { IDS } from '../../common/constants';
-import { initializeIconsForUITests, isMobile, verifyParamExists } from '../../common/testAppUtils';
+import {
+  createAdapterWithRetries,
+  initializeIconsForUITests,
+  isMobile,
+  verifyParamExists
+} from '../../common/testAppUtils';
 import memoizeOne from 'memoize-one';
 // eslint-disable-next-line no-restricted-imports
 import { IContextualMenuItem, mergeStyles } from '@fluentui/react';
@@ -161,13 +166,17 @@ const createCallAdapterWithCredentials = async (): Promise<CallAdapter> => {
   const groupId = verifyParamExists(params.groupId, 'groupId');
   const userId = verifyParamExists(params.userId, 'userId');
 
-  const callAdapter = await createAzureCommunicationCallAdapter({
+  const args = {
     userId: fromFlatCommunicationIdentifier(userId) as CommunicationUserIdentifier,
     displayName,
     credential: new AzureCommunicationTokenCredential(token),
     locator: { groupId: groupId }
-  });
-  return callAdapter;
+  };
+
+  const createAdapter = async (): Promise<CallAdapter> => {
+    return await createAzureCommunicationCallAdapter(args);
+  };
+  return await createAdapterWithRetries(createAdapter);
 };
 
 function onFetchParticipantMenuItems(): IContextualMenuItem[] {


### PR DESCRIPTION
# What
Quick PR to keep trying to create an adapter, instead of trying once and failing the test suite.

# Why
Our e2e tests fail frequently and are stuck in the `initializing adapter` page

## Why might this change be bad
Putting as draft as not sure we want this.
We don't actually know why the create adapter failed, is it network on the build machine? is the service throttling us?
If its the former this change won't fix anything. If its the latter we should really have a discussion with the service layer to see how we could not be throttled.
This masks the problem instead of fixing it.

# How Tested
CI will test.