### PR TITLE
Add permission API to config screen

### DIFF
--- a/change/@internal-react-composites-89afdbf7-dd01-4781-86a4-1b1a376fe1be.json
+++ b/change/@internal-react-composites-89afdbf7-dd01-4781-86a4-1b1a376fe1be.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Use permission API to get device permissions ",
+  "packageName": "@internal/react-composites",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -151,8 +151,9 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
     camera: PermissionState;
     microphone: PermissionState;
   } = {
-    camera: videoState ?? 'denied',
-    microphone: audioState ?? 'denied'
+    // fall back to using cameraPermissionGranted and microphonePermissionGranted if permission API is not supported
+    camera: videoState ?? (cameraPermissionGranted ? 'granted' : 'denied'),
+    microphone: audioState ?? (microphonePermissionGranted ? 'granted' : 'denied')
   };
   /* @conditional-compile-remove(call-readiness) */
   const networkErrors = errorBarProps.activeErrorMessages.filter((message) => message.type === 'callNetworkQualityLow');

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -44,6 +44,8 @@ import { DevicePermissionRestrictions } from '../CallComposite';
 import { ConfigurationpageErrorBar } from '../components/ConfigurationpageErrorBar';
 /* @conditional-compile-remove(call-readiness) */
 import { drawerContainerStyles } from '../styles/CallComposite.styles';
+/* @conditional-compile-remove(call-readiness) */
+import { getDevicePermissionState } from '../utils';
 
 /* @conditional-compile-remove(call-readiness) */
 const DRAWER_HIGH_Z_BAND = 99; // setting z index to  99 so that it sit above all components
@@ -83,6 +85,14 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
   const options = useAdaptedSelector(getCallingSelector(DevicesButton));
   const localDeviceSettingsHandlers = useHandlers(LocalDeviceSettings);
   const { video: cameraPermissionGranted, audio: microphonePermissionGranted } = useSelector(devicePermissionSelector);
+  /* @conditional-compile-remove(call-readiness) */
+  // use permission API to get video and audio permission state
+  const [videoState, setVideoState] = useState<PermissionState | undefined>(undefined);
+  /* @conditional-compile-remove(call-readiness) */
+  const [audioState, setAudioState] = useState<PermissionState | undefined>(undefined);
+  /* @conditional-compile-remove(call-readiness) */
+  getDevicePermissionState(setVideoState, setAudioState);
+
   let errorBarProps = usePropsFor(ErrorBar);
   const adapter = useAdapter();
   const deviceState = adapter.getState().devices;
@@ -141,8 +151,8 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
     camera: PermissionState;
     microphone: PermissionState;
   } = {
-    camera: cameraPermissionGranted ? 'granted' : 'denied',
-    microphone: microphonePermissionGranted ? 'granted' : 'denied'
+    camera: videoState ?? 'denied',
+    microphone: audioState ?? 'denied'
   };
   /* @conditional-compile-remove(call-readiness) */
   const networkErrors = errorBarProps.activeErrorMessages.filter((message) => message.type === 'callNetworkQualityLow');

--- a/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
+++ b/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
@@ -249,3 +249,24 @@ export const isDisabled = (option: boolean | { disabled: boolean } | undefined):
 
   return option.disabled;
 };
+
+/* @conditional-compile-remove(call-readiness) */
+/**
+ *
+ * This function uses permission API to determine if device permission state is granted, prompt or denied
+ * @returns whether device permission state is granted, prompt or denied
+ * If returned value is rejected, means permission API is not supported on this browser
+ * @private
+ */
+export const getDevicePermissionState = (
+  setVideoState: (state: PermissionState) => void,
+  setAudioState: (state: PermissionState) => void
+): void => {
+  navigator.permissions.query({ name: 'camera' }).then((result) => {
+    setVideoState(result.state);
+  });
+
+  navigator.permissions.query({ name: 'microphone' }).then((result) => {
+    setAudioState(result.state);
+  });
+};

--- a/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
+++ b/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
@@ -255,18 +255,28 @@ export const isDisabled = (option: boolean | { disabled: boolean } | undefined):
  *
  * This function uses permission API to determine if device permission state is granted, prompt or denied
  * @returns whether device permission state is granted, prompt or denied
- * If returned value is rejected, means permission API is not supported on this browser
+ * If permission API is not supported on this browser, do nothing and log out error
  * @private
  */
 export const getDevicePermissionState = (
   setVideoState: (state: PermissionState) => void,
   setAudioState: (state: PermissionState) => void
 ): void => {
-  navigator.permissions.query({ name: 'camera' }).then((result) => {
-    setVideoState(result.state);
-  });
+  navigator.permissions
+    .query({ name: 'camera' })
+    .then((result) => {
+      setVideoState(result.state);
+    })
+    .catch((error) => {
+      console.log(error);
+    });
 
-  navigator.permissions.query({ name: 'microphone' }).then((result) => {
-    setAudioState(result.state);
-  });
+  navigator.permissions
+    .query({ name: 'microphone' })
+    .then((result) => {
+      setAudioState(result.state);
+    })
+    .catch((error) => {
+      console.log(error);
+    });
 };


### PR DESCRIPTION
# What
Add permission API to config screen

# Why
Use permission API to get device permissions

# How Tested
Go to samples, enable call readiness, click on permission trouble shooting link, check console and see if correct permission state is logged out 

If permission api is not supported ,both audio state and video state will remain as undefined, and in this case we fall back to using calling's SDK to determine if permission is denied/ granted

