### PR TITLE
Bugfix for Config screen flashing for 2 seconds after leaving a call

### DIFF
--- a/change/@internal-react-composites-5c5b138d-56e9-4522-8fd5-640b55398642.json
+++ b/change/@internal-react-composites-5c5b138d-56e9-4522-8fd5-640b55398642.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Set the call id to undefined in adapter only after we know it has disconnected",
+  "packageName": "@internal/react-composites",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -128,9 +128,9 @@ class CallContext {
     const oldPage = this.state.page;
     const newPage = getCallCompositePage(call, latestEndedCall);
     if (!IsCallEndedPage(oldPage) && IsCallEndedPage(newPage)) {
-      this.emitter.emit('callEnded', {
-        callId: this.callId
-      });
+      this.emitter.emit('callEnded', { callId: this.callId });
+      // Reset the callId to undefined as the call has ended.
+      this.setCurrentCallId(undefined);
     }
 
     if (this.state.page) {
@@ -381,11 +381,8 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
   public async leaveCall(forEveryone?: boolean): Promise<void> {
     await this.handlers.onHangUp(forEveryone);
     this.unsubscribeCallEvents();
-    this.call = undefined;
     this.handlers = createDefaultCallingHandlers(this.callClient, this.callAgent, this.deviceManager, undefined);
-    this.context.setCurrentCallId(undefined);
-    // Resync state after callId is set
-    this.context.updateClientState(this.callClient.getState());
+    this.call = undefined;
     this.stopCamera();
     this.mute();
   }

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -121,7 +121,7 @@ class CallContext {
   }
 
   public updateClientState(clientState: CallClientState): void {
-    const call = this.callId ? clientState.calls[this.callId] : undefined;
+    let call = this.callId ? clientState.calls[this.callId] : undefined;
     const latestEndedCall = findLatestEndedCall(clientState.callsEnded);
 
     // As the state is transitioning to a new state, trigger appropriate callback events.
@@ -131,6 +131,8 @@ class CallContext {
       this.emitter.emit('callEnded', { callId: this.callId });
       // Reset the callId to undefined as the call has ended.
       this.setCurrentCallId(undefined);
+      // Make sure that the call is set to undefined in the state.
+      call = undefined;
     }
 
     if (this.state.page) {

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -382,6 +382,8 @@ export class AzureCommunicationCallAdapter implements CallAdapter {
     await this.handlers.onHangUp(forEveryone);
     this.unsubscribeCallEvents();
     this.handlers = createDefaultCallingHandlers(this.callClient, this.callAgent, this.deviceManager, undefined);
+    // We set the adapter.call object to undefined immediately when a call is ended.
+    // We do not set the context.callId to undefined because it is a part of the immutable data flow loop.
     this.call = undefined;
     this.stopCamera();
     this.mute();


### PR DESCRIPTION
# What
Bugfix for Config screen flashing for 2 seconds after leaving a call

# Why
This bug happens because we set the callId to undefined in the adapter inside the leaveCall function.
However, call client state takes a while to add that call to endedCalls array and remove it from the active call.
Hence, we need to only set call id to undefined once that operation has completed.

# How Tested
Manually

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->