### PR TITLE
[PSTN 1-N calling] Update lobby page with new strings

### DIFF
--- a/change/@internal-react-composites-7452c589-eca7-482e-b144-0572503ede0e.json
+++ b/change/@internal-react-composites-7452c589-eca7-482e-b144-0572503ede0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update lobby screen to reflect to the user who they are calling.",
+  "packageName": "@internal/react-composites",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-react-composites-7452c589-eca7-482e-b144-0572503ede0e.json
+++ b/change/@internal-react-composites-7452c589-eca7-482e-b144-0572503ede0e.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Update lobby screen to reflect to the user who they are calling.",
+  "comment": "Update lobby screen to reflect to the user who they are calling in a  1:1 PSTN or ACS call.",
   "packageName": "@internal/react-composites",
   "email": "94866715+dmceachernmsft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -518,6 +518,7 @@ export interface CallCompositeStrings {
     networkReconnectTitle: string;
     openDialpadButtonLabel: string;
     openDtmfDialpadLabel: string;
+    outboundCallingNoticeString: string;
     peopleButtonLabel: string;
     peopleButtonTooltipClose: string;
     peopleButtonTooltipOpen: string;

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -370,6 +370,7 @@ export interface CallCompositeStrings {
     networkReconnectTitle: string;
     openDialpadButtonLabel: string;
     openDtmfDialpadLabel: string;
+    outboundCallingNoticeString: string;
     peopleButtonLabel: string;
     peopleButtonTooltipClose: string;
     peopleButtonTooltipOpen: string;

--- a/packages/react-composites/src/composites/CallComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Strings.tsx
@@ -322,8 +322,7 @@ export interface CallCompositeStrings {
    * Control bar People button ToolTipContent
    */
   peopleButtonTooltipClose: string;
-  /* @conditional-compile-remove(PSTN-calls) */
-  /* @conditional-compile-remove(1-to-n-calling) */
+  /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
   /**
    * label for when making a outbound call
    *

--- a/packages/react-composites/src/composites/CallComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Strings.tsx
@@ -322,4 +322,12 @@ export interface CallCompositeStrings {
    * Control bar People button ToolTipContent
    */
   peopleButtonTooltipClose: string;
+  /* @conditional-compile-remove(PSTN-calls) */
+  /* @conditional-compile-remove(1-to-n-calling) */
+  /**
+   * label for when making a outbound call
+   *
+   * Will either be the title or the description based on the type of call you are making.
+   */
+  outboundCallingNoticeString: string;
 }

--- a/packages/react-composites/src/composites/CallComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Strings.tsx
@@ -324,9 +324,7 @@ export interface CallCompositeStrings {
   peopleButtonTooltipClose: string;
   /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
   /**
-   * label for when making a outbound call
-   *
-   * Will either be the title or the description based on the type of call you are making.
+   * Label disaplayed on the lobby screen during a 1:1 outbound call.
    */
   outboundCallingNoticeString: string;
 }

--- a/packages/react-composites/src/composites/CallComposite/components/LobbyTile.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LobbyTile.tsx
@@ -12,7 +12,7 @@ import { useHandlers } from '../hooks/useHandlers';
  * @private
  */
 export interface LobbyOverlayProps {
-  overlayIcon: JSX.Element;
+  overlayIcon?: JSX.Element;
   title: string;
   moreDetails?: string;
 }

--- a/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
@@ -14,11 +14,11 @@ import { CallCompositeStrings } from '../Strings';
 import { useLocale } from '../../localization';
 import { useLocalVideoStartTrigger } from '../components/MediaGallery';
 import { CallCompositeIcon } from '../../common/icons';
-/* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(1-to-n-calling) */
+/* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
 import { useAdapter } from '../adapter/CallAdapterProvider';
-/* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(1-to-n-calling) */
+/* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
 import { isPhoneNumberIdentifier } from '@azure/communication-common';
-/* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(1-to-n-calling) */
+/* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
 import { RemoteParticipantState } from '@internal/calling-stateful-client';
 
 /**
@@ -69,14 +69,19 @@ export const LobbyPage = (props: LobbyPageProps): JSX.Element => {
 };
 
 const overlayProps = (strings: CallCompositeStrings, inLobby: boolean): LobbyOverlayProps => {
+  /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
   const remoteParticipants = useAdapter().getState().call?.remoteParticipants;
+  /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
   const outboundCallParticipant = remoteParticipants !== undefined ? Object.values(remoteParticipants)[0] : undefined;
 
+  /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
   return inLobby
     ? overlayPropsWaitingToBeAdmitted(strings)
     : outboundCallParticipant
     ? overlayPropsOutboundCall(strings, outboundCallParticipant)
     : overlayPropsConnectingToCall(strings);
+
+  return inLobby ? overlayPropsWaitingToBeAdmitted(strings) : overlayPropsConnectingToCall(strings);
 };
 
 const overlayPropsConnectingToCall = (strings: CallCompositeStrings): LobbyOverlayProps => ({
@@ -91,7 +96,7 @@ const overlayPropsWaitingToBeAdmitted = (strings: CallCompositeStrings): LobbyOv
   overlayIcon: <CallCompositeIcon iconName="LobbyScreenWaitingToBeAdmitted" />
 });
 
-/* @conditional-compile-remove(PSTN-calls) */
+/* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
 const overlayPropsOutboundCall = (
   strings: CallCompositeStrings,
   participant: RemoteParticipantState

--- a/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
@@ -8,14 +8,12 @@ import { CallCompositeOptions } from '../CallComposite';
 import { CallArrangement } from '../components/CallArrangement';
 import { usePropsFor } from '../hooks/usePropsFor';
 import { LobbyOverlayProps, LobbyTile } from '../components/LobbyTile';
-import { getCallStatus } from '../selectors/baseSelectors';
+import { getCallStatus, getRemoteParticipants } from '../selectors/baseSelectors';
 import { disableCallControls, reduceCallControlsForMobile } from '../utils';
 import { CallCompositeStrings } from '../Strings';
 import { useLocale } from '../../localization';
 import { useLocalVideoStartTrigger } from '../components/MediaGallery';
 import { CallCompositeIcon } from '../../common/icons';
-/* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
-import { useAdapter } from '../adapter/CallAdapterProvider';
 /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
 import { isPhoneNumberIdentifier } from '@azure/communication-common';
 /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
@@ -41,6 +39,7 @@ export const LobbyPage = (props: LobbyPageProps): JSX.Element => {
 
   const callState = useSelector(getCallStatus);
   const inLobby = callState === 'InLobby';
+  const remoteParticipants = useSelector(getRemoteParticipants) ?? {};
 
   useLocalVideoStartTrigger(lobbyProps.localParticipantVideoStream.isAvailable, inLobby);
 
@@ -62,17 +61,23 @@ export const LobbyPage = (props: LobbyPageProps): JSX.Element => {
       mobileView={props.mobileView}
       /* @conditional-compile-remove(one-to-n-calling) */
       modalLayerHostId={props.modalLayerHostId}
-      onRenderGalleryContent={() => <LobbyTile {...lobbyProps} overlayProps={overlayProps(strings, inLobby)} />}
+      onRenderGalleryContent={() => (
+        <LobbyTile {...lobbyProps} overlayProps={overlayProps(strings, inLobby, Object.values(remoteParticipants))} />
+      )}
       dataUiId={'lobby-page'}
     />
   );
 };
 
-const overlayProps = (strings: CallCompositeStrings, inLobby: boolean): LobbyOverlayProps => {
+const overlayProps = (
+  strings: CallCompositeStrings,
+  inLobby: boolean,
+  /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */ remoteParticipants:
+    | RemoteParticipantState[]
+    | undefined
+): LobbyOverlayProps => {
   /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
-  const remoteParticipants = useAdapter().getState().call?.remoteParticipants;
-  /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
-  const outboundCallParticipant = remoteParticipants !== undefined ? Object.values(remoteParticipants)[0] : undefined;
+  const outboundCallParticipant = remoteParticipants !== undefined ? remoteParticipants[0] : undefined;
 
   /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
   return inLobby

--- a/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
@@ -41,9 +41,10 @@ export const LobbyPage = (props: LobbyPageProps): JSX.Element => {
   const callState = useSelector(getCallStatus);
   const inLobby = callState === 'InLobby';
 
+  /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
+  const participants = useSelector(getRemoteParticipants) ?? {};
+
   const remoteParticipantsTrampoline = (): RemoteParticipantState[] | undefined => {
-    /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
-    const participants = useSelector(getRemoteParticipants) ?? {};
     /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
     return Object.values(participants);
     return undefined;

--- a/packages/react-composites/src/composites/localization/locales/en-US/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/en-US/strings.json
@@ -67,7 +67,8 @@
     "resumingCallButtonAriaLabel": "Resume call",
     "holdScreenLabel": "You're on hold",
     "openDtmfDialpadLabel": "Show dialpad",
-    "dtmfDialpadPlaceHolderText": "Enter number"
+    "dtmfDialpadPlaceHolderText": "Enter number",
+    "outboundCallingNoticeString": "Calling..."
   },
   "chat": {
     "chatListHeader": "In this chat",


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
PSTN
![image](https://user-images.githubusercontent.com/94866715/195465691-0ab2bc83-a3bb-4f3a-bafa-57ba0855644e.png)
ACS
![image](https://user-images.githubusercontent.com/94866715/195465969-e99d7497-2c7a-4bbc-9fc3-8b869a83457f.png)
# Why
<!--- What problem does this change solve? -->
Communicates to the end user who they are calling in the Call composite lobby screen
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2968937
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran locally with PSTN and ACS call