### PR TITLE
remove the rejoin button from end call screen in calling composite

### DIFF
--- a/change/@internal-react-composites-aa0ade22-f5ec-4e83-ab62-4f3aaa51c819.json
+++ b/change/@internal-react-composites-aa0ade22-f5ec-4e83-ab62-4f3aaa51c819.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remvoe the rejoin button from the Calling and CallWithChat to support new locator types for PSTN and 1:N calling.",
+  "packageName": "@internal/react-composites",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/pages/NoticePage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/NoticePage.tsx
@@ -3,15 +3,7 @@
 
 import React from 'react';
 import { mergeStyles, Stack, Text } from '@fluentui/react';
-import {
-  containerStyle,
-  moreDetailsStyles,
-  containerItemGap,
-  titleStyles,
-  rejoinCallButtonContainerStyles
-} from '../styles/NoticePage.styles';
-import { useAdapter } from '../adapter/CallAdapterProvider';
-import { StartCallButton } from '../components/StartCallButton';
+import { containerStyle, moreDetailsStyles, containerItemGap, titleStyles } from '../styles/NoticePage.styles';
 import { CallCompositeIcon, CallCompositeIcons } from '../../common/icons';
 
 /**
@@ -30,7 +22,6 @@ export interface NoticePageProps {
  * @private
  */
 export function NoticePage(props: NoticePageProps): JSX.Element {
-  const adapter = useAdapter();
   return (
     <Stack verticalFill verticalAlign="center" horizontalAlign="center" data-ui-id={props.dataUiId} aria-atomic>
       <Stack className={mergeStyles(containerStyle)} tokens={containerItemGap}>
@@ -41,9 +32,6 @@ export function NoticePage(props: NoticePageProps): JSX.Element {
         <Text className={mergeStyles(moreDetailsStyles)} aria-live="assertive">
           {props.moreDetails}
         </Text>
-        <Stack styles={rejoinCallButtonContainerStyles}>
-          <StartCallButton onClick={() => adapter.joinCall()} disabled={false} rejoinCall={true} autoFocus />
-        </Stack>
       </Stack>
     </Stack>
   );


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Remove the end call screen's rejoin call button
# Why
<!--- What problem does this change solve? -->
Better supports the locator method of starting a PSTN or 1:N call, should the users change in the call the locator would not update. the issue here being then that when they action the `rejoin call` button they will redial the original participants of the call. instead of the composite having to update the locator on each new participant change (leave or join) we rely on Contoso to make this button. 

This is probably a breaking UI change so please leave your thoughts about this. 
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
![image](https://user-images.githubusercontent.com/94866715/187243304-38050857-5978-4ca9-af0b-3a107564536c.png)