### PR TITLE
Add tooling support to maintain separate stable and beta change logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ test-results/
 # Ignore the default name used by beachball, allowing just the top-level
 # ./CHANGELOG.md as the entry point.
 */**/CHANGELOG.md
+# Used by tooling to stash away change files for stable build
+change-stable/

--- a/change/@internal-storybook-a31c2a41-166f-4ca5-81c0-dcb57a2c5c60.json
+++ b/change/@internal-storybook-a31c2a41-166f-4ca5-81c0-dcb57a2c5c60.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "xkcd",
+  "packageName": "@internal/storybook",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -12,8 +12,8 @@
     {
       "commandKind": "global",
       "name": "changelog",
-      "summary": "Runs beachball change",
-      "shellCommand": "node common/config/node_modules/beachball/bin/beachball",
+      "summary": "Generate change files",
+      "shellCommand": "node common/scripts/changelog/change.mjs",
       "safeForSimultaneousRushProcesses": true
     },
     {

--- a/common/scripts/changelog/change.mjs
+++ b/common/scripts/changelog/change.mjs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import fs from 'fs';
+import path from 'path';
+
+import { BEACHBALL, CHANGE_DIR, CHANGE_DIR_BETA } from './constants.mjs';
+import { exec, exec_output } from '../lib/index.mjs';
+
+const NEW_CHANGE_FILE_REGEXP = /\s*A\s*change\/(.*\.json)\s*/;
+
+async function main() {
+    await exec(`node ${BEACHBALL}`);
+    await duplicateChangeFiles();
+}
+
+async function duplicateChangeFiles() {
+    const gitLogStdout = await exec_output(`git log -1 --name-status`);
+    const newChangeFiles = parseNewChangeFiles(gitLogStdout);
+    if (newChangeFiles.length === 0) {
+        return;
+    }
+
+    console.log(`Duplicating ${newChangeFiles.length} change files into ${CHANGE_DIR_BETA}`);
+    for (const file of newChangeFiles) {
+        fs.copyFileSync(path.join(CHANGE_DIR, file), path.join(CHANGE_DIR_BETA, file));
+    }
+    await exec(`git add ${CHANGE_DIR_BETA}`);
+    await exec(`git commit -m 'Duplicate change files for beta release'`);
+}
+
+function parseNewChangeFiles(stdout) {
+    const lines = stdout.split('\n');
+    const matches = lines.map(line => line.match(NEW_CHANGE_FILE_REGEXP)).filter(match => !!match);
+    // Extract the first capture group.
+    return matches.map(match => match[1]);
+}
+
+await main();

--- a/common/scripts/changelog/change.mjs
+++ b/common/scripts/changelog/change.mjs
@@ -10,7 +10,7 @@ import { exec, exec_output } from '../lib/index.mjs';
 const NEW_CHANGE_FILE_REGEXP = /\s*A\s*change\/(.*\.json)\s*/;
 
 async function main() {
-    await exec(`node ${BEACHBALL}`);
+    await exec(`node ${BEACHBALL} -p @internal/storybook`);
     await duplicateChangeFiles();
 }
 
@@ -22,6 +22,7 @@ async function duplicateChangeFiles() {
     }
 
     console.log(`Duplicating ${newChangeFiles.length} change files into ${CHANGE_DIR_BETA}`);
+    ensureDirectory(CHANGE_DIR_BETA);
     for (const file of newChangeFiles) {
         fs.copyFileSync(path.join(CHANGE_DIR, file), path.join(CHANGE_DIR_BETA, file));
     }
@@ -34,6 +35,12 @@ function parseNewChangeFiles(stdout) {
     const matches = lines.map(line => line.match(NEW_CHANGE_FILE_REGEXP)).filter(match => !!match);
     // Extract the first capture group.
     return matches.map(match => match[1]);
+}
+
+function ensureDirectory(path) {
+    if (!fs.statSync(path, {throwIfNoEntry: false})) {
+        fs.mkdirSync(path);
+    }
 }
 
 await main();

--- a/common/scripts/changelog/changelog.mjs
+++ b/common/scripts/changelog/changelog.mjs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Workaround for generating changelog without bumping versions.
+ * Beachball doesn't expose changelog command currently.
+ * Upstream feature request: https://github.com/microsoft/beachball/issues/650
+ */
+
+import { getPackageInfos } from '../../config/node_modules/beachball/lib/monorepo/getPackageInfos.js';
+import {gatherBumpInfo} from '../../config/node_modules/beachball/lib/bump/gatherBumpInfo.js';
+import {performBump} from '../../config/node_modules/beachball/lib/bump/performBump.js';
+import { getOptions } from '../../config/node_modules/beachball/lib/options/getOptions.js';
+
+export async function generateChangelogs() {
+  const options = getOptions([]);
+  const packageInfos = getPackageInfos(options.path);
+  // Preserve(deep clone) the current packageInfo before bump, we don't change version number using beachball
+  const preservedPackages = Object.fromEntries(Object.entries(packageInfos).map(([name, info]) => ([name, clone(info)])));
+  const bumpInfo = gatherBumpInfo(options, packageInfos);
+
+  // Restore packageInfo so no bump to versions by beachball
+  for (const name in bumpInfo.packageInfos) {
+    bumpInfo.packageInfos[name] = preservedPackages[name];
+  }
+  await performBump(bumpInfo, options);
+}
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/common/scripts/changelog/collect.mjs
+++ b/common/scripts/changelog/collect.mjs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { copyFile } from 'fs/promises';
+import path from 'path';
+import { REPO_ROOT } from '../lib/constants.mjs';
+import { exec, exec_output } from "../lib/exec.mjs";
+import { CHANGE_DIR, CHANGE_DIR_BETA } from './constants.mjs';
+import { generateChangelogs } from './changelog.mjs';
+
+async function main() {
+    await ensureCleanWorkingDirectory();
+    const changelogs = await listTargetChangelogs('stable');
+
+    console.log('Will update the following CHANLOGEs:');
+    changelogs.forEach(({ target }) => {
+        console.log(`  ${target}`);
+    });
+
+    await createTemporaryChangelogs(changelogs);
+    await generateChangelogs();
+    await commitChangelogs(changelogs);
+
+    // We started by checking that the working directory was clean.
+    // So it is safe to delete any tracked working directory changes
+    // as they could only have been introduced by this script.
+    await cleanWorkingDirectory()
+}
+
+async function ensureCleanWorkingDirectory() {
+    try {
+        await exec('git diff --name-status --exit-code');
+        await exec('git diff --name-status --exit-code --cached');
+    } catch (e) {
+        throw new Error(`Detected dirty working directory: ${e}`);
+    }
+}
+
+async function listTargetChangelogs(buildFlavor) {
+    const stdout = await exec_output(`git ls-files **/CHANGELOG.${buildFlavor}.md`);
+    const subpaths = stdout.split('\n').filter(p => !!p.trim());
+    const paths = subpaths.map(p => path.join(REPO_ROOT, p));
+    return paths.map(target => ({
+        target: target,
+        temporaryFile: target.replace(`CHANGELOG.${buildFlavor}.md`, 'CHANGELOG.md')
+    }));
+}
+
+async function createTemporaryChangelogs(changelogs) {
+    console.log('Copying CHANGELOGs to temporary files...');
+    await Promise.all(changelogs.map(({ target, temporaryFile }) => {
+        return copyFile(target, temporaryFile);
+    }));
+}
+
+async function commitChangelogs(changelogs) {
+    console.log('Copying back updated CHANGELOGS...');
+    await Promise.all(changelogs.map(({ target, temporaryFile }) => {
+        return copyFile(temporaryFile, target);
+    }));
+    await exec(`git add ${changelogs.map(({ target }) => target).join(' ')}`);
+    await exec(`git add **/CHANGELOG.json`);
+    await exec(`git add ${CHANGE_DIR} ${CHANGE_DIR_BETA}`);
+    await exec('git commit -m "Collect CHANGELOGs"');
+}
+
+async function cleanWorkingDirectory() {
+    await exec(`git checkout -f`);
+}
+
+await main();

--- a/common/scripts/changelog/constants.mjs
+++ b/common/scripts/changelog/constants.mjs
@@ -7,3 +7,5 @@ import { REPO_ROOT } from '../lib/index.mjs';
 export const BEACHBALL = path.join(REPO_ROOT, 'common', 'config', 'node_modules', 'beachball', 'bin', 'beachball');
 export const CHANGE_DIR = path.join(REPO_ROOT, 'change');
 export const CHANGE_DIR_BETA = path.join(REPO_ROOT, 'change-beta');
+// .gitignored
+export const CHANGE_DIR_STABLE_TEMP = path.join(REPO_ROOT, 'change-stable');

--- a/common/scripts/changelog/constants.mjs
+++ b/common/scripts/changelog/constants.mjs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import path from 'path';
+import { REPO_ROOT } from '../lib/index.mjs';
+
+export const BEACHBALL = path.join(REPO_ROOT, 'common', 'config', 'node_modules', 'beachball', 'bin', 'beachball');
+export const CHANGE_DIR = path.join(REPO_ROOT, 'change');
+export const CHANGE_DIR_BETA = path.join(REPO_ROOT, 'change-beta');

--- a/common/scripts/lib/exec.mjs
+++ b/common/scripts/lib/exec.mjs
@@ -37,3 +37,29 @@ export async function exec(cmd, extraEnv) {
       });
     });
   }
+
+  export async function exec_output(cmd) {
+    console.log(`Running ${cmd}`);
+
+    const child = child_process.spawn(cmd, {
+      shell: true,
+      stdio: ['inherit', 'pipe', 'inherit']
+    });
+
+    return new Promise((resolve, reject) => {
+      let output = '';
+      child.stdout.on('data', (data) => {
+        output += data;
+      });
+
+      child.on('exit', (code) => {
+        if (code != 0) {
+          reject(`Child exited with non-zero code: ${code}`);
+        }
+        resolve(output);
+      });
+      child.on('error', (err) => {
+        reject(`Child failed to start: ${err}`);
+      });
+    });
+  }


### PR DESCRIPTION
See also: A somewhat simplified alternative approach in #2513

Add, and use, new tools to maintain stable and beta flavor `CHANGELOG`s separately.