### PR TITLE
Simplify participant list selector

### DIFF
--- a/change/@internal-calling-component-bindings-9e12d2da-af09-4be1-8cb2-28c6ab117066.json
+++ b/change/@internal-calling-component-bindings-9e12d2da-af09-4be1-8cb2-28c6ab117066.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "simplify participant list selector",
+  "packageName": "@internal/calling-component-bindings",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/src/participantListSelector.ts
+++ b/packages/calling-component-bindings/src/participantListSelector.ts
@@ -14,7 +14,6 @@ import {
 import { CallParticipantListParticipant } from '@internal/react-components';
 import { _updateUserDisplayNames } from './utils/callUtils';
 import { memoizedConvertAllremoteParticipants } from './utils/participantListSelectorUtils';
-import { toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 
 const convertRemoteParticipantsToParticipantListParticipants = (
   remoteParticipants: RemoteParticipantState[]
@@ -31,7 +30,7 @@ const convertRemoteParticipantsToParticipantListParticipants = (
             (videoStream) => videoStream.mediaStreamType === 'ScreenSharing' && videoStream.isAvailable
           );
           return memoizeFn(
-            toFlatCommunicationIdentifier(participant.identifier),
+            participant.identifier,
             participant.displayName,
             participant.state,
             participant.isMuted,

--- a/packages/calling-component-bindings/src/utils/participantListSelectorUtils.ts
+++ b/packages/calling-component-bindings/src/utils/participantListSelectorUtils.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { getIdentifierKind } from '@azure/communication-common';
-import { fromFlatCommunicationIdentifier, memoizeFnAll } from '@internal/acs-ui-common';
+import { CommunicationIdentifier, getIdentifierKind } from '@azure/communication-common';
+import { toFlatCommunicationIdentifier, memoizeFnAll } from '@internal/acs-ui-common';
 import { CallParticipantListParticipant } from '@internal/react-components';
 
 /**
@@ -10,7 +10,7 @@ import { CallParticipantListParticipant } from '@internal/react-components';
  */
 export const memoizedConvertAllremoteParticipants = memoizeFnAll(
   (
-    userId: string,
+    userId: CommunicationIdentifier,
     displayName: string | undefined,
     state: 'Idle' | 'Connecting' | 'Ringing' | 'Connected' | 'Hold' | 'InLobby' | 'EarlyMedia' | 'Disconnected',
     isMuted: boolean,
@@ -29,16 +29,15 @@ export const memoizedConvertAllremoteParticipants = memoizeFnAll(
 );
 
 const convertRemoteParticipantToParticipantListParticipant = (
-  userId: string,
+  userId: CommunicationIdentifier,
   displayName: string | undefined,
   state: 'Idle' | 'Connecting' | 'Ringing' | 'Connected' | 'Hold' | 'InLobby' | 'EarlyMedia' | 'Disconnected',
   isMuted: boolean,
   isScreenSharing: boolean,
   isSpeaking: boolean
 ): CallParticipantListParticipant => {
-  const identifier = fromFlatCommunicationIdentifier(userId);
   return {
-    userId,
+    userId: toFlatCommunicationIdentifier(userId),
     displayName,
     state,
     isMuted,
@@ -47,6 +46,6 @@ const convertRemoteParticipantToParticipantListParticipant = (
     // ACS users can not remove Teams users.
     // Removing unknown types of users is undefined.
     isRemovable:
-      getIdentifierKind(identifier).kind === 'communicationUser' || getIdentifierKind(identifier).kind === 'phoneNumber'
+      getIdentifierKind(userId).kind === 'communicationUser' || getIdentifierKind(userId).kind === 'phoneNumber'
   };
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
We use `toFlatCommunicationIdentifier` and then `fromFlatCommunicationIdentifier` when converting remote participants to ListParticipants. 

This can actually convert a userId like { kind: 'communicationUser', communicationUserId: 1 } to { id: 1 } based on the implementation of `fromFlatCommunicationIdentifier` [here](https://github.com/Azure/communication-ui-library/blob/6ea6f203ed9715b9d4187c8835dfef4a4ef328d7/packages/acs-ui-common/src/identifier.ts#L28)

We can avoid unnecessarily using `fromFlatCommunicationIdentifier`

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Simplification

# How Tested
<!--- How did you test your change. What tests have you added. -->
Test with local sample. Using CI.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->