### PR TITLE
register icons so they show in sample homescreen

### DIFF
--- a/samples/CallWithChat/src/app/views/HomeScreen.tsx
+++ b/samples/CallWithChat/src/app/views/HomeScreen.tsx
@@ -3,6 +3,8 @@
 
 import React, { useState } from 'react';
 import { Stack, PrimaryButton, Image, ChoiceGroup, IChoiceGroupOption, Text, TextField } from '@fluentui/react';
+/* @conditional-compile-remove(PSTN-calls) */
+import { registerIcons } from '@fluentui/react';
 import heroSVG from '../../assets/hero.svg';
 import {
   imgStyle,
@@ -26,6 +28,8 @@ import { DisplayNameField } from './DisplayNameField';
 import { TeamsMeetingLinkLocator } from '@azure/communication-calling';
 /* @conditional-compile-remove(PSTN-calls) */
 import { Dialpad } from '@azure/communication-react';
+/* @conditional-compile-remove(PSTN-calls) */
+import { Backspace20Regular } from '@fluentui/react-icons';
 
 export interface HomeScreenProps {
   startCallHandler(callDetails: {
@@ -81,6 +85,9 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
       (teamsCallChosen && teamsLink) ||
       /* @conditional-compile-remove(PSTN-calls) */ (pstnCallChosen && dialpadParticipant && alternateCallerId) ||
       /* @conditional-compile-remove(one-to-n-calling) */ (outboundParticipants && acsCallChosen));
+
+  /* @conditional-compile-remove(PSTN-calls) */
+  registerIcons({ icons: { BackSpace: <Backspace20Regular /> } });
   return (
     <Stack
       horizontal

--- a/samples/Calling/src/app/views/HomeScreen.tsx
+++ b/samples/Calling/src/app/views/HomeScreen.tsx
@@ -3,6 +3,8 @@
 
 import React, { useState } from 'react';
 import { Stack, PrimaryButton, Image, ChoiceGroup, IChoiceGroupOption, Text, TextField } from '@fluentui/react';
+/* @conditional-compile-remove(PSTN-calls) */
+import { registerIcons } from '@fluentui/react';
 import heroSVG from '../../assets/hero.svg';
 import {
   imgStyle,
@@ -30,6 +32,8 @@ import { RoomLocator } from '@azure/communication-calling';
 import { getRoomIdFromUrl } from '../utils/AppUtils';
 /* @conditional-compile-remove(PSTN-calls) */
 import { Dialpad } from '@azure/communication-react';
+/* @conditional-compile-remove(PSTN-calls) */
+import { Backspace20Regular } from '@fluentui/react-icons';
 
 export interface HomeScreenProps {
   startCallHandler(callDetails: {
@@ -109,6 +113,9 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
         chosenRoomsRoleOption) ||
       /* @conditional-compile-remove(PSTN-calls) */ (pstnCallChosen && dialPadParticipant && alternateCallerId) ||
       /* @conditional-compile-remove(one-to-n-calling) */ (outboundParticipants && acsCallChosen));
+
+  /* @conditional-compile-remove(PSTN-calls) */
+  registerIcons({ icons: { BackSpace: <Backspace20Regular /> } });
 
   return (
     <Stack


### PR DESCRIPTION
# What
Dialpad delete button was missing in homescreen, now it's visible 

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/2960136

# How Tested
Open calling and callwithchat sample, selete PSTN, type in dialpad and see if delete button pops up 
