### PR TITLE
Don't attach messages if display name is mismatched

### DIFF
--- a/change/@internal-chat-component-bindings-0b04e9d2-ac68-4457-a065-5fa3cc5f585a.json
+++ b/change/@internal-chat-component-bindings-0b04e9d2-ac68-4457-a065-5fa3cc5f585a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Don't attach messages if display name is mismatched",
+  "packageName": "@internal/chat-component-bindings",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-component-bindings/src/utils/updateMessagesWithAttached.ts
+++ b/packages/chat-component-bindings/src/utils/updateMessagesWithAttached.ts
@@ -27,19 +27,27 @@ export const updateMessagesWithAttached = (chatMessagesWithStatus: Message[]): v
     const previousSenderId = previousMessage?.messageType === 'chat' ? previousMessage.senderId : undefined;
     const nextSenderId = nextMessage?.messageType === 'chat' ? nextMessage.senderId : undefined;
 
+    const previousSenderDisplayName =
+      previousMessage?.messageType === 'chat' ? previousMessage.senderDisplayName : undefined;
+    const nextSenderDisplayName = nextMessage?.messageType === 'chat' ? nextMessage.senderDisplayName : undefined;
+
     const timediff =
       new Date(message?.createdOn ?? '').getTime() - new Date(previousMessage?.createdOn ?? '').getTime();
 
     const diffMins = Math.round(timediff / MINUTE_IN_MS); // minutes
 
-    if (previousSenderId !== message.senderId) {
-      attached = message.senderId === nextSenderId ? 'top' : false;
+    if (message.senderDisplayName !== previousSenderDisplayName) {
+      attached = message.senderId === nextSenderId && message.senderId === nextSenderDisplayName ? 'top' : false;
+    } else if (previousSenderId !== message.senderId) {
+      attached = message.senderId === nextSenderId && message.senderId === nextSenderDisplayName ? 'top' : false;
     } else if (diffMins && diffMins >= 5) {
       // if there are more than or equal to 5 mins time gap between messages do not attach and show time stamp
       attached = false;
     } else {
       attached = message.senderId === nextSenderId ? true : 'bottom';
     }
+
+    console.log(message.content + ' > ' + message.senderId + ' > ' + message.senderDisplayName + ' > ' + attached);
 
     message.attached = attached;
   });

--- a/packages/chat-component-bindings/src/utils/updateMessagesWithAttached.ts
+++ b/packages/chat-component-bindings/src/utils/updateMessagesWithAttached.ts
@@ -31,22 +31,23 @@ export const updateMessagesWithAttached = (chatMessagesWithStatus: Message[]): v
       previousMessage?.messageType === 'chat' ? previousMessage.senderDisplayName : undefined;
     const nextSenderDisplayName = nextMessage?.messageType === 'chat' ? nextMessage.senderDisplayName : undefined;
 
-    const timediff =
+    const timeDiffWithPreviousMessage =
       new Date(message?.createdOn ?? '').getTime() - new Date(previousMessage?.createdOn ?? '').getTime();
 
-    const diffMins = Math.round(timediff / MINUTE_IN_MS); // minutes
+    const diffMinsWithPreviousMessage = Math.round(timeDiffWithPreviousMessage / MINUTE_IN_MS); // minutes
 
     if (previousSenderId !== message.senderId) {
       attached =
         message.senderId === nextSenderId && message.senderDisplayName === nextSenderDisplayName ? 'top' : false;
-    } else if (diffMins && diffMins >= 5) {
+    } else if (diffMinsWithPreviousMessage && diffMinsWithPreviousMessage >= 5) {
       // if there are more than or equal to 5 mins time gap between messages do not attach and show time stamp
       attached = false;
-    } else if (message.senderDisplayName !== previousSenderDisplayName) {
+    } else if (previousSenderDisplayName !== message.senderDisplayName) {
       attached =
         message.senderId === nextSenderId && message.senderDisplayName === nextSenderDisplayName ? 'top' : false;
     } else {
-      attached = message.senderId === nextSenderId ? true : 'bottom';
+      attached =
+        message.senderId === nextSenderId && message.senderDisplayName === nextSenderDisplayName ? true : 'bottom';
     }
 
     message.attached = attached;

--- a/packages/chat-component-bindings/src/utils/updateMessagesWithAttached.ts
+++ b/packages/chat-component-bindings/src/utils/updateMessagesWithAttached.ts
@@ -36,18 +36,18 @@ export const updateMessagesWithAttached = (chatMessagesWithStatus: Message[]): v
 
     const diffMins = Math.round(timediff / MINUTE_IN_MS); // minutes
 
-    if (message.senderDisplayName !== previousSenderDisplayName) {
-      attached = message.senderId === nextSenderId && message.senderId === nextSenderDisplayName ? 'top' : false;
-    } else if (previousSenderId !== message.senderId) {
-      attached = message.senderId === nextSenderId && message.senderId === nextSenderDisplayName ? 'top' : false;
+    if (previousSenderId !== message.senderId) {
+      attached =
+        message.senderId === nextSenderId && message.senderDisplayName === nextSenderDisplayName ? 'top' : false;
     } else if (diffMins && diffMins >= 5) {
       // if there are more than or equal to 5 mins time gap between messages do not attach and show time stamp
       attached = false;
+    } else if (message.senderDisplayName !== previousSenderDisplayName) {
+      attached =
+        message.senderId === nextSenderId && message.senderDisplayName === nextSenderDisplayName ? 'top' : false;
     } else {
       attached = message.senderId === nextSenderId ? true : 'bottom';
     }
-
-    console.log(message.content + ' > ' + message.senderId + ' > ' + message.senderDisplayName + ' > ' + attached);
 
     message.attached = attached;
   });


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Don't attach messages together from the same user if the display name is mismatched

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
 #2360 

# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested on storybook
![image](https://user-images.githubusercontent.com/79475487/191663707-3acdb189-6323-4037-819f-4b5fc7b57dcf.png)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->