### PR TITLE
[release] Allow a range of @azure/communication-calling and @azure/communication-chat versions as peerDependency

### DIFF
--- a/packages/calling-component-bindings/package.json
+++ b/packages/calling-component-bindings/package.json
@@ -36,12 +36,12 @@
     "reselect": "~4.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.4",
+    "@azure/communication-calling": ">=1.4.4",
     "@types/react": ">=16.8.0 <18.0.0",
     "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.4",
+    "@azure/communication-calling": ">=1.4.4",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",
     "@microsoft/api-documenter": "~7.12.11",

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -35,10 +35,10 @@
     "immer": "9.0.6"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.4"
+    "@azure/communication-calling": ">=1.4.4"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.4",
+    "@azure/communication-calling": ">=1.4.4",
     "@azure/core-auth": "1.3.2",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",

--- a/packages/chat-component-bindings/package.json
+++ b/packages/chat-component-bindings/package.json
@@ -37,12 +37,12 @@
     "memoize-one": "~5.2.1"
   },
   "peerDependencies": {
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-chat": ">=1.2.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-chat": ">=1.2.0",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",
     "@microsoft/api-documenter": "~7.12.11",

--- a/packages/chat-stateful-client/package.json
+++ b/packages/chat-stateful-client/package.json
@@ -37,10 +37,10 @@
     "nanoid": "3.1.32"
   },
   "peerDependencies": {
-    "@azure/communication-chat": "1.2.0"
+    "@azure/communication-chat": ">=1.2.0"
   },
   "devDependencies": {
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-signaling": "1.0.0-beta.13",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -46,8 +46,8 @@
     "@azure/core-rest-pipeline": "~1.9.2"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.4",
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-calling": ">=1.4.4",
+    "@azure/communication-chat": ">=1.2.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
     "react": ">=16.8.0 <18.0.0",
@@ -81,8 +81,8 @@
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.4",
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-calling": ">=1.4.4",
+    "@azure/communication-chat": ">=1.2.0",
     "@azure/core-auth": "1.3.2",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",

--- a/packages/fake-backends/package.json
+++ b/packages/fake-backends/package.json
@@ -27,7 +27,7 @@
     "_test:by-flavor": "(if-env COMMUNICATION_REACT_FLAVOR=stable && rushx preprocess || if-env COMMUNICATION_REACT_FLAVOR=beta && echo \"skip preprocess\") && jest --passWithNoTests"
   },
   "dependencies": {
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-common": "2.0.0",
     "@azure/communication-signaling": "1.0.0-beta.13",
     "@azure/core-paging": "~1.1.3",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -70,16 +70,16 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.4.4",
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-calling": ">=1.4.4",
+    "@azure/communication-chat": ">=1.2.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
     "react": ">=16.8.0 <18.0.0",
     "react-dom": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.4.4",
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-calling": ">=1.4.4",
+    "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-identity": "~1.1.0",
     "@azure/communication-signaling": "1.0.0-beta.13",
     "@babel/cli": "~7.16.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -18,8 +18,8 @@
     "lint:quiet": "rushx lint -- --quiet"
   },
   "dependencies": {
-    "@azure/communication-calling": "1.4.4",
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-calling": ">=1.4.4",
+    "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-common": "2.0.0",
     "@azure/communication-identity": "~1.1.0",
     "@azure/communication-react": "1.4.0",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -29,8 +29,8 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-identity": "~1.1.0",
-    "@azure/communication-calling": "1.4.4",
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-calling": ">=1.4.4",
+    "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-common": "2.0.0",
     "@azure/communication-react": "1.4.0",
     "@azure/logger": "1.0.3",

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-identity": "~1.1.0",
-    "@azure/communication-calling": "1.4.4",
+    "@azure/communication-calling": ">=1.4.4",
     "@azure/communication-common": "2.0.0",
     "@azure/communication-react": "1.4.0",
     "@azure/logger": "1.0.3",

--- a/samples/Chat/package.json
+++ b/samples/Chat/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-common": "2.0.0",
     "@azure/communication-identity": "~1.1.0",
     "@azure/communication-react": "1.4.0",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -21,8 +21,8 @@
     "_typecheck": "rushx _by-flavor \"if-env COMMUNICATION_REACT_FLAVOR=stable && echo skip || (if-env COMMUNICATION_REACT_FLAVOR=beta && tsc)\""
   },
   "dependencies": {
-    "@azure/communication-chat": "1.2.0",
-    "@azure/communication-calling": "1.4.4",
+    "@azure/communication-chat": ">=1.2.0",
+    "@azure/communication-calling": ">=1.4.4",
     "@azure/communication-common": "2.0.0",
     "@azure/communication-identity": "~1.1.0",
     "@azure/communication-react": "1.4.0",

--- a/samples/Server/package.json
+++ b/samples/Server/package.json
@@ -19,7 +19,7 @@
     "lint:quiet": "eslint */**/*.{ts,tsx} --quiet"
   },
   "dependencies": {
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-common": "2.0.0",
     "@azure/communication-identity": "~1.1.0",
     "@types/cors": "^2.8.8",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@azure/communication-react": "1.4.0",
     "@azure/communication-common": "2.0.0",
-    "@azure/communication-calling": "1.4.4",
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-calling": ">=1.4.4",
+    "@azure/communication-chat": ">=1.2.0",
     "react": "~16.14.0",
     "react-dom": "16.13.1",
     "uuid": "^8.1.0"

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -19,14 +19,14 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.4.4",
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-calling": ">=1.4.4",
+    "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-common": "2.0.0",
     "uuid": "^8.1.0",
     "cross-env": "~7.0.3"
   },
   "devDependencies": {
-    "@azure/communication-chat": "1.2.0",
+    "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-identity": "~1.1.0",
     "@playwright/test": "~1.22.2",
     "@types/node": "^14.14.10",


### PR DESCRIPTION
This is conceptually a cherry pick of #2457.

The PR can't be cherry-picked directly because only the stable package dependencies are chosen on this release branch.