### PR TITLE
Separate out output directories for multiple playwright runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: e2e-results-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.flavor }}-call.json
-          path: packages/react-composites/test-results/e2e-results.json
+          path: packages/react-composites/test-results/*/e2e-results.json
           if-no-files-found: error
       - name: Upload snapshot diff
         if: ${{ always() && steps.visualregressiontests.outcome == 'failure' }}
@@ -223,7 +223,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: e2e-results-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.flavor }}-chat.json
-          path: packages/react-composites/test-results/e2e-results.json
+          path: packages/react-composites/test-results/*/e2e-results.json
           if-no-files-found: error
       - name: Upload snapshot diff
         if: ${{ always() && steps.visualregressiontests.outcome == 'failure' }}
@@ -290,7 +290,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: e2e-results-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.flavor }}-callwithchat.json
-          path: packages/react-composites/test-results/e2e-results.json
+          path: packages/react-composites/test-results/*/e2e-results.json
           if-no-files-found: error
       - name: Upload snapshot diff
         if: ${{ always() && steps.visualregressiontests.outcome == 'failure' }}

--- a/change/@internal-react-composites-68759da2-c6eb-4a8d-a970-b8e68e51c912.json
+++ b/change/@internal-react-composites-68759da2-c6eb-4a8d-a970-b8e68e51c912.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "runBrowserTests: Continue on failure, and separate output from playwright invocations",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/playwright.config.common.ts
+++ b/packages/react-composites/playwright.config.common.ts
@@ -10,7 +10,11 @@ const DESKTOP_VIEWPORT = {
 };
 
 const TEST_ROOT = './tests/browser';
-const OUTPUT_DIR = './test-results';
+
+const outputDir = process.env.PLAYWRIGHT_OUTPUT_DIR;
+if (!outputDir) {
+  throw new Error('Environment variable PLAYWRIGHT_OUTPUT_DIR not set');
+}
 
 const buildFlavor: 'beta' | 'stable' = process.env['COMMUNICATION_REACT_FLAVOR'] === 'stable' ? 'stable' : 'beta';
 
@@ -33,14 +37,14 @@ const chromeLaunchOptions = {
   ]
 };
 
-const CI_REPORTERS: ReporterDescription[] = [['dot'], ['json', { outputFile: `${OUTPUT_DIR}/e2e-results.json` }]];
+const CI_REPORTERS: ReporterDescription[] = [['dot'], ['json', { outputFile: `${outputDir}/e2e-results.json` }]];
 const LOCAL_REPORTERS: ReporterDescription[] = [['list']];
 
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 
 const config: PlaywrightTestConfig = {
-  outputDir: OUTPUT_DIR,
+  outputDir: outputDir,
   // Extend per-test timeout for local debugging so that developers can single-step through
   // the test in playwright inspector.
   timeout: process.env.LOCAL_DEBUG ? 10 * MINUTE : 1 * MINUTE,

--- a/packages/react-composites/scripts/runBrowserTests.mjs
+++ b/packages/react-composites/scripts/runBrowserTests.mjs
@@ -61,13 +61,27 @@ async function runStress(args) {
 }
 
 async function runAll(args) {
+  let success = true;
   for (const composite of args.composites) {
-    await runOne(args, composite, 'hermetic');
+    try {
+      await runOne(args, composite, 'hermetic');
+    } catch(e) {
+      console.error('Hermetic tests failed for {} composite: '.format(composite,), e)
+      success = false;
+    }
   }
   if (!args.hermeticOnly) {
     for (const composite of args.composites) {
-      await runOne(args, composite, 'live');
+      try {
+        await runOne(args, composite, 'live');
+      } catch(e) {
+        console.error('Live tests failed for {} composite: '.format(composite,), e)
+        success = false;
+      }
     }
+  }
+  if (!success) {
+    throw new Error('Some tests failed!')
   }
 }
 

--- a/packages/react-composites/scripts/runBrowserTests.mjs
+++ b/packages/react-composites/scripts/runBrowserTests.mjs
@@ -68,6 +68,9 @@ async function runAll(args) {
     try {
       await runOne(args, composite, 'hermetic');
     } catch (e) {
+      if (args.failFast) {
+        throw e;
+      }
       console.error(`Hermetic tests failed for ${composite} composite: `, e);
       success = false;
     }
@@ -77,6 +80,9 @@ async function runAll(args) {
       try {
         await runOne(args, composite, 'live');
       } catch (e) {
+        if (args.failFast) {
+          throw e;
+        }
         console.error(`Live tests failed for ${composite} composite: `, e);
         success = false;
       }
@@ -111,6 +117,9 @@ async function runOne(args, composite, hermeticity) {
   if (args.debug) {
     cmdArgs.push('--debug');
     env['LOCAL_DEBUG'] = true;
+  }
+  if (args.failFast) {
+    cmdArgs.push('-x');
   }
   cmdArgs.push(...args['_']);
 
@@ -179,6 +188,11 @@ function parseArgs(argv) {
         alias: 'n',
         type: 'boolean',
         describe: 'Print what tests would be run without invoking test harness.'
+      },
+      failFast: {
+        alias: 'x',
+        type: 'boolean',
+        describe: 'Stop execution on first failure. Preferred over passing `-x` directly to playwright.'
       },
       hermeticOnly: {
         alias: 'l',


### PR DESCRIPTION
Starting with https://github.com/Azure/communication-ui-library/pull/2072, browser tests involve multiple invocations of playwright. Before this PR, the multiple invocations end up overwriting the output directory from previous invocations.

* Use a new output directory for each invocation. This PR simply adds a sub-directory with the current Unix timestamp for each invocation.
* Update workflow to upload all playwright test stats from all the invocations.
* Add a new flag `runBrowserTests.mjs -x` to skip further invocations on failure (builds atop `playwright -x`)

## Fixes

* Missing snapshots from some test failures in CI.
* Missing per-test metrics for analysis.

Does *not* affect the results of CI runs.

## Validation

https://github.com/prprabhu-ms/acr-e2e-analysis/commit/dd0b0e0b0e3265dab170e8eef0051c021deef3b8 updates the analysis pipeline and verifies that the data from CI runs for this PR is correctly processed.