### PR TITLE
[Call Readiness] unsupported browser hermetic tests

### DIFF
--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2833,7 +2833,7 @@ export const UnsupportedBrowser: (props: UnsupportedBrowserProps) => JSX.Element
 
 // @beta
 export interface UnsupportedBrowserProps {
-    onTroubleShootingClick: () => void;
+    onTroubleShootingClick?: () => void;
     strings: UnsupportedBrowserStrings;
 }
 

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1439,7 +1439,7 @@ export const UnsupportedBrowser: (props: UnsupportedBrowserProps) => JSX.Element
 
 // @beta
 export interface UnsupportedBrowserProps {
-    onTroubleShootingClick: () => void;
+    onTroubleShootingClick?: () => void;
     strings: UnsupportedBrowserStrings;
 }
 

--- a/packages/react-components/src/components/UnsupportedBrowser.tsx
+++ b/packages/react-components/src/components/UnsupportedBrowser.tsx
@@ -48,7 +48,7 @@ const UnsupportedBrowserContainer = (props: UnsupportedBrowserProps): JSX.Elemen
   const { onTroubleShootingClick, strings } = props;
   return (
     <Stack styles={containerStyles}>
-      <Icon styles={iconStyles} iconName="UnsupportedBrowserWarning"></Icon>
+      <Icon styles={iconStyles} iconName="UnsupportedBrowserWarning" data-ui-id="unsupportedBrowserIcon"></Icon>
       <Text styles={mainTextStyles}>{strings.primaryText}</Text>
       <Text styles={secondaryTextStyles}>{strings.secondaryText}</Text>
       <Link

--- a/packages/react-components/src/components/UnsupportedBrowser.tsx
+++ b/packages/react-components/src/components/UnsupportedBrowser.tsx
@@ -38,7 +38,7 @@ export interface UnsupportedBrowserStrings {
  */
 export interface UnsupportedBrowserProps {
   /** Handler to perform a action when the help link is actioned */
-  onTroubleShootingClick: () => void;
+  onTroubleShootingClick?: () => void;
   /** String overrides for the component */
   strings: UnsupportedBrowserStrings;
 }
@@ -51,14 +51,17 @@ const UnsupportedBrowserContainer = (props: UnsupportedBrowserProps): JSX.Elemen
       <Icon styles={iconStyles} iconName="UnsupportedBrowserWarning" data-ui-id="unsupportedBrowserIcon"></Icon>
       <Text styles={mainTextStyles}>{strings.primaryText}</Text>
       <Text styles={secondaryTextStyles}>{strings.secondaryText}</Text>
-      <Link
-        styles={linkTextStyles}
-        onClick={() => {
-          onTroubleShootingClick();
-        }}
-      >
-        {strings.moreHelpLink}
-      </Link>
+      {onTroubleShootingClick && (
+        <Link
+          styles={linkTextStyles}
+          onClick={() => {
+            onTroubleShootingClick();
+          }}
+          data-ui-id="unsupportedBrowserLink"
+        >
+          {strings.moreHelpLink}
+        </Link>
+      )}
     </Stack>
   );
 };

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -300,11 +300,11 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
     case unsupportedBrowserPageTrampoline():
       pageElement = (
         <>
-          {props.options?.onBrowserTroubleShootingClick && (
+          {
             /* @conditional-compile-remove(unsupported-browser) */ <UnsupportedBrowserPage
               onTroubleShootingClick={props.options?.onBrowserTroubleShootingClick}
             />
-          )}
+          }
         </>
       );
   }

--- a/packages/react-composites/src/composites/CallComposite/pages/UnsupportedBrowser.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/UnsupportedBrowser.tsx
@@ -13,7 +13,7 @@ import { useLocale } from '../../localization';
  * @internal
  */
 export type UnsupportedBrowserPageProps = {
-  onTroubleShootingClick: () => void;
+  onTroubleShootingClick?: () => void;
 };
 
 /**
@@ -30,7 +30,7 @@ export const UnsupportedBrowserPage = (props: UnsupportedBrowserPageProps): JSX.
 
   /* @conditional-compile-remove(unsupported-browser) */
   return (
-    <Stack styles={{ root: { margin: 'auto', paddingTop: '3rem' } }}>
+    <Stack styles={{ root: { margin: 'auto', paddingTop: '3rem', height: '100%' } }}>
       <UnsupportedBrowser onTroubleShootingClick={onTroubleShootingClick} strings={unsupportedBrowserStrings} />
     </Stack>
   );

--- a/packages/react-composites/tests/app/call/BaseApp.tsx
+++ b/packages/react-composites/tests/app/call/BaseApp.tsx
@@ -32,6 +32,8 @@ export function BaseApp(props: { queryArgs: QueryArgs; callAdapter?: CallAdapter
       'Some details about the call that span more than one line - many, many lines in fact. Who would want fewer lines than many, many lines? Could you even imagine?! 😲';
   }
 
+  const useOnBrowserTroubleShootingClick = queryArgs.useTroubleShootingActions;
+
   const ParticipantItemOptions = queryArgs.showParticipantItemIcon ? <MoreHorizontal20Regular /> : <></>;
 
   return (
@@ -59,7 +61,10 @@ export function BaseApp(props: { queryArgs: QueryArgs; callAdapter?: CallAdapter
                         // Hide some buttons to keep the mobile-view control bar narrow
                         devicesButton: false,
                         endCallButton: false
-                      }
+                      },
+                      onBrowserTroubleShootingClick: useOnBrowserTroubleShootingClick
+                        ? () => alert('you are using the wrong browser')
+                        : undefined
                     }
                   : undefined
               }

--- a/packages/react-composites/tests/app/call/BaseApp.tsx
+++ b/packages/react-composites/tests/app/call/BaseApp.tsx
@@ -39,13 +39,15 @@ export function BaseApp(props: { queryArgs: QueryArgs; callAdapter?: CallAdapter
     ? () => alert('you are using a unsupported browser')
     : undefined;
 
-  let customCallCompositeOptions: CallCompositeOptions = {};
+  let customCallCompositeOptions: CallCompositeOptions | undefined = undefined;
 
   if (onBrowserTroubleshootingClick) {
     customCallCompositeOptions = {
       ...queryArgs.customCallCompositeOptions,
       onBrowserTroubleShootingClick: onBrowserTroubleshootingClick
     };
+  } else {
+    customCallCompositeOptions = queryArgs.customCallCompositeOptions;
   }
 
   return (
@@ -64,7 +66,7 @@ export function BaseApp(props: { queryArgs: QueryArgs; callAdapter?: CallAdapter
                 queryArgs.injectParticipantMenuItems ? onFetchParticipantMenuItems : undefined
               }
               options={
-                customCallCompositeOptions
+                customCallCompositeOptions !== undefined
                   ? customCallCompositeOptions
                   : queryArgs.injectCustomButtons
                   ? {

--- a/packages/react-composites/tests/app/call/BaseApp.tsx
+++ b/packages/react-composites/tests/app/call/BaseApp.tsx
@@ -11,7 +11,8 @@ import {
   COMPOSITE_LOCALE_EN_US,
   CustomCallControlButtonCallback,
   CustomCallControlButtonProps,
-  CustomCallControlButtonCallbackArgs
+  CustomCallControlButtonCallbackArgs,
+  CallCompositeOptions
 } from '../../../src';
 import { IDS } from '../../browser/common/constants';
 import { isMobile } from '../lib/utils';
@@ -32,9 +33,20 @@ export function BaseApp(props: { queryArgs: QueryArgs; callAdapter?: CallAdapter
       'Some details about the call that span more than one line - many, many lines in fact. Who would want fewer lines than many, many lines? Could you even imagine?! 😲';
   }
 
-  const useOnBrowserTroubleShootingClick = queryArgs.useTroubleShootingActions;
-
   const ParticipantItemOptions = queryArgs.showParticipantItemIcon ? <MoreHorizontal20Regular /> : <></>;
+
+  const onBrowserTroubleshootingClick = queryArgs.useTroubleShootingActions
+    ? () => alert('you are using a unsupported browser')
+    : undefined;
+
+  let customCallCompositeOptions: CallCompositeOptions = {};
+
+  if (onBrowserTroubleshootingClick) {
+    customCallCompositeOptions = {
+      ...queryArgs.customCallCompositeOptions,
+      onBrowserTroubleShootingClick: onBrowserTroubleshootingClick
+    };
+  }
 
   return (
     <>
@@ -52,8 +64,8 @@ export function BaseApp(props: { queryArgs: QueryArgs; callAdapter?: CallAdapter
                 queryArgs.injectParticipantMenuItems ? onFetchParticipantMenuItems : undefined
               }
               options={
-                queryArgs.customCallCompositeOptions
-                  ? queryArgs.customCallCompositeOptions
+                customCallCompositeOptions
+                  ? customCallCompositeOptions
                   : queryArgs.injectCustomButtons
                   ? {
                       callControls: {
@@ -61,10 +73,7 @@ export function BaseApp(props: { queryArgs: QueryArgs; callAdapter?: CallAdapter
                         // Hide some buttons to keep the mobile-view control bar narrow
                         devicesButton: false,
                         endCallButton: false
-                      },
-                      onBrowserTroubleShootingClick: useOnBrowserTroubleShootingClick
-                        ? () => alert('you are using the wrong browser')
-                        : undefined
+                      }
                     }
                   : undefined
               }

--- a/packages/react-composites/tests/app/call/QueryArgs.ts
+++ b/packages/react-composites/tests/app/call/QueryArgs.ts
@@ -16,6 +16,7 @@ export interface QueryArgs {
   callInvitationUrl?: string;
   showParticipantItemIcon: boolean;
   customCallCompositeOptions?: CallCompositeOptions;
+  useTroubleShootingActions?: boolean;
 
   // These are only set for live tests.
   // TODO: Separate the args out better.
@@ -28,6 +29,7 @@ export interface QueryArgs {
 export function parseQueryArgs(): QueryArgs {
   const urlSearchParams = new URLSearchParams(window.location.search);
   const params = Object.fromEntries(urlSearchParams.entries());
+  console.log(params);
   return {
     mockCallAdapterState: params.mockCallAdapterState ? JSON.parse(params.mockCallAdapterState) : undefined,
     useFrLocale: Boolean(params.useFrLocale),
@@ -35,6 +37,7 @@ export function parseQueryArgs(): QueryArgs {
     injectParticipantMenuItems: Boolean(params.injectParticipantMenuItems),
     injectCustomButtons: Boolean(params.injectCustomButtons),
     showParticipantItemIcon: Boolean(params.showParticipantItemIcon),
+    useTroubleShootingActions: Boolean(params.useTroubleShootingActions),
     userId: params.userId ?? '',
     groupId: params.groupId ?? '',
     token: params.token ?? '',

--- a/packages/react-composites/tests/app/call/QueryArgs.ts
+++ b/packages/react-composites/tests/app/call/QueryArgs.ts
@@ -29,7 +29,6 @@ export interface QueryArgs {
 export function parseQueryArgs(): QueryArgs {
   const urlSearchParams = new URLSearchParams(window.location.search);
   const params = Object.fromEntries(urlSearchParams.entries());
-  console.log(params);
   return {
     mockCallAdapterState: params.mockCallAdapterState ? JSON.parse(params.mockCallAdapterState) : undefined,
     useFrLocale: Boolean(params.useFrLocale),

--- a/packages/react-composites/tests/browser/call/hermetic/UnsupportedBrowserPage.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/UnsupportedBrowserPage.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect } from '@playwright/test';
+import type { MockCallAdapterState } from '../../../common';
+import { IDS } from '../../common/constants';
+import { dataUiId, isTestProfileStableFlavor, stableScreenshot, waitForSelector } from '../../common/utils';
+import { buildUrlWithMockAdapter, defaultMockCallAdapterState, test } from './fixture';
+
+test.describe('unsupportedBrowser page tests', async () => {
+  test.only('unsupportedBrwoser displays correctly', async ({ page, serverUrl }) => {
+    test.skip(isTestProfileStableFlavor());
+
+    const initialState = defaultMockUnsupportedBrowserPageState();
+    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState, { useTroubleShootingActions: 'true' }));
+
+    await waitForSelector(page, dataUiId(IDS.unsupportedBrowserIcon));
+
+    expect(await stableScreenshot(page)).toMatchSnapshot(`unsupportedBrowserPage.png`);
+  });
+});
+
+const defaultMockUnsupportedBrowserPageState = (): MockCallAdapterState => {
+  const state = defaultMockCallAdapterState();
+  state.page = 'unsupportedBrowser';
+  return state;
+};

--- a/packages/react-composites/tests/browser/call/hermetic/UnsupportedBrowserPage.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/UnsupportedBrowserPage.test.ts
@@ -18,7 +18,7 @@ test.describe('unsupportedBrowser page tests', async () => {
     expect(await stableScreenshot(page)).toMatchSnapshot(`unsupportedBrowserPage-no-link.png`);
   });
 
-  test.only('unsupportedBrwoser displays correctly with a help link', async ({ page, serverUrl }) => {
+  test('unsupportedBrowser displays correctly with a help link', async ({ page, serverUrl }) => {
     test.skip(isTestProfileStableFlavor());
 
     await page.goto(

--- a/packages/react-composites/tests/browser/call/hermetic/UnsupportedBrowserPage.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/UnsupportedBrowserPage.test.ts
@@ -8,15 +8,29 @@ import { dataUiId, isTestProfileStableFlavor, stableScreenshot, waitForSelector 
 import { buildUrlWithMockAdapter, defaultMockCallAdapterState, test } from './fixture';
 
 test.describe('unsupportedBrowser page tests', async () => {
-  test.only('unsupportedBrwoser displays correctly', async ({ page, serverUrl }) => {
+  test('unsupportedBrwoser displays correctly without a help link', async ({ page, serverUrl }) => {
     test.skip(isTestProfileStableFlavor());
 
-    const initialState = defaultMockUnsupportedBrowserPageState();
-    await page.goto(buildUrlWithMockAdapter(serverUrl, initialState, { useTroubleShootingActions: 'true' }));
+    await page.goto(buildUrlWithMockAdapter(serverUrl, defaultMockUnsupportedBrowserPageState()));
 
     await waitForSelector(page, dataUiId(IDS.unsupportedBrowserIcon));
 
-    expect(await stableScreenshot(page)).toMatchSnapshot(`unsupportedBrowserPage.png`);
+    expect(await stableScreenshot(page)).toMatchSnapshot(`unsupportedBrowserPage-no-link.png`);
+  });
+
+  test.only('unsupportedBrwoser displays correctly with a help link', async ({ page, serverUrl }) => {
+    test.skip(isTestProfileStableFlavor());
+
+    await page.goto(
+      buildUrlWithMockAdapter(serverUrl, defaultMockUnsupportedBrowserPageState(), {
+        useTroubleShootingActions: 'true'
+      })
+    );
+
+    await waitForSelector(page, dataUiId(IDS.unsupportedBrowserIcon));
+    await waitForSelector(page, dataUiId(IDS.unsupportedBrowserLink));
+
+    expect(await stableScreenshot(page)).toMatchSnapshot(`unsupportedBrowserPage-with-link.png`);
   });
 });
 

--- a/packages/react-composites/tests/browser/common/constants.ts
+++ b/packages/react-composites/tests/browser/common/constants.ts
@@ -28,5 +28,6 @@ export const IDS = {
   holdButton: 'hold-button',
   holdPage: 'hold-page',
   moreButton: 'call-with-chat-composite-more-button',
-  callPage: 'call-page'
+  callPage: 'call-page',
+  unsupportedBrowserIcon: 'unsupportedBrowserIcon'
 };

--- a/packages/react-composites/tests/browser/common/constants.ts
+++ b/packages/react-composites/tests/browser/common/constants.ts
@@ -29,5 +29,6 @@ export const IDS = {
   holdPage: 'hold-page',
   moreButton: 'call-with-chat-composite-more-button',
   callPage: 'call-page',
-  unsupportedBrowserIcon: 'unsupportedBrowserIcon'
+  unsupportedBrowserIcon: 'unsupportedBrowserIcon',
+  unsupportedBrowserLink: 'unsupportedBrowserLink'
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add hermetic tests to call composite
# Why
<!--- What problem does this change solve? -->
tests the new unsupported page in the composite showing and hiding the help link
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2980687
# How Tested
<!--- How did you test your change. What tests have you added. -->
![image](https://user-images.githubusercontent.com/94866715/193925205-fb503e54-340b-4c40-9996-5260baee3db5.png)
Ran tests locally and inspected snapshots