### PR TITLE
Changed z-index so new message button shows on top of chat bubble

### DIFF
--- a/change/@internal-react-components-2fe1fb24-49b7-43c5-99fd-a48c0348cf53.json
+++ b/change/@internal-react-components-2fe1fb24-49b7-43c5-99fd-a48c0348cf53.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "changed z-index so new message button shows ontop of chat bubble",
+  "packageName": "@internal/react-components",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/MessageThread.styles.ts
+++ b/packages/react-components/src/components/styles/MessageThread.styles.ts
@@ -61,7 +61,7 @@ export const chatStyle: ComponentSlotStyle = {
  */
 export const newMessageButtonContainerStyle = mergeStyles({
   position: 'absolute',
-  zIndex: 1,
+  zIndex: 2,
   bottom: 0,
   right: '1.5rem'
 });

--- a/packages/react-components/src/components/styles/MessageThread.styles.ts
+++ b/packages/react-components/src/components/styles/MessageThread.styles.ts
@@ -21,6 +21,8 @@ const MESSAGE_AMOUNT_OUT_FROM_EDGE_REM = 2;
 const MESSAGE_AVATAR_OVERLAP_REM = 0.425;
 const CHAT_MESSAGE_ZINDEX = 1;
 const AVATAR_ZINDEX = 2;
+// new message button should be on top of chat message
+const NEW_MESSAGE_BUTTON_ZINDEX = 2;
 
 /**
  * @private
@@ -61,7 +63,7 @@ export const chatStyle: ComponentSlotStyle = {
  */
 export const newMessageButtonContainerStyle = mergeStyles({
   position: 'absolute',
-  zIndex: 2,
+  zIndex: NEW_MESSAGE_BUTTON_ZINDEX,
   bottom: 0,
   right: '1.5rem'
 });


### PR DESCRIPTION
# What
Changed z-index so new message button shows on top of chat bubble

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/2915516

# How Tested
<img width="834" alt="Screen Shot 2022-07-05 at 11 10 20 PM" src="https://user-images.githubusercontent.com/96077406/177485264-aa794e68-2489-4d74-9fa6-e9d0ab5b1cfe.png">
