### PR TITLE
CI: Build packlets used by browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,35 +117,33 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE so job can access it
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      # Ensure node version is great enough
       - name: Use Node.js v14.x
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      # Try get node_modules from cache
       - name: Restore node_modules from cache
         uses: actions/cache@v2
         with:
           path: common/temp/pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}
-      # Install dependencies
       - name: Install rush
         run: npm install -g @microsoft/rush@5.47.0
       - name: Install dependencies
         run: rush install
-      # Switch flavor if necessary
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: rush switch-flavor:stable
-      # Tests
       - name: Build Call Composite Test App
         run: |
           cd packages/react-composites
           rushx build:e2e:call
+      - name: Install packlets used by browser tests
+        run: |
+          cd packages/react-composites
+          rush build -t .
       - name: Call Composite Visual Regression Tests
         id: visualregressiontests
         run: |
@@ -186,35 +184,33 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE so job can access it
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      # Ensure node version is great enough
       - name: Use Node.js v14.x
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      # Try get node_modules from cache
       - name: Restore node_modules from cache
         uses: actions/cache@v2
         with:
           path: common/temp/pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}
-      # Install dependencies
       - name: Install rush
         run: npm install -g @microsoft/rush@5.47.0
       - name: Install dependencies
         run: rush install
-      # Switch flavor if necessary
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: rush switch-flavor:stable
-      # Tests
       - name: Build Chat Composite Test App
         run: |
           cd packages/react-composites
           rushx build:e2e:chat
+      - name: Install packlets used by browser tests
+        run: |
+          cd packages/react-composites
+          rush build -t .
       - name: Chat Composite Visual Regression Tests
         id: visualregressiontests
         run: |
@@ -255,35 +251,33 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE so job can access it
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      # Ensure node version is great enough
       - name: Use Node.js v14.x
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      # Try get node_modules from cache
       - name: Restore node_modules from cache
         uses: actions/cache@v2
         with:
           path: common/temp/pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}
-      # Install dependencies
       - name: Install rush
         run: npm install -g @microsoft/rush@5.47.0
       - name: Install dependencies
         run: rush install
-      # Switch flavor if necessary
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: rush switch-flavor:stable
-      # Tests
       - name: Build CallWithChatComposite Test App
         run: |
           cd packages/react-composites
           rushx build:e2e:callwithchat
+      - name: Install packlets used by browser tests
+        run: |
+          cd packages/react-composites
+          rush build -t .
       - name: CallWithChatComposite Visual Regression Tests
         id: visualregressiontests
         run: |

--- a/.github/workflows/stress-test-ui-tests.yml
+++ b/.github/workflows/stress-test-ui-tests.yml
@@ -13,22 +13,18 @@ jobs:
     name: Run UI tests 7 times
     runs-on: ubuntu-latest
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE so job can access it
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      # Ensure node version is great enough
       - name: Use Node.js v14.x
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      # Try get node_modules from cache
       - name: Restore node_modules from cache
         uses: actions/cache@v2
         with:
           path: common/temp/pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}
-      # Install dependencies
       - name: Install rush
         run: npm install -g @microsoft/rush@5.47.0
       - name: Install dependencies
@@ -37,6 +33,10 @@ jobs:
         run: |
           cd packages/react-composites
           rushx build:e2e
+      - name: Install packlets used by browser tests
+        run: |
+          cd packages/react-composites
+          rush build -t .
       - name: Test 1
         run: |
           cd packages/react-composites

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -242,24 +242,25 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '14.x'
-      # Try get node_modules from cache
       - name: Restore node_modules from cache
         uses: actions/cache@v2
         with:
           path: common/temp/pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}
-      # Install dependencies
       - name: Install rush
         run: npm install -g @microsoft/rush@5.47.0
       - name: Install dependencies
         run: rush install
-      # Switch flavor when necessary
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: rush switch-flavor:stable
       - name: Build Test
         working-directory: ./packages/react-composites
         run: rushx build:e2e
+      - name: Install packlets used by browser tests
+        run: |
+          cd packages/react-composites
+          rush build -t .
       - name: Update chat snapshot
         id: update-chat-snapshots
         run: rushx test:e2e:chat:update

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -19,7 +19,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-react": "1.3.1-beta.1",
     "@azure/communication-calling": "1.6.1-beta.1 || 1.4.4",
     "@azure/communication-chat": "1.2.0",
     "@azure/communication-common": "2.0.0",


### PR DESCRIPTION
# Why

The browser tests use dependencies of `@internal/react-composites`  in the *test code*. Before this PR, the CI actions did not build these dependencies. When a [recent PR](https://github.com/Azure/communication-ui-library/pull/2076) introduced an import that needed to import from `@internal/acs-ui-common`, the tests started failing at runtime because of missing dependencies.

FixIt.