### PR TITLE
Tooltip strings uncapitilized

### DIFF
--- a/change/@internal-react-components-469c85c3-3bf7-4cb0-a0c9-ba00cd8bba0f.json
+++ b/change/@internal-react-components-469c85c3-3bf7-4cb0-a0c9-ba00cd8bba0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated tooltip strings to not be title case",
+  "packageName": "@internal/react-components",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -39,7 +39,7 @@
   },
   "endCallButton": {
     "label": "Leave",
-    "tooltipContent": "Leave Call"
+    "tooltipContent": "Leave call"
   },
   "cameraButton": {
     "onLabel": "Turn off",
@@ -49,7 +49,7 @@
     "tooltipOffContent": "Turn on camera",
     "tooltipVideoLoadingContent": "Video is loading",
     "cameraMenuTitle": "Camera",
-    "cameraMenuTooltip": "Choose Camera",
+    "cameraMenuTooltip": "Choose camera",
     "cameraButtonSplitRoleDescription": "Split button",
     "onSplitButtonAriaLabel": "Turn off camera and camera options",
     "offSplitButtonAriaLabel": "Turn on camera and camera options",
@@ -63,9 +63,9 @@
     "tooltipOnContent": "Mute microphone",
     "tooltipOffContent": "Unmute microphone",
     "microphoneMenuTitle": "Microphone",
-    "microphoneMenuTooltip": "Choose Microphone",
+    "microphoneMenuTooltip": "Choose microphone",
     "speakerMenuTitle": "Speaker",
-    "speakerMenuTooltip": "Choose Speaker",
+    "speakerMenuTooltip": "Choose speaker",
     "microphoneButtonSplitRoleDescription": "Split button",
     "onSplitButtonAriaLabel": "Mute microphone and audio options",
     "offSplitButtonAriaLabel": "Unmute microphone and audio options",
@@ -76,17 +76,17 @@
     "label": "Devices",
     "tooltipContent": "Manage devices",
     "cameraMenuTitle": "Camera",
-    "cameraMenuTooltip": "Choose Camera",
+    "cameraMenuTooltip": "Choose camera",
     "audioDeviceMenuTitle": "Audio Device",
-    "audioDeviceMenuTooltip": "Choose Audio Device",
+    "audioDeviceMenuTooltip": "Choose audio device",
     "microphoneMenuTitle": "Microphone",
-    "microphoneMenuTooltip": "Choose Microphone",
+    "microphoneMenuTooltip": "Choose microphone",
     "speakerMenuTitle": "Speaker",
-    "speakerMenuTooltip": "Choose Speaker"
+    "speakerMenuTooltip": "Choose speaker"
   },
   "participantsButton": {
     "label": "People",
-    "tooltipContent": "Show Participants",
+    "tooltipContent": "Show participants",
     "menuHeader": "In this call",
     "participantsListButtonLabel": "{numParticipants} people",
     "muteAllButtonLabel": "Mute all",


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Updated en-US tool tip strings to be capitalized but not title case.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2961689

# How Tested
<!--- How did you test your change. What tests have you added. -->
Locally
https://user-images.githubusercontent.com/79475487/190564926-32f47efd-3cc0-44fb-b28f-f7d7cac5042f.mp4

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->