### PR TITLE
Regenerate the PNPM shrinkwrap files for beta flavor

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -29,6 +29,13 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-lNUmDRVGpanCsiUN3NWxFTdwmdFI53xwhkTFfHDGTYk46ca7Ind3nanJc+U6Zj9Tv+9nTCWRBscWEW1DyKOpTw==
+  /@azure/communication-calling/1.4.4:
+    dependencies:
+      '@azure/communication-common': 1.1.0
+      '@azure/logger': 1.0.3
+    dev: false
+    resolution:
+      integrity: sha512-uWzULqnXB7pMIEH8x1mwwT45ncPfAryfoKxd4BtbcL1C3ckMknk/5gP3Ov2/V5DJkoOO3I6A4D1n05eSFRy+zA==
   /@azure/communication-calling/1.8.0-beta.1:
     dependencies:
       '@azure/communication-common': 2.0.0
@@ -55,6 +62,20 @@ packages:
       node: '>=12.0.0'
     resolution:
       integrity: sha512-cgwD+yZubVHohstA/Ik456W7293fYNlhScjEMc0HoMmi+WRIHcW0KddpnY5KJhI4+6BgozOhtMOj0e1tGWyqqA==
+  /@azure/communication-common/1.1.0:
+    dependencies:
+      '@azure/abort-controller': 1.0.4
+      '@azure/core-auth': 1.4.0
+      '@azure/core-http': 2.2.0
+      '@azure/core-tracing': 1.0.0-preview.13
+      events: 3.3.0
+      jwt-decode: 2.2.0
+      tslib: 2.3.1
+    dev: false
+    engines:
+      node: '>=12.0.0'
+    resolution:
+      integrity: sha512-vqTtzDtb4NG3LWoWoqlOOJApZRRIIImNUKlGyTa6c1YC+v5A7UEOL9TX8NRDxvFVUF2wDHsSnkhLBVBgkcAhIQ==
   /@azure/communication-common/2.0.0:
     dependencies:
       '@azure/abort-controller': 1.0.4
@@ -2181,18 +2202,6 @@ packages:
       react-dom: '>=16.8.0 <17.0.0'
     resolution:
       integrity: sha512-fGSgL3Vp/+6t1Ysfz21FWZmqsU+iFVxOigvHnm5uKVyyRPwtaabv/F6kQ2y5isLMI2YmJaUd2i0cDJKu8ggrvw==
-  /@fluentui/react-window-provider/2.2.1_796713c4bb4631ac40b03d54b6277837:
-    dependencies:
-      '@fluentui/set-version': 8.2.2
-      '@types/react': 16.14.13
-      react: 16.14.0
-      tslib: 2.3.1
-    dev: false
-    peerDependencies:
-      '@types/react': '>=16.8.0 <18.0.0'
-      react: '>=16.8.0 <18.0.0'
-    resolution:
-      integrity: sha512-Y0j+lAYKeD/qswzFZWPkHmvtBlRS2WPJIkpyGvfBVZaCeq3DGKRppoOCOmED762bKOXzM/G/ZNEcBa7CY1gkYw==
   /@fluentui/react-window-provider/2.2.2_796713c4bb4631ac40b03d54b6277837:
     dependencies:
       '@fluentui/set-version': 8.2.2
@@ -12422,6 +12431,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==
+  /jwt-decode/2.2.0:
+    dev: false
+    resolution:
+      integrity: sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ==
   /jwt-decode/3.1.2:
     dev: false
     resolution:
@@ -18966,7 +18979,7 @@ packages:
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
     dependencies:
-      '@azure/communication-calling': 1.8.0-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-common': 2.0.0
       '@babel/cli': 7.16.0_@babel+core@7.16.5
       '@babel/core': 7.16.5
@@ -19001,12 +19014,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-P+90FkjkbriUOcnnDtebFJ4Pqy/fu/cOUW8mCQfJnZ3LLrhuLK5FE/y94cPxykoywcZKV62vCB1EbJgWJgOCDg==
+      integrity: sha512-oIAF1fzZpaYE97mvvfgMdy17rN4Fey7cHPrT13zIuIwV/yLWHKgdzU8s0aTzb7hJ4t4aqJmZKgiqopkjRFlypA==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
     dependencies:
-      '@azure/communication-calling': 1.8.0-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-common': 2.0.0
       '@azure/core-auth': 1.3.2
       '@azure/logger': 1.0.3
@@ -19041,13 +19054,13 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-BO6RqrCP4+u+j0sbHai+ZsIONbxgEkIOuLv7DEHTnLY90o7ygn4a/mypWccIFId4MjbHykB6bmhroUQhaXBb9Q==
+      integrity: sha512-8jqGqHkJAUIgFSBnA9JoUtUGNrTM7p1gL8vuOyaHs/ecYeSHNQ1kptQkIBnyTXQGgBvAeVQ7d3ywdyb4/KuMsA==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
     dependencies:
       '@azure/abort-controller': 1.0.4
-      '@azure/communication-calling': 1.8.0-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-common': 2.0.0
       '@azure/communication-identity': 1.1.0
       '@azure/communication-signaling': 1.0.0-beta.13
@@ -19123,13 +19136,13 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-C/d/Qx937nPn8CQ4kgijC3IAheK3zDp2UUaebvZw4n2CsZjmdt/9+t9lz8XWK7ZCDcuK+i3W2IVtHn2yhf0zJg==
+      integrity: sha512-qAHsft1cXGo0RcUiPEoTqe0yRYpG4ktkjRTJtjhYrrAlOxMENpJ1fbOnNmPt+MoJgBz6JFHbKkDCRM6T7bvEyQ==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
     dependencies:
       '@azure/abort-controller': 1.0.4
-      '@azure/communication-calling': 1.8.0-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.0.0
       '@azure/communication-identity': 1.1.0
@@ -19199,7 +19212,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-FicH3iZyX+eKVkhIymcy7IhxLNAV2HOm/3RCKEV7e2Cs6YKvm9RlHnwSTXltuUI3fABAp4MXwLJIqAr5/eT2wA==
+      integrity: sha512-VxGWcyZSeeTh79whB601GhW/3k2TqOCNAlyDmXl4JyTbuZETrCmLMtrM3umU9SMArKE+wvXDJbkV/kq2qsn5JA==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19238,7 +19251,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-component-bindings'
     resolution:
-      integrity: sha512-iK8NdM6c2sPnRSazgZE3yC95nl54T5M1YsRkwn0a8BSwtyREJ0trrxwaA1ovafZgdID5OvUiZJ1QEd8T3ziLkQ==
+      integrity: sha512-QeZZ8rWLthCumEpBZ3r7EDyevqc0RE1fuBYPv0Lb1HdqhYDPaAhn+rONZiuLjBn7TL2L/7jGBdCu7e3aArZvSQ==
       tarball: file:projects/chat-component-bindings.tgz
     version: 0.0.0
   file:projects/chat-stateful-client.tgz:
@@ -19280,7 +19293,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-stateful-client'
     resolution:
-      integrity: sha512-jdM/dwQJo7lBUFHXYL7Xe/5UejcyMZpevHa+QtAqrPANKxsKJFhtduzDolo8ZqdUoSE6n3tTb4UlXqLft8zsrA==
+      integrity: sha512-IZ3lDJ+dwZ1BTAVQrlJXmYv6QWjrv5DbK1UKegPhCvUixwMYtV0ZXcxHc+ovGT8njc+0W04n1jzTog3hzt7CkA==
       tarball: file:projects/chat-stateful-client.tgz
     version: 0.0.0
   file:projects/chat.tgz:
@@ -19353,7 +19366,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-JxWLM9cIwAfIcs3OIVGdjGcLNxsQfT9A1V3QFzbBo9uuAEIzZm5m5gKbEjRjhFShv94LY1LF9blVCExJFRXgbA==
+      integrity: sha512-3TCNw6EK9YHcLnDNuX/lBf69+Eijb+lTg99p+FcCV+qMvoXv7QuZUlL+NvlY4wfxpwq3NLtYHaLUKt98LR5DcQ==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19371,12 +19384,12 @@ packages:
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-+DAQpXLDFx39n3LHx4XodbYiKGkCx2ATEsEGG77AHMQbo6uIKLB+OfjnvGiDm596p6P5WgrT/VMSiy0G1hxRKQ==
+      integrity: sha512-WaNqqiWH9dFdAc4L4OOvpYksaZ3kOOWZWHN8FjJBY1T4O1MnJUCtshjeix/OjuzlWRCUNTz+/aqgLNnA5E7GHw==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
     dependencies:
-      '@azure/communication-calling': 1.8.0-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.0.0
       '@azure/communication-signaling': 1.0.0-beta.13
@@ -19393,7 +19406,7 @@ packages:
       '@fluentui/react-hooks': 8.3.8_796713c4bb4631ac40b03d54b6277837
       '@fluentui/react-icons': 1.1.145
       '@fluentui/react-northstar': 0.61.0_f09bd12f717275b09a3c137857e6b9f2
-      '@fluentui/react-window-provider': 2.2.1_796713c4bb4631ac40b03d54b6277837
+      '@fluentui/react-window-provider': 2.2.2_796713c4bb4631ac40b03d54b6277837
       '@microsoft/api-documenter': 7.12.22
       '@microsoft/api-extractor': 7.18.5
       '@rollup/plugin-json': 4.1.0_rollup@2.42.4
@@ -19463,12 +19476,12 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-K2RWBnyVi3RFFS4mnS1USa+pYvt2rJ5ZFJxmtooTo6oHHw96A+ffountRmKLv8BfhFRzvgrJ4mHYQJ+Ae0qbGA==
+      integrity: sha512-hCA/4cya+XN5AqaeBsyrlLoABPo71iWdt9quCVrb1Wv+pmoZAvOZaoA638iWpBVDLbS+FL/qawOW2FLQCTHJDg==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
     dependencies:
-      '@azure/communication-calling': 1.8.0-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.0.0
       '@azure/communication-identity': 1.1.0
@@ -19533,7 +19546,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-50SkRSEgd7kRGZk8YsqVfQpaiPJGH2EIaKGstK+7w6+s6L8HeDvFDejKYgqyymw4OuaZvbCDQ6JjJEttG+Atgw==
+      integrity: sha512-/nqgqOXGWLwAlDRoUs7T/noufMjmAn0399u/pvbZhLI+mN9247N85BRyUwPhB3QzVT3LqUO9LUwpqxCz26QbPw==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19593,7 +19606,7 @@ packages:
     dev: false
     name: '@rush-temp/fake-backends'
     resolution:
-      integrity: sha512-VDHSQVgGMwvAkgIRRn9TJDrVX2N4iaqwGTBZx9THnEqiwv+KqiR3UcvluWMkr4hSNj2jOmcE5uGwjYBgT/W2Kw==
+      integrity: sha512-OGtD9ptUZOZBZ/nk90PFF+tNbEtE1yUFKptpaMFM5n3Lz0M/gZ+6msQgCJ3jyGQcKoPRyBy1y4aheeaB0izH/Q==
       tarball: file:projects/fake-backends.tgz
     version: 0.0.0
   file:projects/react-components.tgz:
@@ -19606,7 +19619,7 @@ packages:
       '@fluentui/react-hooks': 8.3.8_796713c4bb4631ac40b03d54b6277837
       '@fluentui/react-icons': 1.1.145
       '@fluentui/react-northstar': 0.61.0_f09bd12f717275b09a3c137857e6b9f2
-      '@fluentui/react-window-provider': 2.2.1_796713c4bb4631ac40b03d54b6277837
+      '@fluentui/react-window-provider': 2.2.2_796713c4bb4631ac40b03d54b6277837
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@microsoft/api-documenter': 7.12.22
       '@microsoft/api-extractor': 7.18.5
@@ -19682,12 +19695,12 @@ packages:
     dev: false
     name: '@rush-temp/react-components'
     resolution:
-      integrity: sha512-ruJH4cnByXMpIkS5ZwaHHxOQLNacepPTvGM6bKy6tyOYMYnze912aioRiiCYPbXU1acafetRj9RAJqD2asf6LQ==
+      integrity: sha512-EvBw3WxcZdNniNyWA74DE3dZKzAD6WNd6XLNUDwn80RfqONU7a/nuJMN+lAefxiYVfp3BZjf/vGjXXNJxLFilw==
       tarball: file:projects/react-components.tgz
     version: 0.0.0
   file:projects/react-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.8.0-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.0.0
       '@azure/communication-identity': 1.1.0
@@ -19796,12 +19809,12 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-dHs0ZSS44mxBm466JovUqLR/6l2qA8c7hKHipDfcbXRxoWJSxFSWJFEumhnubHDCTuB6o+MzDBRgmJHgCvWnuw==
+      integrity: sha512-sujd/hPbIkkZHDYNZ1NRvRh8O7IUr5kQirsWoAVs770daOsjI6lQqYnliYZWYHKmzF+Y2KYXgRS79+xTHen4lg==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
     dependencies:
-      '@azure/communication-calling': 1.8.0-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.0.0
       '@azure/communication-identity': 1.1.0
@@ -19820,12 +19833,12 @@ packages:
     dev: false
     name: '@rush-temp/sample-automation-tests'
     resolution:
-      integrity: sha512-DO00FxMvVsgR+l4G4pn2G0J8TpL/vumwlbu5a50LoK7I3hpjYt1p2xDBx06BafhjjaLQa4WZQSy+46T9diD/hw==
+      integrity: sha512-PVF2ixIXl/gX9qtuqqUx0Rv3ZZu2rPJ4X7XlYYADsXduHEmRxzo8vG7GsSFeGGHZAVbuypZspIHymecBLsfP5Q==
       tarball: file:projects/sample-automation-tests.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.8.0-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.0.0
       '@azure/communication-identity': 1.1.0
@@ -19861,7 +19874,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-Q8YhiEdCLCj+EqPdcvgTCUF1mvLvQ4vsmNAUTCE0cAIYa+i/kRPBHQL9YcclU1ubKSHKZeP0i61xprLbRTBMrw==
+      integrity: sha512-19UsWuWZMmis2TCb7AQ0w9Nqz8EdbK61ReM+Lgdap03uYsbUiU0pMQxYnXUWQchdvJJJ/5G1B70UhozIVH3Y0A==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -19922,7 +19935,7 @@ packages:
     version: 0.0.0
   file:projects/storybook.tgz:
     dependencies:
-      '@azure/communication-calling': 1.8.0-beta.1
+      '@azure/communication-calling': 1.4.4
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.0.0
       '@azure/communication-identity': 1.1.0
@@ -20027,7 +20040,7 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-9jxJr3T1cZ1W3fMTncSSF2FnocAAVCha/dgvVX+gDb/8MgsgW6TMqQ8znt+xEbAaBTbIQm7IzLHoaK4grV0q+Q==
+      integrity: sha512-E6UlbSgXWLHDfmcPGF3BWQs21ELJa/x3WbR9+DnkrUUl5fmk/HKZyPsfltYizFq+KUmh6Sbnw/2TL8voOKrevw==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:


### PR DESCRIPTION
`1.4.0` is a stable release, but the GitHub workflows are failing in an early step where then need to install beta build's dependencies.

Fix it first while I try to figure out how we got into this state.