### PR TITLE
showing no noticePage if option set in CallComposite

### DIFF
--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -377,6 +377,7 @@ export type CallCompositeIcons = {
 export type CallCompositeOptions = {
     errorBar?: boolean;
     callControls?: boolean | CallControlOptions;
+    endCallScreen?: boolean;
 };
 
 // @public

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -273,6 +273,7 @@ export type CallCompositeIcons = {
 export type CallCompositeOptions = {
     errorBar?: boolean;
     callControls?: boolean | CallControlOptions;
+    endCallScreen?: boolean;
 };
 
 // @public

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -65,6 +65,13 @@ export type CallCompositeOptions = {
    * @defaultValue true
    */
   callControls?: boolean | CallControlOptions;
+
+  /**
+   * Hide or Customize the end call screen.
+   * Can be customized by providing an object of type {@link @azure/communication-react#CallControlOptions}.
+   * @defaultValue true
+   */
+  endCallScreen?: boolean;
 };
 
 type MainScreenProps = {
@@ -94,21 +101,31 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
         />
       );
     case 'accessDeniedTeamsMeeting':
+      if (props.options?.endCallScreen === false) {
+        return <></>;
+      }
+
       return (
         <NoticePage
           iconName="NoticePageAccessDeniedTeamsMeeting"
           title={locale.strings.call.failedToJoinTeamsMeetingReasonAccessDeniedTitle}
           moreDetails={locale.strings.call.failedToJoinTeamsMeetingReasonAccessDeniedMoreDetails}
           dataUiId={'access-denied-teams-meeting-page'}
+          showStartOrRejoinButton={false}
         />
       );
     case 'removedFromCall':
+      if (props.options?.endCallScreen === false) {
+        return <></>;
+      }
+
       return (
         <NoticePage
           iconName="NoticePageRemovedFromCall"
           title={locale.strings.call.removedFromCallTitle}
           moreDetails={locale.strings.call.removedFromCallMoreDetails}
           dataUiId={'removed-from-call-page'}
+          showStartOrRejoinButton={false}
         />
       );
     case 'joinCallFailedDueToNoNetwork':
@@ -121,14 +138,20 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
         />
       );
     case 'leftCall':
+      if (props.options?.endCallScreen === false) {
+        return <></>;
+      }
+
       return (
         <NoticePage
           iconName="NoticePageLeftCall"
           title={locale.strings.call.leftCallTitle}
           moreDetails={locale.strings.call.leftCallMoreDetails}
           dataUiId={'left-call-page'}
+          showStartOrRejoinButton={false}
         />
       );
+
     case 'lobby':
       return <LobbyPage mobileView={props.mobileView} options={props.options} />;
     case 'call':

--- a/packages/react-composites/src/composites/CallComposite/pages/NoticePage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/NoticePage.tsx
@@ -22,6 +22,7 @@ export interface NoticePageProps {
   title: string;
   moreDetails?: string;
   dataUiId: string;
+  showStartOrRejoinButton?: boolean;
 }
 
 /**
@@ -41,9 +42,11 @@ export function NoticePage(props: NoticePageProps): JSX.Element {
         <Text className={mergeStyles(moreDetailsStyles)} aria-live="assertive">
           {props.moreDetails}
         </Text>
-        <Stack styles={rejoinCallButtonContainerStyles}>
-          <StartCallButton onClick={() => adapter.joinCall()} disabled={false} rejoinCall={true} autoFocus />
-        </Stack>
+        {props.showStartOrRejoinButton && (
+          <Stack styles={rejoinCallButtonContainerStyles}>
+            <StartCallButton onClick={() => adapter.joinCall()} disabled={false} rejoinCall={true} autoFocus />
+          </Stack>
+        )}
       </Stack>
     </Stack>
   );

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -34,7 +34,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
   const afterCreate = useCallback(
     async (adapter: CallAdapter): Promise<CallAdapter> => {
       adapter.on('callEnded', () => {
-        onCallEnded();
+        //   onCallEnded();
       });
       adapter.on('error', (e) => {
         // Error is already acted upon by the Call composite, but the surrounding application could
@@ -89,6 +89,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
       rtl={currentRtl}
       callInvitationUrl={window.location.href}
       formFactor={isMobileSession ? 'mobile' : 'desktop'}
+      options={{ endCallScreen: false }}
     />
   );
 };


### PR DESCRIPTION
# What
I was curious if we can avoid rendering anything for the endcall screen if it was undesired. This is just a minor PoC and is meant to only go as far as draft

# Why
There is a rejoin button that can exist. This may be undesirable for Contoso and creating the option to hide it could be helpful.

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->