### PR TITLE
[A11y][bugfix] Add "required" attribute to chat sample DisplayNameField in configuration page

### DIFF
--- a/samples/Chat/src/app/DisplayNameField.tsx
+++ b/samples/Chat/src/app/DisplayNameField.tsx
@@ -56,6 +56,7 @@ const DisplayNameFieldComponent = (props: DisplayNameFieldProps): JSX.Element =>
       }}
       styles={TextFieldStyleProps}
       errorMessage={isEmpty ? TEXTFIELD_EMPTY_ERROR_MSG : undefined}
+      required={true}
     />
   );
 };


### PR DESCRIPTION
# What
Add required attribute to DisplayNameField on chat configuration page.
Results in asterisk and voiceover "required" announcement for the field.

# Why
Required fields should be announced and labeled with an asterisk.
https://skype.visualstudio.com/SPOOL/_workitems/edit/2908415

# How Tested
MacOS chrome browser

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->