### PR TITLE
Fix rush changelog not working for forks of the repo

### DIFF
--- a/common/config/beachball/changelog-config.ts
+++ b/common/config/beachball/changelog-config.ts
@@ -2,7 +2,6 @@ import { BeachballConfig } from 'beachball';
 import { renderHeader, renderEntry } from './changelog-custom-renders';
 
 export const config: BeachballConfig = {
-  branch: 'origin/main',
   changelog: {
     customRenderers: {
       renderHeader,

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://azure.github.io/communication-ui-library/",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Azure/communication-ui-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Azure/communication-ui-library/issues/new/choose"
+  }
+}


### PR DESCRIPTION
# What
* Change the beachball config to use the default repo origin specified in a root package json
* Add a root level package.json that specifies this repo as the root repo to use

# Why
`rush changelog` is not working for forks of the repo (as origin/main on a fork of the repo is the forked repo and not this repo, we need rush changelog to check new changes against _this_ repo)

More information: https://github.com/Azure/communication-ui-library/pull/2285#issuecomment-1258756974

# How Tested
* Upon pulling the branch first verified running without this change rush changelog did not work, then manually applying this change it now works.
* Locally a branch on this repo still detects changes
   ![image](https://user-images.githubusercontent.com/2684369/193098775-f6e7ac0c-275c-4b9a-9c30-d5208ffb2f9e.png)
