### PR TITLE
Fix poll script timing and exit code

### DIFF
--- a/common/scripts/poll-npm-package-published.mjs
+++ b/common/scripts/poll-npm-package-published.mjs
@@ -44,9 +44,7 @@ const main = async () => {
       process.exitCode = 0;
       return;
     } else if ((new Date() - startTime) > TIMEOUT_TIME_MS) {
-      console.error("Failed to find package on the npm registry");
-      process.exitCode = 1;
-      return;
+      throw new Error('Failed to find package on the npm registry');
     } else {
       console.log('Sleeping for a bit...');
       await sleep(POLL_INTERVAL_MS);
@@ -54,4 +52,4 @@ const main = async () => {
   }
 };
 
-main();
+await main();

--- a/common/scripts/poll-npm-package-published.mjs
+++ b/common/scripts/poll-npm-package-published.mjs
@@ -11,7 +11,7 @@ import process from "process";
  */
 
 const POLL_INTERVAL_MS = 5000; // 5 seconds in millis
-const TIMEOUT_TIME_MS = 12 * 1000; // 5 minutes in millis
+const TIMEOUT_TIME_MS = 5 * 60 * 1000; // 5 minutes in millis
 const GET_REQUEST_TIMEOUT_MS = 5000;
 
 const GET_REQUEST_OPTIONS = {
@@ -44,7 +44,9 @@ const main = async () => {
       process.exitCode = 0;
       return;
     } else if ((new Date() - startTime) > TIMEOUT_TIME_MS) {
-      throw new Error('Failed to find package on the npm registry');
+      console.error("Failed to find package on the npm registry");
+      process.exitCode = 1;
+      return;
     } else {
       console.log('Sleeping for a bit...');
       await sleep(POLL_INTERVAL_MS);


### PR DESCRIPTION
# What
* Update npm script to wait for 5 minutes instead of 12 seconds (which was just for testing and not meant to be committed to code)
* Added `await main()` to ensure the exit code is propagated and ensure the github action actually fails

# Why
Currently, despite not finding the package, the action still passed:
![image](https://user-images.githubusercontent.com/2684369/183453012-c61dbce5-2a32-49fc-b5b5-15a1255217bc.png)
https://github.com/Azure/communication-ui-library/runs/7700649145?check_suite_focus=true

# How Tested
Will be tested in nightly CD