### PR TITLE
update name for alternateCallerId

### DIFF
--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -415,7 +415,7 @@ export interface CallClientState {
   /**
    * Stores an ACS aquired phone number for making PSTN calls.
    */
-  alternativeCallerId?: string;
+  alternateCallerId?: string;
 }
 
 /**

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -51,7 +51,7 @@ export class CallContext {
   constructor(
     userId: CommunicationIdentifierKind,
     maxListeners = 50,
-    /* @conditional-compile-remove(PSTN-calls) */ alternativeCallerId?: string
+    /* @conditional-compile-remove(PSTN-calls) */ alternateCallerId?: string
   ) {
     this._logger = createClientLogger('communication-react:calling-context');
     this._state = {
@@ -68,7 +68,7 @@ export class CallContext {
       },
       callAgent: undefined,
       userId: userId,
-      /* @conditional-compile-remove(PSTN-calls) */ alternativeCallerId: alternativeCallerId,
+      /* @conditional-compile-remove(PSTN-calls) */ alternateCallerId: alternateCallerId,
       latestErrors: {} as CallErrors
     };
     this._emitter = new EventEmitter();

--- a/packages/calling-stateful-client/src/StatefulCallClient.test.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.test.ts
@@ -90,7 +90,7 @@ describe('Stateful call client', () => {
   });
 
   /* @conditional-compile-remove(PSTN-calls) */
-  test('should update CallClient state and have alternativeCallerId set when callAgent is created', async () => {
+  test('should update CallClient state and have alternateCallerId set when callAgent is created', async () => {
     const phoneNumber = '+15555555';
     const userId: CommunicationUserKind = { kind: 'communicationUser', communicationUserId: 'someUser' };
     const client = createStatefulCallClientWithDeps(
@@ -98,7 +98,7 @@ describe('Stateful call client', () => {
       new CallContext(userId, undefined, phoneNumber),
       new InternalCallContext()
     );
-    expect(client.getState().alternativeCallerId).toEqual(phoneNumber);
+    expect(client.getState().alternateCallerId).toEqual(phoneNumber);
   });
 
   test('should update call in state when new call is added and removed', async () => {

--- a/packages/calling-stateful-client/src/StatefulCallClient.ts
+++ b/packages/calling-stateful-client/src/StatefulCallClient.ts
@@ -230,10 +230,10 @@ export type StatefulCallClientArgs = {
   userId: CommunicationUserIdentifier;
   /* @conditional-compile-remove(PSTN-calls) */
   /**
-   * ACS phone number required to make outbound PSTN calls. This is provided for developer convenience to easily access the alternativeCallerId from the
+   * ACS phone number required to make outbound PSTN calls. This is provided for developer convenience to easily access the alternateCallerId from the
    * state. It is not used by StatefulCallClient.
    */
-  alternativeCallerId?: string;
+  alternateCallerId?: string;
 };
 
 /**
@@ -277,7 +277,7 @@ export const createStatefulCallClient = (
     new CallContext(
       getIdentifierKind(args.userId),
       options?.maxStateChangeListeners,
-      /* @conditional-compile-remove(PSTN-calls) */ args.alternativeCallerId
+      /* @conditional-compile-remove(PSTN-calls) */ args.alternateCallerId
     ),
     new InternalCallContext()
   );

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -79,7 +79,7 @@ class CallContext {
       page: 'configuration',
       latestErrors: clientState.latestErrors,
       isTeamsCall,
-      /* @conditional-compile-remove(PSTN-calls) */ alternativeCallerId: clientState.alternativeCallerId
+      /* @conditional-compile-remove(PSTN-calls) */ alternateCallerId: clientState.alternateCallerId
     };
   }
 
@@ -289,7 +289,7 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
     /* @conditional-compile-remove(teams-adhoc-call) */
     /* @conditional-compile-remove(PSTN-calls) */
     if (isOutboundCall(this.locator)) {
-      const phoneNumber = this.getState().alternativeCallerId;
+      const phoneNumber = this.getState().alternateCallerId;
       return this.startCall(this.locator.participantIDs, {
         alternateCallerId: phoneNumber ? { phoneNumber: phoneNumber } : undefined
       });
@@ -428,7 +428,7 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
       const backendId = fromFlatCommunicationIdentifier(participant);
       if (isPhoneNumberIdentifier(backendId)) {
         if (options?.alternateCallerId === undefined) {
-          throw new Error('unable to start call, PSTN user present with no alternativeCallerID.');
+          throw new Error('unable to start call, PSTN user present with no alternateCallerId.');
         }
         return backendId as PhoneNumberIdentifier;
       } else if (isCommunicationUserIdentifier(backendId)) {
@@ -662,7 +662,7 @@ export type AzureCommunicationCallAdapterArgs = {
   credential: CommunicationTokenCredential;
   locator: CallAdapterLocator;
   /* @conditional-compile-remove(PSTN-calls) */
-  alternativeCallerId?: string;
+  alternateCallerId?: string;
 };
 
 /**
@@ -679,11 +679,11 @@ export const createAzureCommunicationCallAdapter = async ({
   displayName,
   credential,
   locator,
-  /* @conditional-compile-remove(PSTN-calls) */ alternativeCallerId
+  /* @conditional-compile-remove(PSTN-calls) */ alternateCallerId
 }: AzureCommunicationCallAdapterArgs): Promise<CallAdapter> => {
   const callClient = createStatefulCallClient({
     userId,
-    /* @conditional-compile-remove(PSTN-calls) */ alternativeCallerId
+    /* @conditional-compile-remove(PSTN-calls) */ alternateCallerId
   });
   const callAgent = await callClient.createCallAgent(credential, {
     displayName
@@ -727,7 +727,7 @@ export const useAzureCommunicationCallAdapter = (
    */
   beforeDispose?: (adapter: CallAdapter) => Promise<void>
 ): CallAdapter | undefined => {
-  const { credential, displayName, locator, userId, /*@conditional-compile-remove(PSTN-calls) */ alternativeCallerId } =
+  const { credential, displayName, locator, userId, /*@conditional-compile-remove(PSTN-calls) */ alternateCallerId } =
     args;
 
   // State update needed to rerender the parent component when a new adapter is created.
@@ -768,7 +768,7 @@ export const useAzureCommunicationCallAdapter = (
           displayName,
           locator,
           userId,
-          /* @conditional-compile-remove(PSTN-calls) */ alternativeCallerId
+          /* @conditional-compile-remove(PSTN-calls) */ alternateCallerId
         });
         if (afterCreateRef.current) {
           newAdapter = await afterCreateRef.current(newAdapter);
@@ -781,7 +781,7 @@ export const useAzureCommunicationCallAdapter = (
     [
       adapterRef,
       afterCreateRef,
-      /* @conditional-compile-remove(PSTN-calls) */ alternativeCallerId,
+      /* @conditional-compile-remove(PSTN-calls) */ alternateCallerId,
       beforeDisposeRef,
       credential,
       displayName,

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -66,7 +66,7 @@ export type CallAdapterClientState = {
   /**
    * Azure communications Phone number to make PSTN calls with.
    */
-  alternativeCallerId?: string;
+  alternateCallerId?: string;
 };
 
 /**

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatTypeAssertions.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatTypeAssertions.ts
@@ -88,7 +88,7 @@ type CallWithChatClientStateInternal = Omit<
   | 'endedCall'
   | 'latestErrors'
   | 'userId'
-  | /* @conditional-compile-remove(PSTN-calls) */ 'alternativeCallerId'
+  | /* @conditional-compile-remove(PSTN-calls) */ 'alternateCallerId'
 >;
 
 const CallWithChatClientStateTypeAssertion = (value: CallWithChatClientState): CallWithChatClientStateInternal => value;

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -51,7 +51,7 @@ const App = (): JSX.Element => {
   const [callLocator, setCallLocator] = useState<CallAdapterLocator>(createGroupId());
   const [displayName, setDisplayName] = useState<string>('');
 
-  const [alternativeCallerId, setAlternativeCallerId] = useState<string | undefined>();
+  const [alternateCallerId, setAlternateCallerId] = useState<string | undefined>();
 
   // Get Azure Communications Service token from the server
   useEffect(() => {
@@ -96,7 +96,7 @@ const App = (): JSX.Element => {
           joiningExistingCall={joiningExistingCall}
           startCallHandler={(callDetails) => {
             setDisplayName(callDetails.displayName);
-            setAlternativeCallerId(callDetails.alternativeCallerId);
+            setAlternateCallerId(callDetails.alternateCallerId);
             const isTeamsCall = !!callDetails.teamsLink;
             const makeLocator = (
               teamsLink?: TeamsMeetingLinkLocator | undefined,
@@ -160,7 +160,7 @@ const App = (): JSX.Element => {
           displayName={displayName}
           callLocator={callLocator}
           /* @conditional-compile-remove(PSTN-calls) */
-          alternativeCallerId={alternativeCallerId}
+          alternateCallerId={alternateCallerId}
           onCallEnded={() => setPage('endCall')}
         />
       );

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -22,16 +22,16 @@ export interface CallScreenProps {
   userId: CommunicationUserIdentifier;
   callLocator: CallAdapterLocator;
   displayName: string;
-  alternativeCallerId?: string;
+  alternateCallerId?: string;
   onCallEnded: () => void;
 }
 
 export const CallScreen = (props: CallScreenProps): JSX.Element => {
-  const { token, userId, callLocator, displayName, onCallEnded, alternativeCallerId } = props;
+  const { token, userId, callLocator, displayName, onCallEnded, alternateCallerId } = props;
   const callIdRef = useRef<string>();
   const { currentTheme, currentRtl } = useSwitchableFluentTheme();
   const isMobileSession = useIsMobile();
-  console.log(alternativeCallerId);
+  console.log(alternateCallerId);
   const afterCreate = useCallback(
     async (adapter: CallAdapter): Promise<CallAdapter> => {
       adapter.on('callEnded', () => {
@@ -67,7 +67,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
       credential,
       locator: callLocator,
       /* @conditional-compile-remove(PSTN-calls) */
-      alternativeCallerId
+      alternateCallerId
     },
     afterCreate
   );

--- a/samples/Calling/src/app/views/HomeScreen.tsx
+++ b/samples/Calling/src/app/views/HomeScreen.tsx
@@ -31,7 +31,7 @@ export interface HomeScreenProps {
     /* @conditional-compile-remove(PSTN-calls) */
     outboundParticipants?: string[];
     /* @conditional-compile-remove(PSTN-calls) */
-    alternativeCallerId?: string;
+    alternateCallerId?: string;
   }): void;
   joiningExistingCall: boolean;
 }
@@ -54,7 +54,7 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
 
   const [chosenCallOption, setChosenCallOption] = useState<IChoiceGroupOption>(callOptions[0]);
   const [teamsLink, setTeamsLink] = useState<TeamsMeetingLinkLocator>();
-  const [alternativeCallerId, setAlternativeCallerId] = useState<string>();
+  const [alternateCallerId, setAlternateCallerId] = useState<string>();
   const [outboundParticipants, setOutboundParticipants] = useState<string | undefined>();
 
   const teamsCallChosen: boolean = chosenCallOption.key === 'TeamsMeeting';
@@ -110,7 +110,7 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
                     className={outboundtextField}
                     label={'ACS phone number for PSTN'}
                     placeholder={'Enter your ACS aquired phone number'}
-                    onChange={(_, newValue) => newValue && setAlternativeCallerId(newValue)}
+                    onChange={(_, newValue) => newValue && setAlternateCallerId(newValue)}
                   />
                 </Stack>
               )
@@ -131,7 +131,7 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
                   /* @conditional-compile-remove(PSTN-calls) */
                   outboundParticipants: participantsToCall,
                   /* @conditional-compile-remove(PSTN-calls) */
-                  alternativeCallerId
+                  alternateCallerId
                 });
               }
             }}


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fix naming for `alternativeCallerId`
# Why
<!--- What problem does this change solve? -->
When programming this prop out I deviated from the name that the CallingSDK uses. this is to bring us back into parity (OOPS!)
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran the updated Calling sample to verify this prop now is correct across the board.