### PR TITLE
disable beta ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: '14.x'
       # gets the matrix for ci run from the config file
       - id: get-matrix
-        run: echo "::set-output name=matrix::{\"include\":[{\"flavor\":\"stable\"},{\"flavor\":\"beta\"}]}"
+        run: echo "::set-output name=matrix::{\"include\":[{\"flavor\":\"stable\"}]}"
 
   build_packages:
     needs: get_matrix

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: '14.x'
       # gets the matrix for ci run from the config file
       - id: get-matrix
-        run: echo "::set-output name=matrix::{\"include\":[{\"flavor\":\"stable\"},{\"flavor\":\"beta\"}]}"
+        run: echo "::set-output name=matrix::{\"include\":[{\"flavor\":\"stable\"}]}"
 
   update_examples_snapshot:
     needs: get_matrix


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Disable the beta CI matrix and beta update snapshots
# Why
<!--- What problem does this change solve? -->
cherry picks will only run against the stable CI flavor
<!--- Provide a link if you are addressing an open issue. -->