### PR TITLE
[DraftPR] Add Callback for removing participant in PeoplePaneContent

### DIFF
--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
@@ -91,9 +91,23 @@ export const CallWithChatPane = (props: {
     />
   );
 
+  /**
+   * In a CallWithChat when a participant is removed, we must remove them from both
+   * the call and the chat thread.
+   */
+  const removeParticipantFromCallWithChat = async (participantId: string): Promise<void> => {
+    await props.callAdapter.removeParticipant(participantId);
+    await props.chatAdapter.removeParticipant(participantId);
+  };
+
   const peopleContent = (
     <CallAdapterProvider adapter={props.callAdapter}>
-      <PeoplePaneContent {...props} setDrawerMenuItems={setDrawerMenuItems} strings={callWithChatStrings} />
+      <PeoplePaneContent
+        {...props}
+        onRemoveParticipant={removeParticipantFromCallWithChat}
+        setDrawerMenuItems={setDrawerMenuItems}
+        strings={callWithChatStrings}
+      />
     </CallAdapterProvider>
   );
 

--- a/packages/react-composites/src/composites/CallWithChatComposite/PeoplePaneContent.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/PeoplePaneContent.tsx
@@ -11,9 +11,7 @@ import {
 import copy from 'copy-to-clipboard';
 import React, { useMemo } from 'react';
 import { CallWithChatCompositeStrings } from '.';
-import { CallAdapter } from '../CallComposite';
 import { usePropsFor } from '../CallComposite/hooks/usePropsFor';
-import { ChatAdapter } from '../ChatComposite';
 import { AvatarPersonaDataCallback } from '../common/AvatarPersona';
 import { CallWithChatCompositeIcon } from '../common/icons';
 import { ParticipantListWithHeading } from '../common/ParticipantContainer';
@@ -32,15 +30,14 @@ import {
  */
 export const PeoplePaneContent = (props: {
   inviteLink?: string;
-  callAdapter: CallAdapter;
-  chatAdapter: ChatAdapter;
+  onRemoveParticipant: (participantId: string) => void;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
   strings: CallWithChatCompositeStrings;
   setDrawerMenuItems: (_DrawerMenuItemProps) => void;
   mobileView?: boolean;
 }): JSX.Element => {
-  const { callAdapter, chatAdapter, inviteLink, onFetchParticipantMenuItems, setDrawerMenuItems, strings } = props;
+  const { inviteLink, onFetchParticipantMenuItems, setDrawerMenuItems, strings } = props;
 
   const participantListDefaultProps = usePropsFor(ParticipantList);
 
@@ -76,7 +73,7 @@ export const PeoplePaneContent = (props: {
 
   const participantListProps: ParticipantListProps = useMemo(() => {
     const onRemoveParticipant = async (participantId: string): Promise<void> =>
-      removeParticipantFromCallWithChat(callAdapter, chatAdapter, participantId);
+      props.onRemoveParticipant(participantId);
     return {
       ...participantListDefaultProps,
       // Passing undefined callback for mobile to avoid context menus for participants in ParticipantList are clicked
@@ -84,7 +81,7 @@ export const PeoplePaneContent = (props: {
       // We want the drawer menu items to appear when participants in ParticipantList are clicked
       onParticipantClick: props.mobileView ? setDrawerMenuItemsForParticipant : undefined
     };
-  }, [participantListDefaultProps, props.mobileView, setDrawerMenuItemsForParticipant, callAdapter, chatAdapter]);
+  }, [participantListDefaultProps, props.mobileView, setDrawerMenuItemsForParticipant, props.onRemoveParticipant]);
 
   const participantList = (
     <ParticipantListWithHeading
@@ -143,19 +140,6 @@ export const PeoplePaneContent = (props: {
       {participantList}
     </Stack>
   );
-};
-
-/**
- * In a CallWithChat when a participant is removed, we must remove them from both
- * the call and the chat thread.
- */
-const removeParticipantFromCallWithChat = async (
-  callAdapter: CallAdapter,
-  chatAdapter: ChatAdapter,
-  participantId: string
-): Promise<void> => {
-  await callAdapter.removeParticipant(participantId);
-  await chatAdapter.removeParticipant(participantId);
 };
 
 /**


### PR DESCRIPTION
# What
Add callback for removing participants in PeoplePane in CallWithChat.
Removing CallAdapter and ChatAdapter specific props and replaced with onRemoveParticipant callback.

# Why
Proof of concept.
Working on Possible solutions to bring Call Composite and CallWIthChat Composite into parity.
ChatAdapter is not needed for Call Composite but is needed for CallWithChat Composite.

In order to make PeoplePaneContent a common file to be used in both composites, we need to remove composite specific dependencies.

# How Tested
Tested Locally on MacOS on multiple browsers removing participants.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->