### PR TITLE
Add troubleshooting guide error bar to call composite config screen 

### DIFF
--- a/change/@internal-react-components-d1226ee2-d5ac-43b5-bd50-021d08c81673.json
+++ b/change/@internal-react-components-d1226ee2-d5ac-43b5-bd50-021d08c81673.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enabled troubleshooting guide error bar to display network error guide/device error guide based on error type ",
+  "packageName": "@internal/react-components",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-react-composites-93739eae-6467-4523-af0e-4afbe6d8c5c9.json
+++ b/change/@internal-react-composites-93739eae-6467-4523-af0e-4afbe6d8c5c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add troubleshooting error bar to call composite config ",
+  "packageName": "@internal/react-composites",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@internal-storybook-129a9fcb-bbc7-4af3-a5bf-d762a10c02d0.json
+++ b/change/@internal-storybook-129a9fcb-bbc7-4af3-a5bf-d762a10c02d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Updated troubleshooting error bar storybook ",
+  "packageName": "@internal/storybook",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1465,9 +1465,11 @@ export interface _TroubleshootingGuideErrorBarProps extends ErrorBarProps {
 // @internal
 export interface _TroubleshootingGuideErrorBarStrings {
     // (undocumented)
+    devicePermissionLinkText?: string;
+    // (undocumented)
     dismissButtonText?: string;
     // (undocumented)
-    linkText?: string;
+    networkTroubleshootingLinkText?: string;
 }
 
 // @public

--- a/packages/react-components/review/stable/react-components.api.md
+++ b/packages/react-components/review/stable/react-components.api.md
@@ -1288,9 +1288,11 @@ export interface _TroubleshootingGuideErrorBarProps extends ErrorBarProps {
 // @internal
 export interface _TroubleshootingGuideErrorBarStrings {
     // (undocumented)
+    devicePermissionLinkText?: string;
+    // (undocumented)
     dismissButtonText?: string;
     // (undocumented)
-    linkText?: string;
+    networkTroubleshootingLinkText?: string;
 }
 
 // @public

--- a/packages/react-components/src/components/TroubleshootingGuideErrorBar.tsx
+++ b/packages/react-components/src/components/TroubleshootingGuideErrorBar.tsx
@@ -21,7 +21,8 @@ import {
  * @internal
  */
 export interface _TroubleshootingGuideErrorBarStrings {
-  linkText?: string;
+  devicePermissionLinkText?: string;
+  networkTroubleshootingLinkText?: string;
   dismissButtonText?: string;
 }
 
@@ -108,47 +109,70 @@ export const _TroubleshootingGuideErrorBar = (props: _TroubleshootingGuideErrorB
 
   return (
     <Stack data-ui-id="error-bar-stack">
-      {toShow.map((error) => (
-        <MessageBar
-          {...props}
-          styles={messageBarStyle(theme, messageBarType(error.type))}
-          key={error.type}
-          messageBarType={messageBarType(error.type)}
-          messageBarIconProps={messageBarIconProps(error.type)}
-          actions={
-            <MessageBarButton
-              text={troubleshootingGuideStrings.dismissButtonText}
-              styles={dismissButtonStyle(theme)}
-              onClick={() => {
-                setDismissedErrors(dismissError(dismissedErrors, error));
-              }}
-              ariaLabel={strings.dismissButtonAriaLabel}
-            />
-          }
-          isMultiline={false}
-        >
-          {onPermissionsTroubleshootingClick || onNetworkingTroubleshootingClick ? (
-            <div>
-              {strings[error.type]}
+      {toShow.map((error) => {
+        const devicePermissionErrorBar = (
+          <div>
+            {strings[error.type]}
+            {onPermissionsTroubleshootingClick && (
               <Link
                 styles={linkStyle(theme)}
                 onClick={() => {
-                  if (onPermissionsTroubleshootingClick) {
-                    onPermissionsTroubleshootingClick(permissionsState);
-                  } else if (onNetworkingTroubleshootingClick) {
-                    onNetworkingTroubleshootingClick();
-                  }
+                  onPermissionsTroubleshootingClick(permissionsState);
                 }}
                 underline
               >
-                <span>{troubleshootingGuideStrings.linkText}</span>
+                <span>{troubleshootingGuideStrings.devicePermissionLinkText}</span>
               </Link>
-            </div>
-          ) : (
-            <div>{strings[error.type]} </div>
-          )}
-        </MessageBar>
-      ))}
+            )}
+          </div>
+        );
+
+        const networkErrorBar = (
+          <div>
+            {strings[error.type]}
+            {onNetworkingTroubleshootingClick && (
+              <Link styles={linkStyle(theme)} onClick={onNetworkingTroubleshootingClick} underline>
+                <span>{troubleshootingGuideStrings.networkTroubleshootingLinkText}</span>
+              </Link>
+            )}
+          </div>
+        );
+
+        return (
+          <MessageBar
+            {...props}
+            styles={messageBarStyle(theme, messageBarType(error.type))}
+            key={error.type}
+            messageBarType={messageBarType(error.type)}
+            messageBarIconProps={messageBarIconProps(error.type)}
+            actions={
+              <MessageBarButton
+                text={troubleshootingGuideStrings.dismissButtonText}
+                styles={dismissButtonStyle(theme)}
+                onClick={() => {
+                  setDismissedErrors(dismissError(dismissedErrors, error));
+                }}
+                ariaLabel={strings.dismissButtonAriaLabel}
+              />
+            }
+            isMultiline={false}
+          >
+            {showErrorBar(error.type, devicePermissionErrorBar, networkErrorBar)}
+          </MessageBar>
+        );
+      })}
     </Stack>
   );
+};
+
+const showErrorBar = (
+  errorType: string,
+  devicePermissionErrorBar: JSX.Element,
+  networkErrorBar: JSX.Element
+): JSX.Element => {
+  if (errorType === 'callNetworkQualityLow') {
+    return networkErrorBar;
+  } else {
+    return devicePermissionErrorBar;
+  }
 };

--- a/packages/react-components/src/components/TroubleshootingGuideErrorBar.tsx
+++ b/packages/react-components/src/components/TroubleshootingGuideErrorBar.tsx
@@ -112,7 +112,7 @@ export const _TroubleshootingGuideErrorBar = (props: _TroubleshootingGuideErrorB
       {toShow.map((error) => {
         const devicePermissionErrorBar = (
           <div>
-            {strings[error.type]}
+            {strings[error.type]}{' '}
             {onPermissionsTroubleshootingClick && (
               <Link
                 styles={linkStyle(theme)}
@@ -129,7 +129,7 @@ export const _TroubleshootingGuideErrorBar = (props: _TroubleshootingGuideErrorB
 
         const networkErrorBar = (
           <div>
-            {strings[error.type]}
+            {strings[error.type]}{' '}
             {onNetworkingTroubleshootingClick && (
               <Link styles={linkStyle(theme)} onClick={onNetworkingTroubleshootingClick} underline>
                 <span>{troubleshootingGuideStrings.networkTroubleshootingLinkText}</span>

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -217,6 +217,10 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
           }}
           /* @conditional-compile-remove(call-readiness) */
           devicePermissions={props.options?.devicePermissions}
+          /* @conditional-compile-remove(call-readiness) */
+          onPermissionsTroubleshootingClick={props.options?.onPermissionsTroubleshootingClick}
+          /* @conditional-compile-remove(call-readiness) */
+          onNetworkingTroubleShootingClick={props.options?.onNetworkingTroubleShootingClick}
         />
       );
       break;

--- a/packages/react-composites/src/composites/CallComposite/components/ConfigurationpageErrorBar.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/ConfigurationpageErrorBar.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import React from 'react';
+import {
+  _DevicePermissionDropdownStrings,
+  _DevicePermissionDropdown,
+  _DevicePermissionDropdownProps,
+  ActiveErrorMessage,
+  ErrorBarProps,
+  _TroubleshootingGuideErrorBarStrings,
+  _TroubleshootingGuideErrorBar,
+  ErrorBar
+} from '@internal/react-components';
+import { CallingHandlers } from '@internal/calling-component-bindings';
+import { Common } from '@internal/acs-ui-common';
+
+/**
+ * @private
+ */
+export interface ConfigurationpageErrorBarProps {
+  errorBarProps: {
+    activeErrorMessages: ActiveErrorMessage[];
+  } & Common<CallingHandlers, ErrorBarProps>;
+  showTroubleShootingErrorBar?: boolean;
+  onPermissionsTroubleshootingClick?: (permissionsState: {
+    camera: PermissionState;
+    microphone: PermissionState;
+  }) => void;
+  onNetworkingTroubleShootingClick?: () => void;
+  permissionsState?: {
+    camera: PermissionState;
+    microphone: PermissionState;
+  };
+}
+
+/**
+ * @private
+ */
+export const ConfigurationpageErrorBar = (props: ConfigurationpageErrorBarProps): JSX.Element => {
+  const {
+    errorBarProps,
+    /* @conditional-compile-remove(call-readiness) */
+    showTroubleShootingErrorBar = false,
+    /* @conditional-compile-remove(call-readiness) */
+    onPermissionsTroubleshootingClick,
+    /* @conditional-compile-remove(call-readiness) */
+    onNetworkingTroubleShootingClick,
+    /* @conditional-compile-remove(call-readiness) */
+    permissionsState
+  } = props;
+
+  /* @conditional-compile-remove(call-readiness) */
+  const permissionTroubleshootingGuideStrings: _TroubleshootingGuideErrorBarStrings = {
+    devicePermissionLinkText: 'Troubleshooting Camera and Microphone Permissions',
+    networkTroubleshootingLinkText: 'Troubleshooting Network Connection',
+    dismissButtonText: 'OK'
+  };
+
+  /* @conditional-compile-remove(call-readiness) */
+  if (showTroubleShootingErrorBar) {
+    return (
+      <_TroubleshootingGuideErrorBar
+        troubleshootingGuideStrings={permissionTroubleshootingGuideStrings}
+        onPermissionsTroubleshootingClick={onPermissionsTroubleshootingClick}
+        onNetworkingTroubleshootingClick={onNetworkingTroubleShootingClick}
+        permissionsState={permissionsState}
+        {...errorBarProps}
+      />
+    );
+  }
+
+  return <ErrorBar {...errorBarProps} />;
+};

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -35,6 +35,7 @@ import { usePropsFor } from '../hooks/usePropsFor';
 import { useAdapter } from '../adapter/CallAdapterProvider';
 /* @conditional-compile-remove(call-readiness) */
 import { DevicePermissionRestrictions } from '../CallComposite';
+import { ConfigurationpageErrorBar } from '../components/ConfigurationpageErrorBar';
 
 /**
  * @private
@@ -44,13 +45,26 @@ export interface ConfigurationPageProps {
   startCallHandler(): void;
   /* @conditional-compile-remove(call-readiness) */
   devicePermissions?: DevicePermissionRestrictions;
+  /* @conditional-compile-remove(call-readiness) */
+  onPermissionsTroubleshootingClick?: (permissionsState: {
+    camera: PermissionState;
+    microphone: PermissionState;
+  }) => void;
+  /* @conditional-compile-remove(call-readiness) */
+  onNetworkingTroubleShootingClick?: () => void;
 }
 
 /**
  * @private
  */
 export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element => {
-  const { startCallHandler, mobileView, /* @conditional-compile-remove(call-readiness) */ devicePermissions } = props;
+  const {
+    startCallHandler,
+    mobileView,
+    /* @conditional-compile-remove(call-readiness) */ devicePermissions,
+    /* @conditional-compile-remove(call-readiness) */ onPermissionsTroubleshootingClick,
+    /* @conditional-compile-remove(call-readiness) */ onNetworkingTroubleShootingClick
+  } = props;
 
   const options = useAdaptedSelector(getCallingSelector(DevicesButton));
   const localDeviceSettingsHandlers = useHandlers(LocalDeviceSettings);
@@ -108,10 +122,34 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
   /* @conditional-compile-remove(rooms) */
   mobileWithPreview = mobileWithPreview && rolePermissions.cameraButton;
 
+  /* @conditional-compile-remove(call-readiness) */
+  const permissionsState: {
+    camera: PermissionState;
+    microphone: PermissionState;
+  } = {
+    camera: cameraPermissionGranted ? 'granted' : 'denied',
+    microphone: microphonePermissionGranted ? 'granted' : 'denied'
+  };
+  /* @conditional-compile-remove(call-readiness) */
+  const networkErrors = errorBarProps.activeErrorMessages.filter((message) => message.type === 'callNetworkQualityLow');
+
   return (
     <Stack className={mobileView ? configurationContainerStyleMobile : configurationContainerStyleDesktop}>
       <Stack styles={bannerNotificationStyles}>
-        <ErrorBar {...errorBarProps} />
+        <ConfigurationpageErrorBar
+          /* @conditional-compile-remove(call-readiness) */
+          // show trouble shooting error bar when encountering network error/ permission error
+          showTroubleShootingErrorBar={
+            !cameraPermissionGranted || !microphonePermissionGranted || networkErrors.length > 0
+          }
+          /* @conditional-compile-remove(call-readiness) */
+          permissionsState={permissionsState}
+          /* @conditional-compile-remove(call-readiness) */
+          onNetworkingTroubleShootingClick={onNetworkingTroubleShootingClick}
+          /* @conditional-compile-remove(call-readiness) */
+          onPermissionsTroubleshootingClick={onPermissionsTroubleshootingClick}
+          errorBarProps={errorBarProps}
+        />
       </Stack>
       <Stack
         grow

--- a/packages/storybook/stories/INTERNAL/CallReadiness/TroubleshootingGuideErrorBar/TroubleshootingGuideErrorBar.stories.tsx
+++ b/packages/storybook/stories/INTERNAL/CallReadiness/TroubleshootingGuideErrorBar/TroubleshootingGuideErrorBar.stories.tsx
@@ -32,13 +32,9 @@ const TroubleshootingGuideErrorBarStory = (args): JSX.Element => {
     microphone: 'granted'
   };
 
-  const permissionTroubleshootingGuideStrings: _TroubleshootingGuideErrorBarStrings = {
-    linkText: 'Troubleshooting Camera and Microphone Permissions',
-    dismissButtonText: 'OK'
-  };
-
-  const networkTroubleshootingGuideStrings: _TroubleshootingGuideErrorBarStrings = {
-    linkText: 'Troubleshooting Network Connection',
+  const troubleshootingGuideStrings: _TroubleshootingGuideErrorBarStrings = {
+    devicePermissionLinkText: 'Troubleshooting Camera and Microphone Permissions',
+    networkTroubleshootingLinkText: 'Troubleshooting Network Connection',
     dismissButtonText: 'OK'
   };
 
@@ -54,15 +50,9 @@ const TroubleshootingGuideErrorBarStory = (args): JSX.Element => {
       <_TroubleshootingGuideErrorBar
         activeErrorMessages={args.errorTypes.map((t) => ({ type: t, timestamp: new Date(Date.now()) }))}
         onPermissionsTroubleshootingClick={onPermissionsTroubleshootingClick}
-        permissionsState={permissionsState}
-        troubleshootingGuideStrings={permissionTroubleshootingGuideStrings}
-      />
-
-      <_TroubleshootingGuideErrorBar
-        activeErrorMessages={args.errorTypes.map((t) => ({ type: t, timestamp: new Date(Date.now()) }))}
         onNetworkingTroubleshootingClick={onNetworkingTroubleshootingClick}
         permissionsState={permissionsState}
-        troubleshootingGuideStrings={networkTroubleshootingGuideStrings}
+        troubleshootingGuideStrings={troubleshootingGuideStrings}
       />
     </div>
   );

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -108,6 +108,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     camera: PermissionState;
     microphone: PermissionState;
   }): void => {
+    console.log(permissionState);
     alert('permission troubleshooting clicked');
   };
 

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -104,6 +104,17 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     callInvitationUrl = undefined;
   }
 
+  const onPermissionsTroubleshootingClick = (permissionState: {
+    camera: PermissionState;
+    microphone: PermissionState;
+  }): void => {
+    console.log(permissionState);
+  };
+
+  const onNetworkingTroubleShootingClick = (): void => {
+    console.log('network trouble shoot');
+  };
+
   return (
     <CallComposite
       adapter={adapter}
@@ -113,6 +124,8 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
       formFactor={isMobileSession ? 'mobile' : 'desktop'}
       /* @conditional-compile-remove(rooms) */
       role={role}
+      /* @conditional-compile-remove(call-readiness) */
+      options={{ onPermissionsTroubleshootingClick, onNetworkingTroubleShootingClick }}
     />
   );
 };

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -108,11 +108,11 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     camera: PermissionState;
     microphone: PermissionState;
   }): void => {
-    console.log(permissionState);
+    alert('permission troubleshooting clicked');
   };
 
   const onNetworkingTroubleShootingClick = (): void => {
-    console.log('network trouble shoot');
+    alert('network troubleshooting clicked');
   };
 
   return (


### PR DESCRIPTION
# What
Add troubleshooting guide error bar to call composite config screen 
<img width="1704" alt="Screen Shot 2022-10-24 at 8 35 24 AM" src="https://user-images.githubusercontent.com/96077406/197576908-0c805521-189a-4394-ac6e-b6b639a9bd05.png">


# Why
call readiness work 
