### PR TITLE
Convert SidePaneHeader and TabHeader to common files for Composite use

### DIFF
--- a/change/@internal-react-composites-920a3f3e-4763-49ab-ba27-88d1e7b7a4d9.json
+++ b/change/@internal-react-composites-920a3f3e-4763-49ab-ba27-88d1e7b7a4d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Convert TabHeader and SidePaneHeader to common files",
+  "packageName": "@internal/react-composites",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
@@ -19,12 +19,12 @@ import {
   scrollableContainer,
   scrollableContainerContents
 } from '../common/styles/ParticipantContainer.styles';
-import { SidePaneHeader } from './SidePaneHeader';
+import { SidePaneHeader } from '../common/SidePaneHeader';
 import { useCallWithChatCompositeStrings } from './hooks/useCallWithChatCompositeStrings';
 import { ModalLocalAndRemotePIP, ModalLocalAndRemotePIPStyles } from './ModalLocalAndRemotePIP';
 import { PeoplePaneContent } from './PeoplePaneContent';
 import { drawerContainerStyles } from './styles/CallWithChatCompositeStyles';
-import { TabHeader } from './TabHeader';
+import { TabHeader } from '../common/TabHeader';
 /* @conditional-compile-remove(file-sharing) */
 import { FileSharingOptions } from '../ChatComposite';
 import { _ICoordinates } from '@internal/react-components';
@@ -61,10 +61,11 @@ export const CallWithChatPane = (props: {
 
   const header =
     props.activePane === 'none' ? null : props.mobileView ? (
-      <TabHeader {...props} activeTab={props.activePane} />
+      <TabHeader {...props} strings={callWithChatStrings} activeTab={props.activePane} />
     ) : (
       <SidePaneHeader
         {...props}
+        strings={callWithChatStrings}
         headingText={
           props.activePane === 'chat'
             ? callWithChatStrings.chatPaneTitle

--- a/packages/react-composites/src/composites/common/SidePaneHeader.tsx
+++ b/packages/react-composites/src/composites/common/SidePaneHeader.tsx
@@ -3,13 +3,17 @@
 import { CommandBarButton, Stack } from '@fluentui/react';
 import { useTheme } from '@internal/react-components';
 import React, { useMemo } from 'react';
+import { CallWithChatCompositeStrings } from '../CallWithChatComposite';
 import { sidePaneHeaderContainerStyles, sidePaneHeaderStyles } from '../common/styles/ParticipantContainer.styles';
-import { useCallWithChatCompositeStrings } from './hooks/useCallWithChatCompositeStrings';
 
 /**
  * @private
  */
-export const SidePaneHeader = (props: { headingText: string; onClose: () => void }): JSX.Element => {
+export const SidePaneHeader = (props: {
+  headingText: string;
+  onClose: () => void;
+  strings: CallWithChatCompositeStrings;
+}): JSX.Element => {
   const theme = useTheme();
   const sidePaneCloseButtonStyles = useMemo(
     () => ({
@@ -21,13 +25,11 @@ export const SidePaneHeader = (props: { headingText: string; onClose: () => void
     [theme.palette.neutralSecondary]
   );
 
-  const callWithChatStrings = useCallWithChatCompositeStrings();
-
   return (
     <Stack horizontal horizontalAlign="space-between" styles={sidePaneHeaderContainerStyles}>
       <Stack.Item styles={sidePaneHeaderStyles}>{props.headingText}</Stack.Item>
       <CommandBarButton
-        ariaLabel={callWithChatStrings.dismissSidePaneButtonLabel}
+        ariaLabel={props.strings.dismissSidePaneButtonLabel}
         styles={sidePaneCloseButtonStyles}
         iconProps={{ iconName: 'cancel' }}
         onClick={props.onClose}

--- a/packages/react-composites/src/composites/common/TabHeader.tsx
+++ b/packages/react-composites/src/composites/common/TabHeader.tsx
@@ -3,8 +3,8 @@
 import { concatStyleSets, DefaultButton, Stack } from '@fluentui/react';
 import { useTheme } from '@internal/react-components';
 import React, { useMemo } from 'react';
+import { CallWithChatCompositeStrings } from '../CallWithChatComposite';
 import { CallWithChatCompositeIcon } from '../common/icons';
-import { useCallWithChatCompositeStrings } from './hooks/useCallWithChatCompositeStrings';
 import {
   mobilePaneBackButtonStyles,
   mobilePaneButtonStyles,
@@ -22,14 +22,16 @@ type TabHeaderProps = {
   // If set, show a button to open people tab.
   onPeopleButtonClicked?: () => void;
   activeTab: TabHeaderTab;
+  strings: CallWithChatCompositeStrings;
 };
 
 /**
  * @private
  */
 export const TabHeader = (props: TabHeaderProps): JSX.Element => {
+  const { onClose, onChatButtonClicked, onPeopleButtonClicked, activeTab, strings } = props;
   const theme = useTheme();
-  const haveMultipleTabs = props.onChatButtonClicked && props.onPeopleButtonClicked;
+  const haveMultipleTabs = onChatButtonClicked && onPeopleButtonClicked;
   const mobilePaneButtonStylesThemed = useMemo(() => {
     return concatStyleSets(
       mobilePaneButtonStyles,
@@ -51,24 +53,23 @@ export const TabHeader = (props: TabHeaderProps): JSX.Element => {
         : {}
     );
   }, [theme, haveMultipleTabs]);
-  const strings = useCallWithChatCompositeStrings();
 
   return (
     <Stack horizontal grow styles={mobilePaneControlBarStyle}>
       <DefaultButton
         ariaLabel={strings.returnToCallButtonAriaLabel}
         ariaDescription={strings.returnToCallButtonAriaDescription}
-        onClick={props.onClose}
+        onClick={onClose}
         styles={mobilePaneBackButtonStyles}
         onRenderIcon={() => <CallWithChatCompositeIcon iconName="ChevronLeft" />}
         autoFocus
       ></DefaultButton>
       <Stack.Item grow>
-        {props.onChatButtonClicked && (
+        {onChatButtonClicked && (
           <DefaultButton
-            onClick={props.onChatButtonClicked}
+            onClick={onChatButtonClicked}
             styles={mobilePaneButtonStylesThemed}
-            checked={props.activeTab === 'chat'}
+            checked={activeTab === 'chat'}
             role={'tab'}
           >
             {strings.chatButtonLabel}
@@ -76,11 +77,11 @@ export const TabHeader = (props: TabHeaderProps): JSX.Element => {
         )}
       </Stack.Item>
       <Stack.Item grow>
-        {props.onPeopleButtonClicked && (
+        {onPeopleButtonClicked && (
           <DefaultButton
-            onClick={props.onPeopleButtonClicked}
+            onClick={onPeopleButtonClicked}
             styles={mobilePaneButtonStylesThemed}
-            checked={props.activeTab === 'people'}
+            checked={activeTab === 'people'}
             role={'tab'}
           >
             {strings.peopleButtonLabel}

--- a/packages/react-composites/src/composites/common/styles/MobilePane.styles.ts
+++ b/packages/react-composites/src/composites/common/styles/MobilePane.styles.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { concatStyleSets, IButtonStyles, IStackStyles } from '@fluentui/react';
+
+/**
+ * @private
+ */
+export const mobilePaneStyle = { root: { width: '100%', height: '100%' } };
+
+/**
+ * @private
+ */
+export const hiddenMobilePaneStyle: IStackStyles = concatStyleSets(mobilePaneStyle, { root: { display: 'none' } });
+
+/**
+ * @private
+ */
+export const mobilePaneControlBarStyle: IStackStyles = { root: { height: '3rem' } };
+
+/**
+ * @private
+ */
+export const mobilePaneBackButtonStyles: IButtonStyles = {
+  root: { border: 'none', minWidth: '2.5rem', height: '100%', background: 'none', padding: '0 1rem' },
+  rootChecked: { background: 'none' },
+  rootCheckedHovered: { background: 'none' }
+};
+
+/**
+ * @private
+ */
+export const mobilePaneHiddenIconStyles: IButtonStyles = concatStyleSets(mobilePaneBackButtonStyles, {
+  root: { visibility: 'hidden' }
+});
+
+/**
+ * @private
+ */
+export const mobilePaneButtonStyles: IButtonStyles = {
+  root: {
+    border: 'none',
+    borderBottom: '0.125rem solid transparent',
+    width: '8rem',
+    height: '100%',
+    background: 'none',
+    padding: '0'
+  },
+  rootChecked: { background: 'none' },
+  rootCheckedHovered: { background: 'none' },
+  flexContainer: { flexFlow: 'column', display: 'contents' },
+  label: {
+    fontSize: '1rem',
+    fontWeight: 100,
+    lineHeight: '2rem',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
+  },
+  labelChecked: { fontWeight: 600 }
+};


### PR DESCRIPTION
# What
Convert SidePaneHeader.tsx and TabHeader.tsx to a common file to be used in both Call Composite and CallWithChatComposite

# Why
In order to bring participant list view in Call Composite in sync with CallWithChat Composite.
Initial steps requiring converting CallWIthChat composite specific files to common files to be used in Call Composite.
https://skype.visualstudio.com/SPOOL/_workitems/edit/2919196 
https://skype.visualstudio.com/SPOOL/_workitems/edit/2919204 

# How Tested
Tested locally on MacOs on mobile and desktop view.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->