### PR TITLE
Fixed bug where voice over is not announcing menu item checked 

### DIFF
--- a/change/@internal-react-components-e8878b2e-95c0-441d-a922-4e347a14f81b.json
+++ b/change/@internal-react-components-e8878b2e-95c0-441d-a922-4e347a14f81b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed bug where voice over does not annouce menu item selected in both calling and callwithchat",
+  "packageName": "@internal/react-components",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/DevicesButton.tsx
+++ b/packages/react-components/src/components/DevicesButton.tsx
@@ -289,7 +289,6 @@ export const generateDefaultDeviceMenuProps = (
           itemProps: {
             styles: menuItemStyles
           },
-          role: 'menuitem',
           canCheck: true,
           isChecked: camera.id === selectedCamera?.id,
           onClick: () => {
@@ -324,7 +323,6 @@ export const generateDefaultDeviceMenuProps = (
           itemProps: {
             styles: menuItemStyles
           },
-          role: 'menuitem',
           canCheck: true,
           isChecked: microphone.id === selectedMicrophone?.id,
           onClick: () => {
@@ -352,7 +350,6 @@ export const generateDefaultDeviceMenuProps = (
           itemProps: {
             styles: menuItemStyles
           },
-          role: 'menuitem',
           canCheck: true,
           isChecked: speaker.id === selectedSpeaker?.id,
           onClick: () => {


### PR DESCRIPTION
# What
Fixed bug where voice over is not announcing menu item checked 

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/2908125

# How Tested

<img width="693" alt="Screen Shot 2022-07-08 at 12 41 57 PM" src="https://user-images.githubusercontent.com/96077406/178060600-501e3dc3-faa4-4d27-8512-5b5b2d76b6fe.png">
est your change.
