### PR TITLE
Resolve ModalPip boundary issue in callpane in Call Composite

### DIFF
--- a/change/@internal-react-composites-5fa1435e-62af-451a-89b4-7ae6ed70f2a9.json
+++ b/change/@internal-react-composites-5fa1435e-62af-451a-89b4-7ae6ed70f2a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Resolve ModalLocalAndRemotePIP boundary clipping in PeoplePane mobile view",
+  "packageName": "@internal/react-composites",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -252,7 +252,7 @@ export const CallComposite = (props: CallCompositeProps): JSX.Element => {
             // the Modal because the draggable bounds thinks it has no space and will always return to its initial position after dragging.
             // Additionally, this layer host cannot be in the Call Arrangement as it needs to be rendered before useMinMaxDragPosition() in
             // common/utils useRef is called.
-            // This modal needs to be called before a call gets connected.
+            // Warning: this is fragile and works because the call arrangement page is only rendered after the call has connected and thus this LayerHost will be guaranteed to have rendered (and subsequently mounted in the DOM). This ensures the DOM element will be available before the call to `document.getElementById(modalLayerHostId)` is made.
             /* @conditional-compile-remove(one-to-n-calling) */
             mobileView && <LayerHost id={modalLayerHostId} className={mergeStyles(modalLayerHostStyle)} />
           }

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -21,6 +21,12 @@ import { CallControlOptions } from './types/CallControlOptions';
 
 /* @conditional-compile-remove(rooms) */
 import { _PermissionsProvider, Role, _getPermissions } from '@internal/react-components';
+/* @conditional-compile-remove(one-to-n-calling) */
+import { LayerHost, mergeStyles } from '@fluentui/react';
+/* @conditional-compile-remove(one-to-n-calling) */
+import { modalLayerHostStyle } from '../common/styles/ModalLocalAndRemotePIP.styles';
+/* @conditional-compile-remove(one-to-n-calling) */
+import { useId } from '@fluentui/react-hooks';
 
 /**
  * Props for {@link CallComposite}.
@@ -78,6 +84,8 @@ export type CallCompositeOptions = {
 
 type MainScreenProps = {
   mobileView: boolean;
+  /* @conditional-compile-remove(one-to-n-calling) */
+  modalLayerHostId: string;
   onRenderAvatar?: OnRenderAvatarCallback;
   callInvitationUrl?: string;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
@@ -148,7 +156,14 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
       );
       break;
     case 'lobby':
-      pageElement = <LobbyPage mobileView={props.mobileView} options={props.options} />;
+      pageElement = (
+        <LobbyPage
+          mobileView={props.mobileView}
+          /* @conditional-compile-remove(one-to-n-calling) */
+          modalLayerHostId={props.modalLayerHostId}
+          options={props.options}
+        />
+      );
       break;
     case 'call':
       pageElement = (
@@ -158,6 +173,8 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
           onFetchAvatarPersonaData={onFetchAvatarPersonaData}
           onFetchParticipantMenuItems={onFetchParticipantMenuItems}
           mobileView={props.mobileView}
+          /* @conditional-compile-remove(one-to-n-calling) */
+          modalLayerHostId={props.modalLayerHostId}
           options={props.options}
         />
       );
@@ -207,6 +224,9 @@ export const CallComposite = (props: CallCompositeProps): JSX.Element => {
 
   const mobileView = formFactor === 'mobile';
 
+  /* @conditional-compile-remove(one-to-n-calling) */
+  const modalLayerHostId = useId('modalLayerhost');
+
   const mainScreenContainerClassName = useMemo(() => {
     return mobileView ? mainScreenContainerStyleMobile : mainScreenContainerStyleDesktop;
   }, [mobileView]);
@@ -220,10 +240,22 @@ export const CallComposite = (props: CallCompositeProps): JSX.Element => {
             onFetchAvatarPersonaData={onFetchAvatarPersonaData}
             onFetchParticipantMenuItems={onFetchParticipantMenuItems}
             mobileView={mobileView}
+            /* @conditional-compile-remove(one-to-n-calling) */
+            modalLayerHostId={modalLayerHostId}
             options={options}
             /* @conditional-compile-remove(rooms) */
             role={role}
           />
+          {
+            // This layer host is for ModalLocalAndRemotePIP in CallPane. This LayerHost cannot be inside the CallPane
+            // because when the CallPane is hidden, ie. style property display is 'none', it takes up no space. This causes problems when dragging
+            // the Modal because the draggable bounds thinks it has no space and will always return to its initial position after dragging.
+            // Additionally, this layer host cannot be in the Call Arrangement as it needs to be rendered before useMinMaxDragPosition() in
+            // common/utils useRef is called.
+            // This modal needs to be called before a call gets connected.
+            /* @conditional-compile-remove(one-to-n-calling) */
+            mobileView && <LayerHost id={modalLayerHostId} className={mergeStyles(modalLayerHostStyle)} />
+          }
         </CallAdapterProvider>
       </BaseProvider>
     </div>

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -2,10 +2,6 @@
 // Licensed under the MIT license.
 
 import { mergeStyles, Stack } from '@fluentui/react';
-/* @conditional-compile-remove(one-to-n-calling) */
-import { LayerHost } from '@fluentui/react';
-/* @conditional-compile-remove(one-to-n-calling) */
-import { useId } from '@fluentui/react-hooks';
 import {
   _ComplianceBanner,
   _ComplianceBannerProps,
@@ -21,8 +17,6 @@ import { useCallback, useState } from 'react';
 /* @conditional-compile-remove(one-to-n-calling) */
 import { AvatarPersonaDataCallback } from '../../common/AvatarPersona';
 import { containerDivStyles } from '../../common/ContainerRectProps';
-/* @conditional-compile-remove(one-to-n-calling) */
-import { modalLayerHostStyle } from '../../common/styles/ModalLocalAndRemotePIP.styles';
 /* @conditional-compile-remove(one-to-n-calling) */
 import { useAdapter } from '../adapter/CallAdapterProvider';
 import { CallControls, CallControlsProps } from '../components/CallControls';
@@ -57,6 +51,8 @@ export interface CallArrangementProps {
   dataUiId: string;
   mobileView: boolean;
   /* @conditional-compile-remove(one-to-n-calling) */
+  modalLayerHostId: string;
+  /* @conditional-compile-remove(one-to-n-calling) */
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
 }
 
@@ -90,8 +86,6 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
     setActivePane('none');
   }, [setActivePane]);
 
-  /* @conditional-compile-remove(one-to-n-calling) */
-  const modalLayerHostId = useId('modalLayerhost');
   /* @conditional-compile-remove(one-to-n-calling) */
   const isMobileWithActivePane = props.mobileView && activePane !== 'none';
 
@@ -135,7 +129,7 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
           onPeopleButtonClicked={
             showShowPeopleTabHeaderButton(props.callControlProps.options) ? selectPeople : undefined
           }
-          modalLayerHostId={modalLayerHostId}
+          modalLayerHostId={props.modalLayerHostId}
           activePane={activePane}
           mobileView={props.mobileView}
           inviteLink={props.callControlProps.callInvitationURL}
@@ -186,13 +180,6 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
               />
             </Stack.Item>
           )}
-        {
-          // This layer host is for ModalLocalAndRemotePIP in CallPane. This LayerHost cannot be inside the CallPane
-          // because when the CallPane is hidden, ie. style property display is 'none', it takes up no space. This causes problems when dragging
-          // the Modal because the draggable bounds thinks it has no space and will always return to its initial position after dragging.
-          /* @conditional-compile-remove(one-to-n-calling) */
-          props.mobileView && <LayerHost id={modalLayerHostId} className={mergeStyles(modalLayerHostStyle)} />
-        }
       </Stack>
     </div>
   );

--- a/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
@@ -25,6 +25,8 @@ import { reduceCallControlsForMobile } from '../utils';
  */
 export interface CallPageProps {
   mobileView: boolean;
+  /* @conditional-compile-remove(one-to-n-calling) */
+  modalLayerHostId: string;
   callInvitationURL?: string;
   onRenderAvatar?: OnRenderAvatarCallback;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
@@ -74,6 +76,8 @@ export const CallPage = (props: CallPageProps): JSX.Element => {
       /* @conditional-compile-remove(one-to-n-calling) */
       onFetchAvatarPersonaData={onFetchAvatarPersonaData}
       mobileView={mobileView}
+      /* @conditional-compile-remove(one-to-n-calling) */
+      modalLayerHostId={props.modalLayerHostId}
       onRenderGalleryContent={() =>
         callStatus === 'Connected' ? (
           isNetworkHealthy(networkReconnectTileProps.networkReconnectValue) ? (

--- a/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
@@ -21,6 +21,8 @@ import { CallCompositeIcon } from '../../common/icons';
  */
 export interface LobbyPageProps {
   mobileView: boolean;
+  /* @conditional-compile-remove(one-to-n-calling) */
+  modalLayerHostId: string;
   options?: CallCompositeOptions;
 }
 
@@ -53,6 +55,8 @@ export const LobbyPage = (props: LobbyPageProps): JSX.Element => {
         increaseFlyoutItemSize: props.mobileView
       }}
       mobileView={props.mobileView}
+      /* @conditional-compile-remove(one-to-n-calling) */
+      modalLayerHostId={props.modalLayerHostId}
       onRenderGalleryContent={() => <LobbyTile {...lobbyProps} overlayProps={overlayProps(strings, inLobby)} />}
       dataUiId={'lobby-page'}
     />


### PR DESCRIPTION
# What
Move LayerHost for ModalLocalAndRemotePIP outside of CallArrangement into CallComposite file

Boundaries properly set 

https://user-images.githubusercontent.com/97130533/181358663-73aef1ce-3b27-4d06-86dd-edb785091f26.mov



# Why
Resolve boundary issue with pip when in mobile view with people pane open. 
LayerHost needs to be rendered before useMinMaxDragPosition in common/utils is called. 
Cannot be in CallArrangement as previously done as CallArrangement is rendered when callStatus is connected, causing useRef reference to the ModalLayerHost to be initialized as null.

Clipping and boundaries not properly set

https://user-images.githubusercontent.com/97130533/181358591-c6cbf8d0-f824-494d-985c-d43ce2506467.mov



# How Tested
Test locally on MacOS on Chrome mobile view.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->