### PR TITLE
Rename buildUrlWithMockAdapterNext to buildUrlWithMockAdapter

### DIFF
--- a/packages/react-composites/tests/browser/call/hermetic/CallControls.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/CallControls.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { buildUrlWithMockAdapterNext, defaultMockCallAdapterState, test } from './fixture';
+import { buildUrlWithMockAdapter, defaultMockCallAdapterState, test } from './fixture';
 import { expect } from '@playwright/test';
 import { dataUiId, stableScreenshot, waitForSelector } from '../../common/utils';
 import { IDS } from '../../common/constants';
@@ -10,7 +10,7 @@ test.describe('CallControls tests', async () => {
   test('CallControls when number of mics drops to zero', async ({ page, serverUrl }) => {
     const initialState = defaultMockCallAdapterState();
     initialState.devices.microphones = [];
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('no-mics.png');
   });
@@ -18,7 +18,7 @@ test.describe('CallControls tests', async () => {
   test('CallControls when number of available cameras drops to zero', async ({ page, serverUrl }) => {
     const initialState = defaultMockCallAdapterState();
     initialState.devices.cameras = [];
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('no-videos.png');
   });

--- a/packages/react-composites/tests/browser/call/hermetic/ErrorBar.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/ErrorBar.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { buildUrlWithMockAdapterNext, defaultMockCallAdapterState, test } from './fixture';
+import { buildUrlWithMockAdapter, defaultMockCallAdapterState, test } from './fixture';
 import { expect, Page } from '@playwright/test';
 import { dataUiId, stableScreenshot, waitForSelector } from '../../common/utils';
 import { IDS } from '../../common/constants';
@@ -18,7 +18,7 @@ test.describe('Error bar tests', async () => {
         innerError: new Error('Inner error of failure to start video')
       }
     };
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
@@ -44,7 +44,7 @@ test.describe('Error bar tests', async () => {
         innerError: new Error('Inner error of failure to stop video')
       }
     };
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('multiple-errors-on-error-bar.png');
     await dismissFirstErrorOnErrorBar(page);

--- a/packages/react-composites/tests/browser/call/hermetic/HorizontalGallery.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/HorizontalGallery.test.ts
@@ -3,7 +3,7 @@
 
 import {
   addVideoStream,
-  buildUrlWithMockAdapterNext,
+  buildUrlWithMockAdapter,
   defaultMockCallAdapterState,
   defaultMockRemoteParticipant,
   test
@@ -22,7 +22,7 @@ test.describe('HorizontalGallery tests', async () => {
 
     const participants = [paul, defaultMockRemoteParticipant('Eryka Klein'), fiona];
     const initialState = defaultMockCallAdapterState(participants);
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
@@ -56,7 +56,7 @@ test.describe('HorizontalGallery tests', async () => {
       defaultMockRemoteParticipant('Gerald Ho')
     ];
     const initialState = defaultMockCallAdapterState(participants);
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(

--- a/packages/react-composites/tests/browser/call/hermetic/LoadingVideo.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/LoadingVideo.test.ts
@@ -7,7 +7,7 @@ import { stableScreenshot, waitForSelector, dataUiId } from '../../common/utils'
 import {
   addScreenshareStream,
   addVideoStream,
-  buildUrlWithMockAdapterNext,
+  buildUrlWithMockAdapter,
   defaultMockCallAdapterState,
   defaultMockRemoteParticipant,
   test
@@ -24,7 +24,7 @@ test.describe('Loading Video Spinner tests', async () => {
       return participant;
     });
     const initialState = defaultMockCallAdapterState(participants);
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     expect(await stableScreenshot(page, { dismissTooltips: true, hideVideoLoadingSpinner: false })).toMatchSnapshot(
@@ -38,7 +38,7 @@ test.describe('Loading Video Spinner tests', async () => {
     const horizontalGalleryParticipant = defaultMockRemoteParticipant('Horizontal Gallery User');
     addVideoStream(horizontalGalleryParticipant, false);
     const initialState = defaultMockCallAdapterState([screenSharingParticipant, horizontalGalleryParticipant]);
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     expect(await stableScreenshot(page, { dismissTooltips: true, hideVideoLoadingSpinner: false })).toMatchSnapshot(

--- a/packages/react-composites/tests/browser/call/hermetic/PageState.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/PageState.test.ts
@@ -3,27 +3,27 @@
 
 import { expect } from '@playwright/test';
 import { stableScreenshot, waitForPageFontsLoaded, waitForSelector, dataUiId } from '../../common/utils';
-import { buildUrlWithMockAdapterNext, defaultMockCallAdapterState, test } from './fixture';
+import { buildUrlWithMockAdapter, defaultMockCallAdapterState, test } from './fixture';
 
 test.describe('Page state tests', async () => {
   test('Page when waiting in lobby', async ({ page, serverUrl }) => {
     const initialState = defaultMockCallAdapterState();
     initialState.page = 'lobby';
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('lobby-page.png');
   });
   test('Page when access is denied', async ({ page, serverUrl }) => {
     const initialState = defaultMockCallAdapterState();
     initialState.page = 'accessDeniedTeamsMeeting';
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('access-denied-page.png');
   });
   test('Page when join call failed due to network', async ({ page, serverUrl }) => {
     const initialState = defaultMockCallAdapterState();
     initialState.page = 'joinCallFailedDueToNoNetwork';
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
       'call-failed-due-to-network-page.png'
@@ -32,14 +32,14 @@ test.describe('Page state tests', async () => {
   test('Page when local participant left call', async ({ page, serverUrl }) => {
     const initialState = defaultMockCallAdapterState();
     initialState.page = 'leftCall';
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('left-call-page.png');
   });
   test('Page when local participant is removed from call', async ({ page, serverUrl }) => {
     const initialState = defaultMockCallAdapterState();
     initialState.page = 'removedFromCall';
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForPageFontsLoaded(page);
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('removed-from-call-page.png');

--- a/packages/react-composites/tests/browser/call/hermetic/Screenshare.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/Screenshare.test.ts
@@ -4,7 +4,7 @@
 import {
   addScreenshareStream,
   addVideoStream,
-  buildUrlWithMockAdapterNext,
+  buildUrlWithMockAdapter,
   defaultMockCallAdapterState,
   defaultMockRemoteParticipant,
   test
@@ -42,7 +42,7 @@ test.describe('Screenshare tests', async () => {
     ];
     const initialState = defaultMockCallAdapterState(participants);
     (initialState.call as MockCallState).isScreenSharingOn = true;
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('local-screenshare.png');
@@ -74,7 +74,7 @@ test.describe('Screenshare tests', async () => {
       fiona
     ];
     const initialState = defaultMockCallAdapterState(participants);
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(

--- a/packages/react-composites/tests/browser/call/hermetic/UserFacingDiagnostics.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/UserFacingDiagnostics.test.ts
@@ -3,7 +3,7 @@
 
 import { expect } from '@playwright/test';
 import { dataUiId, waitForSelector, stableScreenshot } from '../../common/utils';
-import { buildUrlWithMockAdapterNext, defaultMockCallAdapterState, test } from './fixture';
+import { buildUrlWithMockAdapter, defaultMockCallAdapterState, test } from './fixture';
 import type { LatestMediaDiagnostics, LatestNetworkDiagnostics } from '@azure/communication-calling';
 import type { MockCallAdapterState } from '../MockCallAdapterState';
 import { DiagnosticQuality } from './constants';
@@ -14,7 +14,7 @@ test.describe('User Facing Diagnostics tests', async () => {
     setMediaDiagnostic(initialState, {
       speakingWhileMicrophoneIsMuted: { value: true, valueType: 'DiagnosticFlag' }
     });
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
@@ -27,7 +27,7 @@ test.describe('User Facing Diagnostics tests', async () => {
     setNetworkDiagnostic(initialState, {
       networkReconnect: { value: DiagnosticQuality.Bad, valueType: 'DiagnosticQuality' }
     });
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
@@ -40,7 +40,7 @@ test.describe('User Facing Diagnostics tests', async () => {
     setMediaDiagnostic(initialState, {
       cameraFreeze: { value: true, valueType: 'DiagnosticFlag' }
     });
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
@@ -53,7 +53,7 @@ test.describe('User Facing Diagnostics tests', async () => {
     setMediaDiagnostic(initialState, {
       cameraStoppedUnexpectedly: { value: DiagnosticQuality.Bad, valueType: 'DiagnosticFlag' }
     });
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
@@ -66,7 +66,7 @@ test.describe('User Facing Diagnostics tests', async () => {
     setMediaDiagnostic(initialState, {
       cameraStoppedUnexpectedly: { value: DiagnosticQuality.Good, valueType: 'DiagnosticFlag' }
     });
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot('error-bar-camera-recovered.png');
@@ -77,7 +77,7 @@ test.describe('User Facing Diagnostics tests', async () => {
     setMediaDiagnostic(initialState, {
       microphoneMuteUnexpectedly: { value: DiagnosticQuality.Bad, valueType: 'DiagnosticFlag' }
     });
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(
@@ -90,7 +90,7 @@ test.describe('User Facing Diagnostics tests', async () => {
     setMediaDiagnostic(initialState, {
       microphoneMuteUnexpectedly: { value: DiagnosticQuality.Good, valueType: 'DiagnosticFlag' }
     });
-    await page.goto(buildUrlWithMockAdapterNext(serverUrl, initialState));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
     expect(await stableScreenshot(page, { dismissTooltips: true })).toMatchSnapshot(

--- a/packages/react-composites/tests/browser/call/hermetic/fixture.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/fixture.ts
@@ -19,14 +19,12 @@ const APP_DIR = path.join(__dirname, '../app');
 /**
  * Create the test URL.
  *
- * TODO: Rename to buildUrlWithMockAdapter once all tests are ported over.
- *
  * @param serverUrl - URL of webpage to test, this is typically https://localhost:3000
  * @param mockCallAdapterState - Initial state for the {@link MockCallAdapter} constructed by the test app.
  * @param qArgs - Optional args to add to the query search parameters of the URL.
  * @returns URL string
  */
-export const buildUrlWithMockAdapterNext = (
+export const buildUrlWithMockAdapter = (
   serverUrl: string,
   mockCallAdapterState?: MockCallAdapterState,
   qArgs?: { [key: string]: string }


### PR DESCRIPTION
#2093 deleted the deprecated function that this replaces. This PR renames the function to remove transitional suffix.