### PR TITLE
Drop `isTestProfileStableFlavor` and all references

### DIFF
--- a/docs/references/beta-only-features.md
+++ b/docs/references/beta-only-features.md
@@ -107,15 +107,3 @@ You an help with the manual step of figuring out what the CHANGELOG is in each r
 * `prerelease` for a change that affects only the beta flavor build
 * `patch`, `minor` or `major` for changes that affect the stable (and of course beta) flavor build as appropriate.
 * `none` for documentation changes etc that don't affect the NPM bundle meaningfully.
-
-# Conditionally Adding a E2E test
-
-Conditional compilation creates a problem with the e2e tests. The tests themselves are not actually conditionally compiled, while the applications themselves are served in the different flavors.
-
-So when adding a new test to the suite keep this in mind and use the following call:
-
-```TypeScript
-test.skip(isTestProfileStableFlavor());
-```
-
-The `isTestProfileStableFlavor()` function is checking the environment variables of the session to check what flavor it is running in since it wont conditionally compile the test out.

--- a/packages/react-composites/scripts/runBrowserTests.mjs
+++ b/packages/react-composites/scripts/runBrowserTests.mjs
@@ -123,8 +123,6 @@ async function runOne(testRoot, args, composite, hermeticity) {
     // Snapshots are always stored with the original test sources, even when the test root
     // is different due to preprocessed test files.
     SNAPSHOT_DIR: path.join(SNAPSHOT_ROOT, getBuildFlavor()),
-    // TODO(prprabhu) Drop this envvar once tests stop using `isTestProfileStableFlavor()`.
-    COMMUNICATION_REACT_FLAVOR: getBuildFlavor(),
     PLAYWRIGHT_OUTPUT_DIR: path.join(BASE_OUTPUT_DIR, Date.now().toString())
   };
 

--- a/packages/react-composites/tests/README.md
+++ b/packages/react-composites/tests/README.md
@@ -110,14 +110,30 @@ When developing (hermetic or live) browswer tests, use the following workflow:
 
 ### Conditional Compilation
 
+Just like the rest of the UI library code, the test applications and the browser tests use conditional compilation.
 For a primer on conditional compilation in this repository, see the [top-level docs](../../../docs/references/beta-only-features.md).
 
-Just like the rest of the UI library code, the test applications for browser tests use conditional compilation. By contrast, the browser tests themselves are not conditionally compiled (yet!).
+Most commonly, you may want to write a test that runs only when a conditionally compiled feature is enabled or disabled. A common pattern for this is to define a helper function that uses conditional compilation, and use `test.skip()`:
 
-For now, you must explicitly skip tests that are not relevant to stable flavored builds via [`isTestProfileStableFlavor()`](./browser/common/utils.ts)
+```Typescript
 
-```TypeScript
-test.skip(isTestProfileStableFlavor());
+const demoFeatureEnabled = (): boolean => {
+  /* @conditional-compile-remove(demo) */
+  return true;
+  return false;
+};
+
+test('test demo feature', async () => {
+  test.skip(!demoFeatureEnabled());
+
+  // ...
+});
+
+test('test default behavior when demo feature is disabled', async () => {
+  test.skip(demoFeatureEnabled());
+
+  // ...
+});
 ```
 
 ### Mobile Only tests
@@ -127,7 +143,7 @@ If you are writing a test for only on Mobile make sure to add it to a test suite
 Once you have added your test to the appropriate suite use the following call to make sure it is not run on the desktop project:
 
 ```Typescript
-test.only('Your test name here', async ({ pages }, testInfo) => {
+test('Your test name here', async ({ pages }, testInfo) => {
     // Mobile check
     test.skip(skipTestIfDesktop(testInfo));
     '...'

--- a/packages/react-composites/tests/browser/call/hermetic/PeoplePane.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/PeoplePane.test.ts
@@ -14,7 +14,6 @@ import {
   dataUiId,
   isTestProfileDesktop,
   isTestProfileMobile,
-  isTestProfileStableFlavor,
   pageClick,
   perStepLocalTimeout,
   stableScreenshot,

--- a/packages/react-composites/tests/browser/common/utils.ts
+++ b/packages/react-composites/tests/browser/common/utils.ts
@@ -394,20 +394,6 @@ export const isTestProfileDesktop = (testInfo: TestInfo): boolean => {
   return testName.includes('desktop') ? true : false;
 };
 
-/**
- * Helper function to determine whether to skip a test for a beta feature in stable test run.
- */
-export const isTestProfileStableFlavor = (): boolean => {
-  const flavor = process.env?.['COMMUNICATION_REACT_FLAVOR'];
-  if (flavor === 'stable') {
-    return true;
-  } else if (flavor === 'beta') {
-    return false;
-  } else {
-    throw 'Faled to find Communication React Flavor env variable';
-  }
-};
-
 export interface StubOptions {
   /** Stub out all timestamps in the chat message thread. */
   stubMessageTimestamps?: boolean;


### PR DESCRIPTION
We can now conditionally compile browser tests!

This PR drops the old helper that checked build flavor at runtime and updates documentation to refer to the new and improved way to write feature-specific browser tests.