### PR TITLE
Allow contoso to directly set the value inside textfield 

### DIFF
--- a/change/@internal-react-components-8a640ab7-f76f-4826-ae80-f26044d265d6.json
+++ b/change/@internal-react-components-8a640ab7-f76f-4826-ae80-f26044d265d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "removed ondisplaydialpadinput, add textFieldValue for contoso to directly set the value inside textfield",
+  "packageName": "@internal/react-components",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-storybook-625d5539-f0cc-4445-bc18-900dd7f4939a.json
+++ b/change/@internal-storybook-625d5539-f0cc-4445-bc18-900dd7f4939a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update storybook to show how to use onchange and textfieldValue props to customize formatting",
+  "packageName": "@internal/storybook",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1740,13 +1740,13 @@ export interface DialpadButtonProps {
 export interface DialpadProps {
     onChange?: (input: string) => void;
     onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
-    onDisplayDialpadInput?: (input: string) => string;
     onSendDtmfTone?: (dtmfTone: DtmfTone) => Promise<void>;
     showDeleteButton?: boolean;
     // (undocumented)
     strings?: DialpadStrings;
     // (undocumented)
     styles?: DialpadStyles;
+    textFieldValue?: string;
 }
 
 // @beta

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -457,13 +457,13 @@ export interface DialpadButtonProps {
 export interface DialpadProps {
     onChange?: (input: string) => void;
     onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
-    onDisplayDialpadInput?: (input: string) => string;
     onSendDtmfTone?: (dtmfTone: DtmfTone) => Promise<void>;
     showDeleteButton?: boolean;
     // (undocumented)
     strings?: DialpadStrings;
     // (undocumented)
     styles?: DialpadStyles;
+    textFieldValue?: string;
 }
 
 // @beta

--- a/packages/react-components/review/stable/react-components.api.md
+++ b/packages/react-components/review/stable/react-components.api.md
@@ -432,6 +432,19 @@ export interface DialpadProps {
 }
 
 // @beta
+export interface DialpadProps {
+    onChange?: (input: string) => void;
+    onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
+    onSendDtmfTone?: (dtmfTone: DtmfTone) => Promise<void>;
+    showDeleteButton?: boolean;
+    // (undocumented)
+    strings?: DialpadStrings;
+    // (undocumented)
+    styles?: DialpadStyles;
+    textFieldValue?: string;
+}
+
+// @beta
 export interface DialpadStrings {
     // (undocumented)
     deleteButtonAriaLabel?: string;

--- a/packages/react-components/review/stable/react-components.api.md
+++ b/packages/react-components/review/stable/react-components.api.md
@@ -422,19 +422,6 @@ export const Dialpad: (props: DialpadProps) => JSX.Element;
 export interface DialpadProps {
     onChange?: (input: string) => void;
     onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
-    onDisplayDialpadInput?: (input: string) => string;
-    onSendDtmfTone?: (dtmfTone: DtmfTone) => Promise<void>;
-    showDeleteButton?: boolean;
-    // (undocumented)
-    strings?: DialpadStrings;
-    // (undocumented)
-    styles?: DialpadStyles;
-}
-
-// @beta
-export interface DialpadProps {
-    onChange?: (input: string) => void;
-    onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
     onSendDtmfTone?: (dtmfTone: DtmfTone) => Promise<void>;
     showDeleteButton?: boolean;
     // (undocumented)

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-<<<<<<< HEAD
-import React, { useEffect } from 'react';
-=======
-import React, { useCallback } from 'react';
->>>>>>> b4ff2cfcd37a8d13143e560fae5a775760623137
+import React, { useEffect, useCallback } from 'react';
 import { IStyle, IButtonStyles, ITextFieldStyles } from '@fluentui/react';
 
 import { IconButton } from '@fluentui/react';
@@ -102,7 +98,6 @@ export type DtmfTone =
   | 'Pound'
   | 'Star';
 
-<<<<<<< HEAD
 /**
  * Props for {@link Dialpad} component.
  *
@@ -126,11 +121,8 @@ export interface DialpadProps {
   styles?: DialpadStyles;
 }
 
-const DialpadButton = (props: {
-=======
 type DialpadButtonContent = {
   /** Number displayed on each dialpad button */
->>>>>>> b4ff2cfcd37a8d13143e560fae5a775760623137
   primaryContent: string;
   /** Letters displayed on each dialpad button */
   secondaryContent?: string;
@@ -250,23 +242,16 @@ const DialpadContainer = (props: {
   };
 
   const onLongPressDialpad = (input: string, index: number): void => {
-    let value;
     if (input === '0' && index === 10) {
-      // remove non-valid characters from input: letters,special characters excluding +, *,#
-      value = sanitizeInput(textValue + '+');
-      setTextValue(value);
+      setText(plainTextValue + '+');
     } else {
-      value = sanitizeInput(textValue + input);
-      setTextValue(value);
+      setText(plainTextValue + input);
     }
     if (onSendDtmfTone) {
       onSendDtmfTone(DtmfTones[index]);
     }
     if (onClickDialpadButton) {
       onClickDialpadButton(input, index);
-    }
-    if (onChange) {
-      onChange(onDisplayDialpadInput ? onDisplayDialpadInput(value) : formatPhoneNumber(value));
     }
   };
 

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -91,7 +91,7 @@ export interface DialpadProps {
   onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
   /** set dialpad textfield content */
   textFieldValue?: string;
-  /**  on change function for text field */
+  /**  on change function for text field, provides an unformatted plain text*/
   onChange?: (input: string) => void;
   /**  boolean input to determine when to show/hide delete button, default true */
   showDeleteButton?: boolean;
@@ -186,7 +186,7 @@ const DialpadContainer = (props: {
   onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
   /** Pass in custom content to dialpad textfield */
   textFieldValue?: string;
-  /**  on change function for text field */
+  /**  on change function for text field, provides an unformatted plain text */
   onChange?: (input: string) => void;
   /**  boolean input to determine when to show/hide delete button, default true */
   showDeleteButton?: boolean;

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -199,7 +199,7 @@ const DialpadContainer = (props: {
     if (onChange) {
       onChange(plainTextValue);
     }
-  }, [plainTextValue]);
+  }, [plainTextValue, onChange]);
 
   useEffect(() => {
     setText(textFieldValue ?? '');

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -55,26 +55,6 @@ export interface DialpadStyles {
 }
 
 /**
- * Props for {@link Dialpad} component.
- *
- * @beta
- */
-export interface DialpadProps {
-  strings?: DialpadStrings;
-  /**  function to send dtmf tones on button click */
-  onSendDtmfTone?: (dtmfTone: DtmfTone) => Promise<void>;
-  /**  Callback for dialpad button behavior*/
-  onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
-  /**  customize dialpad input formatting */
-  onDisplayDialpadInput?: (input: string) => string;
-  /**  on change function for text field */
-  onChange?: (input: string) => void;
-  /**  boolean input to determine when to show/hide delete button, default true */
-  showDeleteButton?: boolean;
-  styles?: DialpadStyles;
-}
-
-/**
  * DTMF tone for PSTN calls.
  *
  * @beta
@@ -105,14 +85,11 @@ export type DtmfTone =
  */
 export interface DialpadProps {
   strings?: DialpadStrings;
-  // Potential Improvement:
-  // comment out the following prop for now to disable customization for dialpad content
-  // dialpadButtons?: DialpadButtonProps[][];
   /**  function to send dtmf tones on button click */
   onSendDtmfTone?: (dtmfTone: DtmfTone) => Promise<void>;
   /**  Callback for dialpad button behavior*/
   onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
-  /** Pass in custom content to dialpad textfield */
+  /** set dialpad textfield content */
   textFieldValue?: string;
   /**  on change function for text field */
   onChange?: (input: string) => void;

--- a/packages/storybook/stories/Dialpad/Dialpad.stories.tsx
+++ b/packages/storybook/stories/Dialpad/Dialpad.stories.tsx
@@ -31,10 +31,8 @@ const getDocs: () => JSX.Element = () => {
       </Canvas>
       <Heading>Example Dialpad with custom content</Heading>
       <Description>
-        On Dialpad button click, the corresponding dtmf tone, the index and value of the button clicked will be shown on
-        the screen. On Keyboard click, the corresponding keyboard input will be shown on the screen as well. This
-        example showcases how to customize the format for dialpad input, and how to add custom functions to textfield to
-        listen to keyboard changes and how to add extra functionality to dialpad buttons.
+        This example showcases how to customize the format for dialpad input using onChange, how to grab textfield
+        values using onChange and how to add extra functionality to dialpad buttons.
       </Description>
       <Canvas mdxSource={CustomDialpadText}>
         <CustomDialpadExample />

--- a/packages/storybook/stories/Dialpad/snippets/CustomDialpad.snippet.tsx
+++ b/packages/storybook/stories/Dialpad/snippets/CustomDialpad.snippet.tsx
@@ -6,24 +6,11 @@ import { Dialpad, FluentThemeProvider } from '@azure/communication-react';
 import { Stack } from '@fluentui/react';
 import React, { useState } from 'react';
 
-const onDisplayDialpadInput = (phoneNumber: string): string => {
-  // if input value is falsy eg if the user deletes the input, then just return
-  if (!phoneNumber) {
-    return phoneNumber;
-  }
-
-  if (phoneNumber.length <= 4) {
-    return phoneNumber;
-  } else {
-    return `(${phoneNumber.slice(0, 4)}) ${phoneNumber.slice(4, phoneNumber.length)}`;
-  }
-};
-
 export const CustomDialpadExample: () => JSX.Element = () => {
   const [dtmftone, setDtmftone] = useState('');
   const [buttonValue, setButtonValue] = useState('');
   const [buttonIndex, setButtonIndex] = useState('');
-  const [textfieldInput, setTextfieldInput] = useState('');
+  const [textFieldValue, setTextFieldValue] = useState('');
 
   const onSendDtmfTone = (dtmfTone: DtmfTone): Promise<void> => {
     setDtmftone(dtmfTone);
@@ -36,7 +23,21 @@ export const CustomDialpadExample: () => JSX.Element = () => {
   };
 
   const onChange = (input: string): void => {
-    setTextfieldInput(input);
+    // if there is already a plus sign at the front remove it
+    if (input[0] === '+') {
+      input = input.slice(1, input.length);
+    }
+    // add + sign and brackets to format phone number
+    if (input.length < 4 && input.length > 0) {
+      // store the new value in textFieldValue and pass it back to dialpad textfield
+      setTextFieldValue(`+ ${input}`);
+    } else if (input.length >= 4) {
+      // store the new value in textFieldValue and pass it back to dialpad textfield
+      setTextFieldValue(`+ (${input.slice(0, 3)}) ${input.slice(3, input.length)}`);
+    } else {
+      // store the new value in textFieldValue and pass it back to dialpad textfield
+      setTextFieldValue(input);
+    }
   };
 
   return (
@@ -46,13 +47,10 @@ export const CustomDialpadExample: () => JSX.Element = () => {
         <div style={{ fontSize: '1.5rem', marginBottom: '1rem', fontFamily: 'Segoe UI' }}>
           Button Clicked: {buttonValue} index at {buttonIndex}
         </div>
-        <div style={{ fontSize: '1.5rem', marginBottom: '1rem', fontFamily: 'Segoe UI' }}>
-          Textfield Input from keyboard: {textfieldInput}
-        </div>
 
         <Dialpad
           onSendDtmfTone={onSendDtmfTone}
-          onDisplayDialpadInput={onDisplayDialpadInput}
+          textFieldValue={textFieldValue}
           onClickDialpadButton={onClickDialpadButton}
           onChange={onChange}
         />


### PR DESCRIPTION
# What
removed ondisplaydialpadinput, add textFieldValue for contoso to directly set the value inside textfield

# Why
Change made according to internal review recommendations 

# How Tested
storybook example showing how to use those 2 props to customized textfield format 
