### PR TITLE
Stable release branch hotfix: Fix camera turning back on when turned off on connecting screen

### DIFF
--- a/packages/calling-component-bindings/src/handlers/createHandlers.ts
+++ b/packages/calling-component-bindings/src/handlers/createHandlers.ts
@@ -137,15 +137,23 @@ export const createDefaultCallingHandlers = memoizeOne(
 
       if (previewOn && call && _isInLobbyOrConnecting(call.state)) {
         // This is to workaround: https://skype.visualstudio.com/SPOOL/_workitems/edit/3030558.
-        // Currently when we transition from connecting -> call state, if the camera was on,
-        // in MediaGallery we trigger toggleCamera. This triggers onStartLocalVideo which destroys
-        // the unparentedView and creates a new stream in the call - so all looks well.
+        // The root cause of the issue is caused by never transitioning the unparented view to the
+        // call object when going from configuration page (disconnected call state) to connecting.
+        //
+        // Currently the only time the local video stream is moved from unparented view to the call
+        // object is when we transition from connecting -> call state. If the camera was on,
+        // inside the MediaGallery we trigger toggleCamera. This triggers onStartLocalVideo which
+        // destroys the unparentedView and creates a new stream in the call - so all looks well.
+        //
         // However, if someone turns off their camera during the lobbyOrConnecting screen, the
         // call.localVideoStreams will be empty (as the stream is currently stored in the unparented
-        // views and was never transitioned to the call object).
+        // views and was never transitioned to the call object) and thus we incorrectly try to create
+        // a new video stream for the call object, instead of only stopping the unparented view.
+        //
         // The correct fix for this is to ensure that callAgent.onStartCall is called with the
-        // localvideostream as a videoOption, then when call.onLocalVideoStreamsUpdated is called
-        // with the local video stream we clean up the state.
+        // localvideostream as a videoOption. That will mean call.onLocalVideoStreamsUpdated will
+        // be triggered when the call is in connecting state, which we can then transition the
+        // local video stream to the stateful call client and get into a clean state.
         await onDisposeLocalStreamView();
         return;
       }

--- a/packages/calling-component-bindings/src/handlers/createHandlers.ts
+++ b/packages/calling-component-bindings/src/handlers/createHandlers.ts
@@ -135,7 +135,7 @@ export const createDefaultCallingHandlers = memoizeOne(
     const onToggleCamera = async (options?: VideoStreamOptions): Promise<void> => {
       const previewOn = _isPreviewOn(callClient.getState().deviceManager);
 
-      if (previewOn && call && _isInLobbyOrConnecting(call.state)) {
+      if (previewOn && call && call.state === 'Connecting') {
         // This is to workaround: https://skype.visualstudio.com/SPOOL/_workitems/edit/3030558.
         // The root cause of the issue is caused by never transitioning the unparented view to the
         // call object when going from configuration page (disconnected call state) to connecting.


### PR DESCRIPTION
## What
Hotfix for regression caused by #2412 (more details: https://skype.visualstudio.com/SPOOL/_workitems/edit/3030558). See code comment for details.

## How Tested
Joined acs call with:
* Camera on, then toggled off and on on call page
* Camera off, then toggled on and off on call page
* Camera off, then camera turned on in connecting screen, then toggled off and on on call page
* Camera on, then camera turned off in connecting screen, then toggled on and off on call page
* Switching camera source during the connecting screen
* Turning on camera in connecting screen, but ensuring call had connected before the camera had finished turning on (scenario of #2412 )

Teams interop testing:
* Camera on, then toggled off and on on call page
* Camera off, then toggled on and off on call page
* Camera off, then camera turned on in connecting screen, then toggled off and on on call page
* Camera on, then camera turned off in connecting screen, then toggled on and off on call page
* Camera off, then camera turned on in Lobby screen, then toggled off and on on call page
* Camera on, then camera turned off in Lobby screen, then toggled on and off on call page
* Camera off, then camera turned on in connecting screen, then camera turned off in Lobby screen, then toggled off and on on call page
* Camera on, then camera turned off in connecting screen, then camera turned on in Lobby screen, then toggled on and off on call page