### PR TITLE
[Up for discussion] Re-hook buttons to permissions

### DIFF
--- a/change/@internal-react-components-3559264c-7cb3-42d7-9724-db311a1e2481.json
+++ b/change/@internal-react-components-3559264c-7cb3-42d7-9724-db311a1e2481.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hook permissions to CameraButton, DevicesButton, MicrophoneButton, and ScreenShareButton.",
+  "packageName": "@internal/react-components",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/CameraButton.test.tsx
+++ b/packages/react-components/src/components/CameraButton.test.tsx
@@ -7,6 +7,12 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { createTestLocale, mountWithLocalization } from './utils/testUtils';
 import { registerIcons } from '@fluentui/react';
+/* @conditional-compile-remove(rooms) */
+import { mountWithPermissions } from './utils/testUtils';
+/* @conditional-compile-remove(rooms) */
+import { _getPermissions } from '../permissions';
+/* @conditional-compile-remove(rooms) */
+import { ControlBarButton } from './ControlBarButton';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -42,5 +48,35 @@ describe('CameraButton strings should be localizable and overridable', () => {
     expect(component.text()).toBe(cameraButtonStrings.offLabel);
     component.setProps({ checked: true });
     expect(component.text()).toBe(cameraButtonStrings.onLabel);
+  });
+});
+
+/* @conditional-compile-remove(rooms) */
+describe('Camera button tests for different roles', () => {
+  beforeEach(() => {
+    registerIcons({
+      icons: {
+        controlbuttoncameraoff: <></>,
+        chevrondown: <></>,
+        controlbuttoncameraon: <></>
+      }
+    });
+  });
+  test('Camera button should have been enabled for Presenter role', async () => {
+    const wrapper = mountWithPermissions(<CameraButton showLabel={true} />, _getPermissions('Presenter'));
+    const cameraButton = wrapper.find(ControlBarButton).first();
+    expect(cameraButton.prop('disabled')).toBe(false);
+  });
+
+  test('Camera button should have been enabled for Attendee role', async () => {
+    const wrapper = mountWithPermissions(<CameraButton showLabel={true} />, _getPermissions('Attendee'));
+    const cameraButton = wrapper.find(ControlBarButton).first();
+    expect(cameraButton.prop('disabled')).toBe(false);
+  });
+
+  test('Camera button should have been disabled for Consumer role', async () => {
+    const wrapper = mountWithPermissions(<CameraButton showLabel={true} />, _getPermissions('Consumer'));
+    const cameraButton = wrapper.find(ControlBarButton).first();
+    expect(cameraButton.prop('disabled')).toBe(true);
   });
 });

--- a/packages/react-components/src/components/CameraButton.tsx
+++ b/packages/react-components/src/components/CameraButton.tsx
@@ -11,6 +11,8 @@ import { IContextualMenuItemStyles, IContextualMenuStyles } from '@fluentui/reac
 import { ControlBarButtonStyles } from './ControlBarButton';
 import { OptionsDevice, generateDefaultDeviceMenuProps } from './DevicesButton';
 import { Announcer } from './Announcer';
+/* @conditional-compile-remove(rooms) */
+import { _usePermissions } from '../permissions';
 
 const defaultLocalVideoViewOptions = {
   scalingMode: 'Crop',
@@ -146,7 +148,11 @@ export const CameraButton = (props: CameraButtonProps): JSX.Element => {
   const strings = { ...localeStrings, ...props.strings };
   const [announcerString, setAnnouncerString] = useState<string | undefined>(undefined);
 
-  const disabled = props.disabled || waitForCamera;
+  let disabled = props.disabled || waitForCamera;
+  /* @conditional-compile-remove(rooms) */
+  const permissions = _usePermissions();
+  /* @conditional-compile-remove(rooms) */
+  disabled = disabled || !permissions.cameraButton;
 
   const onRenderCameraOnIcon = (): JSX.Element => (
     <HighContrastAwareIcon disabled={disabled} iconName="ControlButtonCameraOn" />

--- a/packages/react-components/src/components/DevicesButton.test.tsx
+++ b/packages/react-components/src/components/DevicesButton.test.tsx
@@ -7,6 +7,12 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { createTestLocale, mountWithLocalization } from './utils/testUtils';
 import { setIconOptions } from '@fluentui/react';
+/* @conditional-compile-remove(rooms) */
+import { mountWithPermissions } from './utils/testUtils';
+/* @conditional-compile-remove(rooms) */
+import { _getPermissions } from '../permissions';
+/* @conditional-compile-remove(rooms) */
+import { ControlBarButton } from './ControlBarButton';
 // Suppress icon warnings for tests. Icons are fetched from CDN which we do not want to perform during tests.
 // More information: https://github.com/microsoft/fluentui/wiki/Using-icons#test-scenarios
 setIconOptions({
@@ -45,5 +51,49 @@ describe('DevicesButton strings should be localizable and overridable', () => {
       testLocale
     );
     expect(component.text()).toBe(devicesButtonStrings.label);
+  });
+});
+
+/* @conditional-compile-remove(rooms) */
+describe('DeviceButton tests for different roles', () => {
+  test('Camera, Speaker, and Microphone section in context menu are shown for Presenter role', async () => {
+    const wrapper = mountWithPermissions(
+      <DevicesButton showLabel={true} {...mockProps} />,
+      _getPermissions('Presenter')
+    );
+    const deviceButton = wrapper.find(ControlBarButton).first();
+    expect(deviceButton.prop('menuProps')?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'sectionCamera' }),
+        expect.objectContaining({ key: 'sectionMicrophone' }),
+        expect.objectContaining({ key: 'sectionSpeaker' })
+      ])
+    );
+  });
+
+  test('Camera, Speaker, and Microphone section in context menu are shown for Attendee role', async () => {
+    const wrapper = mountWithPermissions(
+      <DevicesButton showLabel={true} {...mockProps} />,
+      _getPermissions('Attendee')
+    );
+    const deviceButton = wrapper.find(ControlBarButton).first();
+    expect(deviceButton.prop('menuProps')?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'sectionCamera' }),
+        expect.objectContaining({ key: 'sectionMicrophone' }),
+        expect.objectContaining({ key: 'sectionSpeaker' })
+      ])
+    );
+  });
+
+  test('Camera and Microphone section in context menu are not shown for Consumer role', async () => {
+    const wrapper = mountWithPermissions(
+      <DevicesButton showLabel={true} {...mockProps} />,
+      _getPermissions('Consumer')
+    );
+    const deviceButton = wrapper.find(ControlBarButton).first();
+    expect(deviceButton.prop('menuProps')?.items).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'sectionSpeaker' })])
+    );
   });
 });

--- a/packages/react-components/src/components/DevicesButton.tsx
+++ b/packages/react-components/src/components/DevicesButton.tsx
@@ -11,6 +11,8 @@ import {
 } from '@fluentui/react';
 import React from 'react';
 import { useLocale } from '../localization';
+/* @conditional-compile-remove(rooms) */
+import { _usePermissions } from '../permissions/PermissionsProvider';
 import { ControlBarButton, ControlBarButtonProps, ControlBarButtonStyles } from './ControlBarButton';
 import { HighContrastAwareIcon } from './HighContrastAwareIcon';
 import { buttonFlyoutItemStyles } from './styles/ControlBar.styles';
@@ -374,8 +376,21 @@ export const DevicesButton = (props: DevicesButtonProps): JSX.Element => {
   const localeStrings = useLocale().strings.devicesButton;
   const strings = { ...localeStrings, ...props.strings };
 
+  /* @conditional-compile-remove(rooms) */
+  const isSelectMicAllowed = _usePermissions().microphoneButton;
+  /* @conditional-compile-remove(rooms) */
+  const isSelectCamAllowed = _usePermissions().cameraButton;
+
   const devicesButtonMenu =
-    props.menuProps ?? generateDefaultDeviceMenuProps({ ...props, styles: props.styles?.menuStyles }, strings);
+    props.menuProps ??
+    generateDefaultDeviceMenuProps(
+      { ...props, styles: props.styles?.menuStyles },
+      strings,
+      /* @conditional-compile-remove(rooms) */
+      isSelectCamAllowed,
+      /* @conditional-compile-remove(rooms) */
+      isSelectMicAllowed
+    );
 
   const onRenderOptionsIcon = (): JSX.Element => (
     <HighContrastAwareIcon disabled={props.disabled} iconName="ControlButtonOptions" />

--- a/packages/react-components/src/components/MicrophoneButton.test.tsx
+++ b/packages/react-components/src/components/MicrophoneButton.test.tsx
@@ -6,6 +6,12 @@ import { MicrophoneButton } from './MicrophoneButton';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { createTestLocale, mountWithLocalization } from './utils/testUtils';
+/* @conditional-compile-remove(rooms) */
+import { mountWithPermissions } from './utils/testUtils';
+/* @conditional-compile-remove(rooms) */
+import { _getPermissions } from '../permissions';
+/* @conditional-compile-remove(rooms) */
+import { ControlBarButton } from './ControlBarButton';
 import { registerIcons } from '@fluentui/react';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -42,5 +48,35 @@ describe('MicrophoneButton strings should be localizable and overridable', () =>
     expect(component.text()).toBe(microphoneButtonStrings.offLabel);
     component.setProps({ checked: true });
     expect(component.text()).toBe(microphoneButtonStrings.onLabel);
+  });
+});
+
+/* @conditional-compile-remove(rooms) */
+describe('MicrophoneButton tests for different roles', () => {
+  beforeEach(() => {
+    registerIcons({
+      icons: {
+        controlbuttonmicoff: <></>,
+        chevrondown: <></>,
+        controlbuttonmicon: <></>
+      }
+    });
+  });
+  test('MicrophoneButton should have been enabled for Presenter role', async () => {
+    const wrapper = mountWithPermissions(<MicrophoneButton showLabel={true} />, _getPermissions('Presenter'));
+    const controlBarButton = wrapper.find(ControlBarButton).first();
+    expect(controlBarButton.prop('disabled')).toBeUndefined();
+  });
+
+  test('MicrophoneButton should have been enabled for Attendee role', async () => {
+    const wrapper = mountWithPermissions(<MicrophoneButton showLabel={true} />, _getPermissions('Attendee'));
+    const controlBarButton = wrapper.find(ControlBarButton).first();
+    expect(controlBarButton.prop('disabled')).toBeUndefined();
+  });
+
+  test('MicrophoneButton should have been disabled for Consumer role', async () => {
+    const wrapper = mountWithPermissions(<MicrophoneButton showLabel={true} />, _getPermissions('Consumer'));
+    const controlBarButton = wrapper.find(ControlBarButton).first();
+    expect(controlBarButton.prop('disabled')).toBe(true);
   });
 });

--- a/packages/react-components/src/components/MicrophoneButton.tsx
+++ b/packages/react-components/src/components/MicrophoneButton.tsx
@@ -10,6 +10,8 @@ import { IContextualMenuItemStyles, IContextualMenuStyles } from '@fluentui/reac
 import { ControlBarButtonStyles } from './ControlBarButton';
 import { OptionsDevice, generateDefaultDeviceMenuProps } from './DevicesButton';
 import { Announcer } from './Announcer';
+/* @conditional-compile-remove(rooms) */
+import { _usePermissions } from '../permissions/PermissionsProvider';
 
 /**
  * Strings of {@link MicrophoneButton} that can be overridden.
@@ -159,10 +161,13 @@ export const MicrophoneButton = (props: MicrophoneButtonProps): JSX.Element => {
   // no mics but there are speakers, then only the primary part of the button should be disabled to allow for
   // speaker change.
   const primaryDisabled = props.primaryDisabled || (isSplit && !props.microphones?.length ? true : undefined);
-  const disabled =
+  let disabled =
     props.disabled ||
     (isSplit && !props.microphones?.length && !props.speakers?.length) ||
     (!isSplit && props.microphones && props.microphones?.length === 0);
+
+  /* @conditional-compile-remove(rooms) */
+  disabled = !_usePermissions().microphoneButton || disabled;
 
   const onRenderMicOnIcon = (): JSX.Element => {
     return <HighContrastAwareIcon disabled={disabled} iconName="ControlButtonMicOn" />;

--- a/packages/react-components/src/components/ScreenShareButton.test.tsx
+++ b/packages/react-components/src/components/ScreenShareButton.test.tsx
@@ -6,6 +6,12 @@ import { ScreenShareButton } from './ScreenShareButton';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { createTestLocale, mountWithLocalization } from './utils/testUtils';
+/* @conditional-compile-remove(rooms) */
+import { mountWithPermissions } from './utils/testUtils';
+/* @conditional-compile-remove(rooms) */
+import { _getPermissions } from '../permissions';
+/* @conditional-compile-remove(rooms) */
+import { ControlBarButton } from './ControlBarButton';
 import { registerIcons } from '@fluentui/react';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -41,5 +47,34 @@ describe('ScreenShareButton strings should be localizable and overridable', () =
     expect(component.text()).toBe(screenShareButtonStrings.offLabel);
     component.setProps({ checked: true });
     expect(component.text()).toBe(screenShareButtonStrings.onLabel);
+  });
+});
+
+/* @conditional-compile-remove(rooms) */
+describe('Screenshare button tests for different roles', () => {
+  beforeEach(() => {
+    registerIcons({
+      icons: {
+        controlbuttonscreensharestart: <></>,
+        controlbuttonscreensharestop: <></>
+      }
+    });
+  });
+  test('Screenshare button should have been enabled for Presenter role', async () => {
+    const wrapper = mountWithPermissions(<ScreenShareButton showLabel={true} />, _getPermissions('Presenter'));
+    const controlBarButton = wrapper.find(ControlBarButton).first();
+    expect(controlBarButton.prop('disabled')).toBeUndefined();
+  });
+
+  test('Screenshare button should have been disabled for Attendee role', async () => {
+    const wrapper = mountWithPermissions(<ScreenShareButton showLabel={true} />, _getPermissions('Attendee'));
+    const controlBarButton = wrapper.find(ControlBarButton).first();
+    expect(controlBarButton.prop('disabled')).toBe(true);
+  });
+
+  test('Screenshare button should have been disabled for Consumer role', async () => {
+    const wrapper = mountWithPermissions(<ScreenShareButton showLabel={true} />, _getPermissions('Consumer'));
+    const controlBarButton = wrapper.find(ControlBarButton).first();
+    expect(controlBarButton.prop('disabled')).toBe(true);
   });
 });

--- a/packages/react-components/src/components/ScreenShareButton.tsx
+++ b/packages/react-components/src/components/ScreenShareButton.tsx
@@ -6,6 +6,8 @@ import { useLocale } from '../localization';
 import { ControlBarButton, ControlBarButtonProps } from './ControlBarButton';
 import { DefaultPalette, IButtonStyles, mergeStyles, Theme, useTheme } from '@fluentui/react';
 import { HighContrastAwareIcon } from './HighContrastAwareIcon';
+/* @conditional-compile-remove(rooms) */
+import { _usePermissions } from '../permissions/PermissionsProvider';
 
 /**
  * Strings of {@link ScreenShareButton} that can be overridden.
@@ -57,11 +59,15 @@ export const ScreenShareButton = (props: ScreenShareButtonProps): JSX.Element =>
   const theme = useTheme();
   const styles = screenshareButtonStyles(theme);
 
+  let disabled = props.disabled;
+  /* @conditional-compile-remove(rooms) */
+  disabled = !_usePermissions().screenShare || disabled;
+
   const onRenderScreenShareOnIcon = (): JSX.Element => (
-    <HighContrastAwareIcon disabled={props.disabled} iconName="ControlButtonScreenShareStop" />
+    <HighContrastAwareIcon disabled={disabled} iconName="ControlButtonScreenShareStop" />
   );
   const onRenderScreenShareOffIcon = (): JSX.Element => (
-    <HighContrastAwareIcon disabled={props.disabled} iconName="ControlButtonScreenShareStart" />
+    <HighContrastAwareIcon disabled={disabled} iconName="ControlButtonScreenShareStart" />
   );
 
   return (
@@ -73,7 +79,7 @@ export const ScreenShareButton = (props: ScreenShareButtonProps): JSX.Element =>
       onRenderOffIcon={props.onRenderOffIcon ?? onRenderScreenShareOffIcon}
       strings={strings}
       labelKey={props.labelKey ?? 'screenShareButtonLabel'}
-      disabled={props.disabled}
+      disabled={disabled}
     />
   );
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Restored old code to hook back the CameraButton, MicrophoneButton, and ScreenShareButton components to permissions so that they are disabled based on role.
Hooked back DeviceButton component to not show devices based on role.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
From this PR comment https://github.com/Azure/communication-ui-library/pull/2303#pullrequestreview-1101505030

# How Tested
<!--- How did you test your change. What tests have you added. -->
Locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->