### PR TITLE
Fix CallWithChatPane persisting drawer menu

### DIFF
--- a/change/@internal-react-composites-19aa482f-d5a5-4818-851a-067fd8654bbf.json
+++ b/change/@internal-react-composites-19aa482f-d5a5-4818-851a-067fd8654bbf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix CallWithChatPane drawer menu that stays open after swithching tabs",
+  "packageName": "@internal/react-composites",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatPane.tsx
@@ -95,53 +95,58 @@ export const CallWithChatPane = (props: {
       />
     );
 
-  const chatContent = (
-    <ChatComposite
-      {...props.chatCompositeProps}
-      adapter={props.chatAdapter}
-      fluentTheme={theme}
-      options={{
-        topic: false,
-        /* @conditional-compile-remove(chat-composite-participant-pane) */
-        participantPane: false,
-        /* @conditional-compile-remove(file-sharing) */
-        fileSharing: props.fileSharing
-      }}
-      onFetchAvatarPersonaData={props.onFetchAvatarPersonaData}
-    />
-  );
-
-  /**
-   * In a CallWithChat when a participant is removed, we must remove them from both
-   * the call and the chat thread.
-   */
-  const removeParticipantFromCallWithChat = async (participantId: string): Promise<void> => {
-    await props.callAdapter.removeParticipant(participantId);
-    await props.chatAdapter.removeParticipant(participantId);
-  };
-
-  /* @conditional-compile-remove(PSTN-calls) */
-  const addParticipantToCall = async (
-    participant: PhoneNumberIdentifier,
-    options?: AddPhoneNumberOptions
-  ): Promise<void> => {
-    await props.callAdapter.addParticipant(participant, options);
-  };
-
-  const peopleContent = (
-    <CallAdapterProvider adapter={props.callAdapter}>
-      <PeoplePaneContent
-        {...props}
-        onRemoveParticipant={removeParticipantFromCallWithChat}
-        setDrawerMenuItems={setDrawerMenuItems}
-        strings={callWithChatStrings}
-        /* @conditional-compile-remove(PSTN-calls) */
-        onAddParticipant={addParticipantToCall}
-        /* @conditional-compile-remove(PSTN-calls) */
-        alternateCallerId={alternateCallerId}
+  const chatContent = useMemo(
+    () => (
+      <ChatComposite
+        {...props.chatCompositeProps}
+        adapter={props.chatAdapter}
+        fluentTheme={theme}
+        options={{
+          topic: false,
+          /* @conditional-compile-remove(chat-composite-participant-pane) */
+          participantPane: false,
+          /* @conditional-compile-remove(file-sharing) */
+          fileSharing: props.fileSharing
+        }}
+        onFetchAvatarPersonaData={props.onFetchAvatarPersonaData}
       />
-    </CallAdapterProvider>
+    ),
+    [props.chatCompositeProps, props.chatAdapter, props.fileSharing, props.onFetchAvatarPersonaData, theme]
   );
+
+  const peopleContent = useMemo(() => {
+    /**
+     * In a CallWithChat when a participant is removed, we must remove them from both
+     * the call and the chat thread.
+     */
+    const removeParticipantFromCallWithChat = async (participantId: string): Promise<void> => {
+      await props.callAdapter.removeParticipant(participantId);
+      await props.chatAdapter.removeParticipant(participantId);
+    };
+
+    /* @conditional-compile-remove(PSTN-calls) */
+    const addParticipantToCall = async (
+      participant: PhoneNumberIdentifier,
+      options?: AddPhoneNumberOptions
+    ): Promise<void> => {
+      await props.callAdapter.addParticipant(participant, options);
+    };
+
+    return (
+      <CallAdapterProvider adapter={props.callAdapter}>
+        <PeoplePaneContent
+          {...props}
+          onRemoveParticipant={removeParticipantFromCallWithChat}
+          setDrawerMenuItems={setDrawerMenuItems}
+          strings={callWithChatStrings}
+          /* @conditional-compile-remove(PSTN-calls) */
+          onAddParticipant={addParticipantToCall}
+          /* @conditional-compile-remove(PSTN-calls) */
+          alternateCallerId={alternateCallerId}
+        />
+      </CallAdapterProvider>
+    );
+  }, [alternateCallerId, callWithChatStrings, props]);
 
   const minMaxDragPosition = useMinMaxDragPosition(props.modalLayerHostId, props.rtl);
 
@@ -160,8 +165,8 @@ export const CallWithChatPane = (props: {
       <Stack.Item verticalFill grow styles={paneBodyContainer}>
         <Stack horizontal styles={scrollableContainer}>
           <Stack.Item verticalFill styles={scrollableContainerContents}>
-            <Stack styles={props.activePane === 'chat' ? availableSpaceStyles : hiddenStyles}>{chatContent}</Stack>
-            <Stack styles={props.activePane === 'people' ? availableSpaceStyles : hiddenStyles}>{peopleContent}</Stack>
+            {props.activePane === 'chat' && <Stack styles={availableSpaceStyles}>{chatContent}</Stack>}
+            {props.activePane === 'people' && <Stack styles={availableSpaceStyles}>{peopleContent}</Stack>}
           </Stack.Item>
         </Stack>
       </Stack.Item>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Re-rendering people pane and chat pane when activePane prop is changed

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3015810

# How Tested
<!--- How did you test your change. What tests have you added. -->
Local CallWithChat sample
https://user-images.githubusercontent.com/79475487/197706807-ca302d59-3e2e-4a4a-b4cc-2472a2f9f196.mp4

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->