### PR TITLE
Increase max event listener limit for call and callwithchat samples

### DIFF
--- a/change/@internal-react-composites-fcfc34c7-0f03-4336-9e24-518abb812687.json
+++ b/change/@internal-react-composites-fcfc34c7-0f03-4336-9e24-518abb812687.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Increase max listener limit to remove warning in console",
+  "packageName": "@internal/react-composites",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -72,7 +72,7 @@ class CallContext {
   private state: CallAdapterState;
   private callId: string | undefined;
 
-  constructor(clientState: CallClientState, isTeamsCall: boolean) {
+  constructor(clientState: CallClientState, isTeamsCall: boolean, maxListeners = 50) {
     this.state = {
       isLocalPreviewMicrophoneEnabled: false,
       userId: clientState.userId,
@@ -84,6 +84,7 @@ class CallContext {
       isTeamsCall,
       /* @conditional-compile-remove(PSTN-calls) */ alternateCallerId: clientState.alternateCallerId
     };
+    this.emitter.setMaxListeners(maxListeners);
   }
 
   public onStateChange(handler: (_uiState: CallAdapterState) => void): void {

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -85,8 +85,9 @@ class CallWithChatContext {
   private emitter = new EventEmitter();
   private state: CallWithChatAdapterState;
 
-  constructor(clientState: CallWithChatAdapterState) {
+  constructor(clientState: CallWithChatAdapterState, maxListeners = 50) {
     this.state = clientState;
+    this.emitter.setMaxListeners(maxListeners);
   }
 
   public onStateChange(handler: CallWithChatAdapterStateChangedHandler): void {


### PR DESCRIPTION
# What
Increase max event listener limit for call and callwithchat composite

# Why
This removes the max event listener warnings for our composites 

# How Tested
load the sample, check if still see warnings in console
load storybook and check if still see warnings in console

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->