### PR TITLE
Actually typecheck browser test code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,6 @@ jobs:
       # Builds
       - name: Build Packages
         run: rush build -t @azure/communication-react
-      # Type check test folder, must be run after building all packlets
-      - name: Type check test folder
-        run: cd packages/react-composites && rushx tsc:e2e
       # Verify no uncommitted api extractor changes
       - name: API Extractor Check
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,12 @@ jobs:
       # Perform lint check
       - name: Run linter
         run: rush lint
-      # Type check test folder
-      - name: Type check test folder
-        run: cd packages/react-composites && rushx tsc:e2e
       # Builds
       - name: Build Packages
         run: rush build -t @azure/communication-react
+      # Type check test folder, must be run after building all packlets
+      - name: Type check test folder
+        run: cd packages/react-composites && rushx tsc:e2e
       # Verify no uncommitted api extractor changes
       - name: API Extractor Check
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       # Builds
       - name: Build Packages
         run: rush build -t @azure/communication-react
+      # Type check test folder, must be run after building all packlets
+      - name: Type check test folder
+        run: cd packages/react-composites && rushx tsc:e2e
       # Verify no uncommitted api extractor changes
       - name: API Extractor Check
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,11 @@ jobs:
       # Builds
       - name: Build Packages
         run: rush build -t @azure/communication-react
-      # Type check test folder, must be run after building all packlets
+      # Type check test folder
+      # - must be run after building all packlets because it depends on compiled packlet dependencies
+      # - must be run only on beta flavor build because the browser test code is not conditional compiled
       - name: Type check test folder
+        if: ${{ matrix.flavor == 'beta' }}
         run: cd packages/react-composites && rushx tsc:e2e
       # Verify no uncommitted api extractor changes
       - name: API Extractor Check

--- a/change/@internal-fake-backends-b249fcd5-81f6-4250-8523-ecafe7beeee7.json
+++ b/change/@internal-fake-backends-b249fcd5-81f6-4250-8523-ecafe7beeee7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use conventional build setup for @internal/fake-backends",
+  "packageName": "@internal/fake-backends",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-composites-4fb23d44-d5ff-40e8-8151-659e1a3a6541.json
+++ b/change/@internal-react-composites-4fb23d44-d5ff-40e8-8151-659e1a3a6541.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "typecheck browser test as part of build",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -19554,10 +19554,15 @@ packages:
       '@azure/communication-common': 2.0.0
       '@azure/communication-signaling': 1.0.0-beta.13
       '@azure/core-paging': 1.1.3
+      '@babel/cli': 7.16.0_@babel+core@7.16.5
+      '@babel/core': 7.16.5
+      '@babel/preset-env': 7.13.10_@babel+core@7.16.5
       '@microsoft/api-extractor': 7.18.5
       '@types/jest': 26.0.24
       '@typescript-eslint/eslint-plugin': 4.29.2_b01b7137116ac50f0745961d9cf72d34
       '@typescript-eslint/parser': 4.29.2_eslint@7.32.0+typescript@4.3.5
+      babel-jest: 26.6.3_@babel+core@7.16.5
+      babel-loader: 8.1.0_d2cf782a6a3ef7f12832dd3c8e9943a9
       copyfiles: 2.4.1
       cpx: 1.5.0
       cross-env: 7.0.3
@@ -19578,10 +19583,11 @@ packages:
       rollup: 2.42.4
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
       typescript: 4.3.5
+      webpack: 5.38.1
     dev: false
     name: '@rush-temp/fake-backends'
     resolution:
-      integrity: sha512-KrzzbBvxT8PB7ZM5L7UyakACST0RKOxXTkEe2UNNqiE2/wqtg5Njbwmk3yGL2AtVzFBBAL/ckdnLYJZvzh0Ivg==
+      integrity: sha512-VDHSQVgGMwvAkgIRRn9TJDrVX2N4iaqwGTBZx9THnEqiwv+KqiR3UcvluWMkr4hSNj2jOmcE5uGwjYBgT/W2Kw==
       tarball: file:projects/fake-backends.tgz
     version: 0.0.0
   file:projects/react-components.tgz:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -39,12 +39,12 @@ packages:
   /@azure/communication-chat/1.2.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
-      '@azure/communication-common': 2.0.0
+      '@azure/communication-common': 2.1.0
       '@azure/communication-signaling': 1.0.0-beta.13
-      '@azure/core-auth': 1.3.2
-      '@azure/core-client': 1.3.0
+      '@azure/core-auth': 1.4.0
+      '@azure/core-client': 1.6.1
       '@azure/core-paging': 1.1.3
-      '@azure/core-rest-pipeline': 1.8.0
+      '@azure/core-rest-pipeline': 1.9.1
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
       events: 3.3.0
@@ -72,8 +72,8 @@ packages:
   /@azure/communication-common/2.0.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
-      '@azure/core-auth': 1.3.2
-      '@azure/core-rest-pipeline': 1.8.0
+      '@azure/core-auth': 1.4.0
+      '@azure/core-rest-pipeline': 1.9.1
       '@azure/core-tracing': 1.0.0-preview.13
       events: 3.3.0
       jwt-decode: 3.1.2
@@ -86,8 +86,8 @@ packages:
   /@azure/communication-common/2.1.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
-      '@azure/core-auth': 1.3.2
-      '@azure/core-rest-pipeline': 1.8.0
+      '@azure/core-auth': 1.4.0
+      '@azure/core-rest-pipeline': 1.9.1
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/core-util': 1.0.0
       events: 3.3.0
@@ -102,7 +102,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@azure/communication-common': 1.1.0
-      '@azure/core-auth': 1.3.2
+      '@azure/core-auth': 1.4.0
       '@azure/core-http': 1.2.4
       '@azure/core-lro': 1.0.5
       '@azure/core-paging': 1.1.3
@@ -119,9 +119,9 @@ packages:
   /@azure/communication-rooms/1.0.0-beta.1:
     dependencies:
       '@azure/communication-common': 2.1.0
-      '@azure/core-auth': 1.3.2
+      '@azure/core-auth': 1.4.0
       '@azure/core-client': 1.6.1
-      '@azure/core-rest-pipeline': 1.8.0
+      '@azure/core-rest-pipeline': 1.9.1
       '@azure/core-tracing': 1.0.1
       '@azure/logger': 1.0.3
       tslib: 1.14.1
@@ -178,19 +178,6 @@ packages:
       node: '>=12.0.0'
     resolution:
       integrity: sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==
-  /@azure/core-client/1.3.0:
-    dependencies:
-      '@azure/abort-controller': 1.0.4
-      '@azure/core-asynciterator-polyfill': 1.0.0
-      '@azure/core-auth': 1.3.2
-      '@azure/core-rest-pipeline': 1.8.0
-      '@azure/core-tracing': 1.0.0-preview.13
-      tslib: 2.3.1
-    dev: false
-    engines:
-      node: '>=12.0.0'
-    resolution:
-      integrity: sha512-4ricu3aM1TQP2vglBcvFX8KgbWVe+7hl1jVAw6BzIGG4CTAvO3ygDS6th3O+zFwGN9xkgXFHa7Tp3u9za8ciIA==
   /@azure/core-client/1.6.1:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -209,7 +196,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@azure/core-asynciterator-polyfill': 1.0.0
-      '@azure/core-auth': 1.3.2
+      '@azure/core-auth': 1.4.0
       '@azure/core-tracing': 1.0.0-preview.11
       '@azure/logger': 1.0.3
       '@types/node-fetch': 2.5.12
@@ -269,22 +256,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-his7Ah40ThEYORSpIAwuh6B8wkGwO/zG7gqVtmSE4WAJ46e36zUDXTKReUCLBDc6HmjjApQQxxcRFy5FruG79A==
-  /@azure/core-rest-pipeline/1.8.0:
-    dependencies:
-      '@azure/abort-controller': 1.0.4
-      '@azure/core-auth': 1.3.2
-      '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.3
-      form-data: 4.0.0
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.0
-      tslib: 2.3.1
-      uuid: 8.3.2
-    dev: false
-    engines:
-      node: '>=12.0.0'
-    resolution:
-      integrity: sha512-o8eZr96erQpiq8EZhZU/SyN6ncOfZ6bexwN2nMm9WpDmZGvaq907kopADt8XvNhbEF7kRA1l901Pg8mXjWp3UQ==
   /@azure/core-rest-pipeline/1.9.1:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -19029,7 +19000,7 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-bTOUzxs4WHRGmErO3d7vqCq10FRrIVUuo5h6CpKLM0GVrg/BKMgv2LpD1PUPt1GOC0wcpchJ2sus+ttyycHMOA==
+      integrity: sha512-4aCCL/3CNE2oXjocXxYB/S6GCl+0ndsj7vd/WM87nH7qmaKWwsMP8XFoILTLBf0X0Q1uOQSNjRppKSQRtXnOtg==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
@@ -19069,7 +19040,7 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-2OM8c261EgNKsRPN8LACgxo0aYOr6qpiwiM3WHtMMnkKqJjgeEah3KLJdxKhoiwFC9NSNoJ9Ao8tDsDMDP+FOQ==
+      integrity: sha512-DIWRTh1xMQ0rlq1aLNX7wmYPPbA1jFEYTaecUcThC2NkH8E+6qbfn+1TAnTckDSibsuo+YDqgenhykjPtqwUrQ==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
@@ -19150,7 +19121,7 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-uF2JJruRs8K0D8v2ZF5n7mWh2RfyfO4n5NxVds9THOwAgDh448/ZAtHqkgZw3KKWcDCtqv9mfiLEXiFv4dQvsA==
+      integrity: sha512-pQuXj7ubdmGqkio6MM2u0SDY7UDkWE47zUvX69m4t69ee8Uk8qz6BLVbRYaVVEhDe6JCV7a+vhze6n7XJWtKwQ==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
@@ -19225,7 +19196,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-v052L4oRdJWZ8RL4n2SDOtKauw0B8mz2pIibaUepjYEv1a7SSRQlyIiYsNnfOdzk0BJirGxRLnm6BjeBqXuj1g==
+      integrity: sha512-I1SqrHFAVdcuDObeqPR2JT0g3eqHunfQpD9G3OGAMDkxRYdTbaC3Kgub0NsIl4x5fIEBpTKZLJpTjhOmGDgwCg==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19264,7 +19235,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-component-bindings'
     resolution:
-      integrity: sha512-9mxtVZfbvCiAbBx3vjlXS5hWoFK46Ph42zo/dEpvbpq2VhDHAiTsaFIal72yR7veWl/M1keu/KYT2f10n+9b/g==
+      integrity: sha512-iK8NdM6c2sPnRSazgZE3yC95nl54T5M1YsRkwn0a8BSwtyREJ0trrxwaA1ovafZgdID5OvUiZJ1QEd8T3ziLkQ==
       tarball: file:projects/chat-component-bindings.tgz
     version: 0.0.0
   file:projects/chat-stateful-client.tgz:
@@ -19306,7 +19277,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-stateful-client'
     resolution:
-      integrity: sha512-paRlaBAv2hf/4yC1KiXHD4faJH1mGySJhHd6lgaL83kqecqKaHWpfWg9yadvnmuvJv9oU2TEF3/iD2+xG93mDA==
+      integrity: sha512-jdM/dwQJo7lBUFHXYL7Xe/5UejcyMZpevHa+QtAqrPANKxsKJFhtduzDolo8ZqdUoSE6n3tTb4UlXqLft8zsrA==
       tarball: file:projects/chat-stateful-client.tgz
     version: 0.0.0
   file:projects/chat.tgz:
@@ -19378,7 +19349,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-jrLcYvkrPZAWl3Jievp8pJz12B2CqfzpgFMCCWKHH3cD2T1dWkuJroUttkyoY7TMgUOCOuZNOoKgFfXHN1IO9A==
+      integrity: sha512-FvkDvUEHRvieL+dM9Iv8mCZEolcH08UaLWOmxFGSE4yjqh7OTC3GDWKdpNeuDERmAL9/WM7yRFD5qQZvYTfaag==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19396,7 +19367,7 @@ packages:
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-YTucy12zfGkX9XP3qd0G+/38O0wBaRkm1gxLUIoRI878l1ifcVnNrzlGNATxn2iG4p4ShD+9+zwmP7V1R+FYLg==
+      integrity: sha512-+DAQpXLDFx39n3LHx4XodbYiKGkCx2ATEsEGG77AHMQbo6uIKLB+OfjnvGiDm596p6P5WgrT/VMSiy0G1hxRKQ==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
@@ -19486,7 +19457,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-evmgq00aPMsfWGNQlyQEo66lMAHh+92SIqaCr3wbdJw6OVLNLUSV1cg+F1X5wTJqXT5ReYmw6WYqvZBVZCUy7g==
+      integrity: sha512-QSeFEAn7FO9DDhmdBcPhhN/A7Bi1z/x7XrBPcNcVmGgY3mt3AQ/h3PycJnnCUe7HLASTJA8Il6f/4MdexjBJyQ==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
@@ -19556,7 +19527,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-nFif+4a7PCyiwMXVu/dYlvUgwqSuX9CTIdXuKI7p2u7kCXy7B1+qvtRO/ZZ6UA7LVvnsODIXNAD0Ee/rAIMO3Q==
+      integrity: sha512-0kPz9gSwLJ6me+REWCGSynk/ABOqv4YFXz4pTOs93otAVC+sYONWb49GeYN3t4rf1lhwhIKlnRGOb5mfH+LIfw==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19583,10 +19554,14 @@ packages:
       '@azure/communication-common': 2.0.0
       '@azure/communication-signaling': 1.0.0-beta.13
       '@azure/core-paging': 1.1.3
+      '@microsoft/api-extractor': 7.18.5
       '@types/jest': 26.0.24
       '@typescript-eslint/eslint-plugin': 4.29.2_b01b7137116ac50f0745961d9cf72d34
       '@typescript-eslint/parser': 4.29.2_eslint@7.32.0+typescript@4.3.5
       copyfiles: 2.4.1
+      cpx: 1.5.0
+      cross-env: 7.0.3
+      env-cmd: 10.1.0
       eslint: 7.32.0
       eslint-config-prettier: 6.15.0_eslint@7.32.0
       eslint-plugin-header: 3.1.1_eslint@7.32.0
@@ -19594,17 +19569,19 @@ packages:
       eslint-plugin-jsdoc: 36.1.0_eslint@7.32.0
       eslint-plugin-prettier: 3.4.0_8142a4287e8e8e0691574dfac8adcedb
       events: 3.3.0
+      if-env: 1.0.4
       immer: 9.0.6
       jest: 26.6.0
       nanoid: 3.1.32
       prettier: 2.3.1
       rimraf: 2.7.1
+      rollup: 2.42.4
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
       typescript: 4.3.5
     dev: false
     name: '@rush-temp/fake-backends'
     resolution:
-      integrity: sha512-MT/KEEgkh4asg1NMHuduXv/TU5D6KItOfASBR5P7i5Mz7Wwvsj1H2iUipKJ9F26KEMiWU4PeIlEY+aPAxuu3xA==
+      integrity: sha512-KrzzbBvxT8PB7ZM5L7UyakACST0RKOxXTkEe2UNNqiE2/wqtg5Njbwmk3yGL2AtVzFBBAL/ckdnLYJZvzh0Ivg==
       tarball: file:projects/fake-backends.tgz
     version: 0.0.0
   file:projects/react-components.tgz:
@@ -19693,7 +19670,7 @@ packages:
     dev: false
     name: '@rush-temp/react-components'
     resolution:
-      integrity: sha512-MTVdl8BQKrSfD+MbxZSMXiHwwVdLP3AwBxYsYheESLAiVkHi1X/AJAPtnjaao3sHMXykhUiTvF5E3a+D44mtaw==
+      integrity: sha512-nbrsPs0dD4L7evJGYum4zbUlSRvc3gsTH7JYklarkIoZNKqyjq2XKk14rFVLpVyVP4vr4QdSCZvhTowQF5jhzg==
       tarball: file:projects/react-components.tgz
     version: 0.0.0
   file:projects/react-composites.tgz:
@@ -19806,7 +19783,7 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-IKU3vA8rojgaqzXTJ+SLKilakn/5d18xPutQCA/NplxvlStzHe7dNOo+c3/DfGjDufLitm5P2A7pKtSn60Z0yg==
+      integrity: sha512-ujodcvvo1shNwr+NHLHpiOO5OskZysb7/a2QVSvUlGosLiOrUrcCBhjEyv8QxlzPTu6qjDEveJ/9JymOYbsLkQ==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
@@ -19871,7 +19848,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-fLS88u0bTuJGS+o71/teuZriPJowDsvK5geBgnljPI4crYN0SL8iMAGhOBE/ZSgbsQFKnCoBob5cWnbueILxmA==
+      integrity: sha512-GXggI+fLThlig+bgvvHskGQ8zbAliWgqbivU9ujeu4ChWCdD0yIOKTyg3UlbzNL6dBczSgXUDy3PlMUzSJ3y9w==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -20037,7 +20014,7 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-p5XB80bOhb2aNq9gNjmjA5uVGFM82O5/cnwZU5S0/xSp3FDd3AUwB4bL7TXk3UpYiMDjzabtIk6Lcs1r5uJhsA==
+      integrity: sha512-83WmKbDaDWBqXteQ1s3lmv+BAWaAg7ZPwDGr4Fi3SoMl8tM+1HwC4sl27jxVhqkODISZ6wmLO37H780JDGlLWA==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -19275,10 +19275,15 @@ packages:
       '@azure/communication-common': 2.0.0
       '@azure/communication-signaling': 1.0.0-beta.13
       '@azure/core-paging': 1.1.3
+      '@babel/cli': 7.16.8_@babel+core@7.16.12
+      '@babel/core': 7.16.12
+      '@babel/preset-env': 7.13.10_@babel+core@7.16.12
       '@microsoft/api-extractor': 7.18.21
       '@types/jest': 26.0.24
       '@typescript-eslint/eslint-plugin': 4.33.0_d212f40a84a592446cd1718bfda08a13
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.3.5
+      babel-jest: 26.6.3_@babel+core@7.16.12
+      babel-loader: 8.1.0_aa6d88355c68f323db0a612de3ad0c55
       copyfiles: 2.4.1
       cpx: 1.5.0
       cross-env: 7.0.3
@@ -19299,10 +19304,11 @@ packages:
       rollup: 2.42.4
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
       typescript: 4.3.5
+      webpack: 5.38.1
     dev: false
     name: '@rush-temp/fake-backends'
     resolution:
-      integrity: sha512-KrzzbBvxT8PB7ZM5L7UyakACST0RKOxXTkEe2UNNqiE2/wqtg5Njbwmk3yGL2AtVzFBBAL/ckdnLYJZvzh0Ivg==
+      integrity: sha512-VDHSQVgGMwvAkgIRRn9TJDrVX2N4iaqwGTBZx9THnEqiwv+KqiR3UcvluWMkr4hSNj2jOmcE5uGwjYBgT/W2Kw==
       tarball: file:projects/fake-backends.tgz
     version: 0.0.0
   file:projects/react-components.tgz:

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -39,12 +39,12 @@ packages:
   /@azure/communication-chat/1.2.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
-      '@azure/communication-common': 2.0.0
+      '@azure/communication-common': 2.1.0
       '@azure/communication-signaling': 1.0.0-beta.13
-      '@azure/core-auth': 1.3.2
-      '@azure/core-client': 1.5.0
+      '@azure/core-auth': 1.4.0
+      '@azure/core-client': 1.6.1
       '@azure/core-paging': 1.2.1
-      '@azure/core-rest-pipeline': 1.7.0
+      '@azure/core-rest-pipeline': 1.9.1
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
       events: 3.3.0
@@ -72,8 +72,8 @@ packages:
   /@azure/communication-common/2.0.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
-      '@azure/core-auth': 1.3.2
-      '@azure/core-rest-pipeline': 1.7.0
+      '@azure/core-auth': 1.4.0
+      '@azure/core-rest-pipeline': 1.9.1
       '@azure/core-tracing': 1.0.0-preview.13
       events: 3.3.0
       jwt-decode: 3.1.2
@@ -86,8 +86,8 @@ packages:
   /@azure/communication-common/2.1.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
-      '@azure/core-auth': 1.3.2
-      '@azure/core-rest-pipeline': 1.7.0
+      '@azure/core-auth': 1.4.0
+      '@azure/core-rest-pipeline': 1.9.1
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/core-util': 1.0.0
       events: 3.3.0
@@ -102,7 +102,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@azure/communication-common': 1.1.0
-      '@azure/core-auth': 1.3.2
+      '@azure/core-auth': 1.4.0
       '@azure/core-http': 1.2.4
       '@azure/core-lro': 1.0.5
       '@azure/core-paging': 1.2.1
@@ -119,9 +119,9 @@ packages:
   /@azure/communication-rooms/1.0.0-beta.1:
     dependencies:
       '@azure/communication-common': 2.1.0
-      '@azure/core-auth': 1.3.2
+      '@azure/core-auth': 1.4.0
       '@azure/core-client': 1.6.1
-      '@azure/core-rest-pipeline': 1.7.0
+      '@azure/core-rest-pipeline': 1.9.1
       '@azure/core-tracing': 1.0.1
       '@azure/logger': 1.0.3
       tslib: 1.14.1
@@ -167,20 +167,6 @@ packages:
       node: '>=12.0.0'
     resolution:
       integrity: sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==
-  /@azure/core-client/1.5.0:
-    dependencies:
-      '@azure/abort-controller': 1.0.4
-      '@azure/core-asynciterator-polyfill': 1.0.2
-      '@azure/core-auth': 1.3.2
-      '@azure/core-rest-pipeline': 1.7.0
-      '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.3
-      tslib: 2.3.1
-    dev: false
-    engines:
-      node: '>=12.0.0'
-    resolution:
-      integrity: sha512-YNk8i9LT6YcFdFO+RRU0E4Ef+A8Y5lhXo6lz61rwbG8Uo7kSqh0YqK04OexiilM43xd6n3Y9yBhLnb1NFNI9dA==
   /@azure/core-client/1.6.1:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -199,7 +185,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.0.4
       '@azure/core-asynciterator-polyfill': 1.0.2
-      '@azure/core-auth': 1.3.2
+      '@azure/core-auth': 1.4.0
       '@azure/core-tracing': 1.0.0-preview.11
       '@azure/logger': 1.0.3
       '@types/node-fetch': 2.6.1
@@ -268,22 +254,6 @@ packages:
       node: '>=12.0.0'
     resolution:
       integrity: sha512-UtH5iMlYsvg+nQYIl4UHlvvSrsBjOlRF4fs0j7mxd3rWdAStrKYrh2durOpHs5C9yZbVhsVDaisoyaf/lL1EVA==
-  /@azure/core-rest-pipeline/1.7.0:
-    dependencies:
-      '@azure/abort-controller': 1.0.4
-      '@azure/core-auth': 1.3.2
-      '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/logger': 1.0.3
-      form-data: 4.0.0
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.0
-      tslib: 2.3.1
-      uuid: 8.3.2
-    dev: false
-    engines:
-      node: '>=12.0.0'
-    resolution:
-      integrity: sha512-e2awPzwMKHrmvYgZ0qIKNkqnCM1QoDs7A0rOiS3OSAlOQOz/kL7PPKHXwFMuBeaRvS8i7fgobJn79q2Cji5f+Q==
   /@azure/core-rest-pipeline/1.9.1:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -19305,10 +19275,14 @@ packages:
       '@azure/communication-common': 2.0.0
       '@azure/communication-signaling': 1.0.0-beta.13
       '@azure/core-paging': 1.1.3
+      '@microsoft/api-extractor': 7.18.21
       '@types/jest': 26.0.24
       '@typescript-eslint/eslint-plugin': 4.33.0_d212f40a84a592446cd1718bfda08a13
       '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.3.5
       copyfiles: 2.4.1
+      cpx: 1.5.0
+      cross-env: 7.0.3
+      env-cmd: 10.1.0
       eslint: 7.32.0
       eslint-config-prettier: 6.15.0_eslint@7.32.0
       eslint-plugin-header: 3.1.1_eslint@7.32.0
@@ -19316,17 +19290,19 @@ packages:
       eslint-plugin-jsdoc: 36.1.1_eslint@7.32.0
       eslint-plugin-prettier: 3.4.1_8142a4287e8e8e0691574dfac8adcedb
       events: 3.3.0
+      if-env: 1.0.4
       immer: 9.0.6
       jest: 26.6.0
       nanoid: 3.1.32
       prettier: 2.3.1
       rimraf: 2.7.1
+      rollup: 2.42.4
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
       typescript: 4.3.5
     dev: false
     name: '@rush-temp/fake-backends'
     resolution:
-      integrity: sha512-cQM5uljFxgyMth0GHO0vm5ccGNe8Mq2+84bVMLa8Td3hJnx4gVmWS3krkAEWjo9khC+5OuamCrDQRBQfgsqs1g==
+      integrity: sha512-KrzzbBvxT8PB7ZM5L7UyakACST0RKOxXTkEe2UNNqiE2/wqtg5Njbwmk3yGL2AtVzFBBAL/ckdnLYJZvzh0Ivg==
       tarball: file:projects/fake-backends.tgz
     version: 0.0.0
   file:projects/react-components.tgz:

--- a/packages/fake-backends/.babelrc.js
+++ b/packages/fake-backends/.babelrc.js
@@ -1,0 +1,5 @@
+const commonConfig = require('../../common/config/babel/.babelrc.js');
+
+module.exports = {
+  ...commonConfig
+};

--- a/packages/fake-backends/api-extractor.json
+++ b/packages/fake-backends/api-extractor.json
@@ -1,0 +1,38 @@
+{
+  "extends": "../../common/config/api-extractor/api-extractor.json",
+  "apiReport": {
+    "enabled": false
+  },
+  "docModel": {
+    "enabled": false
+  },
+  "messages": {
+    "extractorMessageReporting": {
+      // All exports from this packlet are intended to be internal only.
+      // If they are ever exported from a public packlet, api-extractor
+      // will complain about missing release tags for the that packlet.
+      "ae-missing-release-tag": {
+        "logLevel": "none"
+      },
+      "ae-unresolved-link": {
+        // This must be set to none, as when our individual packlets reference exports
+        // from other packlets this throws an error. Ideally we should turn this on just
+        // for the communication-react api.md file.
+        "logLevel": "none"
+      },
+      "ae-forgotten-export": {
+        "logLevel": "error",
+        "addToApiReportFile": false
+      },
+      "ae-incompatible-release-tags": {
+        "logLevel": "none",
+        "addToApiReportFile": false
+      }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-undefined-tag": {
+        "logLevel": "none"
+      }
+    }
+  }
+}

--- a/packages/fake-backends/api-extractor.stable.json
+++ b/packages/fake-backends/api-extractor.stable.json
@@ -1,0 +1,38 @@
+{
+  "extends": "../../common/config/api-extractor/api-extractor.stable.json",
+  "apiReport": {
+    "enabled": false
+  },
+  "docModel": {
+    "enabled": false
+  },
+  "messages": {
+    "extractorMessageReporting": {
+      // All exports from this packlet are intended to be internal only.
+      // If they are ever exported from a public packlet, api-extractor
+      // will complain about missing release tags for the that packlet.
+      "ae-missing-release-tag": {
+        "logLevel": "none"
+      },
+      "ae-unresolved-link": {
+        // This must be set to none, as when our individual packlets reference exports
+        // from other packlets this throws an error. Ideally we should turn this on just
+        // for the communication-react api.md file.
+        "logLevel": "none"
+      },
+      "ae-forgotten-export": {
+        "logLevel": "error",
+        "addToApiReportFile": false
+      },
+      "ae-incompatible-release-tags": {
+        "logLevel": "none",
+        "addToApiReportFile": false
+      }
+    },
+    "tsdocMessageReporting": {
+      "tsdoc-undefined-tag": {
+        "logLevel": "none"
+      }
+    }
+  }
+}

--- a/packages/fake-backends/package.json
+++ b/packages/fake-backends/package.json
@@ -38,10 +38,15 @@
     "nanoid": "3.1.32"
   },
   "devDependencies": {
+    "@babel/cli": "~7.16.0",
+    "@babel/core": "~7.16.0",
+    "@babel/preset-env": "7.13.10",
     "@microsoft/api-extractor": "~7.18.0",
     "@types/jest": "~26.0.22",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "babel-jest": "^26.6.0",
+    "babel-loader": "8.1.0",
     "copyfiles": "^2.4.1",
     "cpx": "~1.5.0",
     "cross-env": "~7.0.3",
@@ -58,6 +63,7 @@
     "rimraf": "^2.6.2",
     "rollup": "~2.42.4",
     "ts-jest": "^26.4.4",
-    "typescript": "4.3.5"
+    "typescript": "4.3.5",
+    "webpack": "5.38.1"
   }
 }

--- a/packages/fake-backends/package.json
+++ b/packages/fake-backends/package.json
@@ -6,16 +6,26 @@
   "main": "dist/dist-cjs/index.js",
   "types": "dist/fake-backends.d.ts",
   "scripts": {
-    "build": "rushx clean && tsc",
+    "build": "rushx _by-flavor \"rushx _build:by-flavor\"",
+    "build:esm": "if-env COMMUNICATION_REACT_FLAVOR=stable && rushx preprocess && tsc -project tsconfig.preprocess.json || (if-env COMMUNICATION_REACT_FLAVOR=beta && tsc)",
+    "build:cjs": "rollup -c --silent --failAfterWarnings",
     "build:watch": "rushx build",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf preprocessed",
+    "test": "rushx _by-flavor \"rushx _test:by-flavor\"",
+    "preprocess": "cpx \"./src/**\" ./preprocessed && babel ./src --out-dir ../preprocessed --extensions \".ts,.tsx\" --keep-file-extension --config-file ./.babelrc.js --relative && rimraf ../preprocessed",
+    "api-extractor": "rushx _by-flavor \"rushx build:esm && rushx _api-extractor:by-flavor\"",
     "prettier": "prettier --no-error-on-unmatched-pattern --write --config ../../.prettierrc --ignore-path=../../.prettierignore \"**/*.js\" \"**/*.jsx\" \"**/*.ts\" \"**/*.tsx\"",
     "prettier:check": "prettier --no-error-on-unmatched-pattern --check --config ../../.prettierrc --ignore-path=../../.prettierignore \"**/*.js\" \"**/*.jsx\" \"**/*.ts\" \"**/*.tsx\"",
-    "test": "jest --passWithNoTests",
     "test:coverage": "npm run test -- --coverage",
     "lint": "eslint \"*/**/*.{ts,tsx}\"",
     "lint:fix": "npm run lint -- --fix",
-    "lint:quiet": "npm run lint -- --quiet"
+    "lint:quiet": "npm run lint -- --quiet",
+    "_api-extractor:by-flavor": "if-env COMMUNICATION_REACT_FLAVOR=stable && api-extractor run -c api-extractor.stable.json --local || (if-env COMMUNICATION_REACT_FLAVOR=beta && api-extractor run --local)",
+    "_build:by-flavor": "rushx clean && rushx build:esm && rushx build:cjs && rushx _api-extractor:by-flavor",
+    "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell",
+    "_current-flavor": "echo You are running under COMMUNICATION_REACT_FLAVOR: && env-cmd -f ../../common/config/env/.env node -p process.env.COMMUNICATION_REACT_FLAVOR",
+    "_test:by-flavor": "(if-env COMMUNICATION_REACT_FLAVOR=stable && rushx preprocess || if-env COMMUNICATION_REACT_FLAVOR=beta && echo \"skip preprocess\") && jest --passWithNoTests"
+
   },
   "dependencies": {
     "@azure/communication-chat": "1.2.0",
@@ -28,19 +38,25 @@
     "nanoid": "3.1.32"
   },
   "devDependencies": {
+    "@microsoft/api-extractor": "~7.18.0",
     "@types/jest": "~26.0.22",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "copyfiles": "^2.4.1",
+    "cpx": "~1.5.0",
+    "cross-env": "~7.0.3",
+    "env-cmd": "~10.1.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-header": "^3.1.0",
     "eslint-plugin-import": "~2.22.1",
     "eslint-plugin-jsdoc": "~36.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint": "^7.7.0",
+    "if-env": "~1.0.4",
     "jest": "26.6.0",
     "prettier": "2.3.1",
     "rimraf": "^2.6.2",
+    "rollup": "~2.42.4",
     "ts-jest": "^26.4.4",
     "typescript": "4.3.5"
   }

--- a/packages/fake-backends/rollup.config.js
+++ b/packages/fake-backends/rollup.config.js
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import Package from './package.json';
+import commonConfig from '../../common/config/rollup/rollup.config';
+
+export default commonConfig(Package);

--- a/packages/fake-backends/src/index.ts
+++ b/packages/fake-backends/src/index.ts
@@ -4,4 +4,5 @@
 export { FakeChatService } from './ChatService';
 export { FakeChatClient } from './FakeChatClient';
 export { Model } from './Model';
-export type { IChatClient } from './types';
+export type { IChatClient, NetworkEventModel, PublicInterface, Thread } from './types';
+export type { ThreadEventEmitter } from './ThreadEventEmitter';

--- a/packages/fake-backends/tsconfig.preprocess.json
+++ b/packages/fake-backends/tsconfig.preprocess.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../common/config/tsc/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./preprocessed",
+    "outDir": "./dist/dist-esm"
+  },
+  "typeRoots": ["./node_modules/@types"],
+  "include": ["preprocessed/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -15,7 +15,6 @@
     "build:cjs": "rollup -c --silent --failAfterWarnings",
     "build:watch": "rushx build",
     "clean": "rimraf dist && rimraf preprocessed",
-    "tsc:e2e": "tsc -project tests/tsconfig.json",
     "build:e2e": "rushx _by-flavor \"rushx build:e2e:call && rushx build:e2e:chat && rushx build:e2e:callwithchat\"",
     "build:e2e:call": "rushx _by-flavor \"webpack-cli build --config ./tests/browser/call/app/webpack.config.js --mode=production --env production\"",
     "build:e2e:chat": "rushx _by-flavor \"webpack-cli build --config ./tests/browser/chat/app/webpack.config.js --mode=production --env production\"",
@@ -39,8 +38,9 @@
     "lint": "eslint --max-warnings 0 \"*/**/*.{ts,tsx}\"",
     "lint:fix": "rushx lint -- --fix",
     "lint:quiet": "rushx lint -- --quiet",
+    "_tsc:e2e": "tsc -project tests/tsconfig.json",
     "_api-extractor:by-flavor": "if-env COMMUNICATION_REACT_FLAVOR=stable && api-extractor run -c api-extractor.stable.json --local || (if-env COMMUNICATION_REACT_FLAVOR=beta && api-extractor run --local)",
-    "_build:by-flavor": "rushx clean && rushx build:esm && rushx build:cjs && rushx _api-extractor:by-flavor",
+    "_build:by-flavor": "rushx clean && rushx build:esm && rushx build:cjs && rushx _api-extractor:by-flavor && rushx _tsc:e2e",
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell",
     "_current-flavor": "echo You are running under COMMUNICATION_REACT_FLAVOR: && env-cmd -f ../../common/config/env/.env node -p process.env.COMMUNICATION_REACT_FLAVOR",
     "_test:by-flavor": "(if-env COMMUNICATION_REACT_FLAVOR=stable && rushx preprocess || if-env COMMUNICATION_REACT_FLAVOR=beta && echo \"skip preprocess\") && jest"

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -15,6 +15,7 @@
     "build:cjs": "rollup -c --silent --failAfterWarnings",
     "build:watch": "rushx build",
     "clean": "rimraf dist && rimraf preprocessed",
+    "tsc:e2e": "tsc -project tests/tsconfig.json",
     "build:e2e": "rushx _by-flavor \"rushx build:e2e:call && rushx build:e2e:chat && rushx build:e2e:callwithchat\"",
     "build:e2e:call": "rushx _by-flavor \"webpack-cli build --config ./tests/browser/call/app/webpack.config.js --mode=production --env production\"",
     "build:e2e:chat": "rushx _by-flavor \"webpack-cli build --config ./tests/browser/chat/app/webpack.config.js --mode=production --env production\"",
@@ -38,9 +39,8 @@
     "lint": "eslint --max-warnings 0 \"*/**/*.{ts,tsx}\"",
     "lint:fix": "rushx lint -- --fix",
     "lint:quiet": "rushx lint -- --quiet",
-    "_tsc:e2e": "tsc -project tests/tsconfig.json",
     "_api-extractor:by-flavor": "if-env COMMUNICATION_REACT_FLAVOR=stable && api-extractor run -c api-extractor.stable.json --local || (if-env COMMUNICATION_REACT_FLAVOR=beta && api-extractor run --local)",
-    "_build:by-flavor": "rushx clean && rushx build:esm && rushx build:cjs && rushx _api-extractor:by-flavor && rushx _tsc:e2e",
+    "_build:by-flavor": "rushx clean && rushx build:esm && rushx build:cjs && rushx _api-extractor:by-flavor",
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell",
     "_current-flavor": "echo You are running under COMMUNICATION_REACT_FLAVOR: && env-cmd -f ../../common/config/env/.env node -p process.env.COMMUNICATION_REACT_FLAVOR",
     "_test:by-flavor": "(if-env COMMUNICATION_REACT_FLAVOR=stable && rushx preprocess || if-env COMMUNICATION_REACT_FLAVOR=beta && echo \"skip preprocess\") && jest"

--- a/packages/react-composites/tests/browser/call/app/mocks/MockCallAdapter.ts
+++ b/packages/react-composites/tests/browser/call/app/mocks/MockCallAdapter.ts
@@ -91,6 +91,9 @@ export class MockCallAdapter implements CallAdapter {
   resumeCall(): Promise<void> {
     throw Error('resumeCall not implemented');
   }
+  sendDtmfTone(): Promise<void> {
+    throw Error('sendDtmfTone not implemented');
+  }
   setCamera(): Promise<void> {
     throw Error('setCamera not implemented');
   }

--- a/packages/react-composites/tests/browser/call/hermetic/ConfigurationPage.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/ConfigurationPage.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { buildUrlWithMockAdapter, defaultMockCallAdapterState, test } from './fixture';
-import { expect } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 import { dataUiId, stableScreenshot, waitForCallCompositeToLoad, waitForSelector } from '../../common/utils';
 import type { MockCallAdapterState } from '../MockCallAdapterState';
 

--- a/packages/react-composites/tests/browser/chat/app/CustomDataModel.tsx
+++ b/packages/react-composites/tests/browser/chat/app/CustomDataModel.tsx
@@ -1,16 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ChatParticipant } from '@azure/communication-signaling';
 import { Stack } from '@fluentui/react';
-import { MessageProps } from '@internal/react-components';
+import { CommunicationParticipant, MessageProps } from '@internal/react-components';
 import React from 'react';
 import { AvatarPersonaData } from '../../../../src';
 
 /**
  * Custom onRenderTypingIndicator prop of {@link ChatComposite} used for UI test
  */
-export const customOnRenderTypingIndicator = (typingUsers: ChatParticipant[]): JSX.Element => (
+export const customOnRenderTypingIndicator = (typingUsers: CommunicationParticipant[]): JSX.Element => (
   <Stack style={{ width: '100%' }}>
     <text id="custom-data-model-typing-indicator">
       {typingUsers.length > 0
@@ -37,7 +36,7 @@ const getMessageContentInUppercase = (messageProps: MessageProps): string => {
   switch (message.messageType) {
     case 'chat':
     case 'custom':
-      return message.content.toUpperCase();
+      return (message.content ?? '').toUpperCase();
     case 'system':
       switch (message.systemMessageType) {
         case 'content':
@@ -54,6 +53,7 @@ const getMessageContentInUppercase = (messageProps: MessageProps): string => {
     default:
       'CUSTOM MESSAGE';
   }
+  throw new Error('unrechange code');
 };
 
 /**

--- a/packages/react-composites/tests/browser/chat/app/CustomDataModel.tsx
+++ b/packages/react-composites/tests/browser/chat/app/CustomDataModel.tsx
@@ -53,7 +53,7 @@ const getMessageContentInUppercase = (messageProps: MessageProps): string => {
     default:
       'CUSTOM MESSAGE';
   }
-  throw new Error('unrechange code');
+  throw new Error('unreachable code');
 };
 
 /**

--- a/packages/react-composites/tests/browser/chat/app/FakeChatAdapterArgs.ts
+++ b/packages/react-composites/tests/browser/chat/app/FakeChatAdapterArgs.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { ChatParticipant, ChatThreadClient } from '@azure/communication-chat';
-import { FileMetadata } from '@internal/react-components';
+import type { FileMetadata } from '@internal/react-components';
 
 /**
  * Type to represent a file upload the local participant will perform.

--- a/packages/react-composites/tests/browser/chat/app/LiveTestApp.tsx
+++ b/packages/react-composites/tests/browser/chat/app/LiveTestApp.tsx
@@ -4,15 +4,9 @@
 import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from '@azure/communication-common';
 import { Stack } from '@fluentui/react';
 import { fromFlatCommunicationIdentifier } from '@internal/acs-ui-common';
-import { MessageProps, _IdentifierProvider } from '@internal/react-components';
+import { _IdentifierProvider, FileDownloadError, FileDownloadHandler, MessageProps } from '@internal/react-components';
 import React, { useMemo } from 'react';
-import {
-  ChatComposite,
-  COMPOSITE_LOCALE_FR_FR,
-  FileDownloadError,
-  FileDownloadHandler,
-  useAzureCommunicationChatAdapter
-} from '../../../../src';
+import { ChatComposite, COMPOSITE_LOCALE_FR_FR, useAzureCommunicationChatAdapter } from '../../../../src';
 // eslint-disable-next-line no-restricted-imports
 import { IDS } from '../../common/constants';
 import { verifyParamExists } from '../../common/testAppUtils';
@@ -161,7 +155,7 @@ function getMessageContentInUppercase(messageProps: MessageProps): string {
   switch (message.messageType) {
     case 'chat':
     case 'custom':
-      return message.content.toUpperCase();
+      return (message.content ?? '').toUpperCase();
     case 'system':
       switch (message.systemMessageType) {
         case 'content':
@@ -178,4 +172,5 @@ function getMessageContentInUppercase(messageProps: MessageProps): string {
     default:
       'CUSTOM MESSAGE';
   }
+  throw new Error('unreachable code');
 }

--- a/packages/react-composites/tests/browser/common/utils.ts
+++ b/packages/react-composites/tests/browser/common/utils.ts
@@ -105,7 +105,11 @@ export async function waitForFunction<R>(
  */
 export const waitForPageFontsLoaded = async (page: Page): Promise<void> => {
   await waitForFunction(page, async () => {
-    await document.fonts.ready;
+    // typescript libraries in Node define the type of `document` as
+    //     interface Document {}
+    // this breaks `tsc`, even though it works correctly in the browser.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (document as any).fonts.ready;
   });
 };
 

--- a/packages/react-composites/tests/tsconfig.json
+++ b/packages/react-composites/tests/tsconfig.json
@@ -1,16 +1,10 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@azure/communication-react": ["../../communication-react/src"],
-      "@internal/acs-ui-common": ["../../acs-ui-common/src"],
-      "@internal/calling-component-bindings": ["../../calling-component-bindings/src"],
-      "@internal/calling-stateful-client": ["../../calling-stateful-client/src"],
-      "@internal/chat-component-bindings": ["../../chat-component-bindings/src"],
-      "@internal/chat-stateful-client": ["../../chat-stateful-client/src"],
-      "@internal/fake-backends": ["../../fake-backends/src"],
-      "@internal/react-components": ["../../react-components/src"]
+      "@internal/react-components": ["../../react-components/src"],
+      "@internal/acs-ui-common": ["../../acs-ui-common/src"]
     }
   },
   "include": ["browser/**/*.ts", "server/**/*.ts"]

--- a/packages/react-composites/tests/tsconfig.json
+++ b/packages/react-composites/tests/tsconfig.json
@@ -7,5 +7,5 @@
       "@internal/acs-ui-common": ["../../acs-ui-common/src"]
     }
   },
-  "include": ["/browser/**/*.ts", "server/**/*.ts"]
+  "include": ["browser/**/*.ts", "server/**/*.ts"]
 }

--- a/packages/react-composites/tests/tsconfig.json
+++ b/packages/react-composites/tests/tsconfig.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@internal/react-components": ["../../react-components/src"],
-      "@internal/acs-ui-common": ["../../acs-ui-common/src"]
+      "@internal/acs-ui-common": ["../../acs-ui-common/src"],
+      "@internal/fake-backends": ["../../fake-backends/src"],
+      "@internal/react-components": ["../../react-components/src"]
     }
   },
   "include": ["browser/**/*.ts", "browser/**/*.tsx", "server/**/*.ts"]

--- a/packages/react-composites/tests/tsconfig.json
+++ b/packages/react-composites/tests/tsconfig.json
@@ -7,5 +7,5 @@
       "@internal/acs-ui-common": ["../../acs-ui-common/src"]
     }
   },
-  "include": ["browser/**/*.ts", "server/**/*.ts"]
+  "include": ["browser/**/*.ts", "browser/**/*.tsx", "server/**/*.ts"]
 }

--- a/packages/react-composites/tests/tsconfig.json
+++ b/packages/react-composites/tests/tsconfig.json
@@ -1,12 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@internal/acs-ui-common": ["../../acs-ui-common/src"],
-      "@internal/fake-backends": ["../../fake-backends/src"],
-      "@internal/react-components": ["../../react-components/src"]
-    }
+    "baseUrl": "./"
   },
   "include": ["browser/**/*.ts", "browser/**/*.tsx", "server/**/*.ts"]
 }

--- a/packages/react-composites/tests/tsconfig.json
+++ b/packages/react-composites/tests/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@internal/react-components": ["../../react-components/src/components/index.ts"],
+      "@internal/react-components": ["../../react-components/src"],
       "@internal/acs-ui-common": ["../../acs-ui-common/src"]
     }
   },

--- a/packages/react-composites/tests/tsconfig.json
+++ b/packages/react-composites/tests/tsconfig.json
@@ -1,10 +1,16 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "@internal/react-components": ["../../react-components/src"],
-      "@internal/acs-ui-common": ["../../acs-ui-common/src"]
+      "@azure/communication-react": ["../../communication-react/src"],
+      "@internal/acs-ui-common": ["../../acs-ui-common/src"],
+      "@internal/calling-component-bindings": ["../../calling-component-bindings/src"],
+      "@internal/calling-stateful-client": ["../../calling-stateful-client/src"],
+      "@internal/chat-component-bindings": ["../../chat-component-bindings/src"],
+      "@internal/chat-stateful-client": ["../../chat-stateful-client/src"],
+      "@internal/fake-backends": ["../../fake-backends/src"],
+      "@internal/react-components": ["../../react-components/src"]
     }
   },
   "include": ["browser/**/*.ts", "server/**/*.ts"]

--- a/packages/react-composites/tests/tsconfig.json
+++ b/packages/react-composites/tests/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
+    "baseUrl": "./",
+    // Required for playwright to correctly interpret *test internal* imports.
+    "paths": {}
   },
   "include": ["browser/**/*.ts", "browser/**/*.tsx", "server/**/*.ts"]
 }


### PR DESCRIPTION
* Fix typo in `packages/react-composites/tests/tsconfig.json` that resulted in the test code never getting type checked.
* Fix uncovered type errors

In particular, fix the problems caused by `@internal/fake-backends` packlet not being setup properly:

* Drop source maps in `react-composites/tests/tsconfig.json` -- source maps don't work with stable flavor builds (the only other `tsconfig.json` that has source maps is `storybook`, but that is never built in stable flavor)
* Fix the build setup of `@internal/fake-backends` so that it correctly generates the rolled up types file for both beta and stable flavor builds.