### PR TITLE
[WIP] Fetch translated strings for `1.3.1` release

### DIFF
--- a/packages/react-composites/src/composites/localization/locales/de-DE/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/de-DE/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "Videofeeds. Klicken Sie hier, um zum Anrufbildschirm zurückzukehren.",
     "removeMenuLabel": "Entfernen",
     "copyInviteLinkButtonLabel": "Einladungslink kopieren",
-    "dismissSidePaneButton": "Schließen",
+    "dismissSidePaneButtonLabel": "Close",
     "returnToCallButtonAriaDescription": "Zurück zum Anruf",
     "returnToCallButtonAriaLabel": "Zurück"
   }

--- a/packages/react-composites/src/composites/localization/locales/en-GB/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/en-GB/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "Video Feeds. Click to return to call screen.",
     "removeMenuLabel": "Remove",
     "copyInviteLinkButtonLabel": "Copy invite link",
-    "dismissSidePaneButton": "Close",
+    "dismissSidePaneButtonLabel": "Close",
     "returnToCallButtonAriaDescription": "Return to Call",
     "returnToCallButtonAriaLabel": "Back"
   }

--- a/packages/react-composites/src/composites/localization/locales/es-ES/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/es-ES/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "Fuentes de vídeo. Hacer clic para volver a la pantalla de la llamada.",
     "removeMenuLabel": "Quitar",
     "copyInviteLinkButtonLabel": "Copiar vínculo de invitación",
-    "dismissSidePaneButton": "Cerrar",
+    "dismissSidePaneButtonLabel": "Close",
     "returnToCallButtonAriaDescription": "Volver a llamada",
     "returnToCallButtonAriaLabel": "Volver"
   }

--- a/packages/react-composites/src/composites/localization/locales/fr-FR/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/fr-FR/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "Flux vidéo. Cliquez pour revenir à l’écran d’appel.",
     "removeMenuLabel": "Supprimer",
     "copyInviteLinkButtonLabel": "Copier le lien d'invitation",
-    "dismissSidePaneButton": "Fermer",
+    "dismissSidePaneButtonLabel": "Close",
     "returnToCallButtonAriaDescription": "Revenir à l’appel",
     "returnToCallButtonAriaLabel": "Précédent"
   }

--- a/packages/react-composites/src/composites/localization/locales/it-IT/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/it-IT/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "Feed video. Fare clic per tornare alla schermata della chiamata.",
     "removeMenuLabel": "Rimuovi",
     "copyInviteLinkButtonLabel": "Copia il collegamento dell’invito",
-    "dismissSidePaneButton": "Chiudi",
+    "dismissSidePaneButtonLabel": "Close",
     "returnToCallButtonAriaDescription": "Torna alla chiamata",
     "returnToCallButtonAriaLabel": "Indietro"
   }

--- a/packages/react-composites/src/composites/localization/locales/ja-JP/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/ja-JP/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "ビデオ フィード。 クリックすると通話画面に戻ります。",
     "removeMenuLabel": "削除",
     "copyInviteLinkButtonLabel": "招待用のリンクをコピー",
-    "dismissSidePaneButton": "閉じる",
+    "dismissSidePaneButtonLabel": "Close",
     "returnToCallButtonAriaDescription": "通話に戻る",
     "returnToCallButtonAriaLabel": "戻る"
   }

--- a/packages/react-composites/src/composites/localization/locales/ko-KR/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/ko-KR/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "비디오 피드입니다. 클릭하면 통화 화면으로 돌아갑니다.",
     "removeMenuLabel": "제거",
     "copyInviteLinkButtonLabel": "초대 링크 복사",
-    "dismissSidePaneButton": "닫기",
+    "dismissSidePaneButtonLabel": "닫기",
     "returnToCallButtonAriaDescription": "통화로 돌아가기",
     "returnToCallButtonAriaLabel": "뒤로"
   }

--- a/packages/react-composites/src/composites/localization/locales/nl-NL/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/nl-NL/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "Videofeeds. Klik om terug te keren naar het oproepscherm.",
     "removeMenuLabel": "Verwijderen",
     "copyInviteLinkButtonLabel": "Uitnodigingskoppeling kopiëren",
-    "dismissSidePaneButton": "Sluiten",
+    "dismissSidePaneButtonLabel": "Close",
     "returnToCallButtonAriaDescription": "Terug naar gesprek",
     "returnToCallButtonAriaLabel": "Terug"
   }

--- a/packages/react-composites/src/composites/localization/locales/pt-BR/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/pt-BR/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "Feeds de vídeo. Clique para retornar à tela de chamada.",
     "removeMenuLabel": "Remover",
     "copyInviteLinkButtonLabel": "Copiar o link de convite",
-    "dismissSidePaneButton": "Fechar",
+    "dismissSidePaneButtonLabel": "Close",
     "returnToCallButtonAriaDescription": "Retornar à Chamada",
     "returnToCallButtonAriaLabel": "Voltar"
   }

--- a/packages/react-composites/src/composites/localization/locales/ru-RU/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/ru-RU/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "Ленты видео. Щелкните, чтобы вернуться на экран вызова.",
     "removeMenuLabel": "Удалить",
     "copyInviteLinkButtonLabel": "Копировать ссылку с приглашением",
-    "dismissSidePaneButton": "Закрыть",
+    "dismissSidePaneButtonLabel": "Закрыть",
     "returnToCallButtonAriaDescription": "Вернуться к звонку",
     "returnToCallButtonAriaLabel": "Назад"
   }

--- a/packages/react-composites/src/composites/localization/locales/tr-TR/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/tr-TR/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "Video Akışları. Çağrı ekranına dönmek için tıklayın.",
     "removeMenuLabel": "Kaldır",
     "copyInviteLinkButtonLabel": "Davet bağlantısını kopyala",
-    "dismissSidePaneButton": "Kapat",
+    "dismissSidePaneButtonLabel": "Close",
     "returnToCallButtonAriaDescription": "Aramaya Dön",
     "returnToCallButtonAriaLabel": "Geri"
   }

--- a/packages/react-composites/src/composites/localization/locales/zh-CN/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/zh-CN/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "视频源。单击以返回到通话屏幕。",
     "removeMenuLabel": "删除",
     "copyInviteLinkButtonLabel": "复制邀请链接",
-    "dismissSidePaneButton": "关闭",
+    "dismissSidePaneButtonLabel": "关闭",
     "returnToCallButtonAriaDescription": "返回通话",
     "returnToCallButtonAriaLabel": "返回"
   }

--- a/packages/react-composites/src/composites/localization/locales/zh-TW/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/zh-TW/strings.json
@@ -62,7 +62,7 @@
     "pictureInPictureTileAriaLabel": "影片摘要。按一下以返回通話畫面。",
     "removeMenuLabel": "移除",
     "copyInviteLinkButtonLabel": "複製邀請連結",
-    "dismissSidePaneButton": "關閉",
+    "dismissSidePaneButtonLabel": "Close",
     "returnToCallButtonAriaDescription": "返回通話",
     "returnToCallButtonAriaLabel": "返回"
   }


### PR DESCRIPTION
TODO: Fetch strings once `dismissSidePaneButtonLabel` has been translated.

* `1.3.0` stable release shipped with this string untranslated.
  * Compare: [en-US](https://github.com/Azure/communication-ui-library/blob/1.3.0/packages/react-composites/src/composites/localization/locales/en-US/strings.json#L65) vs [es-ES](https://github.com/Azure/communication-ui-library/blob/1.3.0/packages/react-composites/src/composites/localization/locales/es-ES/strings.json#L65)
  * This bug was fixed in [1.3.1-beta.1](https://github.com/Azure/communication-ui-library/blob/1.3.1-beta.1/packages/react-composites/src/composites/localization/locales/es-ES/strings.json#L66)

Fix this bug for the `1.3.1` stable release.