### PR TITLE
Return participant state from videoGallerySelector

### DIFF
--- a/packages/calling-component-bindings/src/videoGallerySelector.ts
+++ b/packages/calling-component-bindings/src/videoGallerySelector.ts
@@ -81,6 +81,7 @@ export const videoGallerySelector: VideoGallerySelector = createSelector(
             screenShareRemoteParticipant.isMuted,
             checkIsSpeaking(screenShareRemoteParticipant),
             screenShareRemoteParticipant.videoStreams,
+            screenShareRemoteParticipant.state,
             screenShareRemoteParticipant.displayName
           )
         : undefined,

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1202,6 +1202,7 @@ export const _RemoteVideoTile: React_2.MemoExoticComponent<(props: {
     showMuteIndicator?: boolean | undefined;
     showLabel?: boolean | undefined;
     personaMinSize?: number | undefined;
+    state?: VideoGalleryRemoteParticipantState | undefined;
 }) => JSX.Element>;
 
 // @beta (undocumented)

--- a/packages/react-components/src/components/RemoteVideoTile.tsx
+++ b/packages/react-components/src/components/RemoteVideoTile.tsx
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import React, { useMemo } from 'react';
-import { CreateVideoStreamViewResult, OnRenderAvatarCallback, VideoStreamOptions } from '../types';
+import {
+  CreateVideoStreamViewResult,
+  OnRenderAvatarCallback,
+  VideoGalleryRemoteParticipantState,
+  VideoStreamOptions
+} from '../types';
 import { StreamMedia } from './StreamMedia';
 import {
   useRemoteVideoStreamLifecycleMaintainer,
@@ -37,6 +42,7 @@ export const _RemoteVideoTile = React.memo(
     showMuteIndicator?: boolean;
     showLabel?: boolean;
     personaMinSize?: number;
+    state?: VideoGalleryRemoteParticipantState;
   }) => {
     const {
       isAvailable,
@@ -51,7 +57,8 @@ export const _RemoteVideoTile = React.memo(
       userId,
       displayName,
       onRenderAvatar,
-      showMuteIndicator
+      showMuteIndicator,
+      state
     } = props;
 
     const remoteVideoStreamProps: RemoteVideoStreamLifecycleMaintainerProps = useMemo(
@@ -105,6 +112,7 @@ export const _RemoteVideoTile = React.memo(
         showMuteIndicator={showMuteIndicator}
         showLabel={props.showLabel}
         personaMinSize={props.personaMinSize}
+        participantState={state}
       />
     );
   }


### PR DESCRIPTION
# What
Return participant state from videoGallerySelector and wire it in video gallery -> remote video tiles

# Why
To show remote participant states such as ringing, connecting in videogallery during pstn / 1:N calls

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->