### PR TITLE
Add 100% height to Chat component in MessageThread to prevent invalid…

### DIFF
--- a/packages/react-components/src/components/styles/MessageThread.styles.ts
+++ b/packages/react-components/src/components/styles/MessageThread.styles.ts
@@ -50,7 +50,10 @@ export const chatStyle: ComponentSlotStyle = {
   paddingBottom: '0.5rem',
   paddingTop: '0.8rem',
   border: 'none',
-  overflow: 'auto'
+  overflow: 'auto',
+  // `height: 100%` ensures that the Chat component covers 100% of it's parents height
+  // to prevent intermittent scrollbars when gifs are present in the chat.
+  height: '100%'
 };
 
 /**


### PR DESCRIPTION
# What
Prevent invalid scrollbars from appearing in Message Thread Chat when Gif images are shared.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->