### PR TITLE
Suppress camera access error bar error for consumer

### DIFF
--- a/change/@internal-react-composites-825c806c-7788-4a9c-be79-e02c2c17464f.json
+++ b/change/@internal-react-composites-825c806c-7788-4a9c-be79-e02c2c17464f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove camera access error bar error for consumer role",
+  "packageName": "@internal/react-composites",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -142,6 +142,7 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
   let errorBarProps = props.errorBarProps;
 
   /* @conditional-compile-remove(rooms) */
+  // TODO: move this logic to the error bar selector once role is plumbed from the headless SDK
   if (!rolePermissions.cameraButton && props.errorBarProps) {
     errorBarProps = {
       ...props.errorBarProps,

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -139,13 +139,14 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
   /* @conditional-compile-remove(rooms) */
   canUnmute = rolePermissions.microphoneButton;
 
-  const errorBarProps = props.errorBarProps;
+  let errorBarProps = props.errorBarProps;
 
   /* @conditional-compile-remove(rooms) */
-  if (!rolePermissions.cameraButton && errorBarProps) {
-    errorBarProps.activeErrorMessages = errorBarProps.activeErrorMessages.filter(
-      (e) => e.type !== 'callCameraAccessDenied'
-    );
+  if (!rolePermissions.cameraButton && props.errorBarProps) {
+    errorBarProps = {
+      ...props.errorBarProps,
+      activeErrorMessages: props.errorBarProps.activeErrorMessages.filter((e) => e.type !== 'callCameraAccessDenied')
+    };
   }
 
   return (

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -139,6 +139,15 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
   /* @conditional-compile-remove(rooms) */
   canUnmute = rolePermissions.microphoneButton;
 
+  const errorBarProps = props.errorBarProps;
+
+  /* @conditional-compile-remove(rooms) */
+  if (!rolePermissions.cameraButton && errorBarProps) {
+    errorBarProps.activeErrorMessages = errorBarProps.activeErrorMessages.filter(
+      (e) => e.type !== 'callCameraAccessDenied'
+    );
+  }
+
   return (
     <div ref={containerRef} className={mergeStyles(containerDivStyles)}>
       <Stack verticalFill horizontalAlign="stretch" className={containerClassName} data-ui-id={props.dataUiId}>
@@ -147,9 +156,9 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
             <Stack styles={bannerNotificationStyles}>
               <_ComplianceBanner {...props.complianceBannerProps} />
             </Stack>
-            {props.errorBarProps !== false && (
+            {errorBarProps !== false && (
               <Stack styles={bannerNotificationStyles}>
-                <ErrorBar {...props.errorBarProps} />
+                <ErrorBar {...errorBarProps} />
               </Stack>
             )}
             {canUnmute && !!props.mutedNotificationProps && <MutedNotification {...props.mutedNotificationProps} />}

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -64,6 +64,7 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
   const rolePermissions = _usePermissions();
 
   /* @conditional-compile-remove(rooms) */
+  // TODO: move this logic to the error bar selector once role is plumbed from the headless SDK
   if (!rolePermissions.cameraButton) {
     errorBarProps = {
       ...errorBarProps,

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -63,6 +63,12 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
   /* @conditional-compile-remove(rooms) */
   const rolePermissions = _usePermissions();
   /* @conditional-compile-remove(rooms) */
+  if (!rolePermissions.cameraButton) {
+    errorBarProps.activeErrorMessages = errorBarProps.activeErrorMessages.filter(
+      (e) => e.type !== 'callCameraAccessDenied'
+    );
+  }
+  /* @conditional-compile-remove(rooms) */
   if (!rolePermissions.microphoneButton) {
     // If user's role permissions do not allow access to the microphone button then DO NOT disable the start call button
     // because microphone device permission is not needed for the user's role

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -55,18 +55,20 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
   const options = useAdaptedSelector(getCallingSelector(DevicesButton));
   const localDeviceSettingsHandlers = useHandlers(LocalDeviceSettings);
   const { video: cameraPermissionGranted, audio: microphonePermissionGranted } = useSelector(devicePermissionSelector);
-  const errorBarProps = usePropsFor(ErrorBar);
+  let errorBarProps = usePropsFor(ErrorBar);
   const adapter = useAdapter();
   const deviceState = adapter.getState().devices;
 
   let disableStartCallButton = !microphonePermissionGranted || deviceState.microphones?.length === 0;
   /* @conditional-compile-remove(rooms) */
   const rolePermissions = _usePermissions();
+
   /* @conditional-compile-remove(rooms) */
   if (!rolePermissions.cameraButton) {
-    errorBarProps.activeErrorMessages = errorBarProps.activeErrorMessages.filter(
-      (e) => e.type !== 'callCameraAccessDenied'
-    );
+    errorBarProps = {
+      ...errorBarProps,
+      activeErrorMessages: errorBarProps.activeErrorMessages.filter((e) => e.type !== 'callCameraAccessDenied')
+    };
   }
   /* @conditional-compile-remove(rooms) */
   if (!rolePermissions.microphoneButton) {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Suppress camera access error bar error for consumer.

The errorBarSelector pushes the error message with type 'callCameraAccessDenied' when the DeviceManagerState property deviceAccess.video is false. It is NOT from Calling SDK UFD

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3015756

# How Tested
<!--- How did you test your change. What tests have you added. -->
https://user-images.githubusercontent.com/79475487/195479583-c808c065-a7e4-4be1-b5f6-3a7f9ccd8aa2.mp4

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->