### PR TITLE
Fix SendBox button when using VoiceOver on iOS

### DIFF
--- a/packages/react-components/src/components/InputBoxComponent.tsx
+++ b/packages/react-components/src/components/InputBoxComponent.tsx
@@ -23,7 +23,8 @@ import {
   inlineButtonsContainerStyle,
   newLineButtonsContainerStyle,
   inputBoxNewLineSpaceAffordance,
-  inputButtonTooltipStyle
+  inputButtonTooltipStyle,
+  iconWrapperStyle
 } from './styles/InputBoxComponent.style';
 
 import { isDarkThemed } from '../theming/themeUtils';
@@ -192,8 +193,9 @@ export const InputBoxButton = (props: InputBoxButtonProps): JSX.Element => {
         onMouseLeave={() => {
           setIsHover(false);
         }}
-        onRenderIcon={() => onRenderIcon(isHover)}
       />
+      {/* VoiceOver fix: Avoid rerender of element with onMouseEnter and onMouseLeave handlers by keeping rerendering icon separate */}
+      <div className={iconWrapperStyle}>{onRenderIcon(isHover)}</div>
     </TooltipHost>
   );
 };

--- a/packages/react-components/src/components/styles/InputBoxComponent.style.ts
+++ b/packages/react-components/src/components/styles/InputBoxComponent.style.ts
@@ -117,3 +117,8 @@ export const inputButtonTooltipStyle = mergeStyles({
   // The toolTip host container show be a flex box, so that alignItems: 'center' works for inside buttons
   display: 'flex'
 });
+
+/**
+ * @private
+ */
+export const iconWrapperStyle = mergeStyles({ position: 'absolute', pointerEvents: 'none' });


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fix SendBox button when using VoiceOver on iOS

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2791680

# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested while using VoiceOver on IPad by accessing app through ngrok tunnel. 
Also tested that SendBox button works as before on: 
- IPad without VoiceOver
- Desktop

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->