### PR TITLE
Update to newer syntax for github actions job outputs

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get datetime for alpha release name
         id: datetime
         run: |
-          echo "::set-output name=datetime::$(date +'%Y%m%d%H%M')"
+          echo "datetime=$(date +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT
 
       # Bump alpha package versions
       - name: Bump alpha package versions
@@ -70,7 +70,7 @@ jobs:
         run: |
           ver=$(jq -r .version packages/communication-react/package.json)
           echo version: $ver
-          echo "::set-output name=version::$ver"
+          echo "version=$ver" >> $GITHUB_OUTPUT
 
       # Push git tags
       - name: Create and push git tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: '14.x'
       - id: get-matrix
-        run: echo "::set-output name=matrix::$(node ./common/scripts/workflow-read-matrix.mjs)"
+        run: echo "matrix=$(node ./common/scripts/workflow-read-matrix.mjs)" >> $GITHUB_OUTPUT
 
   build_packages:
     needs: get_matrix
@@ -585,12 +585,12 @@ jobs:
         id: bundles
         run: |
           base_size=$(jq -r ".[0].parsedSize" base/report.json)
-          echo "::set-output name=base_size::${base_size}"
+          echo "base_size=${base_size}" >> $GITHUB_OUTPUT
           current_size=$(jq -r ".[0].parsedSize" current/report.json)
-          echo "::set-output name=current_size::${current_size}"
+          echo "current_size=${current_size}" >> $GITHUB_OUTPUT
           change=$([ $current_size -gt $base_size ] && echo "increased❗" || ([ $current_size = $base_size ] && echo "not changed" || echo "decreased✅"))
-          echo "::set-output name=change::${change}"
-          echo "::set-output name=diff::$(($current_size - $base_size))"
+          echo "change=${change}" >> $GITHUB_OUTPUT
+          echo "diff=$(($current_size - $base_size))" >> $GITHUB_OUTPUT
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         id: fc

--- a/.github/workflows/create-prerelease-branch.yml
+++ b/.github/workflows/create-prerelease-branch.yml
@@ -97,14 +97,14 @@ jobs:
         run: |
           ver=$(jq -r .version packages/communication-react/package.json)
           echo version: $ver
-          echo "::set-output name=version::$ver"
+          echo "version=$ver" >> $GITHUB_OUTPUT
 
       # Commit changes
       - name: Hop into new branch
         id: prereleasebranch
         run: |
           git checkout -b prerelease-${{github.event.inputs.bump_type}}/${{ steps.version.outputs.version }}
-          echo "::set-output name=prereleasebranch::prerelease-${{github.event.inputs.bump_type}}/${{ steps.version.outputs.version }}"
+          echo "prereleasebranch=prerelease-${{github.event.inputs.bump_type}}/${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
       - name: Commit changes
         run: |
           git add .
@@ -120,7 +120,7 @@ jobs:
         id: groombranch
         run: |
           git checkout -b groom-changelog-${{github.event.inputs.bumptype}}/${{ steps.version.outputs.version }}
-          echo "::set-output name=groombranch::groom-changelog-${{github.event.inputs.bumptype}}/${{ steps.version.outputs.version }}"
+          echo "groombranch=groom-changelog-${{github.event.inputs.bumptype}}/${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
 
       # Push groom changes
       - name: Create groom file and push changes

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -63,14 +63,14 @@ jobs:
         run: |
           ver=$(jq -r .version packages/communication-react/package.json)
           echo version: $ver
-          echo "::set-output name=version::$ver"
+          echo "version=$ver" >> $GITHUB_OUTPUT
 
       # Create new release branch
       - name: Hop into new branch
         id: releasebranch
         run: |
           git checkout -b release/${{ steps.version.outputs.version }}
-          echo "::set-output name=releasebranch::release/${{ steps.version.outputs.version }}"
+          echo "releasebranch=release/${{ steps.version.outputs.version }}" >> $GITHUB_OUTPUT
 
       # After forcing the dependency package versions to that for stable build, we regenerate the
       # PNPM shrinkwrap file for the *beta* build variant. This is needed because CI workflows

--- a/.github/workflows/nightly-cd.yml
+++ b/.github/workflows/nightly-cd.yml
@@ -49,9 +49,9 @@ jobs:
           echo Days since last commit: $days
 
           if [ $days = "0" ]; then
-            echo "::set-output name=hasChanged::true"
+            echo "hasChanged=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=hasChanged::false"
+            echo "hasChanged=false" >> $GITHUB_OUTPUT
           fi
 
   release:
@@ -88,7 +88,7 @@ jobs:
       - name: Get datetime for alpha release name
         id: datetime
         run: |
-          echo "::set-output name=datetime::$(date +'%Y%m%d%H%M')"
+          echo "datetime=$(date +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT
 
       # Bump alpha package versions
       - name: Bump alpha package versions
@@ -115,7 +115,7 @@ jobs:
         run: |
           ver=$(jq -r .version packages/communication-react/package.json)
           echo version: $ver
-          echo "::set-output name=version::$ver"
+          echo "version=$ver" >> $GITHUB_OUTPUT
 
       # Push git tags
       - name: Create and push git tags

--- a/.github/workflows/npm-release-publish.yml
+++ b/.github/workflows/npm-release-publish.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           ver=$(jq -r .version packages/communication-react/package.json)
           echo version: $ver
-          echo "::set-output name=version::$ver"
+          echo "version=$ver" >> $GITHUB_OUTPUT
 
       # Publish package
       - name: Package packages for release

--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -61,7 +61,7 @@ jobs:
           echo "Storybook URL before: $storybookurl"
           newurl=${storybookurl/%iframe.html}
           echo "Storybook URL after: $newurl"
-          echo "::set-output name=url::$newurl"
+          echo "url=$newurl" >> $GITHUB_OUTPUT
 
       - name: Add Storybook URL as Issue Comment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/update-api-files.yml
+++ b/.github/workflows/update-api-files.yml
@@ -71,9 +71,9 @@ jobs:
         run: |
           if [[ -z $(git status packages -s) ]]
           then
-            echo "::set-output name=hasChanged::false"
+            echo "hasChanged=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=hasChanged::true"
+            echo "hasChanged=true" >> $GITHUB_OUTPUT
           fi
       - name: Commit new snapshots
         if: ${{ always() && steps.changescheck.outputs.hasChanged == 'true' }}

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Found workflow disptach
         id: workflow_dispatch
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: echo "::set-output name=found::true"
+        run: echo "found=true" >> $GITHUB_OUTPUT
       - name: Found required label
         id: label
         if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'update_snapshots') }}
@@ -36,7 +36,7 @@ jobs:
           # Required for running `gh`.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::set-output name=found::true"
+          echo "found=true" >> $GITHUB_OUTPUT
           gh pr edit ${{ github.event.number }} --remove-label update_snapshots
 
   get_matrix:
@@ -55,7 +55,7 @@ jobs:
         with:
           node-version: '14.x'
       - id: get-matrix
-        run: echo "::set-output name=matrix::$(node ./common/scripts/workflow-read-matrix.mjs)"
+        run: echo "matrix=$(node ./common/scripts/workflow-read-matrix.mjs)" >> $GITHUB_OUTPUT
 
   component_examples:
     needs: [precondition, get_matrix]
@@ -123,9 +123,9 @@ jobs:
         run: |
           if [[ -z $(git status samples/tests -s) ]]
           then
-            echo "::set-output name=hasChanged::false"
+            echo "hasChanged=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=hasChanged::true"
+            echo "hasChanged=true" >> $GITHUB_OUTPUT
             exit
           fi
       - name: Create a patch file for snapshot updates
@@ -207,9 +207,9 @@ jobs:
         run: |
           if [[ -z $(git status samples/tests -s) ]]
           then
-            echo "::set-output name=hasChanged::false"
+            echo "hasChanged=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=hasChanged::true"
+            echo "hasChanged=true" >> $GITHUB_OUTPUT
             exit
           fi
       - name: Push new snapshots, if any
@@ -298,9 +298,9 @@ jobs:
         run: |
           if [[ -z $(git status packages -s) ]]
           then
-            echo "::set-output name=hasChanged::false"
+            echo "hasChanged=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=hasChanged::true"
+            echo "hasChanged=true" >> $GITHUB_OUTPUT
           fi
       - name: Push new snapshots, if any
         if: ${{ steps.changescheck.outputs.hasChanged == 'true' }}
@@ -388,9 +388,9 @@ jobs:
         run: |
           if [[ -z $(git status packages -s) ]]
           then
-            echo "::set-output name=hasChanged::false"
+            echo "hasChanged=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=hasChanged::true"
+            echo "hasChanged=true" >> $GITHUB_OUTPUT
           fi
       - name: Push new snapshots, if any
         if: ${{ steps.changescheck.outputs.hasChanged == 'true' }}
@@ -478,9 +478,9 @@ jobs:
         run: |
           if [[ -z $(git status packages -s) ]]
           then
-            echo "::set-output name=hasChanged::false"
+            echo "hasChanged=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=hasChanged::true"
+            echo "hasChanged=true" >> $GITHUB_OUTPUT
           fi
       - name: Push new snapshots, if any
         if: ${{ steps.changescheck.outputs.hasChanged == 'true' }}


### PR DESCRIPTION
# What
Update to use the newer github action syntax for setting output variables of jobs

# Why
GitHub is deprecating the old syntax on May 31st 2023: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

# How Tested
CI will verify the ci.yml, nightly alpha will do further useful tests. And hopefully given its the name change to all everything will auto work if they both pass.