### PR TITLE
Create common composite strings for CallWithChat and Call Composite

### DIFF
--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -396,11 +396,10 @@ export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcon
 }
 
 // @public
-export interface CallCompositeStrings {
+export interface CallCompositeStrings extends CommonCompositeStrings {
     cameraLabel: string;
     cameraPermissionDenied: string;
     cameraTurnedOff: string;
-    chatButtonLabel: string;
     close: string;
     complianceBannerNowOnlyRecording: string;
     complianceBannerNowOnlyTranscription: string;
@@ -416,9 +415,7 @@ export interface CallCompositeStrings {
     complianceBannerTranscriptionStopped: string;
     configurationPageCallDetails?: string;
     configurationPageTitle: string;
-    copyInviteLinkButtonLabel: string;
     defaultPlaceHolder: string;
-    dismissSidePaneButtonLabel?: string;
     failedToJoinCallDueToNoNetworkMoreDetails?: string;
     failedToJoinCallDueToNoNetworkTitle: string;
     failedToJoinTeamsMeetingReasonAccessDeniedMoreDetails?: string;
@@ -435,16 +432,10 @@ export interface CallCompositeStrings {
     mutedMessage: string;
     networkReconnectMoreDetails: string;
     networkReconnectTitle: string;
-    peopleButtonLabel: string;
-    peoplePaneSubTitle: string;
-    peoplePaneTitle: string;
     privacyPolicy: string;
     rejoinCallButtonLabel: string;
     removedFromCallMoreDetails?: string;
     removedFromCallTitle: string;
-    removeMenuLabel: string;
-    returnToCallButtonAriaDescription?: string;
-    returnToCallButtonAriaLabel?: string;
     soundLabel: string;
     startCallButtonLabel: string;
 }
@@ -828,29 +819,20 @@ export interface CallWithChatCompositeProps extends BaseCompositeProps<CallWithC
 }
 
 // @public
-export interface CallWithChatCompositeStrings {
-    chatButtonLabel: string;
+export interface CallWithChatCompositeStrings extends CommonCompositeStrings {
     chatButtonNewMessageNotificationLabel: string;
     chatButtonTooltipClose: string;
     chatButtonTooltipClosedWithMessageCount: string;
     chatButtonTooltipOpen: string;
     chatPaneTitle: string;
-    copyInviteLinkButtonLabel: string;
-    dismissSidePaneButtonLabel?: string;
     moreDrawerAudioDeviceMenuTitle?: string;
     moreDrawerButtonLabel: string;
     moreDrawerButtonTooltip: string;
     moreDrawerMicrophoneMenuTitle: string;
     moreDrawerSpeakerMenuTitle: string;
-    peopleButtonLabel: string;
     peopleButtonTooltipClose: string;
     peopleButtonTooltipOpen: string;
-    peoplePaneSubTitle: string;
-    peoplePaneTitle: string;
     pictureInPictureTileAriaLabel: string;
-    removeMenuLabel: string;
-    returnToCallButtonAriaDescription?: string;
-    returnToCallButtonAriaLabel?: string;
 }
 
 // @public
@@ -1155,6 +1137,19 @@ export type ClientState = CallClientState & ChatClientState;
 
 // @public
 export type Common<A, B> = Pick<A, CommonProperties<A, B>>;
+
+// @public
+export interface CommonCompositeStrings {
+    chatButtonLabel: string;
+    copyInviteLinkButtonLabel: string;
+    dismissSidePaneButtonLabel?: string;
+    peopleButtonLabel: string;
+    peoplePaneSubTitle: string;
+    peoplePaneTitle: string;
+    removeMenuLabel: string;
+    returnToCallButtonAriaDescription?: string;
+    returnToCallButtonAriaLabel?: string;
+}
 
 // @public
 export type CommonProperties<A, B> = {

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -372,7 +372,7 @@ export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcon
 }
 
 // @public
-export interface CallCompositeStrings {
+export interface CallCompositeStrings extends CommonCompositeStrings {
     cameraLabel: string;
     cameraPermissionDenied: string;
     cameraTurnedOff: string;
@@ -763,29 +763,20 @@ export interface CallWithChatCompositeProps extends BaseCompositeProps<CallWithC
 }
 
 // @public
-export interface CallWithChatCompositeStrings {
-    chatButtonLabel: string;
+export interface CallWithChatCompositeStrings extends CommonCompositeStrings {
     chatButtonNewMessageNotificationLabel: string;
     chatButtonTooltipClose: string;
     chatButtonTooltipClosedWithMessageCount: string;
     chatButtonTooltipOpen: string;
     chatPaneTitle: string;
-    copyInviteLinkButtonLabel: string;
-    dismissSidePaneButtonLabel?: string;
     moreDrawerAudioDeviceMenuTitle?: string;
     moreDrawerButtonLabel: string;
     moreDrawerButtonTooltip: string;
     moreDrawerMicrophoneMenuTitle: string;
     moreDrawerSpeakerMenuTitle: string;
-    peopleButtonLabel: string;
     peopleButtonTooltipClose: string;
     peopleButtonTooltipOpen: string;
-    peoplePaneSubTitle: string;
-    peoplePaneTitle: string;
     pictureInPictureTileAriaLabel: string;
-    removeMenuLabel: string;
-    returnToCallButtonAriaDescription?: string;
-    returnToCallButtonAriaLabel?: string;
 }
 
 // @public
@@ -1076,6 +1067,19 @@ export type ClientState = CallClientState & ChatClientState;
 
 // @public
 export type Common<A, B> = Pick<A, CommonProperties<A, B>>;
+
+// @public
+export interface CommonCompositeStrings {
+    chatButtonLabel: string;
+    copyInviteLinkButtonLabel: string;
+    dismissSidePaneButtonLabel?: string;
+    peopleButtonLabel: string;
+    peoplePaneSubTitle: string;
+    peoplePaneTitle: string;
+    removeMenuLabel: string;
+    returnToCallButtonAriaDescription?: string;
+    returnToCallButtonAriaLabel?: string;
+}
 
 // @public
 export type CommonProperties<A, B> = {

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -292,11 +292,10 @@ export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcon
 }
 
 // @public
-export interface CallCompositeStrings {
+export interface CallCompositeStrings extends CommonCompositeStrings {
     cameraLabel: string;
     cameraPermissionDenied: string;
     cameraTurnedOff: string;
-    chatButtonLabel: string;
     close: string;
     complianceBannerNowOnlyRecording: string;
     complianceBannerNowOnlyTranscription: string;
@@ -312,9 +311,7 @@ export interface CallCompositeStrings {
     complianceBannerTranscriptionStopped: string;
     configurationPageCallDetails?: string;
     configurationPageTitle: string;
-    copyInviteLinkButtonLabel: string;
     defaultPlaceHolder: string;
-    dismissSidePaneButtonLabel?: string;
     failedToJoinCallDueToNoNetworkMoreDetails?: string;
     failedToJoinCallDueToNoNetworkTitle: string;
     failedToJoinTeamsMeetingReasonAccessDeniedMoreDetails?: string;
@@ -331,16 +328,10 @@ export interface CallCompositeStrings {
     mutedMessage: string;
     networkReconnectMoreDetails: string;
     networkReconnectTitle: string;
-    peopleButtonLabel: string;
-    peoplePaneSubTitle: string;
-    peoplePaneTitle: string;
     privacyPolicy: string;
     rejoinCallButtonLabel: string;
     removedFromCallMoreDetails?: string;
     removedFromCallTitle: string;
-    removeMenuLabel: string;
-    returnToCallButtonAriaDescription?: string;
-    returnToCallButtonAriaLabel?: string;
     soundLabel: string;
     startCallButtonLabel: string;
 }
@@ -617,29 +608,20 @@ export interface CallWithChatCompositeProps extends BaseCompositeProps<CallWithC
 }
 
 // @public
-export interface CallWithChatCompositeStrings {
-    chatButtonLabel: string;
+export interface CallWithChatCompositeStrings extends CommonCompositeStrings {
     chatButtonNewMessageNotificationLabel: string;
     chatButtonTooltipClose: string;
     chatButtonTooltipClosedWithMessageCount: string;
     chatButtonTooltipOpen: string;
     chatPaneTitle: string;
-    copyInviteLinkButtonLabel: string;
-    dismissSidePaneButtonLabel?: string;
     moreDrawerAudioDeviceMenuTitle?: string;
     moreDrawerButtonLabel: string;
     moreDrawerButtonTooltip: string;
     moreDrawerMicrophoneMenuTitle: string;
     moreDrawerSpeakerMenuTitle: string;
-    peopleButtonLabel: string;
     peopleButtonTooltipClose: string;
     peopleButtonTooltipOpen: string;
-    peoplePaneSubTitle: string;
-    peoplePaneTitle: string;
     pictureInPictureTileAriaLabel: string;
-    removeMenuLabel: string;
-    returnToCallButtonAriaDescription?: string;
-    returnToCallButtonAriaLabel?: string;
 }
 
 // @public
@@ -755,6 +737,19 @@ export interface ChatCompositeProps extends BaseCompositeProps<ChatCompositeIcon
 export interface ChatCompositeStrings {
     chatListHeader: string;
     uploadFile: string;
+}
+
+// @public
+export interface CommonCompositeStrings {
+    chatButtonLabel: string;
+    copyInviteLinkButtonLabel: string;
+    dismissSidePaneButtonLabel?: string;
+    peopleButtonLabel: string;
+    peoplePaneSubTitle: string;
+    peoplePaneTitle: string;
+    removeMenuLabel: string;
+    returnToCallButtonAriaDescription?: string;
+    returnToCallButtonAriaLabel?: string;
 }
 
 // @public

--- a/packages/react-composites/review/stable/react-composites.api.md
+++ b/packages/react-composites/review/stable/react-composites.api.md
@@ -275,7 +275,7 @@ export interface CallCompositeProps extends BaseCompositeProps<CallCompositeIcon
 }
 
 // @public
-export interface CallCompositeStrings {
+export interface CallCompositeStrings extends CommonCompositeStrings {
     cameraLabel: string;
     cameraPermissionDenied: string;
     cameraTurnedOff: string;
@@ -562,29 +562,20 @@ export interface CallWithChatCompositeProps extends BaseCompositeProps<CallWithC
 }
 
 // @public
-export interface CallWithChatCompositeStrings {
-    chatButtonLabel: string;
+export interface CallWithChatCompositeStrings extends CommonCompositeStrings {
     chatButtonNewMessageNotificationLabel: string;
     chatButtonTooltipClose: string;
     chatButtonTooltipClosedWithMessageCount: string;
     chatButtonTooltipOpen: string;
     chatPaneTitle: string;
-    copyInviteLinkButtonLabel: string;
-    dismissSidePaneButtonLabel?: string;
     moreDrawerAudioDeviceMenuTitle?: string;
     moreDrawerButtonLabel: string;
     moreDrawerButtonTooltip: string;
     moreDrawerMicrophoneMenuTitle: string;
     moreDrawerSpeakerMenuTitle: string;
-    peopleButtonLabel: string;
     peopleButtonTooltipClose: string;
     peopleButtonTooltipOpen: string;
-    peoplePaneSubTitle: string;
-    peoplePaneTitle: string;
     pictureInPictureTileAriaLabel: string;
-    removeMenuLabel: string;
-    returnToCallButtonAriaDescription?: string;
-    returnToCallButtonAriaLabel?: string;
 }
 
 // @public
@@ -690,6 +681,19 @@ export interface ChatCompositeProps extends BaseCompositeProps<ChatCompositeIcon
 // @public
 export interface ChatCompositeStrings {
     chatListHeader: string;
+}
+
+// @public
+export interface CommonCompositeStrings {
+    chatButtonLabel: string;
+    copyInviteLinkButtonLabel: string;
+    dismissSidePaneButtonLabel?: string;
+    peopleButtonLabel: string;
+    peoplePaneSubTitle: string;
+    peoplePaneTitle: string;
+    removeMenuLabel: string;
+    returnToCallButtonAriaDescription?: string;
+    returnToCallButtonAriaLabel?: string;
 }
 
 // @public

--- a/packages/react-composites/src/composites/CallComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Strings.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CommonCompositeStrings } from '../common/Strings';
+
 /**
  * Strings used by the {@link CallComposite} directly.
  *
@@ -8,7 +10,7 @@
  *
  * @public
  */
-export interface CallCompositeStrings {
+export interface CallCompositeStrings extends CommonCompositeStrings {
   /**
    * Title of configuration page.
    */
@@ -173,49 +175,4 @@ export interface CallCompositeStrings {
    * Tooltip text used to inform a user that toggling microphone in lobby is not supported.
    */
   microphoneToggleInLobbyNotAllowed: string;
-  /* @conditional-compile-remove(one-to-n-calling) */
-  /**
-   * Side pane People section Title.
-   */
-  peoplePaneTitle: string;
-  /* @conditional-compile-remove(one-to-n-calling) */
-  /**
-   * Aria label string for return to call back button
-   */
-  returnToCallButtonAriaLabel?: string;
-  /* @conditional-compile-remove(one-to-n-calling) */
-  /**
-   * Aria Description string for return to call button
-   */
-  returnToCallButtonAriaDescription?: string;
-  /* @conditional-compile-remove(one-to-n-calling) */
-  /**
-   * control bar People button label
-   */
-  peopleButtonLabel: string;
-  /* @conditional-compile-remove(one-to-n-calling) */
-  /**
-   * control bar Chat button label.
-   */
-  chatButtonLabel: string;
-  /* @conditional-compile-remove(one-to-n-calling) */
-  /**
-   * Label for SidePaneHeader dismiss button
-   */
-  dismissSidePaneButtonLabel?: string;
-  /* @conditional-compile-remove(one-to-n-calling) */
-  /**
-   * Side pane People section subheader.
-   */
-  peoplePaneSubTitle: string;
-  /* @conditional-compile-remove(one-to-n-calling) */
-  /**
-   * Label for button to copy invite link
-   */
-  copyInviteLinkButtonLabel: string;
-  /* @conditional-compile-remove(one-to-n-calling) */
-  /**
-   * Label for menu item to remove participant
-   */
-  removeMenuLabel: string;
 }

--- a/packages/react-composites/src/composites/CallComposite/components/CallPane.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallPane.tsx
@@ -59,7 +59,7 @@ export const CallPane = (props: {
   const getStrings = (): CommonCompositeStrings => {
     /* @conditional-compile-remove(one-to-n-calling) */
     return localeStrings.strings.call;
-
+    // To be removed when feature goes from beta to stable
     return {} as CommonCompositeStrings;
   };
 

--- a/packages/react-composites/src/composites/CallComposite/components/CallPane.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallPane.tsx
@@ -25,10 +25,12 @@ import { drawerContainerStyles } from '../styles/CallComposite.styles';
 import { TabHeader } from '../../common/TabHeader';
 import { _ICoordinates } from '@internal/react-components';
 import { _pxToRem } from '@internal/acs-ui-common';
+/* @conditional-compile-remove(one-to-n-calling) */
 import { useLocale } from '../../localization';
 import { getPipStyles } from '../../common/styles/ModalLocalAndRemotePIP.styles';
 import { useMinMaxDragPosition } from '../../common/utils';
 import { availableSpaceStyles, hiddenStyles, sidePaneStyles, sidePaneTokens } from '../../common/styles/Pane.styles';
+import { CommonCompositeStrings } from '../../common/Strings';
 
 /**
  * Pane that is used to store participants for Call composite
@@ -51,14 +53,14 @@ export const CallPane = (props: {
 
   const hidden = props.activePane === 'none';
   const paneStyles = hidden ? hiddenStyles : props.mobileView ? availableSpaceStyles : sidePaneStyles;
+  /* @conditional-compile-remove(one-to-n-calling) */
   const localeStrings = useLocale();
 
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  const getStrings = () => {
+  const getStrings = (): CommonCompositeStrings => {
     /* @conditional-compile-remove(one-to-n-calling) */
     return localeStrings.strings.call;
 
-    return localeStrings.strings.callWithChat;
+    return {} as CommonCompositeStrings;
   };
 
   const strings = getStrings();

--- a/packages/react-composites/src/composites/CallWithChatComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/Strings.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { CommonCompositeStrings } from '../common/Strings';
+
 /**
  * Strings used by the {@link CallWithChatComposite} directly.
  *
@@ -8,11 +10,7 @@
  *
  * @public
  */
-export interface CallWithChatCompositeStrings {
-  /**
-   * {@link CallWithChatComposite} control bar People button label
-   */
-  peopleButtonLabel: string;
+export interface CallWithChatCompositeStrings extends CommonCompositeStrings {
   /**
    * {@link CallWithChatComposite} control bar People button ToolTipContent
    */
@@ -21,10 +19,6 @@ export interface CallWithChatCompositeStrings {
    * {@link CallWithChatComposite} control bar People button ToolTipContent
    */
   peopleButtonTooltipClose: string;
-  /**
-   * {@link CallWithChatComposite} control bar Chat button label.
-   */
-  chatButtonLabel: string;
   /**
    * {@Link CallWithChatComposite} control bar Chat button ToolTipContent.
    */
@@ -64,14 +58,6 @@ export interface CallWithChatCompositeStrings {
    */
   moreDrawerButtonTooltip: string;
   /**
-   * Side pane People section Title.
-   */
-  peoplePaneTitle: string;
-  /**
-   * Side pane People section subheader.
-   */
-  peoplePaneSubTitle: string;
-  /**
    * Side pane Chat screen title.
    */
   chatPaneTitle: string;
@@ -87,24 +73,4 @@ export interface CallWithChatCompositeStrings {
    * returns the user to the call screen.
    */
   pictureInPictureTileAriaLabel: string;
-  /**
-   * Label for menu item to remove participant
-   */
-  removeMenuLabel: string;
-  /**
-   * Label for button to copy invite link
-   */
-  copyInviteLinkButtonLabel: string;
-  /**
-   * Label for SidePaneHeader dismiss button
-   */
-  dismissSidePaneButtonLabel?: string;
-  /**
-   * Aria Description string for return to call button
-   */
-  returnToCallButtonAriaDescription?: string;
-  /**
-   * Aria label string for return to call back button
-   */
-  returnToCallButtonAriaLabel?: string;
 }

--- a/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
+++ b/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
@@ -10,7 +10,6 @@ import {
 } from '@internal/react-components';
 import copy from 'copy-to-clipboard';
 import React, { useMemo } from 'react';
-import { CallWithChatCompositeStrings } from '../CallWithChatComposite';
 import { usePropsFor } from '../CallComposite/hooks/usePropsFor';
 import { AvatarPersonaDataCallback } from '../common/AvatarPersona';
 import { CallWithChatCompositeIcon } from '../common/icons';
@@ -24,8 +23,7 @@ import {
   participantListContainerStyles,
   peoplePaneContainerStyle
 } from './styles/PeoplePaneContent.styles';
-/* @conditional-compile-remove(one-to-n-calling) */
-import { CallCompositeStrings } from '../CallComposite';
+import { CommonCompositeStrings } from './Strings';
 
 /**
  * @private
@@ -35,7 +33,7 @@ export const PeoplePaneContent = (props: {
   onRemoveParticipant: (participantId: string) => void;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
-  strings: CallWithChatCompositeStrings | /* @conditional-compile-remove(one-to-n-calling) */ CallCompositeStrings;
+  strings: CommonCompositeStrings;
   setDrawerMenuItems: (_DrawerMenuItemProps) => void;
   mobileView?: boolean;
 }): JSX.Element => {
@@ -153,7 +151,7 @@ export const PeoplePaneContent = (props: {
  */
 const createDefaultContextualMenuItems = (
   participant: ParticipantListParticipant,
-  strings: CallWithChatCompositeStrings | /* @conditional-compile-remove(one-to-n-calling) */ CallCompositeStrings,
+  strings: CommonCompositeStrings,
   onRemoveParticipant: (userId: string) => Promise<void>,
   localParticipantUserId?: string
 ): IContextualMenuItem[] => {

--- a/packages/react-composites/src/composites/common/SidePaneHeader.tsx
+++ b/packages/react-composites/src/composites/common/SidePaneHeader.tsx
@@ -3,10 +3,8 @@
 import { CommandBarButton, Stack } from '@fluentui/react';
 import { useTheme } from '@internal/react-components';
 import React, { useMemo } from 'react';
-/* @conditional-compile-remove(one-to-n-calling) */
-import { CallCompositeStrings } from '../CallComposite';
-import { CallWithChatCompositeStrings } from '../CallWithChatComposite';
 import { sidePaneHeaderContainerStyles, sidePaneHeaderStyles } from '../common/styles/ParticipantContainer.styles';
+import { CommonCompositeStrings } from './Strings';
 
 /**
  * @private
@@ -14,7 +12,7 @@ import { sidePaneHeaderContainerStyles, sidePaneHeaderStyles } from '../common/s
 export const SidePaneHeader = (props: {
   headingText: string;
   onClose: () => void;
-  strings: CallWithChatCompositeStrings | /* @conditional-compile-remove(one-to-n-calling) */ CallCompositeStrings;
+  strings: CommonCompositeStrings;
 }): JSX.Element => {
   const theme = useTheme();
   const sidePaneCloseButtonStyles = useMemo(

--- a/packages/react-composites/src/composites/common/Strings.tsx
+++ b/packages/react-composites/src/composites/common/Strings.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Strings used by the {@link CallComposite} and {@link CallWIthChatComposite}.
+ *
+ * This strings are in addition to those used by the components from the component library.
+ *
+ * @public
+ */
+export interface CommonCompositeStrings {
+  /**
+   * Side pane People section Title.
+   */
+  peoplePaneTitle: string;
+  /**
+   * Aria label string for return to call back button
+   */
+  returnToCallButtonAriaLabel?: string;
+  /**
+   * Aria Description string for return to call button
+   */
+  returnToCallButtonAriaDescription?: string;
+  /**
+   * control bar People button label
+   */
+  peopleButtonLabel: string;
+  /**
+   * control bar Chat button label.
+   */
+  chatButtonLabel: string;
+  /**
+   * Label for SidePaneHeader dismiss button
+   */
+  dismissSidePaneButtonLabel?: string;
+  /**
+   * Side pane People section subheader.
+   */
+  peoplePaneSubTitle: string;
+  /**
+   * Label for button to copy invite link
+   */
+  copyInviteLinkButtonLabel: string;
+  /**
+   * Label for menu item to remove participant
+   */
+  removeMenuLabel: string;
+}

--- a/packages/react-composites/src/composites/common/TabHeader.tsx
+++ b/packages/react-composites/src/composites/common/TabHeader.tsx
@@ -3,10 +3,8 @@
 import { concatStyleSets, DefaultButton, Stack } from '@fluentui/react';
 import { useTheme } from '@internal/react-components';
 import React, { useMemo } from 'react';
-/* @conditional-compile-remove(one-to-n-calling) */
-import { CallCompositeStrings } from '../CallComposite';
-import { CallWithChatCompositeStrings } from '../CallWithChatComposite';
 import { CallWithChatCompositeIcon } from '../common/icons';
+import { CommonCompositeStrings } from './Strings';
 import {
   mobilePaneBackButtonStyles,
   mobilePaneButtonStyles,
@@ -24,7 +22,7 @@ type TabHeaderProps = {
   // If set, show a button to open people tab.
   onPeopleButtonClicked?: () => void;
   activeTab: TabHeaderTab;
-  strings: CallWithChatCompositeStrings | /* @conditional-compile-remove(one-to-n-calling) */ CallCompositeStrings;
+  strings: CommonCompositeStrings;
 };
 
 /**

--- a/packages/react-composites/src/composites/index.ts
+++ b/packages/react-composites/src/composites/index.ts
@@ -19,3 +19,4 @@ export * from './localization/locales';
 export type { CompositeStrings, CompositeLocale } from './localization';
 export type { AdapterError, AdapterErrors } from './common/adapters';
 export type { BaseCompositeProps } from './common/BaseComposite';
+export type { CommonCompositeStrings } from './common/Strings';


### PR DESCRIPTION
# What
Create a common set of strings to be used by both CallWithChat and Call Composite.

# Why
Brought about when converting multiple files to Common files related to participant pane from CallWithChat.
API Changes are minimal, but are present, hence I would love some feedback and your expertise @JamesBurnside, @prprabhu-ms, and @anjulgarg. 

# How Tested
Tested Locally on MacOS on both Desktop and Mobile. No issues seen.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->