### PR TITLE
Dialpad overflow ellipsis fix

### DIFF
--- a/change/@internal-react-composites-9386fdf7-ecb9-41bf-aa8f-577124303c52.json
+++ b/change/@internal-react-composites-9386fdf7-ecb9-41bf-aa8f-577124303c52.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix dialpad styles so that ellipsis are on left of the number that is being dialed.",
+  "packageName": "@internal/react-composites",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/CallingDialpad.styles.ts
+++ b/packages/react-composites/src/composites/common/CallingDialpad.styles.ts
@@ -33,6 +33,7 @@ export const themedDialpadStyle = (isMobile: boolean, theme: Theme): Partial<Dia
       backgroundColor: theme.palette.white,
       fontSize: theme.fonts.large.fontSize,
       padding: '0 0.5rem',
+      direction: 'rtl',
       textAlign: isMobile ? 'center' : 'left',
       ':active': {
         padding: '0 0.5rem'

--- a/packages/react-composites/src/composites/common/SendDtmfDialpad.styles.ts
+++ b/packages/react-composites/src/composites/common/SendDtmfDialpad.styles.ts
@@ -33,7 +33,8 @@ export const themedDialpadStyle = (isMobile: boolean, theme: Theme): Partial<Dia
       backgroundColor: theme.palette.white,
       fontSize: theme.fonts.large.fontSize,
       padding: '0 0.5rem ',
-      textAlign: 'center',
+      direction: 'rtl',
+      textAlign: 'left',
       ':active': {
         padding: '0 0.5rem'
       }

--- a/packages/react-composites/src/composites/common/SendDtmfDialpad.styles.ts
+++ b/packages/react-composites/src/composites/common/SendDtmfDialpad.styles.ts
@@ -34,7 +34,7 @@ export const themedDialpadStyle = (isMobile: boolean, theme: Theme): Partial<Dia
       fontSize: theme.fonts.large.fontSize,
       padding: '0 0.5rem ',
       direction: 'rtl',
-      textAlign: 'left',
+      textAlign: 'center',
       ':active': {
         padding: '0 0.5rem'
       }


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Moves Ellipsis to left side of dialpad overflow
# Why
<!--- What problem does this change solve? -->
makes sure end user can see the last numbers they were typing
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2958039
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran locally
![image](https://user-images.githubusercontent.com/94866715/186543726-3ff226d6-73d9-4b10-ad65-8d6487f52936.png)
