### PR TITLE
Fix typo in GitHub action to update snapshots

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -36,7 +36,7 @@ jobs:
           # Required for running `gh`.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          run: echo "::set-output name=found::true"
+          echo "::set-output name=found::true"
           gh pr edit ${{ github.event.number }} --remove-label update_snapshots
 
   get_matrix:


### PR DESCRIPTION
Fix a typo in parts of a new GitHub action. These parts are hard to test before merging to `main` :(