### PR TITLE
Update webpack-cli version to fix sample rushx start error

### DIFF
--- a/change/@internal-react-composites-ad65e724-4108-421e-845e-9a87741e4196.json
+++ b/change/@internal-react-composites-ad65e724-4108-421e-845e-9a87741e4196.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update webpack-cli dev dep",
+  "packageName": "@internal/react-composites",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -763,7 +763,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.9:
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.18.9
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.9
       '@babel/plugin-transform-parameters': 7.18.8_@babel+core@7.12.9
     dev: false
@@ -2148,7 +2148,7 @@ packages:
     dependencies:
       '@fluentui/set-version': 8.2.1
       '@fluentui/theme': 2.6.7_0593675b4d5fe572998fa3e4bddd25f7
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: false
     peerDependencies:
       '@types/react': '*'
@@ -2194,7 +2194,7 @@ packages:
       '@fluentui/react': 8.62.4_45310a9056d3778805408cde56755bb3
       '@fluentui/scheme-utilities': 8.3.8_0593675b4d5fe572998fa3e4bddd25f7
       '@fluentui/set-version': 8.2.1
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: false
     peerDependencies:
       '@types/react': '*'
@@ -2504,7 +2504,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       '@types/yargs': 15.0.14
       chalk: 4.1.2
     dev: false
@@ -2984,7 +2984,7 @@ packages:
       integrity: sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw==
   /@playwright/test/1.22.2:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       playwright-core: 1.22.2
     dev: false
     engines:
@@ -4175,7 +4175,7 @@ packages:
       flat-cache: 3.0.4
       micromatch: 4.0.5
       react-docgen-typescript: 2.2.2_typescript@4.3.5
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.3.5
       webpack: 5.38.1
     dev: false
@@ -4469,19 +4469,19 @@ packages:
   /@types/body-parser/1.19.2:
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
   /@types/bonjour/3.5.10:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==
   /@types/cheerio/0.22.31:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==
@@ -4495,13 +4495,13 @@ packages:
   /@types/connect-history-api-fallback/1.3.5:
     dependencies:
       '@types/express-serve-static-core': 4.17.29
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==
   /@types/connect/3.4.35:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
@@ -4535,13 +4535,13 @@ packages:
   /@types/eslint-scope/3.7.4:
     dependencies:
       '@types/eslint': 8.4.5
-      '@types/estree': 0.0.47
+      '@types/estree': 1.0.0
     dev: false
     resolution:
       integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==
   /@types/eslint/8.4.5:
     dependencies:
-      '@types/estree': 0.0.47
+      '@types/estree': 1.0.0
       '@types/json-schema': 7.0.11
     dev: false
     resolution:
@@ -4564,7 +4564,7 @@ packages:
       integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
   /@types/express-serve-static-core/4.17.29:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: false
@@ -4582,7 +4582,7 @@ packages:
   /@types/glob/7.2.0:
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
@@ -4608,7 +4608,7 @@ packages:
       integrity: sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==
   /@types/http-proxy/1.17.9:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==
@@ -4677,13 +4677,13 @@ packages:
       integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
   /@types/morgan/1.9.3:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==
   /@types/node-fetch/2.6.2:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       form-data: 3.0.1
     dev: false
     resolution:
@@ -4691,7 +4691,7 @@ packages:
   /@types/node-static/0.7.7:
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-Cq3c9lfC9zRrGxe7ox073219Mpy/kmWNsISG0yEG7aUEk33xv/g+uqz/+4b7hM4WN9LsGageBzGuvy09inaGhg==
@@ -4741,7 +4741,7 @@ packages:
       integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
   /@types/puppeteer/5.4.6:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-98Kghehs7+/GD9b56qryhqdqVCXUTbetTv3PlvDnmFRTHQH0j9DIp1f7rkAW3BAj4U3yoeSEQnKgdW8bDq0Y0Q==
@@ -4808,13 +4808,13 @@ packages:
   /@types/serve-static/1.13.10:
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
   /@types/sockjs/0.3.33:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==
@@ -4837,7 +4837,7 @@ packages:
   /@types/superagent/4.1.15:
     dependencies:
       '@types/cookiejar': 2.1.2
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==
@@ -4865,7 +4865,7 @@ packages:
       integrity: sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
   /@types/tunnel/0.0.1:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
@@ -4893,10 +4893,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-eHSaNYEyxRA5IAG0Ym/yCyf86niZUIF/TpWKofQI/CVfh5HsMEUyfE2kwFxha4ow0s5g0LfISQxpDKjbRDrizw==
-  /@types/webpack-node-externals/2.5.3_webpack-cli@4.9.2:
+  /@types/webpack-node-externals/2.5.3_webpack-cli@4.10.0:
     dependencies:
-      '@types/node': 14.18.22
-      webpack: 5.38.1_webpack-cli@4.9.2
+      '@types/node': 18.0.6
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     peerDependencies:
       webpack-cli: '*'
@@ -4904,7 +4904,7 @@ packages:
       integrity: sha512-A9JxaR8QXoYT95egET4AmCFuChyTlP8d18ZAnmSHuIMsFdS7QlCQQ8pmN/+FHgLIkm+ViE/VngltT5avLACY9A==
   /@types/webpack-sources/3.2.0:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
     dev: false
@@ -4912,7 +4912,7 @@ packages:
       integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==
   /@types/webpack/4.41.32:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       '@types/tapable': 1.0.8
       '@types/uglify-js': 3.16.0
       '@types/webpack-sources': 3.2.0
@@ -4923,7 +4923,7 @@ packages:
       integrity: sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==
   /@types/ws/8.5.3:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
@@ -4945,7 +4945,7 @@ packages:
       integrity: sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==
   /@types/yauzl/2.10.0:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     optional: true
     resolution:
@@ -5320,39 +5320,39 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==
-  /@webpack-cli/configtest/1.2.0_webpack-cli@4.9.2+webpack@4.46.0:
+  /@webpack-cli/configtest/1.2.0_196e681456f11e809d8928f4499c300a:
     dependencies:
-      webpack: 4.46.0_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_webpack@4.46.0
+      webpack: 4.46.0_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_webpack@4.46.0
     dev: false
     peerDependencies:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     resolution:
       integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==
-  /@webpack-cli/configtest/1.2.0_webpack-cli@4.9.2+webpack@5.38.1:
+  /@webpack-cli/configtest/1.2.0_69574e65506de74a817e8de68330e733:
     dependencies:
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
     dev: false
     peerDependencies:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     resolution:
       integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==
-  /@webpack-cli/info/1.5.0_webpack-cli@4.9.2:
+  /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
     dev: false
     peerDependencies:
       webpack-cli: 4.x.x
     resolution:
       integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==
-  /@webpack-cli/serve/1.7.0_8b27d5839a2bdf89ba2338e4c89fea10:
+  /@webpack-cli/serve/1.7.0_de6ef8edff356eae17987a47309ecf6b:
     dependencies:
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
     dev: false
     peerDependencies:
       webpack-cli: 4.x.x
@@ -5362,9 +5362,9 @@ packages:
         optional: true
     resolution:
       integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
-  /@webpack-cli/serve/1.7.0_webpack-cli@4.9.2:
+  /@webpack-cli/serve/1.7.0_webpack-cli@4.10.0:
     dependencies:
-      webpack-cli: 4.9.2_webpack@4.46.0
+      webpack-cli: 4.10.0_webpack@4.46.0
     dev: false
     peerDependencies:
       webpack-cli: 4.x.x
@@ -5473,7 +5473,7 @@ packages:
       integrity: sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig==
   /agent-base/6.0.2:
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.4
     dev: false
     engines:
       node: '>= 6.0.0'
@@ -5942,7 +5942,7 @@ packages:
       integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
   /ast-types/0.14.2:
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: false
     engines:
       node: '>=4'
@@ -5987,7 +5987,7 @@ packages:
       integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
   /autoprefixer/9.8.8:
     dependencies:
-      browserslist: 4.20.4
+      browserslist: 4.21.2
       caniuse-lite: 1.0.30001367
       normalize-range: 0.1.2
       num2fraction: 1.2.2
@@ -6068,7 +6068,7 @@ packages:
       mkdirp: 0.5.6
       pify: 4.0.1
       schema-utils: 2.7.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 6.9'
@@ -7380,7 +7380,7 @@ packages:
       p-limit: 3.1.0
       schema-utils: 3.1.1
       serialize-javascript: 5.0.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-sources: 1.4.3
     dev: false
     engines:
@@ -7648,7 +7648,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 7.3.7
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -8668,7 +8668,7 @@ packages:
       remark-mdx: 1.6.22
       remark-parse: 8.0.3
       remark-stringify: 8.1.1
-      tslib: 2.3.1
+      tslib: 2.4.0
       unified: 9.2.2
     dev: false
     engines:
@@ -8788,7 +8788,7 @@ packages:
       eslint-mdx: 1.17.1_eslint@7.32.0
       eslint-plugin-markdown: 2.2.1_eslint@7.32.0
       synckit: 0.4.1
-      tslib: 2.3.1
+      tslib: 2.4.0
       vfile: 4.2.1
     dev: false
     engines:
@@ -9274,7 +9274,7 @@ packages:
       integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
   /extract-zip/2.0.1:
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.4
       get-stream: 5.2.0
       yauzl: 2.10.0
     dev: false
@@ -10575,7 +10575,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 3.0.4
       tapable: 2.2.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>=10.13.0'
@@ -10708,7 +10708,7 @@ packages:
   /https-proxy-agent/5.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.1
+      debug: 4.3.4
     dev: false
     engines:
       node: '>= 6'
@@ -12116,7 +12116,7 @@ packages:
       integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
   /jest-worker/27.5.1:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -16595,7 +16595,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -16738,7 +16738,7 @@ packages:
       integrity: sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==
   /synckit/0.4.1:
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
       uuid: 8.3.2
     dev: false
     engines:
@@ -16854,7 +16854,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.1
-      webpack: 4.46.0_webpack-cli@4.9.2
+      webpack: 4.46.0_webpack-cli@4.10.0
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: false
@@ -16890,7 +16890,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.14.2
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -17146,7 +17146,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.3.7
       typescript: 4.3.5
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>=10.0.0'
@@ -17654,7 +17654,7 @@ packages:
       loader-utils: 2.0.2
       mime-types: 2.1.35
       schema-utils: 3.1.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -17893,21 +17893,21 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==
-  /webpack-cli/4.9.2_6162a62ebb8c895864a3a412aa800002:
+  /webpack-cli/4.10.0_6162a62ebb8c895864a3a412aa800002:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0_webpack-cli@4.9.2+webpack@5.38.1
-      '@webpack-cli/info': 1.5.0_webpack-cli@4.9.2
-      '@webpack-cli/serve': 1.7.0_8b27d5839a2bdf89ba2338e4c89fea10
+      '@webpack-cli/configtest': 1.2.0_69574e65506de74a817e8de68330e733
+      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
+      '@webpack-cli/serve': 1.7.0_de6ef8edff356eae17987a47309ecf6b
       colorette: 2.0.19
       commander: 7.2.0
-      execa: 5.1.1
+      cross-spawn: 7.0.3
       fastest-levenshtein: 1.0.12
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
       webpack-merge: 5.8.0
     dev: false
     engines:
@@ -17929,23 +17929,23 @@ packages:
       webpack-dev-server:
         optional: true
     resolution:
-      integrity: sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
-  /webpack-cli/4.9.2_67e60b7ff37de853f3f9b3d129e0cb92:
+      integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
+  /webpack-cli/4.10.0_67e60b7ff37de853f3f9b3d129e0cb92:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0_webpack-cli@4.9.2+webpack@5.38.1
-      '@webpack-cli/info': 1.5.0_webpack-cli@4.9.2
-      '@webpack-cli/serve': 1.7.0_8b27d5839a2bdf89ba2338e4c89fea10
+      '@webpack-cli/configtest': 1.2.0_69574e65506de74a817e8de68330e733
+      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
+      '@webpack-cli/serve': 1.7.0_de6ef8edff356eae17987a47309ecf6b
       colorette: 2.0.19
       commander: 7.2.0
-      execa: 5.1.1
+      cross-spawn: 7.0.3
       fastest-levenshtein: 1.0.12
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.5.0
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
       webpack-merge: 5.8.0
     dev: false
     engines:
@@ -17967,21 +17967,21 @@ packages:
       webpack-dev-server:
         optional: true
     resolution:
-      integrity: sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
-  /webpack-cli/4.9.2_webpack@4.46.0:
+      integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
+  /webpack-cli/4.10.0_webpack@4.46.0:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0_webpack-cli@4.9.2+webpack@4.46.0
-      '@webpack-cli/info': 1.5.0_webpack-cli@4.9.2
-      '@webpack-cli/serve': 1.7.0_webpack-cli@4.9.2
+      '@webpack-cli/configtest': 1.2.0_196e681456f11e809d8928f4499c300a
+      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
+      '@webpack-cli/serve': 1.7.0_webpack-cli@4.10.0
       colorette: 2.0.19
       commander: 7.2.0
-      execa: 5.1.1
+      cross-spawn: 7.0.3
       fastest-levenshtein: 1.0.12
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 4.46.0_webpack-cli@4.9.2
+      webpack: 4.46.0_webpack-cli@4.10.0
       webpack-merge: 5.8.0
     dev: false
     engines:
@@ -18003,21 +18003,21 @@ packages:
       webpack-dev-server:
         optional: true
     resolution:
-      integrity: sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
-  /webpack-cli/4.9.2_webpack@5.38.1:
+      integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
+  /webpack-cli/4.10.0_webpack@5.38.1:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0_webpack-cli@4.9.2+webpack@5.38.1
-      '@webpack-cli/info': 1.5.0_webpack-cli@4.9.2
-      '@webpack-cli/serve': 1.7.0_webpack-cli@4.9.2
+      '@webpack-cli/configtest': 1.2.0_69574e65506de74a817e8de68330e733
+      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
+      '@webpack-cli/serve': 1.7.0_webpack-cli@4.10.0
       colorette: 2.0.19
       commander: 7.2.0
-      execa: 5.1.1
+      cross-spawn: 7.0.3
       fastest-levenshtein: 1.0.12
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-merge: 5.8.0
     dev: false
     engines:
@@ -18039,7 +18039,7 @@ packages:
       webpack-dev-server:
         optional: true
     resolution:
-      integrity: sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
+      integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
   /webpack-dev-middleware/3.7.3_webpack@4.46.0:
     dependencies:
       memory-fs: 0.4.1
@@ -18062,7 +18062,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 12.13.0'
@@ -18070,7 +18070,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     resolution:
       integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==
-  /webpack-dev-server/4.8.1_webpack-cli@4.9.2+webpack@5.38.1:
+  /webpack-dev-server/4.8.1_69574e65506de74a817e8de68330e733:
     dependencies:
       '@types/bonjour': 3.5.10
       '@types/connect-history-api-fallback': 1.3.5
@@ -18099,8 +18099,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
       webpack-dev-middleware: 5.3.3_webpack@5.38.1
       ws: 8.8.1
     dev: false
@@ -18217,7 +18217,7 @@ packages:
         optional: true
     resolution:
       integrity: sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
-  /webpack/4.46.0_webpack-cli@4.9.2:
+  /webpack/4.46.0_webpack-cli@4.10.0:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -18241,7 +18241,7 @@ packages:
       tapable: 1.1.3
       terser-webpack-plugin: 1.4.5_webpack@4.46.0
       watchpack: 1.7.5
-      webpack-cli: 4.9.2_webpack@4.46.0
+      webpack-cli: 4.10.0_webpack@4.46.0
       webpack-sources: 1.4.3
     dev: false
     engines:
@@ -18293,7 +18293,7 @@ packages:
         optional: true
     resolution:
       integrity: sha512-OqRmYD1OJbHZph6RUMD93GcCZy4Z4wC0ele4FXyYF0J6AxO1vOSuIlU1hkS/lDlR9CDYBz64MZRmdbdnFFoT2g==
-  /webpack/5.38.1_webpack-cli@4.9.2:
+  /webpack/5.38.1_webpack-cli@4.10.0:
     dependencies:
       '@types/eslint-scope': 3.7.4
       '@types/estree': 0.0.47
@@ -18317,7 +18317,7 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.3_webpack@5.38.1
       watchpack: 2.4.0
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
       webpack-sources: 2.3.1
     dev: false
     engines:
@@ -18930,14 +18930,14 @@ packages:
       typescript: 4.3.5
       url-loader: 4.1.1_webpack@5.38.1
       uuid: 8.3.2
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.5.0
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-lZQb99oQ4Rd+M3Zo7NX/pO63XpqwvT+POXU2uqe7rfgIXx7kZGZH7PKd6pKiWIenmbDD1x9YYFvh25QTRKYLvQ==
+      integrity: sha512-k8yt5pMCZyOhhxUazy4EXykn+HrJ6tsXYpbbjD5qbDQY9YjBQP0i+OWE9kDFIXTjbbIAeNVesGRi+yr/8t6Cmw==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
@@ -19003,14 +19003,14 @@ packages:
       typescript: 4.3.5
       url-loader: 4.1.1_webpack@5.38.1
       uuid: 8.3.2
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.5.0
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-g0Le0UL9s9eS/ATe2KPi3hm3Exruot4ZdsZHX5gd5XOsDey7g3d+m8ntRtfzJ8KaBhDHAgbipXY4dHsmTrpHZg==
+      integrity: sha512-V+HERERivtcxy0QHk8H1kokNZm6kMTen+JhoLiLpp8SV+SxBSrZkqwJ1MGirggWstxxz84CtnwGOpjLnAvOuhQ==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19149,14 +19149,14 @@ packages:
       ts-loader: 8.4.0_typescript@4.3.5+webpack@5.38.1
       typescript: 4.3.5
       url-loader: 4.1.1_webpack@5.38.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.5.0
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-ImICaQ//o6HfO4ByJFJ1wn99saG7Hn/n8qp2GWxNWgpFNfjgsiIQIBeJDHAH8hwp9p/ZEBdIFTfvGtU/qfZ4HQ==
+      integrity: sha512-s/dzwWvB4sGbwoNv0rdHxRqJgsizS204cIm3CQ2BiRCHfvUnXUGUwWaqyQsGKK8P3Jbn0EoU3nfr+xWd/lqthA==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19168,12 +19168,12 @@ packages:
       eslint-plugin-prettier: 3.4.1_8142a4287e8e8e0691574dfac8adcedb
       prettier: 2.3.1
       rimraf: 2.7.1
-      webpack: 4.46.0_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_webpack@4.46.0
+      webpack: 4.46.0_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_webpack@4.46.0
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-kbNTHzire1xBnTQmStIaoDy4qJEPvgtK/OMrkdMv5AX9OicHNdxqumTWLv9DGwzfkFfn0eGr0p5V7Sh4W25kGg==
+      integrity: sha512-YTucy12zfGkX9XP3qd0G+/38O0wBaRkm1gxLUIoRI878l1ifcVnNrzlGNATxn2iG4p4ShD+9+zwmP7V1R+FYLg==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
@@ -19303,13 +19303,13 @@ packages:
       ts-loader: 8.4.0_typescript@4.3.5+webpack@5.38.1
       typescript: 4.3.5
       uuid: 8.3.2
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_6162a62ebb8c895864a3a412aa800002
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_6162a62ebb8c895864a3a412aa800002
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-fAsblf2ZT7O3W6++eg3CMKhh9wJHK4DJdow/OkgTcC5VoRvJaT2k+SQQhtZW8kLmgIEl9Fbtck4rF5N+thH7pw==
+      integrity: sha512-nFif+4a7PCyiwMXVu/dYlvUgwqSuX9CTIdXuKI7p2u7kCXy7B1+qvtRO/ZZ6UA7LVvnsODIXNAD0Ee/rAIMO3Q==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19544,14 +19544,14 @@ packages:
       type-fest: 2.5.4
       typescript: 4.3.5
       uuid: 8.3.2
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_6162a62ebb8c895864a3a412aa800002
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_6162a62ebb8c895864a3a412aa800002
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
       yargs: 17.5.1
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-b51EY0iaOt2tnMoUIlYCiGlMjEo/SGO+uM2G5qq9B2T6Iox5Ll6O2MSkMdjEv2wWHsxAMtPPy81SrBH7CHecMg==
+      integrity: sha512-IKU3vA8rojgaqzXTJ+SLKilakn/5d18xPutQCA/NplxvlStzHe7dNOo+c3/DfGjDufLitm5P2A7pKtSn60Z0yg==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
@@ -19606,12 +19606,12 @@ packages:
       rimraf: 2.7.1
       typescript: 4.3.5
       uuid: 8.3.2
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_webpack@5.38.1
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_webpack@5.38.1
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-g9/oqxHBCT5ngOf0rcGbh9dr1Y2Lum/th7QN84w7S1hz7jTJV0vwge2nJfXHuHzu7ITWxCC1Ki0diBSRkSSmNg==
+      integrity: sha512-tIr2qUir8NxIvAuBlf7UvPLElCajfz3ae1YU13iwLzOn86slz1Hr99FmPAaWi37DzdIvkraV0aCl1cbgBV3kQg==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -19629,7 +19629,7 @@ packages:
       '@types/morgan': 1.9.3
       '@types/node': 14.18.22
       '@types/supertest': 2.0.12
-      '@types/webpack-node-externals': 2.5.3_webpack-cli@4.9.2
+      '@types/webpack-node-externals': 2.5.3_webpack-cli@4.10.0
       '@typescript-eslint/eslint-plugin': 4.33.0_d212f40a84a592446cd1718bfda08a13
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.3.5
       cookie-parser: 1.4.6
@@ -19658,13 +19658,13 @@ packages:
       ts-node: 9.1.1_typescript@4.3.5
       ts-node-dev: 1.1.8_typescript@4.3.5
       typescript: 4.3.5
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_webpack@5.38.1
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_webpack@5.38.1
       webpack-node-externals: 2.5.2
     dev: false
     name: '@rush-temp/server'
     resolution:
-      integrity: sha512-/8dIQL42u4QTgdlW8xL2S7WPWVkI/eqoBiXzQZteFyGGuT1j109hs10Xmfz8ueRugo4/Bdas87OK0E9quvEPTw==
+      integrity: sha512-rYuGMYr4e3NoN5qs5YEW2mNpqWEYocIqxkQCaUWbcRmxpnXvaMx/tv9EYXkjUjsHba1UI8kAM5i9fLQOTlWMaA==
       tarball: file:projects/server.tgz
     version: 0.0.0
   file:projects/storybook.tgz:

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -763,7 +763,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.9:
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.18.9
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.9
       '@babel/plugin-transform-parameters': 7.18.8_@babel+core@7.12.9
     dev: false
@@ -2148,7 +2148,7 @@ packages:
     dependencies:
       '@fluentui/set-version': 8.2.1
       '@fluentui/theme': 2.6.7_0593675b4d5fe572998fa3e4bddd25f7
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: false
     peerDependencies:
       '@types/react': '*'
@@ -2194,7 +2194,7 @@ packages:
       '@fluentui/react': 8.62.4_45310a9056d3778805408cde56755bb3
       '@fluentui/scheme-utilities': 8.3.8_0593675b4d5fe572998fa3e4bddd25f7
       '@fluentui/set-version': 8.2.1
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: false
     peerDependencies:
       '@types/react': '*'
@@ -2504,7 +2504,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       '@types/yargs': 15.0.14
       chalk: 4.1.2
     dev: false
@@ -2984,7 +2984,7 @@ packages:
       integrity: sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw==
   /@playwright/test/1.22.2:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       playwright-core: 1.22.2
     dev: false
     engines:
@@ -4175,7 +4175,7 @@ packages:
       flat-cache: 3.0.4
       micromatch: 4.0.5
       react-docgen-typescript: 2.2.2_typescript@4.3.5
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.3.5
       webpack: 5.38.1
     dev: false
@@ -4469,19 +4469,19 @@ packages:
   /@types/body-parser/1.19.2:
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
   /@types/bonjour/3.5.10:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==
   /@types/cheerio/0.22.31:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==
@@ -4495,13 +4495,13 @@ packages:
   /@types/connect-history-api-fallback/1.3.5:
     dependencies:
       '@types/express-serve-static-core': 4.17.29
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==
   /@types/connect/3.4.35:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
@@ -4535,13 +4535,13 @@ packages:
   /@types/eslint-scope/3.7.4:
     dependencies:
       '@types/eslint': 8.4.5
-      '@types/estree': 0.0.47
+      '@types/estree': 1.0.0
     dev: false
     resolution:
       integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==
   /@types/eslint/8.4.5:
     dependencies:
-      '@types/estree': 0.0.47
+      '@types/estree': 1.0.0
       '@types/json-schema': 7.0.11
     dev: false
     resolution:
@@ -4564,7 +4564,7 @@ packages:
       integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
   /@types/express-serve-static-core/4.17.29:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: false
@@ -4582,7 +4582,7 @@ packages:
   /@types/glob/7.2.0:
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
@@ -4608,7 +4608,7 @@ packages:
       integrity: sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==
   /@types/http-proxy/1.17.9:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==
@@ -4677,7 +4677,7 @@ packages:
       integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
   /@types/morgan/1.9.3:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-BiLcfVqGBZCyNCnCH3F4o2GmDLrpy0HeBVnNlyZG4fo88ZiE9SoiBe3C+2ezuwbjlEyT+PDZ17//TAlRxAn75Q==
@@ -4691,7 +4691,7 @@ packages:
   /@types/node-static/0.7.7:
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-Cq3c9lfC9zRrGxe7ox073219Mpy/kmWNsISG0yEG7aUEk33xv/g+uqz/+4b7hM4WN9LsGageBzGuvy09inaGhg==
@@ -4741,7 +4741,7 @@ packages:
       integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
   /@types/puppeteer/5.4.6:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-98Kghehs7+/GD9b56qryhqdqVCXUTbetTv3PlvDnmFRTHQH0j9DIp1f7rkAW3BAj4U3yoeSEQnKgdW8bDq0Y0Q==
@@ -4808,13 +4808,13 @@ packages:
   /@types/serve-static/1.13.10:
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
   /@types/sockjs/0.3.33:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==
@@ -4837,7 +4837,7 @@ packages:
   /@types/superagent/4.1.15:
     dependencies:
       '@types/cookiejar': 2.1.2
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-mu/N4uvfDN2zVQQ5AYJI/g4qxn2bHB6521t1UuH09ShNWjebTqN0ZFuYK9uYjcgmI0dTQEs+Owi1EO6U0OkOZQ==
@@ -4865,7 +4865,7 @@ packages:
       integrity: sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==
   /@types/tunnel/0.0.1:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
@@ -4893,10 +4893,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-eHSaNYEyxRA5IAG0Ym/yCyf86niZUIF/TpWKofQI/CVfh5HsMEUyfE2kwFxha4ow0s5g0LfISQxpDKjbRDrizw==
-  /@types/webpack-node-externals/2.5.3_webpack-cli@4.9.2:
+  /@types/webpack-node-externals/2.5.3_webpack-cli@4.10.0:
     dependencies:
-      '@types/node': 14.18.22
-      webpack: 5.38.1_webpack-cli@4.9.2
+      '@types/node': 18.0.6
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     peerDependencies:
       webpack-cli: '*'
@@ -4904,7 +4904,7 @@ packages:
       integrity: sha512-A9JxaR8QXoYT95egET4AmCFuChyTlP8d18ZAnmSHuIMsFdS7QlCQQ8pmN/+FHgLIkm+ViE/VngltT5avLACY9A==
   /@types/webpack-sources/3.2.0:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
     dev: false
@@ -4912,7 +4912,7 @@ packages:
       integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==
   /@types/webpack/4.41.32:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       '@types/tapable': 1.0.8
       '@types/uglify-js': 3.16.0
       '@types/webpack-sources': 3.2.0
@@ -4923,7 +4923,7 @@ packages:
       integrity: sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==
   /@types/ws/8.5.3:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     resolution:
       integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
@@ -4945,7 +4945,7 @@ packages:
       integrity: sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==
   /@types/yauzl/2.10.0:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
     dev: false
     optional: true
     resolution:
@@ -5320,39 +5320,39 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==
-  /@webpack-cli/configtest/1.2.0_webpack-cli@4.9.2+webpack@4.46.0:
+  /@webpack-cli/configtest/1.2.0_196e681456f11e809d8928f4499c300a:
     dependencies:
-      webpack: 4.46.0_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_webpack@4.46.0
+      webpack: 4.46.0_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_webpack@4.46.0
     dev: false
     peerDependencies:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     resolution:
       integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==
-  /@webpack-cli/configtest/1.2.0_webpack-cli@4.9.2+webpack@5.38.1:
+  /@webpack-cli/configtest/1.2.0_69574e65506de74a817e8de68330e733:
     dependencies:
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
     dev: false
     peerDependencies:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     resolution:
       integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==
-  /@webpack-cli/info/1.5.0_webpack-cli@4.9.2:
+  /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
     dev: false
     peerDependencies:
       webpack-cli: 4.x.x
     resolution:
       integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==
-  /@webpack-cli/serve/1.7.0_8b27d5839a2bdf89ba2338e4c89fea10:
+  /@webpack-cli/serve/1.7.0_de6ef8edff356eae17987a47309ecf6b:
     dependencies:
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
     dev: false
     peerDependencies:
       webpack-cli: 4.x.x
@@ -5362,9 +5362,9 @@ packages:
         optional: true
     resolution:
       integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
-  /@webpack-cli/serve/1.7.0_webpack-cli@4.9.2:
+  /@webpack-cli/serve/1.7.0_webpack-cli@4.10.0:
     dependencies:
-      webpack-cli: 4.9.2_webpack@4.46.0
+      webpack-cli: 4.10.0_webpack@4.46.0
     dev: false
     peerDependencies:
       webpack-cli: 4.x.x
@@ -5473,7 +5473,7 @@ packages:
       integrity: sha512-tNEZYz5G/zYunxFm7sfhAxkXEuLj3K6BKwv6ZURlsF6yiUQ65z0Q2wZW9L5cPUl9ocofGvXOdFYbFHp0+6MOig==
   /agent-base/6.0.2:
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.4
     dev: false
     engines:
       node: '>= 6.0.0'
@@ -5942,7 +5942,7 @@ packages:
       integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
   /ast-types/0.14.2:
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
     dev: false
     engines:
       node: '>=4'
@@ -5987,7 +5987,7 @@ packages:
       integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
   /autoprefixer/9.8.8:
     dependencies:
-      browserslist: 4.20.4
+      browserslist: 4.21.2
       caniuse-lite: 1.0.30001367
       normalize-range: 0.1.2
       num2fraction: 1.2.2
@@ -6068,7 +6068,7 @@ packages:
       mkdirp: 0.5.6
       pify: 4.0.1
       schema-utils: 2.7.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 6.9'
@@ -7380,7 +7380,7 @@ packages:
       p-limit: 3.1.0
       schema-utils: 3.1.1
       serialize-javascript: 5.0.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-sources: 1.4.3
     dev: false
     engines:
@@ -7648,7 +7648,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 7.3.7
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -8668,7 +8668,7 @@ packages:
       remark-mdx: 1.6.22
       remark-parse: 8.0.3
       remark-stringify: 8.1.1
-      tslib: 2.3.1
+      tslib: 2.4.0
       unified: 9.2.2
     dev: false
     engines:
@@ -8788,7 +8788,7 @@ packages:
       eslint-mdx: 1.17.1_eslint@7.32.0
       eslint-plugin-markdown: 2.2.1_eslint@7.32.0
       synckit: 0.4.1
-      tslib: 2.3.1
+      tslib: 2.4.0
       vfile: 4.2.1
     dev: false
     engines:
@@ -9274,7 +9274,7 @@ packages:
       integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
   /extract-zip/2.0.1:
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.4
       get-stream: 5.2.0
       yauzl: 2.10.0
     dev: false
@@ -10575,7 +10575,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 3.0.4
       tapable: 2.2.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>=10.13.0'
@@ -10708,7 +10708,7 @@ packages:
   /https-proxy-agent/5.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.1
+      debug: 4.3.4
     dev: false
     engines:
       node: '>= 6'
@@ -12116,7 +12116,7 @@ packages:
       integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
   /jest-worker/27.5.1:
     dependencies:
-      '@types/node': 14.18.22
+      '@types/node': 18.0.6
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -16595,7 +16595,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -16738,7 +16738,7 @@ packages:
       integrity: sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==
   /synckit/0.4.1:
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.0
       uuid: 8.3.2
     dev: false
     engines:
@@ -16854,7 +16854,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.1
-      webpack: 4.46.0_webpack-cli@4.9.2
+      webpack: 4.46.0_webpack-cli@4.10.0
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: false
@@ -16890,7 +16890,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       terser: 5.14.2
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -17146,7 +17146,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.3.7
       typescript: 4.3.5
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>=10.0.0'
@@ -17654,7 +17654,7 @@ packages:
       loader-utils: 2.0.2
       mime-types: 2.1.35
       schema-utils: 3.1.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 10.13.0'
@@ -17893,21 +17893,21 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-GUMZlM3SKwS8Z+CKeIFx7CVoHn3dXFcUAjT/dcZQQmfSZGvitPfMob2ipjai7ovFFqPvTqkEZ/leL4O0YOdAYQ==
-  /webpack-cli/4.9.2_6162a62ebb8c895864a3a412aa800002:
+  /webpack-cli/4.10.0_6162a62ebb8c895864a3a412aa800002:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0_webpack-cli@4.9.2+webpack@5.38.1
-      '@webpack-cli/info': 1.5.0_webpack-cli@4.9.2
-      '@webpack-cli/serve': 1.7.0_8b27d5839a2bdf89ba2338e4c89fea10
+      '@webpack-cli/configtest': 1.2.0_69574e65506de74a817e8de68330e733
+      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
+      '@webpack-cli/serve': 1.7.0_de6ef8edff356eae17987a47309ecf6b
       colorette: 2.0.19
       commander: 7.2.0
-      execa: 5.1.1
+      cross-spawn: 7.0.3
       fastest-levenshtein: 1.0.12
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
       webpack-merge: 5.8.0
     dev: false
     engines:
@@ -17929,23 +17929,23 @@ packages:
       webpack-dev-server:
         optional: true
     resolution:
-      integrity: sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
-  /webpack-cli/4.9.2_67e60b7ff37de853f3f9b3d129e0cb92:
+      integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
+  /webpack-cli/4.10.0_67e60b7ff37de853f3f9b3d129e0cb92:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0_webpack-cli@4.9.2+webpack@5.38.1
-      '@webpack-cli/info': 1.5.0_webpack-cli@4.9.2
-      '@webpack-cli/serve': 1.7.0_8b27d5839a2bdf89ba2338e4c89fea10
+      '@webpack-cli/configtest': 1.2.0_69574e65506de74a817e8de68330e733
+      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
+      '@webpack-cli/serve': 1.7.0_de6ef8edff356eae17987a47309ecf6b
       colorette: 2.0.19
       commander: 7.2.0
-      execa: 5.1.1
+      cross-spawn: 7.0.3
       fastest-levenshtein: 1.0.12
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.5.0
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
       webpack-merge: 5.8.0
     dev: false
     engines:
@@ -17967,21 +17967,21 @@ packages:
       webpack-dev-server:
         optional: true
     resolution:
-      integrity: sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
-  /webpack-cli/4.9.2_webpack@4.46.0:
+      integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
+  /webpack-cli/4.10.0_webpack@4.46.0:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0_webpack-cli@4.9.2+webpack@4.46.0
-      '@webpack-cli/info': 1.5.0_webpack-cli@4.9.2
-      '@webpack-cli/serve': 1.7.0_webpack-cli@4.9.2
+      '@webpack-cli/configtest': 1.2.0_196e681456f11e809d8928f4499c300a
+      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
+      '@webpack-cli/serve': 1.7.0_webpack-cli@4.10.0
       colorette: 2.0.19
       commander: 7.2.0
-      execa: 5.1.1
+      cross-spawn: 7.0.3
       fastest-levenshtein: 1.0.12
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 4.46.0_webpack-cli@4.9.2
+      webpack: 4.46.0_webpack-cli@4.10.0
       webpack-merge: 5.8.0
     dev: false
     engines:
@@ -18003,21 +18003,21 @@ packages:
       webpack-dev-server:
         optional: true
     resolution:
-      integrity: sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
-  /webpack-cli/4.9.2_webpack@5.38.1:
+      integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
+  /webpack-cli/4.10.0_webpack@5.38.1:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0_webpack-cli@4.9.2+webpack@5.38.1
-      '@webpack-cli/info': 1.5.0_webpack-cli@4.9.2
-      '@webpack-cli/serve': 1.7.0_webpack-cli@4.9.2
+      '@webpack-cli/configtest': 1.2.0_69574e65506de74a817e8de68330e733
+      '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
+      '@webpack-cli/serve': 1.7.0_webpack-cli@4.10.0
       colorette: 2.0.19
       commander: 7.2.0
-      execa: 5.1.1
+      cross-spawn: 7.0.3
       fastest-levenshtein: 1.0.12
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-merge: 5.8.0
     dev: false
     engines:
@@ -18039,7 +18039,7 @@ packages:
       webpack-dev-server:
         optional: true
     resolution:
-      integrity: sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
+      integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
   /webpack-dev-middleware/3.7.3_webpack@4.46.0:
     dependencies:
       memory-fs: 0.4.1
@@ -18062,7 +18062,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
     dev: false
     engines:
       node: '>= 12.13.0'
@@ -18070,7 +18070,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     resolution:
       integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==
-  /webpack-dev-server/4.8.1_webpack-cli@4.9.2+webpack@5.38.1:
+  /webpack-dev-server/4.8.1_69574e65506de74a817e8de68330e733:
     dependencies:
       '@types/bonjour': 3.5.10
       '@types/connect-history-api-fallback': 1.3.5
@@ -18099,8 +18099,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
       webpack-dev-middleware: 5.3.3_webpack@5.38.1
       ws: 8.8.1
     dev: false
@@ -18217,7 +18217,7 @@ packages:
         optional: true
     resolution:
       integrity: sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
-  /webpack/4.46.0_webpack-cli@4.9.2:
+  /webpack/4.46.0_webpack-cli@4.10.0:
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -18241,7 +18241,7 @@ packages:
       tapable: 1.1.3
       terser-webpack-plugin: 1.4.5_webpack@4.46.0
       watchpack: 1.7.5
-      webpack-cli: 4.9.2_webpack@4.46.0
+      webpack-cli: 4.10.0_webpack@4.46.0
       webpack-sources: 1.4.3
     dev: false
     engines:
@@ -18293,7 +18293,7 @@ packages:
         optional: true
     resolution:
       integrity: sha512-OqRmYD1OJbHZph6RUMD93GcCZy4Z4wC0ele4FXyYF0J6AxO1vOSuIlU1hkS/lDlR9CDYBz64MZRmdbdnFFoT2g==
-  /webpack/5.38.1_webpack-cli@4.9.2:
+  /webpack/5.38.1_webpack-cli@4.10.0:
     dependencies:
       '@types/eslint-scope': 3.7.4
       '@types/estree': 0.0.47
@@ -18317,7 +18317,7 @@ packages:
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.3_webpack@5.38.1
       watchpack: 2.4.0
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
       webpack-sources: 2.3.1
     dev: false
     engines:
@@ -18930,14 +18930,14 @@ packages:
       typescript: 4.3.5
       url-loader: 4.1.1_webpack@5.38.1
       uuid: 8.3.2
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.5.0
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-lZQb99oQ4Rd+M3Zo7NX/pO63XpqwvT+POXU2uqe7rfgIXx7kZGZH7PKd6pKiWIenmbDD1x9YYFvh25QTRKYLvQ==
+      integrity: sha512-k8yt5pMCZyOhhxUazy4EXykn+HrJ6tsXYpbbjD5qbDQY9YjBQP0i+OWE9kDFIXTjbbIAeNVesGRi+yr/8t6Cmw==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
@@ -19003,14 +19003,14 @@ packages:
       typescript: 4.3.5
       url-loader: 4.1.1_webpack@5.38.1
       uuid: 8.3.2
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.5.0
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-g0Le0UL9s9eS/ATe2KPi3hm3Exruot4ZdsZHX5gd5XOsDey7g3d+m8ntRtfzJ8KaBhDHAgbipXY4dHsmTrpHZg==
+      integrity: sha512-V+HERERivtcxy0QHk8H1kokNZm6kMTen+JhoLiLpp8SV+SxBSrZkqwJ1MGirggWstxxz84CtnwGOpjLnAvOuhQ==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19149,14 +19149,14 @@ packages:
       ts-loader: 8.4.0_typescript@4.3.5+webpack@5.38.1
       typescript: 4.3.5
       url-loader: 4.1.1_webpack@5.38.1
-      webpack: 5.38.1_webpack-cli@4.9.2
+      webpack: 5.38.1_webpack-cli@4.10.0
       webpack-bundle-analyzer: 4.5.0
-      webpack-cli: 4.9.2_67e60b7ff37de853f3f9b3d129e0cb92
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack-cli: 4.10.0_67e60b7ff37de853f3f9b3d129e0cb92
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-ImICaQ//o6HfO4ByJFJ1wn99saG7Hn/n8qp2GWxNWgpFNfjgsiIQIBeJDHAH8hwp9p/ZEBdIFTfvGtU/qfZ4HQ==
+      integrity: sha512-s/dzwWvB4sGbwoNv0rdHxRqJgsizS204cIm3CQ2BiRCHfvUnXUGUwWaqyQsGKK8P3Jbn0EoU3nfr+xWd/lqthA==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19168,12 +19168,12 @@ packages:
       eslint-plugin-prettier: 3.4.1_8142a4287e8e8e0691574dfac8adcedb
       prettier: 2.3.1
       rimraf: 2.7.1
-      webpack: 4.46.0_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_webpack@4.46.0
+      webpack: 4.46.0_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_webpack@4.46.0
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-kbNTHzire1xBnTQmStIaoDy4qJEPvgtK/OMrkdMv5AX9OicHNdxqumTWLv9DGwzfkFfn0eGr0p5V7Sh4W25kGg==
+      integrity: sha512-YTucy12zfGkX9XP3qd0G+/38O0wBaRkm1gxLUIoRI878l1ifcVnNrzlGNATxn2iG4p4ShD+9+zwmP7V1R+FYLg==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
@@ -19303,13 +19303,13 @@ packages:
       ts-loader: 8.4.0_typescript@4.3.5+webpack@5.38.1
       typescript: 4.3.5
       uuid: 8.3.2
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_6162a62ebb8c895864a3a412aa800002
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_6162a62ebb8c895864a3a412aa800002
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-fAsblf2ZT7O3W6++eg3CMKhh9wJHK4DJdow/OkgTcC5VoRvJaT2k+SQQhtZW8kLmgIEl9Fbtck4rF5N+thH7pw==
+      integrity: sha512-nFif+4a7PCyiwMXVu/dYlvUgwqSuX9CTIdXuKI7p2u7kCXy7B1+qvtRO/ZZ6UA7LVvnsODIXNAD0Ee/rAIMO3Q==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19544,14 +19544,14 @@ packages:
       type-fest: 2.5.4
       typescript: 4.3.5
       uuid: 8.3.2
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_6162a62ebb8c895864a3a412aa800002
-      webpack-dev-server: 4.8.1_webpack-cli@4.9.2+webpack@5.38.1
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_6162a62ebb8c895864a3a412aa800002
+      webpack-dev-server: 4.8.1_69574e65506de74a817e8de68330e733
       yargs: 17.5.1
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-b51EY0iaOt2tnMoUIlYCiGlMjEo/SGO+uM2G5qq9B2T6Iox5Ll6O2MSkMdjEv2wWHsxAMtPPy81SrBH7CHecMg==
+      integrity: sha512-IKU3vA8rojgaqzXTJ+SLKilakn/5d18xPutQCA/NplxvlStzHe7dNOo+c3/DfGjDufLitm5P2A7pKtSn60Z0yg==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
@@ -19606,12 +19606,12 @@ packages:
       rimraf: 2.7.1
       typescript: 4.3.5
       uuid: 8.3.2
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_webpack@5.38.1
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_webpack@5.38.1
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-g9/oqxHBCT5ngOf0rcGbh9dr1Y2Lum/th7QN84w7S1hz7jTJV0vwge2nJfXHuHzu7ITWxCC1Ki0diBSRkSSmNg==
+      integrity: sha512-tIr2qUir8NxIvAuBlf7UvPLElCajfz3ae1YU13iwLzOn86slz1Hr99FmPAaWi37DzdIvkraV0aCl1cbgBV3kQg==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -19629,7 +19629,7 @@ packages:
       '@types/morgan': 1.9.3
       '@types/node': 14.18.22
       '@types/supertest': 2.0.12
-      '@types/webpack-node-externals': 2.5.3_webpack-cli@4.9.2
+      '@types/webpack-node-externals': 2.5.3_webpack-cli@4.10.0
       '@typescript-eslint/eslint-plugin': 4.33.0_d212f40a84a592446cd1718bfda08a13
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.3.5
       cookie-parser: 1.4.6
@@ -19658,13 +19658,13 @@ packages:
       ts-node: 9.1.1_typescript@4.3.5
       ts-node-dev: 1.1.8_typescript@4.3.5
       typescript: 4.3.5
-      webpack: 5.38.1_webpack-cli@4.9.2
-      webpack-cli: 4.9.2_webpack@5.38.1
+      webpack: 5.38.1_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_webpack@5.38.1
       webpack-node-externals: 2.5.2
     dev: false
     name: '@rush-temp/server'
     resolution:
-      integrity: sha512-/8dIQL42u4QTgdlW8xL2S7WPWVkI/eqoBiXzQZteFyGGuT1j109hs10Xmfz8ueRugo4/Bdas87OK0E9quvEPTw==
+      integrity: sha512-rYuGMYr4e3NoN5qs5YEW2mNpqWEYocIqxkQCaUWbcRmxpnXvaMx/tv9EYXkjUjsHba1UI8kAM5i9fLQOTlWMaA==
       tarball: file:projects/server.tgz
     version: 0.0.0
   file:projects/storybook.tgz:

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -162,7 +162,7 @@
     "type-fest": "~2.5.4",
     "typescript": "4.3.5",
     "uuid": "^8.1.0",
-    "webpack-cli": "~4.9.2",
+    "webpack-cli": "~4.10.0",
     "webpack-dev-server": "4.8.1",
     "webpack": "5.38.1",
     "yargs": "17.5.1"

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -95,7 +95,7 @@
     "typescript": "4.3.5",
     "url-loader": "~4.1.1",
     "webpack": "5.38.1",
-    "webpack-cli": "~4.9.2",
+    "webpack-cli": "~4.10.0",
     "webpack-dev-server": "4.8.1"
   }
 }

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -93,7 +93,7 @@
     "ts-loader": "^8.0.12",
     "typescript": "4.3.5",
     "url-loader": "~4.1.1",
-    "webpack-cli": "~4.9.2",
+    "webpack-cli": "~4.10.0",
     "webpack-dev-server": "4.8.1",
     "webpack": "5.38.1"
   }

--- a/samples/Chat/package.json
+++ b/samples/Chat/package.json
@@ -85,7 +85,7 @@
     "ts-loader": "^8.0.12",
     "typescript": "4.3.5",
     "url-loader": "~4.1.1",
-    "webpack-cli": "~4.9.2",
+    "webpack-cli": "~4.10.0",
     "webpack-dev-server": "4.8.1",
     "webpack": "5.38.1"
   }

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -64,7 +64,7 @@
     "ts-loader": "^8.0.12",
     "typescript": "4.3.5",
     "webpack": "5.38.1",
-    "webpack-cli": "~4.9.2",
+    "webpack-cli": "~4.10.0",
     "webpack-dev-server": "4.8.1"
   }
 }

--- a/samples/Server/package.json
+++ b/samples/Server/package.json
@@ -64,7 +64,7 @@
     "ts-node-dev": "^1.0.0",
     "typescript": "4.3.5",
     "webpack": "5.38.1",
-    "webpack-cli": "~4.9.2",
+    "webpack-cli": "~4.10.0",
     "webpack-node-externals": "^2.5.2"
   }
 }

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -49,6 +49,6 @@
     "rimraf": "^2.6.2",
     "typescript": "4.3.5",
     "webpack": "5.38.1",
-    "webpack-cli": "~4.9.2"
+    "webpack-cli": "~4.10.0"
   }
 }

--- a/tools/check-treeshaking/package.json
+++ b/tools/check-treeshaking/package.json
@@ -34,6 +34,6 @@
     "prettier": "2.3.1",
     "rimraf": "^2.6.2",
     "webpack": "^4.44.0",
-    "webpack-cli": "~4.9.2"
+    "webpack-cli": "~4.10.0"
   }
 }


### PR DESCRIPTION
# What
Update webpack-cli to `4.10.x`

# Why
Error running samples:
![image](https://user-images.githubusercontent.com/2684369/179810749-39e83613-d074-4972-91df-3e97df564b39.png)

Likely after we updated our pnpm lock file in https://github.com/Azure/communication-ui-library/pull/2090

More details on fix: https://stackoverflow.com/a/72693567/3047190

# How Tested
Can run Calling sample locally again now