### PR TITLE
Update read me cd samples\Chat to cd samples/Chat

### DIFF
--- a/samples/Chat/README.md
+++ b/samples/Chat/README.md
@@ -47,7 +47,7 @@ Additional documentation for this sample can be found on [Microsoft Docs](https:
 1. Start the calling app
 
     ```bash
-    cd samples\Chat
+    cd samples/Chat
     rushx start
     ```
 

--- a/samples/Chat/README.md
+++ b/samples/Chat/README.md
@@ -26,8 +26,8 @@ Additional documentation for this sample can be found on [Microsoft Docs](https:
     git clone https://github.com/Azure/communication-ui-library.git
     ```
 
-1. Get the `Connection String` from the Azure portal. For more information on connection strings, see [Create an Azure Communication Resources](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource)
-1. Once you get the `Connection String`, add the connection string to the **samples/Server/appsetting.json** file found under the Chat folder. Input your connection string in the variable: `ResourceConnectionString`.
+1. Get the `Connection String` and `EndpointUrl` from the Azure portal. For more information on connection strings and EndpointUrl, see [Create an Azure Communication Resources](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource)
+1. Once you get the `Connection String` and `EndpointUrl`, add both strings to the **samples/Server/appsetting.json** file found under the Chat folder. Input your connection string in the variable: `ResourceConnectionString`. Input your endpoint url in the variable: `EndpointUrl`.
 
 ## Local run
 


### PR DESCRIPTION
# What
There is a typo on readme, should be cd samples/Chat not cd samples\Chat

# Why
https://github.com/Azure/communication-ui-library/issues/2020