### PR TITLE
Revert breaking API change in `CallEndedListener` callback

### DIFF
--- a/change/@internal-react-composites-4588bf72-bbfd-44d0-bd37-38ce8574b55e.json
+++ b/change/@internal-react-composites-4588bf72-bbfd-44d0-bd37-38ce8574b55e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Revert breaking API change in `CallEndedListener` callback",
+  "packageName": "@internal/react-composites",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -237,7 +237,7 @@ export interface CallAdapter extends AdapterState<CallAdapterState>, Disposable,
 
 // @public
 export type CallAdapterCallEndedEvent = {
-    callId?: string;
+    callId: string;
 };
 
 // @public

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -174,7 +174,7 @@ export interface CallAdapter extends AdapterState<CallAdapterState>, Disposable,
 
 // @public
 export type CallAdapterCallEndedEvent = {
-    callId?: string;
+    callId: string;
 };
 
 // @public

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -136,7 +136,7 @@ export interface CallAdapter extends AdapterState<CallAdapterState>, Disposable,
 
 // @public
 export type CallAdapterCallEndedEvent = {
-    callId?: string;
+    callId: string;
 };
 
 // @public

--- a/packages/react-composites/review/stable/react-composites.api.md
+++ b/packages/react-composites/review/stable/react-composites.api.md
@@ -124,7 +124,7 @@ export interface CallAdapter extends AdapterState<CallAdapterState>, Disposable,
 
 // @public
 export type CallAdapterCallEndedEvent = {
-    callId?: string;
+    callId: string;
 };
 
 // @public

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -157,7 +157,7 @@ export type DisplayNameChangedListener = (event: {
  *
  * @public
  */
-export type CallAdapterCallEndedEvent = { callId?: string };
+export type CallAdapterCallEndedEvent = { callId: string };
 
 /**
  * Callback for {@link CallAdapterSubscribers} 'callEnded' event.


### PR DESCRIPTION
Realized while working on a stable release that we had inadvertently introduced a breaking API change. Revert that change.