### PR TITLE
Change Calling sample room creation to an open policy

### DIFF
--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -23,7 +23,7 @@ import {
   WEB_APP_TITLE
 } from './utils/AppUtils';
 /* @conditional-compile-remove(rooms) */
-import { createRoom, getRoomIdFromUrl, addUserToRoom } from './utils/AppUtils';
+import { createRoom, getRoomIdFromUrl } from './utils/AppUtils';
 import { useIsMobile } from './utils/useIsMobile';
 import { useSecondaryInstanceCheck } from './utils/useSecondaryInstanceCheck';
 import { CallError } from './views/CallError';
@@ -105,6 +105,10 @@ const App = (): JSX.Element => {
         <HomeScreen
           joiningExistingCall={joiningExistingCall}
           startCallHandler={async (callDetails) => {
+            if (!userId) {
+              throw new Error('userId not defined');
+            }
+
             setDisplayName(callDetails.displayName);
             /* @conditional-compile-remove(PSTN-calls) */
             setAlternateCallerId(callDetails.alternateCallerId);
@@ -134,12 +138,10 @@ const App = (): JSX.Element => {
 
             /* @conditional-compile-remove(rooms) */
             if ('roomId' in callLocator) {
-              if (userId) {
-                setRole(callDetails.role as Role);
-                await addUserToRoom(userId.communicationUserId, callLocator.roomId, callDetails.role as Role);
-              } else {
-                throw 'Invalid userId!';
-              }
+              setRole(callDetails.role as Role);
+            } else {
+              // unset role when call is not a Rooms call
+              setRole(undefined);
             }
             setCallLocator(callLocator);
 

--- a/samples/Server/src/routes/createRoom.ts
+++ b/samples/Server/src/routes/createRoom.ts
@@ -25,7 +25,8 @@ router.post('/', async function (req, res, next) {
   // Options payload to create a room
   const createRoomOptions: CreateRoomOptions = {
     validFrom: validFrom,
-    validUntil: validUntil
+    validUntil: validUntil,
+    roomJoinPolicy: 'CommunicationServiceUsers'
   };
 
   // create a room with the request payload


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Change roomJoinPolicy of room when starting a new room in Calling sample.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Solve issue of not being able to join room calls that have already started

# How Tested
<!--- How did you test your change. What tests have you added. -->
Local calling sample

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->