### PR TITLE
Hide Dialpad when it's not 1:1 PSTN call

### DIFF
--- a/change/@internal-react-composites-e008e803-cb48-41f7-925d-acb0d16c6af2.json
+++ b/change/@internal-react-composites-e008e803-cb48-41f7-925d-acb0d16c6af2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Hide dtmf dialpad when not in 1:1 pstn call",
+  "packageName": "@internal/react-composites",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -35,6 +35,7 @@ import { usePropsFor } from '../hooks/usePropsFor';
 import { buttonFlyoutIncreasedSizeStyles } from '../styles/Buttons.styles';
 /* @conditional-compile-remove(PSTN-calls) */
 import { SendDtmfDialpad } from '../../common/SendDtmfDialpad';
+/* @conditional-compile-remove(PSTN-calls) */
 import { useAdapter } from '../adapter/CallAdapterProvider';
 
 /**

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -8,6 +8,8 @@ import { IContextualMenuItem } from '@fluentui/react';
 import { useState } from 'react';
 import { _isInLobbyOrConnecting } from '@internal/calling-component-bindings';
 import { ControlBar, ParticipantMenuItemsCallback } from '@internal/react-components';
+/* @conditional-compile-remove(PSTN-calls) */
+import { ParticipantList } from '@internal/react-components';
 /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
 import { HoldButton } from '@internal/react-components';
 import React, { useMemo } from 'react';
@@ -33,6 +35,7 @@ import { usePropsFor } from '../hooks/usePropsFor';
 import { buttonFlyoutIncreasedSizeStyles } from '../styles/Buttons.styles';
 /* @conditional-compile-remove(PSTN-calls) */
 import { SendDtmfDialpad } from '../../common/SendDtmfDialpad';
+import { useAdapter } from '../adapter/CallAdapterProvider';
 
 /**
  * @private
@@ -97,6 +100,11 @@ export const CallControls = (props: CallControlsProps & ContainerRectProps): JSX
   /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
   const holdButtonProps = usePropsFor(HoldButton);
 
+  /* @conditional-compile-remove(PSTN-calls) */
+  const alternateCallerId = useAdapter().getState().alternateCallerId;
+  /* @conditional-compile-remove(PSTN-calls) */
+  const participantNumber = usePropsFor(ParticipantList).participants.length;
+
   /* @conditional-compile-remove(one-to-n-calling) */ /* @conditional-compile-remove(PSTN-calls) */
   const moreButtonContextualMenuItems = (): IContextualMenuItem[] => {
     const items: IContextualMenuItem[] = [];
@@ -130,17 +138,20 @@ export const CallControls = (props: CallControlsProps & ContainerRectProps): JSX
     });
 
     /* @conditional-compile-remove(PSTN-calls) */
-    items.push({
-      key: 'showDialpadKey',
-      text: localeStrings.strings.call.openDtmfDialpad,
-      onClick: () => {
-        setShowDialpad(true);
-      },
-      iconProps: { iconName: 'Dialpad', styles: { root: { lineHeight: 0 } } },
-      itemProps: {
-        styles: buttonFlyoutIncreasedSizeStyles
-      }
-    });
+    // dtmf tone sending only works for 1:1 PSTN call
+    if (alternateCallerId && participantNumber <= 2) {
+      items.push({
+        key: 'showDialpadKey',
+        text: localeStrings.strings.call.openDtmfDialpad,
+        onClick: () => {
+          setShowDialpad(true);
+        },
+        iconProps: { iconName: 'Dialpad', styles: { root: { lineHeight: 0 } } },
+        itemProps: {
+          styles: buttonFlyoutIncreasedSizeStyles
+        }
+      });
+    }
 
     return items;
   };

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -301,6 +301,9 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
     [callWithChatStrings]
   );
 
+  /* @conditional-compile-remove(PSTN-calls) */
+  const alternateCallerId = callAdapter.getState().alternateCallerId;
+
   return (
     <div ref={containerRef} className={mergeStyles(containerDivStyles)}>
       <Stack verticalFill grow styles={compositeOuterContainerStyles} id={compositeParentDivId}>
@@ -370,7 +373,7 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
                   onLightDismiss={closeDrawer}
                   onPeopleButtonClicked={onMoreDrawerPeopleClicked}
                   /* @conditional-compile-remove(PSTN-calls) */
-                  onClickShowDialpad={onClickShowDialpad}
+                  onClickShowDialpad={alternateCallerId ? onClickShowDialpad : undefined}
                 />
               </Stack>
             </CallAdapterProvider>

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatControlBar.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatControlBar.tsx
@@ -148,6 +148,10 @@ export const CallWithChatControlBar = (props: CallWithChatControlBarProps & Cont
       newMessageLabel={callWithChatStrings.chatButtonNewMessageNotificationLabel}
     />
   );
+
+  /* @conditional-compile-remove(PSTN-calls) */
+  const alternateCallerId = props.callAdapter.getState().alternateCallerId;
+
   return (
     <Stack horizontal className={mergeStyles(callControlsContainerStyles, controlBarContainerStyles)}>
       <Stack.Item grow>
@@ -225,6 +229,7 @@ export const CallWithChatControlBar = (props: CallWithChatControlBarProps & Cont
                         disabled={props.disableButtonsForLobbyPage}
                         styles={commonButtonStyles}
                         onClickShowDialpad={props.onClickShowDialpad}
+                        isPSTNCall={!!alternateCallerId}
                       />
                     )
                 }

--- a/packages/react-composites/src/composites/CallWithChatComposite/PreparedMoreDrawer.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/PreparedMoreDrawer.tsx
@@ -15,7 +15,7 @@ export interface PreparedMoreDrawerProps {
   onPeopleButtonClicked: () => void;
   callControls?: boolean | CallWithChatControlOptions;
   /* @conditional-compile-remove(PSTN-calls) */
-  onClickShowDialpad: () => void;
+  onClickShowDialpad?: () => void;
 }
 
 /** @private */

--- a/packages/react-composites/src/composites/CallWithChatComposite/components/DesktopMoreButton.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/components/DesktopMoreButton.tsx
@@ -3,6 +3,8 @@
 
 import { IContextualMenuItem } from '@fluentui/react';
 import { ControlBarButtonProps } from '@internal/react-components';
+/* @conditional-compile-remove(PSTN-calls) */
+import { ParticipantList } from '@internal/react-components';
 /*@conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
 import { HoldButton } from '@internal/react-components';
 import React from 'react';
@@ -19,6 +21,7 @@ import { useLocale } from '../../localization';
 /** @private */
 export interface DesktopMoreButtonProps extends ControlBarButtonProps {
   onClickShowDialpad?: () => void;
+  isPSTNCall: boolean;
 }
 
 /**
@@ -40,6 +43,9 @@ export const DesktopMoreButton = (props: DesktopMoreButtonProps): JSX.Element =>
     [localeStrings]
   );
 
+  /*@conditional-compile-remove(PSTN-calls) */
+  const participantNumber = usePropsFor(ParticipantList).participants.length;
+
   const moreButtonContextualMenuItems = (): IContextualMenuItem[] => {
     const items: IContextualMenuItem[] = [];
 
@@ -57,7 +63,8 @@ export const DesktopMoreButton = (props: DesktopMoreButtonProps): JSX.Element =>
     });
 
     /*@conditional-compile-remove(PSTN-calls) */
-    if (props.onClickShowDialpad) {
+    // dtmf tone sending only works for 1:1 PSTN call
+    if (props.onClickShowDialpad && props.isPSTNCall && participantNumber <= 2) {
       items.push({
         key: 'showDialpadKey',
         text: localeStrings.strings.callWithChat.openDtmfDialpad,

--- a/packages/react-composites/src/composites/CallWithChatComposite/components/MoreDrawer.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/components/MoreDrawer.tsx
@@ -10,6 +10,8 @@ import {
   _DrawerMenuItemProps as DrawerMenuItemProps,
   _DrawerMenuItemProps
 } from '@internal/react-components';
+/* @conditional-compile-remove(PSTN-calls) */
+import { ParticipantList } from '@internal/react-components';
 /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
 import { HoldButton } from '@internal/react-components';
 import { AudioDeviceInfo } from '@azure/communication-calling';
@@ -127,6 +129,9 @@ export const MoreDrawer = (props: MoreDrawerProps): JSX.Element => {
 
   const drawerSelectionOptions = inferCallWithChatControlOptions(props.callControls);
 
+  /*@conditional-compile-remove(PSTN-calls) */
+  const participantNumber = usePropsFor(ParticipantList).participants.length;
+
   if (props.speakers && props.speakers.length > 0) {
     drawerMenuItems.push({
       itemKey: 'speakers',
@@ -207,7 +212,13 @@ export const MoreDrawer = (props: MoreDrawerProps): JSX.Element => {
   }
 
   /*@conditional-compile-remove(PSTN-calls) */
-  if (drawerSelectionOptions !== false && isEnabled(drawerSelectionOptions?.peopleButton) && props.onClickShowDialpad) {
+  // dtmf tone sending only works for 1:1 PSTN call
+  if (
+    drawerSelectionOptions !== false &&
+    isEnabled(drawerSelectionOptions?.peopleButton) &&
+    props.onClickShowDialpad &&
+    participantNumber <= 2
+  ) {
     drawerMenuItems.push({
       itemKey: 'showDialpadKey',
       text: localeStrings.strings.callWithChat.openDtmfDialpad,

--- a/packages/react-composites/tests/browser/call/hermetic/DtmfDialpad.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/DtmfDialpad.test.ts
@@ -6,7 +6,37 @@ import { dataUiId, isTestProfileStableFlavor, pageClick, stableScreenshot, waitF
 import { buildUrlWithMockAdapter, defaultMockCallAdapterState, defaultMockRemoteParticipant, test } from './fixture';
 
 test.describe('Dtmf dialpad tests', async () => {
-  test('Dtmf dialpad should render correctly', async ({ page, serverUrl }) => {
+  test.only('Dtmf dialpad should render in 1:1 PSTN call', async ({ page, serverUrl }) => {
+    test.skip(isTestProfileStableFlavor());
+
+    const paul = defaultMockRemoteParticipant('Paul Bridges');
+
+    const participant = [paul];
+    const initialState = defaultMockCallAdapterState(participant);
+
+    //PSTN call has alternate caller id
+    initialState.alternateCallerId = '+1676568678999';
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
+
+    await waitForSelector(page, dataUiId('call-with-chat-composite-more-button'));
+    await pageClick(page, dataUiId('call-with-chat-composite-more-button'));
+    const moreButtonShowDialpadButton = await page.$('div[role="menu"] >> text="Show Dialpad"');
+    await moreButtonShowDialpadButton?.click();
+    expect(await stableScreenshot(page)).toMatchSnapshot(`Call-Dtmf-Dialpad.png`);
+  });
+  test.only('Dtmf dialpad should not render in non-PSTN call', async ({ page, serverUrl }) => {
+    test.skip(isTestProfileStableFlavor());
+
+    const initialState = defaultMockCallAdapterState();
+
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
+
+    await waitForSelector(page, dataUiId('call-with-chat-composite-more-button'));
+    await pageClick(page, dataUiId('call-with-chat-composite-more-button'));
+
+    expect(await stableScreenshot(page)).toMatchSnapshot(`Dtmf-Dialpad-Hidden-Non-PSTN.png`);
+  });
+  test.only('Dtmf dialpad should not render in not 1:1 call', async ({ page, serverUrl }) => {
     test.skip(isTestProfileStableFlavor());
 
     const paul = defaultMockRemoteParticipant('Paul Bridges');
@@ -15,11 +45,13 @@ test.describe('Dtmf dialpad tests', async () => {
     const participants = [paul, vasily];
     const initialState = defaultMockCallAdapterState(participants);
 
+    //PSTN call has alternate caller id
+    initialState.alternateCallerId = '+1676568678999';
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
+
     await waitForSelector(page, dataUiId('call-with-chat-composite-more-button'));
     await pageClick(page, dataUiId('call-with-chat-composite-more-button'));
-    const moreButtonShowDialpadButton = await page.$('div[role="menu"] >> text="Show Dialpad"');
-    await moreButtonShowDialpadButton?.click();
-    expect(await stableScreenshot(page)).toMatchSnapshot(`Call-Dtmf-Dialpad.png`);
+
+    expect(await stableScreenshot(page)).toMatchSnapshot(`Dtmf-Dialpad-Hidden-Non-1-to-1.png`);
   });
 });


### PR DESCRIPTION
# What
Hide Dialpad when it's not 1:1 PSTN call

# Why
dtmf tones does not work for non 1:1 call

# How Tested

Hermantic tests for non 1:1 call , non PSTN call and 1:1 PSTN call
