### PR TITLE
Fix: blank video gallery

### DIFF
--- a/change/@internal-calling-stateful-client-9019712f-7d19-4a64-9b53-1492ef8e57b3.json
+++ b/change/@internal-calling-stateful-client-9019712f-7d19-4a64-9b53-1492ef8e57b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix an issue where other participants did not show in the video gallery",
+  "packageName": "@internal/calling-stateful-client",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/src/CallSubscriber.ts
+++ b/packages/calling-stateful-client/src/CallSubscriber.ts
@@ -160,10 +160,18 @@ export class CallSubscriber {
 
   private remoteParticipantsUpdated = (event: { added: RemoteParticipant[]; removed: RemoteParticipant[] }): void => {
     event.added.forEach((participant: RemoteParticipant) => {
-      this.addParticipantListener(participant);
+      try {
+        this.addParticipantListener(participant);
+      } catch (e) {
+        console.error(e);
+      }
     });
     event.removed.forEach((participant: RemoteParticipant) => {
-      this.removeParticipantListener(participant);
+      try {
+        this.removeParticipantListener(participant);
+      } catch (e) {
+        console.error(e);
+      }
     });
 
     // Remove any added participants from remoteParticipantsEnded if they are there and add any removed participants to


### PR DESCRIPTION
# What
Wrap participant subscribers in a try-catch

**Note: this only happened because I was on a stable version of calling but running beta code not stable code. So feel free to reject PR** (however it did cause me much pain)

# Why
I was debugging and suddenly when I joined a call locally I had no one else in the video gallery. I could hear everyone else, chat messages came through but it showed no people in the video gallery or participant pane.

After much debugging I learned the calling sdk onParticipantsUpdated _was_ being called, but for some reason our state never had any remote participants in it.

Turns out the participant subscriber was near-silently throwing an exception (just a hard to spot warning only seen if the azure logger is turned on):
![image](https://user-images.githubusercontent.com/2684369/198144785-ad6fb316-b2f0-4995-b5f3-6ab95f4c8b5b.png)

The exception is now caught on our side, allowing the participants to be propagated to state, and the error is made loud and proud:
![image](https://user-images.githubusercontent.com/2684369/198144930-2ef5285b-d9ce-4092-a4ca-89e2c0d2241e.png)

# How Tested
Left: same call but without fix, Right: same call but with fix:
![image](https://user-images.githubusercontent.com/2684369/198144569-0decb6dc-9596-479f-acbc-7f16771e1032.png)
