### PR TITLE
Alkwa/fix contextmenu with lots of participants

### DIFF
--- a/change/@internal-react-components-7c06ef90-af09-401f-b2af-0759e489e806.json
+++ b/change/@internal-react-components-7c06ef90-af09-401f-b2af-0759e489e806.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "correctly setting maxHeight for people context menu",
+  "packageName": "@internal/react-components",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ParticipantsButton.tsx
+++ b/packages/react-components/src/components/ParticipantsButton.tsx
@@ -18,7 +18,7 @@ import {
   ParticipantListStyles,
   ParticipantMenuItemsCallback
 } from './ParticipantList';
-import { defaultParticipantListContainerStyle, participantsButtonMenuPropsStyle } from './styles/ControlBar.styles';
+import { participantsButtonMenuPropsStyle } from './styles/ControlBar.styles';
 import { useLocale } from '../localization';
 import { ControlBarButton, ControlBarButtonProps, ControlBarButtonStyles } from './ControlBarButton';
 import { useIdentifiers } from '../identifiers';
@@ -195,7 +195,7 @@ export const ParticipantsButton = (props: ParticipantsButtonProps): JSX.Element 
         onRenderAvatar={onRenderAvatar}
         onRemoveParticipant={onRemoveParticipant}
         onFetchParticipantMenuItems={onFetchParticipantMenuItems}
-        styles={merge(defaultParticipantListContainerStyle, styles?.menuStyles?.participantListStyles)}
+        styles={styles?.menuStyles?.participantListStyles}
         showParticipantOverflowTooltip={showParticipantOverflowTooltip}
       />
     );
@@ -299,6 +299,9 @@ export const ParticipantsButton = (props: ParticipantsButtonProps): JSX.Element 
                 // More info: https://github.com/microsoft/fluentui/issues/18835
                 maxWidth: '100%'
               }
+            },
+            style: {
+              maxHeight: '20rem'
             },
             // Disable dismiss on resize to work around a couple Fluent UI bugs
             // See reasoning in the props for the parent menu.

--- a/packages/react-components/src/components/styles/ControlBar.styles.ts
+++ b/packages/react-components/src/components/styles/ControlBar.styles.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { IStyle, IButtonStyles, IContextualMenuStyles, IContextualMenuItemStyles } from '@fluentui/react';
-import { ParticipantListStyles } from '../ParticipantList';
 
 interface IControlBarStyles {
   horizontal: IStyle;
@@ -156,15 +155,6 @@ export const participantsButtonMenuPropsStyle: Partial<IContextualMenuStyles> = 
     paddingLeft: '.5rem',
     fontWeight: 600,
     fontSize: '.75rem'
-  }
-};
-
-/**
- * @private
- */
-export const defaultParticipantListContainerStyle: ParticipantListStyles = {
-  root: {
-    maxHeight: '20rem'
   }
 };
 


### PR DESCRIPTION
# What
When there are too many participants it can mess up how things scroll when there is a divider. The divider and other elements will overlap the participants in the context menu

# Why
The max-height css property is incorrectly set on the wrong component. We should be setting it on the context menu as opposed to the stack that contains all of the participant elements

Before: 
![withoutfix](https://user-images.githubusercontent.com/79329532/176361770-7982b83c-70bc-462d-8936-850b0eebaf52.gif)

After:
![withFix](https://user-images.githubusercontent.com/79329532/176361787-cccd01d4-8726-43aa-89eb-473587eca58c.gif)

# How Tested
Loaded up a UI component in storybook and added some HTML elements 

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->