### PR TITLE
fixing up the setup section snippets

### DIFF
--- a/change/@internal-storybook-67fadbff-d134-42a1-b46d-802ed470f4cf.json
+++ b/change/@internal-storybook-67fadbff-d134-42a1-b46d-802ed470f4cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fixing up the setup section snippets",
+  "packageName": "@internal/storybook",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/Setup.stories.mdx
+++ b/packages/storybook/stories/Setup.stories.mdx
@@ -64,6 +64,7 @@ We recommend the following configuration of React-related dependencies:
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react-hooks": "^3.4.2",
     "@testing-library/user-event": "^13.5.0",
+    "@testing-library/react": "^12.1.5",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.11.49",
     "@types/react": "^16.9.49",

--- a/packages/storybook/stories/snippets/App.tsx
+++ b/packages/storybook/stories/snippets/App.tsx
@@ -3,6 +3,8 @@
 
 import React from 'react';
 
-export function App(): JSX.Element {
+function App(): JSX.Element {
   return <>Sample app</>;
 }
+
+export default App;

--- a/packages/storybook/stories/snippets/ReactIndex.snippet.tsx
+++ b/packages/storybook/stories/snippets/ReactIndex.snippet.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
-import { App } from './App.snippet'; // this should point to your App.tsx file
+import App from './App'; // this should point to your App.tsx file
 
 ReactDOM.render(
   <div className="wrapper">


### PR DESCRIPTION
I found I had to make some changes to the setup section when starting to use some of the samples. I think we should aspire to making the initial setup as close to real as possible.

- Updated the index.tsx replacement file for < React18 to not reference a snippet file
- Added a dependency for @testing-library/react that requires React16 instead of 18

https://skype.visualstudio.com/SPOOL/_workitems/edit/3032434

# Why
Developers are already treading into the unknown. I think we want make sure we make the first try as seamless as possible. We are already asking them to do several steps and having to also fix up some of our snippets is more than I would expect them to do.

# How Tested
Tested locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->