### PR TITLE
Delete an unused rush sub-command

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -59,14 +59,6 @@
     },
     {
       "commandKind": "global",
-      "name": "install:stable",
-      "summary": "Install dependencies for stable version.",
-      "description": "Install dependencies for stable version.",
-      "shellCommand": "rush install --variant stable",
-      "safeForSimultaneousRushProcesses": true
-    },
-    {
-      "commandKind": "global",
       "name": "build:all-flavors",
       "summary": "Build all packages for all flavors in one command",
       "description": "Build all packages for all flavors in one command. This command will switch current flavor to beta.",


### PR DESCRIPTION

# Why

Every subcommand listed by `rush --help` adds cognitive load.

`rush install:stable` is neither used by scripts, nor necessary for devs. Devs always use `rush switch-flavor:stable` instead.