### PR TITLE
Start Call button no longer actionable with 0 microphones.

### DIFF
--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -30,6 +30,7 @@ import {
 import { useLocale } from '../../localization';
 import { bannerNotificationStyles } from '../styles/CallPage.styles';
 import { usePropsFor } from '../hooks/usePropsFor';
+import { useAdapter } from '../adapter/CallAdapterProvider';
 
 /**
  * @private
@@ -49,7 +50,8 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
   const localDeviceSettingsHandlers = useHandlers(LocalDeviceSettings);
   const { video: cameraPermissionGranted, audio: microphonePermissionGranted } = useSelector(devicePermissionSelector);
   const errorBarProps = usePropsFor(ErrorBar);
-
+  const adapter = useAdapter();
+  const deviceState = adapter.getState().devices;
   const locale = useLocale();
   const title = (
     <Stack.Item className={mobileView ? titleContainerStyleMobile : titleContainerStyleDesktop}>
@@ -101,7 +103,7 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
             <StartCallButton
               className={mobileView ? startCallButtonStyleMobile : undefined}
               onClick={startCallHandler}
-              disabled={!microphonePermissionGranted}
+              disabled={!microphonePermissionGranted || deviceState.microphones?.length === 0}
             />
           </Stack>
         </Stack>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Tracks the number of microphones available on a device
# Why
<!--- What problem does this change solve? -->
Blocks the start call button if the number of microphones hits 0
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2883789
# How Tested
<!--- How did you test your change. What tests have you added. -->
locally checked configuration screens microphone count when unplugging and plugging back in a microphone device.