### PR TITLE
Ask device permissions based on role

### DIFF
--- a/packages/react-composites/src/composites/CallComposite/CallComposite.test.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.test.tsx
@@ -5,7 +5,7 @@ import { registerIcons } from '@fluentui/react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
-import { MockCallAdapter } from '../../../tests/browser/call/app/mocks/MockCallAdapter';
+import { MockCallAdapter } from './MockCallAdapter';
 import { CallComposite } from './CallComposite';
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.test.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.test.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { registerIcons } from '@fluentui/react';
+import Enzyme, { mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import { MockCallAdapter } from '../../../tests/browser/call/app/mocks/MockCallAdapter';
+import { CallComposite } from './CallComposite';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('CallComposite device permission test for different roles', () => {
+  let audioDevicePermissionRequests = 0;
+  let videoDevicePermissionRequests = 0;
+
+  const countDevicePermissionRequests = async (constrain: { audio: boolean; video: boolean }): Promise<void> => {
+    if (constrain.video) {
+      videoDevicePermissionRequests++;
+    }
+    if (constrain.audio) {
+      audioDevicePermissionRequests++;
+    }
+  };
+  const adapter = new MockCallAdapter({ askDevicePermission: countDevicePermissionRequests });
+
+  beforeEach(() => {
+    // Register icons used in CallComposite to avoid warnings
+    registerIcons({
+      icons: {
+        chevrondown: <></>
+      }
+    });
+
+    // Reset permission request counters to 0
+    audioDevicePermissionRequests = 0;
+    videoDevicePermissionRequests = 0;
+  });
+
+  test('Audio and video device permission should be requested for Presenter role', async () => {
+    mount(<CallComposite adapter={adapter} role={'Presenter'} />);
+    expect(audioDevicePermissionRequests).toBe(1);
+    expect(videoDevicePermissionRequests).toBe(1);
+  });
+
+  test('Audio and video device permission should be requested for Attendee role', async () => {
+    mount(<CallComposite adapter={adapter} role={'Attendee'} />);
+    expect(audioDevicePermissionRequests).toBe(1);
+    expect(videoDevicePermissionRequests).toBe(1);
+  });
+
+  test('Only audio device permission should be requested for Consumer role', async () => {
+    mount(<CallComposite adapter={adapter} role={'Consumer'} />);
+    expect(audioDevicePermissionRequests).toBe(1);
+    expect(videoDevicePermissionRequests).toBe(0);
+  });
+});

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.test.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.test.tsx
@@ -37,6 +37,12 @@ describe('CallComposite device permission test for different roles', () => {
     videoDevicePermissionRequests = 0;
   });
 
+  test('Audio and video device permission should be requested when no role is assigned', async () => {
+    mount(<CallComposite adapter={adapter} />);
+    expect(audioDevicePermissionRequests).toBe(1);
+    expect(videoDevicePermissionRequests).toBe(1);
+  });
+
   test('Audio and video device permission should be requested for Presenter role', async () => {
     mount(<CallComposite adapter={adapter} role={'Presenter'} />);
     expect(audioDevicePermissionRequests).toBe(1);

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -194,12 +194,17 @@ export const CallComposite = (props: CallCompositeProps): JSX.Element => {
   } = props;
   useEffect(() => {
     (async () => {
-      await adapter.askDevicePermission({ video: true, audio: true });
-      adapter.queryCameras();
-      adapter.queryMicrophones();
+      if (role === 'Consumer') {
+        // Need to ask for audio devices to get access to speakers
+        await adapter.askDevicePermission({ video: false, audio: true });
+      } else {
+        await adapter.askDevicePermission({ video: true, audio: true });
+        adapter.queryCameras();
+        adapter.queryMicrophones();
+      }
       adapter.querySpeakers();
     })();
-  }, [adapter]);
+  }, [adapter, role]);
 
   const mobileView = formFactor === 'mobile';
 

--- a/packages/react-composites/src/composites/CallComposite/MockCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/MockCallAdapter.ts
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AudioDeviceInfo, Call, PermissionConstraints, VideoDeviceInfo } from '@azure/communication-calling';
+import { CallAdapter, CallAdapterState } from './adapter';
+
+/**
+ * Temporary copy of the packages\react-composites\tests\browser\call\app\mocks\MockCallAdapter.ts
+ */
+// TODO: Remove this simplified copy of the MockCallAdapter when the original MockCallAdapter is moved to fake-backends package
+export class MockCallAdapter implements CallAdapter {
+  constructor(testState: { askDevicePermission?: (constrain: PermissionConstraints) => Promise<void> }) {
+    this.state = defaultCallAdapterState;
+
+    if (testState.askDevicePermission) {
+      this.askDevicePermission = testState.askDevicePermission;
+    }
+  }
+
+  state: CallAdapterState;
+
+  addParticipant(): Promise<void> {
+    throw Error('addParticipant not implemented');
+  }
+  onStateChange(): void {
+    return;
+  }
+  offStateChange(): void {
+    return;
+  }
+  getState(): CallAdapterState {
+    return this.state;
+  }
+  dispose(): void {
+    throw Error('dispose not implemented');
+  }
+  joinCall(): Call | undefined {
+    throw Error('joinCall not implemented');
+  }
+  leaveCall(): Promise<void> {
+    throw Error('leaveCall not implemented');
+  }
+  startCamera(): Promise<void> {
+    throw Error('leaveCall not implemented');
+  }
+  stopCamera(): Promise<void> {
+    throw Error('stopCamera not implemented');
+  }
+  mute(): Promise<void> {
+    throw Error('mute not implemented');
+  }
+  unmute(): Promise<void> {
+    throw Error('unmute not implemented');
+  }
+  startCall(): Call | undefined {
+    throw Error('startCall not implemented');
+  }
+  holdCall(): Promise<void> {
+    return Promise.resolve();
+  }
+  resumeCall(): Promise<void> {
+    return Promise.resolve();
+  }
+  startScreenShare(): Promise<void> {
+    throw Error('startScreenShare not implemented');
+  }
+  stopScreenShare(): Promise<void> {
+    throw Error('stopScreenShare not implemented');
+  }
+  removeParticipant(): Promise<void> {
+    throw Error('removeParticipant not implemented');
+  }
+  createStreamView(): Promise<void> {
+    throw Error('createStreamView not implemented');
+  }
+  disposeStreamView(): Promise<void> {
+    throw Error('disposeStreamView not implemented');
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  askDevicePermission(constrain: PermissionConstraints): Promise<void> {
+    throw Error('askDevicePermission not implemented');
+  }
+  async queryCameras(): Promise<VideoDeviceInfo[]> {
+    return [];
+  }
+  async queryMicrophones(): Promise<AudioDeviceInfo[]> {
+    return [];
+  }
+  async querySpeakers(): Promise<AudioDeviceInfo[]> {
+    return [];
+  }
+  setCamera(): Promise<void> {
+    throw Error('setCamera not implemented');
+  }
+  setMicrophone(): Promise<void> {
+    throw Error('setMicrophone not implemented');
+  }
+  setSpeaker(): Promise<void> {
+    throw Error('setSpeaker not implemented');
+  }
+  on(): void {
+    throw Error('on not implemented');
+  }
+  off(): void {
+    throw Error('off not implemented');
+  }
+}
+
+/**
+ * Default call adapter state that the {@link MockCallAdapter} class is initialized with
+ */
+const defaultCallAdapterState: CallAdapterState = {
+  displayName: 'Agnes Thompson',
+  isLocalPreviewMicrophoneEnabled: true,
+  page: 'call',
+  call: {
+    id: 'call1',
+    callerInfo: { displayName: 'caller', identifier: { kind: 'communicationUser', communicationUserId: '1' } },
+    direction: 'Incoming',
+    transcription: { isTranscriptionActive: false },
+    recording: { isRecordingActive: false },
+    startTime: new Date(500000000000),
+    endTime: new Date(500000000000),
+    diagnostics: { network: { latest: {} }, media: { latest: {} } },
+    state: 'Connected',
+    localVideoStreams: [],
+    isMuted: false,
+    isScreenSharingOn: false,
+    remoteParticipants: {},
+    remoteParticipantsEnded: {}
+  },
+  userId: { kind: 'communicationUser', communicationUserId: '1' },
+  devices: {
+    isSpeakerSelectionAvailable: true,
+    selectedCamera: { id: 'camera1', name: '1st Camera', deviceType: 'UsbCamera' },
+    cameras: [{ id: 'camera1', name: '1st Camera', deviceType: 'UsbCamera' }],
+    selectedMicrophone: {
+      id: 'microphone1',
+      name: '1st Microphone',
+      deviceType: 'Microphone',
+      isSystemDefault: true
+    },
+    microphones: [{ id: 'microphone1', name: '1st Microphone', deviceType: 'Microphone', isSystemDefault: true }],
+    selectedSpeaker: { id: 'speaker1', name: '1st Speaker', deviceType: 'Speaker', isSystemDefault: true },
+    speakers: [{ id: 'speaker1', name: '1st Speaker', deviceType: 'Speaker', isSystemDefault: true }],
+    unparentedViews: [],
+    deviceAccess: { video: true, audio: true }
+  },
+  isTeamsCall: false,
+  latestErrors: {}
+};

--- a/packages/react-composites/tests/browser/call/TestCallingState.ts
+++ b/packages/react-composites/tests/browser/call/TestCallingState.ts
@@ -4,7 +4,11 @@
 // @azure/communication-calling makes reference to the window object at import time so cannot be directly
 // imported here because tests are run in a node environment (which does not have a window object.)
 // Instead ensure we only import types.
-import type { LatestMediaDiagnostics, LatestNetworkDiagnostics } from '@azure/communication-calling';
+import type {
+  LatestMediaDiagnostics,
+  LatestNetworkDiagnostics,
+  PermissionConstraints
+} from '@azure/communication-calling';
 import type { DeviceManagerState } from '@internal/calling-stateful-client';
 
 // Redeclare runtime values from the calling sdk package to above the issue mentioned above where the calling
@@ -25,6 +29,7 @@ export type TestCallingState = {
   diagnostics?: TestDiagnostics;
   latestErrors?: AdapterErrors;
   devices?: Partial<DeviceManagerState>;
+  askDevicePermission?: (constrain: PermissionConstraints) => Promise<void>;
 };
 
 /**

--- a/packages/react-composites/tests/browser/call/app/mocks/MockCallAdapter.ts
+++ b/packages/react-composites/tests/browser/call/app/mocks/MockCallAdapter.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { AudioDeviceInfo, Call, VideoDeviceInfo } from '@azure/communication-calling';
+import { AudioDeviceInfo, Call, PermissionConstraints, VideoDeviceInfo } from '@azure/communication-calling';
 import { merge } from '@fluentui/react';
 import {
   LocalVideoStreamState,
@@ -52,11 +52,15 @@ export class MockCallAdapter implements CallAdapter {
     initialState.devices = merge(initialState.devices, testState.devices);
 
     this.state = initialState;
+
+    if (testState.askDevicePermission) {
+      this.askDevicePermission = testState.askDevicePermission;
+    }
   }
 
   state: CallAdapterState;
 
-  addParticipant(): void {
+  addParticipant(): Promise<void> {
     throw Error('addParticipant not implemented');
   }
   onStateChange(): void {
@@ -92,6 +96,12 @@ export class MockCallAdapter implements CallAdapter {
   startCall(): Call | undefined {
     throw Error('startCall not implemented');
   }
+  holdCall(): Promise<void> {
+    return Promise.resolve();
+  }
+  resumeCall(): Promise<void> {
+    return Promise.resolve();
+  }
   startScreenShare(): Promise<void> {
     throw Error('startScreenShare not implemented');
   }
@@ -107,7 +117,8 @@ export class MockCallAdapter implements CallAdapter {
   disposeStreamView(): Promise<void> {
     throw Error('disposeStreamView not implemented');
   }
-  askDevicePermission(): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  askDevicePermission(constrain: PermissionConstraints): Promise<void> {
     throw Error('askDevicePermission not implemented');
   }
   async queryCameras(): Promise<VideoDeviceInfo[]> {

--- a/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
@@ -1,6 +1,7 @@
 import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from '@azure/communication-common';
 import {
   CallAdapter,
+  CallAdapterLocator,
   CallComposite,
   CallCompositeOptions,
   CompositeLocale,
@@ -24,7 +25,7 @@ export type ContainerProps = {
 const isTeamsMeetingLink = (link: string): boolean => link.startsWith('https://teams.microsoft.com/l/meetup-join');
 const isGroupLink = (link: string): boolean => link.indexOf('-') !== -1;
 
-const createLocator = (link: string) => {
+const createLocator = (link: string): CallAdapterLocator => {
   if (isTeamsMeetingLink(link)) {
     return { meetingLink: link };
   } else if (isGroupLink(link)) {

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -120,7 +120,7 @@ const App = (): JSX.Element => {
             if ('roomId' in callLocator) {
               if (userId) {
                 setRole(callDetails.role as Role);
-                await joinRoom(userId.communicationUserId, callLocator.roomId, callDetails.role ?? '');
+                await joinRoom(userId.communicationUserId, callLocator.roomId, callDetails.role as Role);
               } else {
                 throw 'Invalid userId!';
               }

--- a/samples/Calling/src/app/utils/AppUtils.ts
+++ b/samples/Calling/src/app/utils/AppUtils.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { GroupLocator, RoomLocator, TeamsMeetingLinkLocator } from '@azure/communication-calling';
+import { Role } from '@internal/react-components';
 import { v1 as generateGUID } from 'uuid';
 
 /**
@@ -59,7 +60,7 @@ export const createRoomId = async (): Promise<string> => {
  * Joins an ACS room with a given roomId and role
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const joinRoom = async (userId: string, roomId: string, role): Promise<void> => {
+export const joinRoom = async (userId: string, roomId: string, role: Role): Promise<void> => {
   const requestOptions = {
     method: 'POST',
     headers: {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
If role is Consumer, then only request for audio permissions. 

- Need to do access audio devices to show speaker options in dropdown. 
- Also we disable the 'Start Call' button in the configuration page if microphonePermissionGranted is false.

Request for audio and video permissions for other roles or no role at all.

Let me know if there are changes needed.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2919171
https://skype.visualstudio.com/SPOOL/_workitems/edit/2919172

# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested on local rooms sample:
https://user-images.githubusercontent.com/79475487/179336360-790989e5-52b0-4dd6-8c63-68a690aa8088.mp4
Note: There is a ComplianceBanner showing camera device permissions are not granted for the Consumer role. This probably is confusing for the user. Let me know if I should remove this in this PR or another PR.

Also added unit tests

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->