### PR TITLE
Bugfix - Unable to update myChatMessageContainer style in MessageThre…

### DIFF
--- a/change/@internal-react-components-8f431b65-0af5-49fb-baa0-06243a9b6132.json
+++ b/change/@internal-react-components-8f431b65-0af5-49fb-baa0-06243a9b6132.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Add ability to style a failed chat message (fixes #2257)",
   "packageName": "@internal/react-components",
   "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@internal-react-components-8f431b65-0af5-49fb-baa0-06243a9b6132.json
+++ b/change/@internal-react-components-8f431b65-0af5-49fb-baa0-06243a9b6132.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add ability to style a failed chat message (fixes #2257)",
+  "packageName": "@internal/react-components",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2392,6 +2392,7 @@ export interface MessageThreadStyles extends BaseCustomStyles {
     chatContainer?: ComponentSlotStyle;
     chatItemMessageContainer?: ComponentSlotStyle;
     chatMessageContainer?: ComponentSlotStyle;
+    failedMyChatMessageContainer?: ComponentSlotStyle;
     loadPreviousMessagesButtonContainer?: IStyle;
     messageStatusContainer?: (mine: boolean) => IStyle;
     myChatItemMessageContainer?: ComponentSlotStyle;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -1904,6 +1904,7 @@ export interface MessageThreadStyles extends BaseCustomStyles {
     chatContainer?: ComponentSlotStyle;
     chatItemMessageContainer?: ComponentSlotStyle;
     chatMessageContainer?: ComponentSlotStyle;
+    failedMyChatMessageContainer?: ComponentSlotStyle;
     loadPreviousMessagesButtonContainer?: IStyle;
     messageStatusContainer?: (mine: boolean) => IStyle;
     myChatItemMessageContainer?: ComponentSlotStyle;

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1059,6 +1059,7 @@ export interface MessageThreadStyles extends BaseCustomStyles {
     chatContainer?: ComponentSlotStyle;
     chatItemMessageContainer?: ComponentSlotStyle;
     chatMessageContainer?: ComponentSlotStyle;
+    failedMyChatMessageContainer?: ComponentSlotStyle;
     loadPreviousMessagesButtonContainer?: IStyle;
     messageStatusContainer?: (mine: boolean) => IStyle;
     myChatItemMessageContainer?: ComponentSlotStyle;

--- a/packages/react-components/review/stable/react-components.api.md
+++ b/packages/react-components/review/stable/react-components.api.md
@@ -928,6 +928,7 @@ export interface MessageThreadStyles extends BaseCustomStyles {
     chatContainer?: ComponentSlotStyle;
     chatItemMessageContainer?: ComponentSlotStyle;
     chatMessageContainer?: ComponentSlotStyle;
+    failedMyChatMessageContainer?: ComponentSlotStyle;
     loadPreviousMessagesButtonContainer?: IStyle;
     messageStatusContainer?: (mine: boolean) => IStyle;
     myChatItemMessageContainer?: ComponentSlotStyle;

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -152,6 +152,8 @@ export interface MessageThreadStyles extends BaseCustomStyles {
   chatItemMessageContainer?: ComponentSlotStyle;
   /** Styles for my chat message container. */
   myChatMessageContainer?: ComponentSlotStyle;
+  /** Styles for my chat message container in case of failure. */
+  failedMyChatMessageContainer?: ComponentSlotStyle;
   /** Styles for chat message container. */
   chatMessageContainer?: ComponentSlotStyle;
   /** Styles for system message container. */
@@ -359,10 +361,10 @@ const memoizeAllMessages = memoizeFnAll(
     switch (message.messageType) {
       case 'chat': {
         const myChatMessageStyle =
-          styles?.myChatMessageContainer || message.status === 'failed'
-            ? FailedMyChatMessageContainer
-            : defaultMyChatMessageContainer;
-        const chatMessageStyle = styles?.chatMessageContainer || defaultChatMessageContainer;
+          message.status === 'failed'
+            ? styles?.failedMyChatMessageContainer ?? styles?.myChatMessageContainer ?? FailedMyChatMessageContainer
+            : styles?.myChatMessageContainer ?? defaultMyChatMessageContainer;
+        const chatMessageStyle = styles?.chatMessageContainer ?? defaultChatMessageContainer;
         messageProps.messageContainerStyle = message.mine ? myChatMessageStyle : chatMessageStyle;
 
         const chatMessageComponent =


### PR DESCRIPTION
This is a copy of #2285 due to external contributions issues we are working through.

# What
Fixed the inability to change the style of myChatMessageContainer for the MessageThread component.

- Added failedMyChatMessageContainer to the MessageThreadStyles interface.
- Updated the myChatMessageStyle constant according to failedMyChatMessageContainer.

# Why
The `MessageThread `component has a "styles" prop allowing us to change the style of the following elements:
- myChatMessageContainer
- chatMessageContainer

If we add style for both elements we can see that the style is applied for `chatMessageContainer `and not for `myChatMessageContainer`.

Link of the issue: #2257 

# How Tested
We can check the behaviour in the storybook:
- Go to the storybook
- Go to the "Messages with Customized Message Container" section of the `MessageThread `component.

The `MessageThread `will apply the style of `myChatMessageContainer `(fontStyle and boxShadow) instead of applying the style of `FailedMyChatMessageContainer `(red background).