### PR TITLE
Fixed input order bug on calling dialpad and dtmf dialpad

### DIFF
--- a/change/@internal-react-composites-03770501-1787-429f-97a6-03dec1bf9d48.json
+++ b/change/@internal-react-composites-03770501-1787-429f-97a6-03dec1bf9d48.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed input order bug on calling dialpad and dtmf dialpad",
+  "packageName": "@internal/react-composites",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/CallingDialpad.styles.ts
+++ b/packages/react-composites/src/composites/common/CallingDialpad.styles.ts
@@ -33,7 +33,6 @@ export const themedDialpadStyle = (isMobile: boolean, theme: Theme): Partial<Dia
       backgroundColor: theme.palette.white,
       fontSize: theme.fonts.large.fontSize,
       padding: '0 0.5rem',
-      direction: 'rtl',
       textAlign: isMobile ? 'center' : 'left',
       ':active': {
         padding: '0 0.5rem'

--- a/packages/react-composites/src/composites/common/SendDtmfDialpad.styles.ts
+++ b/packages/react-composites/src/composites/common/SendDtmfDialpad.styles.ts
@@ -33,7 +33,6 @@ export const themedDialpadStyle = (isMobile: boolean, theme: Theme): Partial<Dia
       backgroundColor: theme.palette.white,
       fontSize: theme.fonts.large.fontSize,
       padding: '0 0.5rem ',
-      direction: 'rtl',
       textAlign: 'center',
       ':active': {
         padding: '0 0.5rem'


### PR DESCRIPTION
# What
Fixed input order bug on calling dialpad and dtmf dialpad


# How Tested

before: 


https://user-images.githubusercontent.com/96077406/187010118-5f6521bf-63ac-4e84-9753-fac1cf92cbde.mov


after: 


https://user-images.githubusercontent.com/96077406/187010113-9d664fc8-cc95-41af-9bbb-273b9947bfdc.mov


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->