### PR TITLE
Disable two very flakey e2e tests and disable internal retries

### DIFF
--- a/change/@internal-react-composites-67e017a7-8fcf-4b2c-8ea4-5f152b1634fd.json
+++ b/change/@internal-react-composites-67e017a7-8fcf-4b2c-8ea4-5f152b1634fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Disable flakey e2e tests and drop retries",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/playwright.config.hermetic.ts
+++ b/packages/react-composites/playwright.config.hermetic.ts
@@ -11,10 +11,7 @@ const config: PlaywrightTestConfig = {
   workers: process.env.CI ? 3 : undefined,
 
   // All these tests are hermetic. It is safe to run them in parallel.
-  fullyParallel: true,
-
-  // TODO(prprabhu): Remove retries once super flakey tests are fixed or removed.
-  retries: 2
+  fullyParallel: true
 };
 
 export default config;

--- a/packages/react-composites/tests/browser/chat/fake-adapter/ReadReceipt.test.ts
+++ b/packages/react-composites/tests/browser/chat/fake-adapter/ReadReceipt.test.ts
@@ -10,7 +10,9 @@ import { dataUiId, stableScreenshot, stubReadReceiptsToolTip, waitForSelector } 
 import { buildUrlForChatAppUsingFakeAdapter, DEFAULT_FAKE_CHAT_ADAPTER_ARGS, test } from './fixture';
 
 test.describe('Chat Composite E2E Tests', () => {
-  test('participant can receive message and send readReceipt to message sender', async ({ serverUrl, page }) => {
+  // FIXME: This test is very flakey. It fails >25% of the times post-submit (on `main`).
+  // TODO(https://skype.visualstudio.com/SPOOL/_workitems/edit/2925017): Stabilize and re-enable.
+  test.skip('participant can receive message and send readReceipt to message sender', async ({ serverUrl, page }) => {
     const messageReader = DEFAULT_FAKE_CHAT_ADAPTER_ARGS.remoteParticipants[0];
     page.goto(
       buildUrlForChatAppUsingFakeAdapter(serverUrl, {
@@ -34,7 +36,9 @@ test.describe('Chat Composite E2E Tests', () => {
     expect(await page.screenshot()).toMatchSnapshot('read-message-tooltip-text.png');
   });
 
-  test('participant can receive read receipts and readers should show in contextual menu', async ({
+  // FIXME: This test is very flakey. It fails >25% of the times post-submit (on `main`).
+  // TODO(https://skype.visualstudio.com/SPOOL/_workitems/edit/2925017): Stabilize and re-enable.
+  test.skip('participant can receive read receipts and readers should show in contextual menu', async ({
     serverUrl,
     page
   }) => {


### PR DESCRIPTION
# 🚧 Work In Progress  🚧 

* Ferret out all the flakey hermetic tests.
* Disable those tests, file bugs.
* Fix flakey tests, then reenable them.

# Why

See https://skype.visualstudio.com/SPOOL/_workitems/edit/2925017 for context. That bug also tracks stabilizing and re-enabling the disabled tests.

Internal retries for hermetic tests have two very real costs:

* Longer CI times due to retries.
* Lower e2e test quality because we paper over flakey tests.

In the future, we will aggressively disable any flakey tests instead of retrying internally and then re-enable them once they are stabilized.