### PR TITLE
[DO NOT REVIEW] Demonstration of `CHANGELOG.beta.md` collection

### DIFF
--- a/change-beta/@internal-acs-ui-common-18c7bb0b-752a-4f6d-8490-60a1e5c5c5ee.json
+++ b/change-beta/@internal-acs-ui-common-18c7bb0b-752a-4f6d-8490-60a1e5c5c5ee.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Bumped",
-  "packageName": "@internal/acs-ui-common",
-  "email": "41898282+github-actions[bot]@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-acs-ui-common-358e1672-866d-4320-b7c4-48b8765054c4.json
+++ b/change-beta/@internal-acs-ui-common-358e1672-866d-4320-b7c4-48b8765054c4.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "something",
-  "packageName": "@internal/acs-ui-common",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-acs-ui-common-e5247f10-1c57-4293-a031-fa0d8e1ab34b.json
+++ b/change-beta/@internal-acs-ui-common-e5247f10-1c57-4293-a031-fa0d8e1ab34b.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Document template of the application ID used for telemetry",
-  "packageName": "@internal/acs-ui-common",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-calling-component-bindings-00117528-831f-4b99-a7cb-98e93037268a.json
+++ b/change-beta/@internal-calling-component-bindings-00117528-831f-4b99-a7cb-98e93037268a.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Added role to selectors",
-  "packageName": "@internal/calling-component-bindings",
-  "email": "miguelgamis@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-calling-component-bindings-1ffb5d4c-a01f-4f8b-9bba-f24f957377a1.json
+++ b/change-beta/@internal-calling-component-bindings-1ffb5d4c-a01f-4f8b-9bba-f24f957377a1.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "else",
-  "packageName": "@internal/calling-component-bindings",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-calling-component-bindings-a8251982-cecf-4275-8186-85b45744bb37.json
+++ b/change-beta/@internal-calling-component-bindings-a8251982-cecf-4275-8186-85b45744bb37.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Stable release branch hotfix: Fix camera turning back on when turned off on connecting screen (#2458)",
-  "packageName": "@internal/calling-component-bindings",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-calling-component-bindings-b0daf152-9368-402a-b2d0-ba691a513746.json
+++ b/change-beta/@internal-calling-component-bindings-b0daf152-9368-402a-b2d0-ba691a513746.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Bumped",
-  "packageName": "@internal/calling-component-bindings",
-  "email": "41898282+github-actions[bot]@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-calling-component-bindings-b1f0f14e-6b44-46d4-ad22-5e42c1d2dd14.json
+++ b/change-beta/@internal-calling-component-bindings-b1f0f14e-6b44-46d4-ad22-5e42c1d2dd14.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Filter out devices with blank names",
-  "packageName": "@internal/calling-component-bindings",
-  "email": "miguelgamis@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-calling-component-bindings-cbb09ccd-5da4-4e52-a11f-5c4a933a82eb.json
+++ b/change-beta/@internal-calling-component-bindings-cbb09ccd-5da4-4e52-a11f-5c4a933a82eb.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Allow a range of communication services dependency packages",
-  "packageName": "@internal/calling-component-bindings",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-calling-stateful-client-15e218b4-c9b3-48ee-9d37-14269094b912.json
+++ b/change-beta/@internal-calling-stateful-client-15e218b4-c9b3-48ee-9d37-14269094b912.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Allow a range of communication services dependency packages",
-  "packageName": "@internal/calling-stateful-client",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-calling-stateful-client-4773beb8-0da0-4c11-805c-aaf6e7fd6cf8.json
+++ b/change-beta/@internal-calling-stateful-client-4773beb8-0da0-4c11-805c-aaf6e7fd6cf8.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Filter out camera devices with blank name when declarative device manager is used.",
-  "packageName": "@internal/calling-stateful-client",
-  "email": "anjulgarg@live.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-calling-stateful-client-8010c09c-1bc6-4f82-9a12-7d2383b46324.json
+++ b/change-beta/@internal-calling-stateful-client-8010c09c-1bc6-4f82-9a12-7d2383b46324.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "boo",
-  "packageName": "@internal/calling-stateful-client",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-calling-stateful-client-92a99c37-136c-460d-bab5-7d91a5fb7eac.json
+++ b/change-beta/@internal-calling-stateful-client-92a99c37-136c-460d-bab5-7d91a5fb7eac.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Bumped",
-  "packageName": "@internal/calling-stateful-client",
-  "email": "41898282+github-actions[bot]@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-calling-stateful-client-de632f42-dd38-461a-9115-720cb30fe84f.json
+++ b/change-beta/@internal-calling-stateful-client-de632f42-dd38-461a-9115-720cb30fe84f.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add rooms role into calling stateful client",
-  "packageName": "@internal/calling-stateful-client",
-  "email": "miguelgamis@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-calling-stateful-client-e108bf17-9cc5-4189-9c8f-66acc0b48938.json
+++ b/change-beta/@internal-calling-stateful-client-e108bf17-9cc5-4189-9c8f-66acc0b48938.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Only export DeclarativeCallAgent in beta build",
-  "packageName": "@internal/calling-stateful-client",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-calling-stateful-client-eb705db4-7ad2-4024-a1e6-0d49a85188b2.json
+++ b/change-beta/@internal-calling-stateful-client-eb705db4-7ad2-4024-a1e6-0d49a85188b2.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add TeamsCall and TeamsCallAgent to StatefulClient",
-  "packageName": "@internal/calling-stateful-client",
-  "email": "jinan@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-calling-stateful-client-feff7329-c8ce-4585-83f1-f9817a635084.json
+++ b/change-beta/@internal-calling-stateful-client-feff7329-c8ce-4585-83f1-f9817a635084.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Remove DeclarativeCallAgent from stable API",
-  "packageName": "@internal/calling-stateful-client",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-chat-component-bindings-2c00c76e-0907-447e-8a2f-b3d6f89a803b.json
+++ b/change-beta/@internal-chat-component-bindings-2c00c76e-0907-447e-8a2f-b3d6f89a803b.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Bumped",
-  "packageName": "@internal/chat-component-bindings",
-  "email": "41898282+github-actions[bot]@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-chat-component-bindings-dc2510fd-4dab-470b-a9d4-83c5cc9d9ed1.json
+++ b/change-beta/@internal-chat-component-bindings-dc2510fd-4dab-470b-a9d4-83c5cc9d9ed1.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "doo",
-  "packageName": "@internal/chat-component-bindings",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-chat-component-bindings-ff00e6da-942e-4a4f-8014-003f95efba62.json
+++ b/change-beta/@internal-chat-component-bindings-ff00e6da-942e-4a4f-8014-003f95efba62.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Allow a range of communication services dependency packages",
-  "packageName": "@internal/chat-component-bindings",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-chat-stateful-client-22169c0f-872e-4a8c-a00c-3c099fe02622.json
+++ b/change-beta/@internal-chat-stateful-client-22169c0f-872e-4a8c-a00c-3c099fe02622.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "gee",
-  "packageName": "@internal/chat-stateful-client",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-chat-stateful-client-727ea099-eee6-41f7-800a-2be89e999fb8.json
+++ b/change-beta/@internal-chat-stateful-client-727ea099-eee6-41f7-800a-2be89e999fb8.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Bumped",
-  "packageName": "@internal/chat-stateful-client",
-  "email": "41898282+github-actions[bot]@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-chat-stateful-client-9fb87c9e-3647-4483-86b4-24ba3307985b.json
+++ b/change-beta/@internal-chat-stateful-client-9fb87c9e-3647-4483-86b4-24ba3307985b.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Allow a range of communication services dependency packages",
-  "packageName": "@internal/chat-stateful-client",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-chat-stateful-client-bd3e4081-e838-4f5f-8eed-5d5b00cbce11.json
+++ b/change-beta/@internal-chat-stateful-client-bd3e4081-e838-4f5f-8eed-5d5b00cbce11.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix issue where typingIndicator errors were not being caught by the ChatAdapter.",
-  "packageName": "@internal/chat-stateful-client",
-  "email": "94866715+dmceachernmsft@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-fake-backends-0652162d-793a-4636-acc4-e088631462a7.json
+++ b/change-beta/@internal-fake-backends-0652162d-793a-4636-acc4-e088631462a7.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Bumped",
-  "packageName": "@internal/fake-backends",
-  "email": "41898282+github-actions[bot]@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-fake-backends-5715872f-5c47-4ad5-9214-2ce443dc0e55.json
+++ b/change-beta/@internal-fake-backends-5715872f-5c47-4ad5-9214-2ce443dc0e55.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Allow a range of communication services dependency packages",
-  "packageName": "@internal/fake-backends",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-fake-backends-e08ab826-854c-4e05-92c9-c96896dca598.json
+++ b/change-beta/@internal-fake-backends-e08ab826-854c-4e05-92c9-c96896dca598.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "gee",
-  "packageName": "@internal/fake-backends",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-072cc54d-a247-459c-b8a8-8101ff98f2e2.json
+++ b/change-beta/@internal-react-components-072cc54d-a247-459c-b8a8-8101ff98f2e2.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Update html-to-react dependency. Note: This change requires Webpack > 4.",
-  "packageName": "@internal/react-components",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-07857752-97a4-45c4-aa09-94d66add76de.json
+++ b/change-beta/@internal-react-components-07857752-97a4-45c4-aa09-94d66add76de.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add missing PSTN conditional compilation",
-  "packageName": "@internal/react-components",
-  "email": "edwardlee@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-components-0fbe78f6-c749-429e-9950-68f078c9a8b1.json
+++ b/change-beta/@internal-react-components-0fbe78f6-c749-429e-9950-68f078c9a8b1.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Create a device ermissions sub directory",
-  "packageName": "@internal/react-components",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-components-17350fae-92fc-4220-811e-ca9e5873f925.json
+++ b/change-beta/@internal-react-components-17350fae-92fc-4220-811e-ca9e5873f925.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "setting icon definition to undefined if icon is already defined by fluent",
-  "packageName": "@internal/react-components",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-4e04756b-f2a8-428f-abac-91ecbd350452.json
+++ b/change-beta/@internal-react-components-4e04756b-f2a8-428f-abac-91ecbd350452.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "change device permission component string prop to optional",
-  "packageName": "@internal/react-components",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-4ff6ba96-0e55-4fae-b35d-289e192f9bf3.json
+++ b/change-beta/@internal-react-components-4ff6ba96-0e55-4fae-b35d-289e192f9bf3.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add data ui id to device  permission component",
-  "packageName": "@internal/react-components",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-components-52ad3261-a826-4a74-9f6e-f7899d9dc84f.json
+++ b/change-beta/@internal-react-components-52ad3261-a826-4a74-9f6e-f7899d9dc84f.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Refresh string translations",
-  "packageName": "@internal/react-components",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-54ea79fc-a7a3-49fb-9f60-f0981fe3d82a.json
+++ b/change-beta/@internal-react-components-54ea79fc-a7a3-49fb-9f60-f0981fe3d82a.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "jee",
-  "packageName": "@internal/react-components",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-62f79fe2-3683-4827-be7b-d5d8d276a910.json
+++ b/change-beta/@internal-react-components-62f79fe2-3683-4827-be7b-d5d8d276a910.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Fix dtmf dialpad behavior to allow constant visibility of tone sent last.",
-  "packageName": "@internal/react-components",
-  "email": "94866715+dmceachernmsft@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-6d111696-41d7-49bb-a2db-96c3e92ac88a.json
+++ b/change-beta/@internal-react-components-6d111696-41d7-49bb-a2db-96c3e92ac88a.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Remove padding and margins from base dialpad component.",
-  "packageName": "@internal/react-components",
-  "email": "94866715+dmceachernmsft@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-70e6f68e-ff81-4867-bcd3-287adb709bcb.json
+++ b/change-beta/@internal-react-components-70e6f68e-ff81-4867-bcd3-287adb709bcb.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Make components string optional",
-  "packageName": "@internal/react-components",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-8f431b65-0af5-49fb-baa0-06243a9b6132.json
+++ b/change-beta/@internal-react-components-8f431b65-0af5-49fb-baa0-06243a9b6132.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add ability to style a failed chat message (fixes #2257)",
-  "packageName": "@internal/react-components",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-components-90a4197d-a05c-4b8b-a75c-fccdb1fcfd44.json
+++ b/change-beta/@internal-react-components-90a4197d-a05c-4b8b-a75c-fccdb1fcfd44.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Fix dark mode text for TroubleshootingGuideErrorBar messages",
-  "packageName": "@internal/react-components",
-  "email": "edwardlee@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-9d9bf909-9f1a-4639-8ffe-1074bd8f2925.json
+++ b/change-beta/@internal-react-components-9d9bf909-9f1a-4639-8ffe-1074bd8f2925.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add domain permission denied prompt pure UI component",
-  "packageName": "@internal/react-components",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-bcecef4f-ab3b-4bf9-9aa7-f4855a72c273.json
+++ b/change-beta/@internal-react-components-bcecef4f-ab3b-4bf9-9aa7-f4855a72c273.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "New individual camera and microphone permission modals",
-  "packageName": "@internal/react-components",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-d1226ee2-d5ac-43b5-bd50-021d08c81673.json
+++ b/change-beta/@internal-react-components-d1226ee2-d5ac-43b5-bd50-021d08c81673.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Enabled troubleshooting guide error bar to display network error guide/device error guide based on error type ",
-  "packageName": "@internal/react-components",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-e29d9f96-5622-4039-9a8e-bfceb9a045f2.json
+++ b/change-beta/@internal-react-components-e29d9f96-5622-4039-9a8e-bfceb9a045f2.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Bugfix mute indicator color not matching display name",
-  "packageName": "@internal/react-components",
-  "email": "anjulgarg@live.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-e8853d1c-c770-4ac8-bc8b-5a3ac7f734f6.json
+++ b/change-beta/@internal-react-components-e8853d1c-c770-4ac8-bc8b-5a3ac7f734f6.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Bumped",
-  "packageName": "@internal/react-components",
-  "email": "41898282+github-actions[bot]@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-components-e9cd63ce-7fcd-4afb-a8d9-c4cd58eb8088.json
+++ b/change-beta/@internal-react-components-e9cd63ce-7fcd-4afb-a8d9-c4cd58eb8088.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Added role to CallParticipantListParticipant type",
-  "packageName": "@internal/react-components",
-  "email": "miguelgamis@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-f7c9d8b9-3b9b-4489-b6f7-f35521c966fc.json
+++ b/change-beta/@internal-react-components-f7c9d8b9-3b9b-4489-b6f7-f35521c966fc.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add checking device permission prompt pure ui component",
-  "packageName": "@internal/react-components",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-components-fd1e2070-a9d9-4152-92a0-9f576a5e4321.json
+++ b/change-beta/@internal-react-components-fd1e2070-a9d9-4152-92a0-9f576a5e4321.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Bump dependencies to get closer to react 18 support",
-  "packageName": "@internal/react-components",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-0c1fbf71-b066-4288-b003-a41e925191df.json
+++ b/change-beta/@internal-react-composites-0c1fbf71-b066-4288-b003-a41e925191df.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix a string name and restrict it to beta builds",
-  "packageName": "@internal/react-composites",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-0d94c318-0522-4ac7-a3b4-dc495fb5e32c.json
+++ b/change-beta/@internal-react-composites-0d94c318-0522-4ac7-a3b4-dc495fb5e32c.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add TeamsCall and TeamsCallAgent to StatefulClient",
-  "packageName": "@internal/react-composites",
-  "email": "jinan@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-composites-1924a7eb-a156-47a4-8545-976c97f5982c.json
+++ b/change-beta/@internal-react-composites-1924a7eb-a156-47a4-8545-976c97f5982c.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Update pro based on newer api (no functional change)",
-  "packageName": "@internal/react-composites",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-composites-322b7bf6-a136-4c22-967c-9ecf989054a9.json
+++ b/change-beta/@internal-react-composites-322b7bf6-a136-4c22-967c-9ecf989054a9.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "zdc",
-  "packageName": "@internal/react-composites",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-3f887cc4-39ab-422a-805e-0acda349314c.json
+++ b/change-beta/@internal-react-composites-3f887cc4-39ab-422a-805e-0acda349314c.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add missing PSTN conditional compilation",
-  "packageName": "@internal/react-composites",
-  "email": "edwardlee@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-composites-40288e5b-06bf-4b35-afe3-f33e70b2d9ed.json
+++ b/change-beta/@internal-react-composites-40288e5b-06bf-4b35-afe3-f33e70b2d9ed.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix remove participant logic for teams user. Make sure to enforce isRemovable property on participantList participant.",
-  "packageName": "@internal/react-composites",
-  "email": "94866715+dmceachernmsft@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-43594bee-c7ad-484e-a7e6-844473bba4f6.json
+++ b/change-beta/@internal-react-composites-43594bee-c7ad-484e-a7e6-844473bba4f6.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add enable call readiness option for Call and CallWithChat composite",
-  "packageName": "@internal/react-composites",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-4588bf72-bbfd-44d0-bd37-38ce8574b55e.json
+++ b/change-beta/@internal-react-composites-4588bf72-bbfd-44d0-bd37-38ce8574b55e.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Revert breaking API change in `CallEndedListener` callback",
-  "packageName": "@internal/react-composites",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-51414866-d176-4b92-a920-8adf3a59943a.json
+++ b/change-beta/@internal-react-composites-51414866-d176-4b92-a920-8adf3a59943a.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Moved roleHint prop of CallComposite to CallAdapter state.",
-  "packageName": "@internal/react-composites",
-  "email": "miguelgamis@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-5aae8c05-8076-4768-a614-e2ef5185045a.json
+++ b/change-beta/@internal-react-composites-5aae8c05-8076-4768-a614-e2ef5185045a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Focus on participant list when opening people pane",
-  "packageName": "@internal/react-composites",
-  "email": "edwardlee@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-67dd40e6-5ec1-4a04-8b93-419e2d4f4d4e.json
+++ b/change-beta/@internal-react-composites-67dd40e6-5ec1-4a04-8b93-419e2d4f4d4e.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Bumped",
-  "packageName": "@internal/react-composites",
-  "email": "41898282+github-actions[bot]@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-composites-73b66db0-0957-4b1e-9ac5-633d26d5d65f.json
+++ b/change-beta/@internal-react-composites-73b66db0-0957-4b1e-9ac5-633d26d5d65f.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Allow a range of communication services dependency packages",
-  "packageName": "@internal/react-composites",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-789aa640-c146-47ff-909d-f82cc4c901cc.json
+++ b/change-beta/@internal-react-composites-789aa640-c146-47ff-909d-f82cc4c901cc.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add support for conditionally compiled browser tests",
-  "packageName": "@internal/react-composites",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-composites-7975b359-9a1e-4de8-9095-52bf42483025.json
+++ b/change-beta/@internal-react-composites-7975b359-9a1e-4de8-9095-52bf42483025.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Config page local preview does not show a black screen when camera devices are removed.",
-  "packageName": "@internal/react-composites",
-  "email": "anjulgarg@live.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-7b581072-3ab8-4b7d-ba87-215bb6299056.json
+++ b/change-beta/@internal-react-composites-7b581072-3ab8-4b7d-ba87-215bb6299056.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "browser tests: drop runtime test for build flavor environment variable",
-  "packageName": "@internal/react-composites",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-composites-7cc319fa-75a7-4732-b1fb-a9425738de8d.json
+++ b/change-beta/@internal-react-composites-7cc319fa-75a7-4732-b1fb-a9425738de8d.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix issue where typingIndicator errors were not being caught by the ChatAdapter",
-  "packageName": "@internal/react-composites",
-  "email": "94866715+dmceachernmsft@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-80d4e55b-e46f-462b-bd4d-276e2a610d07.json
+++ b/change-beta/@internal-react-composites-80d4e55b-e46f-462b-bd4d-276e2a610d07.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Bump dependencies to get closer to react 18 support",
-  "packageName": "@internal/react-composites",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-837e0e2b-b70a-43d5-921b-fb7bffa1f5de.json
+++ b/change-beta/@internal-react-composites-837e0e2b-b70a-43d5-921b-fb7bffa1f5de.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Access role from stateful call client in CallComposite and changed CallComposite prop name from role to roleHint.",
-  "packageName": "@internal/react-composites",
-  "email": "miguelgamis@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-88e499bf-7a84-4502-9043-8015b78f8998.json
+++ b/change-beta/@internal-react-composites-88e499bf-7a84-4502-9043-8015b78f8998.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Update names",
-  "packageName": "@internal/react-composites",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-composites-89afdbf7-dd01-4781-86a4-1b1a376fe1be.json
+++ b/change-beta/@internal-react-composites-89afdbf7-dd01-4781-86a4-1b1a376fe1be.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Use permission API to get device permissions ",
-  "packageName": "@internal/react-composites",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-react-composites-8b4997f7-a5cb-4701-9fef-49b506ac6236.json
+++ b/change-beta/@internal-react-composites-8b4997f7-a5cb-4701-9fef-49b506ac6236.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Introduce e2e tests for lobby screen in calling composite to validate experience for different call types.",
-  "packageName": "@internal/react-composites",
-  "email": "94866715+dmceachernmsft@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-93739eae-6467-4523-af0e-4afbe6d8c5c9.json
+++ b/change-beta/@internal-react-composites-93739eae-6467-4523-af0e-4afbe6d8c5c9.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add troubleshooting error bar to call composite config ",
-  "packageName": "@internal/react-composites",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-9f8105ae-f465-4f74-9f28-f1180e2a3d0a.json
+++ b/change-beta/@internal-react-composites-9f8105ae-f465-4f74-9f28-f1180e2a3d0a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Fix CallWithChatPane drawer menu that stays open after switching mobile tabs",
-  "packageName": "@internal/react-composites",
-  "email": "miguelgamis@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-a264c3d5-cdfc-4887-92b6-baf6fe3b7d75.json
+++ b/change-beta/@internal-react-composites-a264c3d5-cdfc-4887-92b6-baf6fe3b7d75.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "setting icon definition to undefined if icon is already defined by fluent",
-  "packageName": "@internal/react-composites",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-a40ea921-274f-4e9d-ae55-8c5462c88070.json
+++ b/change-beta/@internal-react-composites-a40ea921-274f-4e9d-ae55-8c5462c88070.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Fix dtmf dialpad behavior to allow constant visibility of tone sent last.",
-  "packageName": "@internal/react-composites",
-  "email": "94866715+dmceachernmsft@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-b040d2b8-ef6c-4fa0-955f-6d8d97a20e36.json
+++ b/change-beta/@internal-react-composites-b040d2b8-ef6c-4fa0-955f-6d8d97a20e36.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Added getRole selector",
-  "packageName": "@internal/react-composites",
-  "email": "miguelgamis@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-c94e387e-a4c4-4baa-b97b-f4ecf3986da0.json
+++ b/change-beta/@internal-react-composites-c94e387e-a4c4-4baa-b97b-f4ecf3986da0.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Refresh string translations",
-  "packageName": "@internal/react-composites",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-ebfaa79a-ab0d-43b6-9400-5fd7e447f271.json
+++ b/change-beta/@internal-react-composites-ebfaa79a-ab0d-43b6-9400-5fd7e447f271.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add allow access modal to configuration screen",
-  "packageName": "@internal/react-composites",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-f36db029-fbe5-41e2-9c1a-052110138500.json
+++ b/change-beta/@internal-react-composites-f36db029-fbe5-41e2-9c1a-052110138500.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add device permission drawer to calling mobile config screen",
-  "packageName": "@internal/react-composites",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-react-composites-fcfc34c7-0f03-4336-9e24-518abb812687.json
+++ b/change-beta/@internal-react-composites-fcfc34c7-0f03-4336-9e24-518abb812687.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Increase max listener limit to remove warning in console",
-  "packageName": "@internal/react-composites",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-storybook-04a48fd2-f18d-4593-b986-81a684a43b07.json
+++ b/change-beta/@internal-storybook-04a48fd2-f18d-4593-b986-81a684a43b07.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Clean up storybook quickstart setup page",
-  "packageName": "@internal/storybook",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-storybook-0cc768d4-6c1b-4489-829a-d2e12e7f7604.json
+++ b/change-beta/@internal-storybook-0cc768d4-6c1b-4489-829a-d2e12e7f7604.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Bump dependencies to get closer to react 18 support",
-  "packageName": "@internal/storybook",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-storybook-129a9fcb-bbc7-4af3-a5bf-d762a10c02d0.json
+++ b/change-beta/@internal-storybook-129a9fcb-bbc7-4af3-a5bf-d762a10c02d0.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Updated troubleshooting error bar storybook ",
-  "packageName": "@internal/storybook",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-storybook-2e8ec229-8cbf-4ab3-98f9-66f0e871777a.json
+++ b/change-beta/@internal-storybook-2e8ec229-8cbf-4ab3-98f9-66f0e871777a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Move icon register code to manager to avoid re-register warning on load",
-  "packageName": "@internal/storybook",
-  "email": "carolinecao@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-storybook-35262f4a-0742-4e83-b8c6-7be0c0f7ac6f.json
+++ b/change-beta/@internal-storybook-35262f4a-0742-4e83-b8c6-7be0c0f7ac6f.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "cc",
-  "packageName": "@internal/storybook",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-storybook-440ace3d-5c4b-40f7-be24-cb685210f659.json
+++ b/change-beta/@internal-storybook-440ace3d-5c4b-40f7-be24-cb685210f659.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Update domain permissions story to have checking device permissions type",
-  "packageName": "@internal/storybook",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-storybook-781ef7fd-6c5c-4a82-b562-5466477b6cbc.json
+++ b/change-beta/@internal-storybook-781ef7fd-6c5c-4a82-b562-5466477b6cbc.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Bumped",
-  "packageName": "@internal/storybook",
-  "email": "41898282+github-actions[bot]@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-storybook-a31c2a41-166f-4ca5-81c0-dcb57a2c5c60.json
+++ b/change-beta/@internal-storybook-a31c2a41-166f-4ca5-81c0-dcb57a2c5c60.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "xkcd",
-  "packageName": "@internal/storybook",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-storybook-a99bbae0-b7c5-4e63-9aef-262f58944017.json
+++ b/change-beta/@internal-storybook-a99bbae0-b7c5-4e63-9aef-262f58944017.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Update internal story to have denied vs request domain permission skus",
-  "packageName": "@internal/storybook",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-storybook-c48ec1c8-3e81-40e3-9828-520fcd106f06.json
+++ b/change-beta/@internal-storybook-c48ec1c8-3e81-40e3-9828-520fcd106f06.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add stories for individual camera and mic permission modals in internal folder",
-  "packageName": "@internal/storybook",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@internal-storybook-cb960e4d-b3ab-4566-a609-14a2ceef145d.json
+++ b/change-beta/@internal-storybook-cb960e4d-b3ab-4566-a609-14a2ceef145d.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Allow a range of communication services dependency packages",
-  "packageName": "@internal/storybook",
-  "email": "82062616+prprabhu-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@internal-storybook-f359b390-2a8f-472c-9495-a2bcf93f3068.json
+++ b/change-beta/@internal-storybook-f359b390-2a8f-472c-9495-a2bcf93f3068.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Add documentation for minimum typescript and webpack versions.",
-  "packageName": "@internal/storybook",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/acs-ui-common/CHANGELOG.json
+++ b/packages/acs-ui-common/CHANGELOG.json
@@ -2,6 +2,35 @@
   "name": "@internal/acs-ui-common",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:33 GMT",
+      "tag": "@internal/acs-ui-common_v1.4.1-beta.0",
+      "version": "1.4.1-beta.0",
+      "comments": {
+        "none": [
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/acs-ui-common",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/acs-ui-common",
+            "commit": "807c931ca9bdc6813b08c1e01bd60f4131be089e",
+            "comment": "Document template of the application ID used for telemetry"
+          }
+        ],
+        "prerelease": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/acs-ui-common",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "something"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:09 GMT",
       "tag": "@internal/acs-ui-common_v1.4.0",
       "version": "1.4.0",

--- a/packages/calling-component-bindings/CHANGELOG.json
+++ b/packages/calling-component-bindings/CHANGELOG.json
@@ -2,6 +2,73 @@
   "name": "@internal/calling-component-bindings",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:33 GMT",
+      "tag": "@internal/calling-component-bindings_v1.4.1-beta.0",
+      "version": "1.4.1-beta.0",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "3d491b8aa403a607549999607b789da7c13c503f",
+            "comment": "Added role to selectors"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "else"
+          }
+        ],
+        "none": [
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "6b4049475e182608504163b25d62692a6f781e7f",
+            "comment": "Stable release branch hotfix: Fix camera turning back on when turned off on connecting screen (#2458)"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          }
+        ],
+        "patch": [
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "4bc76af77fc4f4e108de10b8a6e4227348b82cdb",
+            "comment": "Filter out devices with blank names"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/calling-component-bindings",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/calling-component-bindings",
+            "comment": "Bump @internal/calling-stateful-client to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/calling-component-bindings",
+            "comment": "Bump @internal/react-components to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:09 GMT",
       "tag": "@internal/calling-component-bindings_v1.4.0",
       "version": "1.4.0",

--- a/packages/calling-stateful-client/CHANGELOG.json
+++ b/packages/calling-stateful-client/CHANGELOG.json
@@ -2,6 +2,73 @@
   "name": "@internal/calling-stateful-client",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:33 GMT",
+      "tag": "@internal/calling-stateful-client_v1.4.1-beta.0",
+      "version": "1.4.1-beta.0",
+      "comments": {
+        "patch": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "anjulgarg@live.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "713f8fffeaf64b3f2ed08ccd86f0b473f5c376d3",
+            "comment": "Filter out camera devices with blank name when declarative device manager is used."
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "5c061a95044751fd8e0f4618cd02a0e63d3027dd",
+            "comment": "Remove DeclarativeCallAgent from stable API"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/calling-stateful-client",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ],
+        "prerelease": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "boo"
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "6d2b3839dbdd03864de1921dcb541cd610e331f6",
+            "comment": "Add rooms role into calling stateful client"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "fbfe38ebecbb97f70b8ac17a99da7ae29fd94a29",
+            "comment": "Only export DeclarativeCallAgent in beta build"
+          },
+          {
+            "author": "jinan@microsoft.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "c4fb6aa86817aa302b84094898fc029108d42b32",
+            "comment": "Add TeamsCall and TeamsCallAgent to StatefulClient"
+          }
+        ],
+        "none": [
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:10 GMT",
       "tag": "@internal/calling-stateful-client_v1.4.0",
       "version": "1.4.0",

--- a/packages/chat-component-bindings/CHANGELOG.json
+++ b/packages/chat-component-bindings/CHANGELOG.json
@@ -2,6 +2,55 @@
   "name": "@internal/chat-component-bindings",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:30 GMT",
+      "tag": "@internal/chat-component-bindings_v1.4.1-beta.0",
+      "version": "1.4.1-beta.0",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/chat-component-bindings",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "doo"
+          }
+        ],
+        "patch": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/chat-component-bindings",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/chat-component-bindings",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/chat-component-bindings",
+            "comment": "Bump @internal/chat-stateful-client to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/chat-component-bindings",
+            "comment": "Bump @internal/react-components to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ],
+        "none": [
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/chat-component-bindings",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:10 GMT",
       "tag": "@internal/chat-component-bindings_v1.4.0",
       "version": "1.4.0",

--- a/packages/chat-stateful-client/CHANGELOG.json
+++ b/packages/chat-stateful-client/CHANGELOG.json
@@ -2,6 +2,49 @@
   "name": "@internal/chat-stateful-client",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:30 GMT",
+      "tag": "@internal/chat-stateful-client_v1.4.1-beta.0",
+      "version": "1.4.1-beta.0",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/chat-stateful-client",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "gee"
+          }
+        ],
+        "none": [
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/chat-stateful-client",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          }
+        ],
+        "patch": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/chat-stateful-client",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/chat-stateful-client",
+            "commit": "4a670785567b2de58b3d78df8aeea77aa1f6173e",
+            "comment": "Fix issue where typingIndicator errors were not being caught by the ChatAdapter."
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/chat-stateful-client",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:10 GMT",
       "tag": "@internal/chat-stateful-client_v1.4.0",
       "version": "1.4.0",

--- a/packages/communication-react/CHANGELOG.beta.md
+++ b/packages/communication-react/CHANGELOG.beta.md
@@ -1,8 +1,104 @@
 # Change Log - @azure/communication-react
 
-This log was last generated on Fri, 21 Oct 2022 23:01:52 GMT and should not be manually modified.
+This log was last generated on Thu, 10 Nov 2022 07:17:29 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## [1.4.1-beta.0](https://github.com/azure/communication-ui-library/tree/@azure/communication-react_v1.4.1-beta.0)
+
+Thu, 10 Nov 2022 07:17:29 GMT 
+[Compare changes](https://github.com/azure/communication-ui-library/compare/@azure/communication-react_v1.4.0...@azure/communication-react_v1.4.1-beta.0)
+
+### Minor changes
+
+- `@internal/react-components`
+  - Update html-to-react dependency. Note: This change requires Webpack > 4. ([PR #2428](https://github.com/azure/communication-ui-library/pull/2428) by 2684369+JamesBurnside@users.noreply.github.com)
+- `@internal/react-composites`
+  - Revert breaking API change in `CallEndedListener` callback ([PR #2464](https://github.com/azure/communication-ui-library/pull/2464) by 82062616+prprabhu-ms@users.noreply.github.com)
+
+### Patches
+
+- `@internal/chat-component-bindings`
+  - Allow a range of communication services dependency packages ([PR #2457](https://github.com/azure/communication-ui-library/pull/2457) by 82062616+prprabhu-ms@users.noreply.github.com)
+- `@internal/chat-stateful-client`
+  - Allow a range of communication services dependency packages ([PR #2457](https://github.com/azure/communication-ui-library/pull/2457) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Fix issue where typingIndicator errors were not being caught by the ChatAdapter. ([PR #2471](https://github.com/azure/communication-ui-library/pull/2471) by 94866715+dmceachernmsft@users.noreply.github.com)
+- `@internal/fake-backends`
+  - Allow a range of communication services dependency packages ([PR #2457](https://github.com/azure/communication-ui-library/pull/2457) by 82062616+prprabhu-ms@users.noreply.github.com)
+- `@internal/react-components`
+  - setting icon definition to undefined if icon is already defined by fluent ([PR #2506](https://github.com/azure/communication-ui-library/pull/2506) by carolinecao@microsoft.com)
+  - Refresh string translations ([PR #2443](https://github.com/azure/communication-ui-library/pull/2443) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Bump dependencies to get closer to react 18 support ([PR #2427](https://github.com/azure/communication-ui-library/pull/2427) by 2684369+JamesBurnside@users.noreply.github.com)
+- `@internal/react-composites`
+  - Fix a string name and restrict it to beta builds ([PR #2439](https://github.com/azure/communication-ui-library/pull/2439) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Fix remove participant logic for teams user. Make sure to enforce isRemovable property on participantList participant. ([PR #2454](https://github.com/azure/communication-ui-library/pull/2454) by 94866715+dmceachernmsft@users.noreply.github.com)
+  - Focus on participant list when opening people pane ([PR #2492](https://github.com/azure/communication-ui-library/pull/2492) by edwardlee@microsoft.com)
+  - Allow a range of communication services dependency packages ([PR #2457](https://github.com/azure/communication-ui-library/pull/2457) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Config page local preview does not show a black screen when camera devices are removed. ([PR #2456](https://github.com/azure/communication-ui-library/pull/2456) by anjulgarg@live.com)
+  - Fix issue where typingIndicator errors were not being caught by the ChatAdapter ([PR #2471](https://github.com/azure/communication-ui-library/pull/2471) by 94866715+dmceachernmsft@users.noreply.github.com)
+  - Bump dependencies to get closer to react 18 support ([PR #2427](https://github.com/azure/communication-ui-library/pull/2427) by 2684369+JamesBurnside@users.noreply.github.com)
+  - Fix CallWithChatPane drawer menu that stays open after switching mobile tabs ([PR #2447](https://github.com/azure/communication-ui-library/pull/2447) by miguelgamis@microsoft.com)
+  - setting icon definition to undefined if icon is already defined by fluent ([PR #2506](https://github.com/azure/communication-ui-library/pull/2506) by carolinecao@microsoft.com)
+  - Refresh string translations ([PR #2443](https://github.com/azure/communication-ui-library/pull/2443) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Increase max listener limit to remove warning in console ([PR #2483](https://github.com/azure/communication-ui-library/pull/2483) by carolinecao@microsoft.com)
+- `@internal/storybook`
+  - Bump dependencies to get closer to react 18 support ([PR #2427](https://github.com/azure/communication-ui-library/pull/2427) by 2684369+JamesBurnside@users.noreply.github.com)
+  - Move icon register code to manager to avoid re-register warning on load ([PR #2506](https://github.com/azure/communication-ui-library/pull/2506) by carolinecao@microsoft.com)
+  - Allow a range of communication services dependency packages ([PR #2457](https://github.com/azure/communication-ui-library/pull/2457) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Add documentation for minimum typescript and webpack versions. ([PR #2428](https://github.com/azure/communication-ui-library/pull/2428) by 2684369+JamesBurnside@users.noreply.github.com)
+- `@internal/calling-component-bindings`
+  - Filter out devices with blank names ([PR #2366](https://github.com/azure/communication-ui-library/pull/2366) by miguelgamis@microsoft.com)
+  - Allow a range of communication services dependency packages ([PR #2457](https://github.com/azure/communication-ui-library/pull/2457) by 82062616+prprabhu-ms@users.noreply.github.com)
+- `@internal/calling-stateful-client`
+  - Allow a range of communication services dependency packages ([PR #2457](https://github.com/azure/communication-ui-library/pull/2457) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Filter out camera devices with blank name when declarative device manager is used. ([PR #2456](https://github.com/azure/communication-ui-library/pull/2456) by anjulgarg@live.com)
+  - Remove DeclarativeCallAgent from stable API ([PR #2436](https://github.com/azure/communication-ui-library/pull/2436) by 82062616+prprabhu-ms@users.noreply.github.com)
+
+### Changes
+
+- `@internal/chat-component-bindings`
+  - doo ([commit](https://github.com/azure/communication-ui-library/commit/d087da7a35600150eb119411c99a6142cc0be829) by 82062616+prprabhu-ms@users.noreply.github.com)
+- `@internal/chat-stateful-client`
+  - gee ([commit](https://github.com/azure/communication-ui-library/commit/d087da7a35600150eb119411c99a6142cc0be829) by 82062616+prprabhu-ms@users.noreply.github.com)
+- `@internal/fake-backends`
+  - gee ([commit](https://github.com/azure/communication-ui-library/commit/d087da7a35600150eb119411c99a6142cc0be829) by 82062616+prprabhu-ms@users.noreply.github.com)
+- `@internal/react-components`
+  - change device permission component string prop to optional ([PR #2434](https://github.com/azure/communication-ui-library/pull/2434) by carolinecao@microsoft.com)
+  - jee ([commit](https://github.com/azure/communication-ui-library/commit/d087da7a35600150eb119411c99a6142cc0be829) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Fix dtmf dialpad behavior to allow constant visibility of tone sent last. ([PR #2429](https://github.com/azure/communication-ui-library/pull/2429) by 94866715+dmceachernmsft@users.noreply.github.com)
+  - Remove padding and margins from base dialpad component. ([PR #2474](https://github.com/azure/communication-ui-library/pull/2474) by 94866715+dmceachernmsft@users.noreply.github.com)
+  - Make components string optional ([PR #2463](https://github.com/azure/communication-ui-library/pull/2463) by carolinecao@microsoft.com)
+  - Fix dark mode text for TroubleshootingGuideErrorBar messages ([PR #2501](https://github.com/azure/communication-ui-library/pull/2501) by edwardlee@microsoft.com)
+  - Add domain permission denied prompt pure UI component ([PR #2486](https://github.com/azure/communication-ui-library/pull/2486) by 2684369+JamesBurnside@users.noreply.github.com)
+  - New individual camera and microphone permission modals ([PR #2485](https://github.com/azure/communication-ui-library/pull/2485) by 2684369+JamesBurnside@users.noreply.github.com)
+  - Enabled troubleshooting guide error bar to display network error guide/device error guide based on error type  ([PR #2433](https://github.com/azure/communication-ui-library/pull/2433) by carolinecao@microsoft.com)
+  - Bugfix mute indicator color not matching display name ([PR #2451](https://github.com/azure/communication-ui-library/pull/2451) by anjulgarg@live.com)
+  - Added role to CallParticipantListParticipant type ([PR #2419](https://github.com/azure/communication-ui-library/pull/2419) by miguelgamis@microsoft.com)
+  - Add checking device permission prompt pure ui component ([PR #2489](https://github.com/azure/communication-ui-library/pull/2489) by 2684369+JamesBurnside@users.noreply.github.com)
+- `@internal/react-composites`
+  - zdc ([commit](https://github.com/azure/communication-ui-library/commit/d087da7a35600150eb119411c99a6142cc0be829) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Add enable call readiness option for Call and CallWithChat composite ([PR #2393](https://github.com/azure/communication-ui-library/pull/2393) by carolinecao@microsoft.com)
+  - Moved roleHint prop of CallComposite to CallAdapter state. ([PR #2482](https://github.com/azure/communication-ui-library/pull/2482) by miguelgamis@microsoft.com)
+  - Access role from stateful call client in CallComposite and changed CallComposite prop name from role to roleHint. ([PR #2481](https://github.com/azure/communication-ui-library/pull/2481) by miguelgamis@microsoft.com)
+  - Introduce e2e tests for lobby screen in calling composite to validate experience for different call types. ([PR #2435](https://github.com/azure/communication-ui-library/pull/2435) by 94866715+dmceachernmsft@users.noreply.github.com)
+  - Add troubleshooting error bar to call composite config  ([PR #2433](https://github.com/azure/communication-ui-library/pull/2433) by carolinecao@microsoft.com)
+  - Fix dtmf dialpad behavior to allow constant visibility of tone sent last. ([PR #2429](https://github.com/azure/communication-ui-library/pull/2429) by 94866715+dmceachernmsft@users.noreply.github.com)
+  - Added getRole selector ([PR #2419](https://github.com/azure/communication-ui-library/pull/2419) by miguelgamis@microsoft.com)
+  - Add allow access modal to configuration screen ([PR #2463](https://github.com/azure/communication-ui-library/pull/2463) by carolinecao@microsoft.com)
+  - Add device permission drawer to calling mobile config screen ([PR #2434](https://github.com/azure/communication-ui-library/pull/2434) by carolinecao@microsoft.com)
+- `@internal/storybook`
+  - Updated troubleshooting error bar storybook  ([PR #2433](https://github.com/azure/communication-ui-library/pull/2433) by carolinecao@microsoft.com)
+  - cc ([commit](https://github.com/azure/communication-ui-library/commit/d087da7a35600150eb119411c99a6142cc0be829) by 82062616+prprabhu-ms@users.noreply.github.com)
+- `@internal/acs-ui-common`
+  - something ([commit](https://github.com/azure/communication-ui-library/commit/d087da7a35600150eb119411c99a6142cc0be829) by 82062616+prprabhu-ms@users.noreply.github.com)
+- `@internal/calling-component-bindings`
+  - Added role to selectors ([PR #2419](https://github.com/azure/communication-ui-library/pull/2419) by miguelgamis@microsoft.com)
+  - else ([commit](https://github.com/azure/communication-ui-library/commit/d087da7a35600150eb119411c99a6142cc0be829) by 82062616+prprabhu-ms@users.noreply.github.com)
+- `@internal/calling-stateful-client`
+  - boo ([commit](https://github.com/azure/communication-ui-library/commit/d087da7a35600150eb119411c99a6142cc0be829) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Add rooms role into calling stateful client ([PR #2417](https://github.com/azure/communication-ui-library/pull/2417) by miguelgamis@microsoft.com)
+  - Only export DeclarativeCallAgent in beta build ([PR #2469](https://github.com/azure/communication-ui-library/pull/2469) by 82062616+prprabhu-ms@users.noreply.github.com)
+  - Add TeamsCall and TeamsCallAgent to StatefulClient ([PR #2396](https://github.com/azure/communication-ui-library/pull/2396) by jinan@microsoft.com)
 
 ## [1.3.2-beta.1](https://github.com/azure/communication-ui-library/tree/1.3.2-beta.1)
 

--- a/packages/communication-react/CHANGELOG.json
+++ b/packages/communication-react/CHANGELOG.json
@@ -2,6 +2,561 @@
   "name": "@azure/communication-react",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:29 GMT",
+      "tag": "@azure/communication-react_v1.4.1-beta.0",
+      "version": "1.4.1-beta.0",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/chat-component-bindings",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "doo"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/chat-stateful-client",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "gee"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/fake-backends",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "gee"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "7b0e29772ac2e4a8111572fefb43624919e842a9",
+            "comment": "change device permission component string prop to optional"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "jee"
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "a4885ef50b259dc13f864cade5203c8eb2225544",
+            "comment": "Fix dtmf dialpad behavior to allow constant visibility of tone sent last."
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "1b91cc5a3b775c3db0bedd577defeb62e0075a1e",
+            "comment": "Remove padding and margins from base dialpad component."
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "d614a2b2c8f2a7a9a7174f1d7981fde443c986b1",
+            "comment": "Make components string optional"
+          },
+          {
+            "author": "edwardlee@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "2a279a14cc990a9716c96a582931a8b277bbfa34",
+            "comment": "Fix dark mode text for TroubleshootingGuideErrorBar messages"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "363401bdd3c81c42cf776243734740ea8d25390c",
+            "comment": "Add domain permission denied prompt pure UI component"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "3aab73e61303d02385497dfe6116f4d5f03b4f94",
+            "comment": "New individual camera and microphone permission modals"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "d5c6baf76a616d8c3556e0e479da975b6a366305",
+            "comment": "Enabled troubleshooting guide error bar to display network error guide/device error guide based on error type "
+          },
+          {
+            "author": "anjulgarg@live.com",
+            "package": "@internal/react-components",
+            "commit": "1b49a7e17ef1d7c18d2322d01da28b9116074fc3",
+            "comment": "Bugfix mute indicator color not matching display name"
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "3d491b8aa403a607549999607b789da7c13c503f",
+            "comment": "Added role to CallParticipantListParticipant type"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "c5efaf6677c46c017e3297a003a1df905f4044f1",
+            "comment": "Add checking device permission prompt pure ui component"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "zdc"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "d075433a363565a25612db2a26088253fbe3c340",
+            "comment": "Add enable call readiness option for Call and CallWithChat composite"
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "0b60aba0f6c7fe265ac415ce0b077cc52796746a",
+            "comment": "Moved roleHint prop of CallComposite to CallAdapter state."
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "cbde9d2aa633d732f80a0df855d8e4d6ea7cc595",
+            "comment": "Access role from stateful call client in CallComposite and changed CallComposite prop name from role to roleHint."
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "adb2a443098f13b37cdc7bcc032dad0f63224638",
+            "comment": "Introduce e2e tests for lobby screen in calling composite to validate experience for different call types."
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "d5c6baf76a616d8c3556e0e479da975b6a366305",
+            "comment": "Add troubleshooting error bar to call composite config "
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "a4885ef50b259dc13f864cade5203c8eb2225544",
+            "comment": "Fix dtmf dialpad behavior to allow constant visibility of tone sent last."
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "3d491b8aa403a607549999607b789da7c13c503f",
+            "comment": "Added getRole selector"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "d614a2b2c8f2a7a9a7174f1d7981fde443c986b1",
+            "comment": "Add allow access modal to configuration screen"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "7b0e29772ac2e4a8111572fefb43624919e842a9",
+            "comment": "Add device permission drawer to calling mobile config screen"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/storybook",
+            "commit": "d5c6baf76a616d8c3556e0e479da975b6a366305",
+            "comment": "Updated troubleshooting error bar storybook "
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "cc"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/acs-ui-common",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "something"
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "3d491b8aa403a607549999607b789da7c13c503f",
+            "comment": "Added role to selectors"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "else"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "boo"
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "6d2b3839dbdd03864de1921dcb541cd610e331f6",
+            "comment": "Add rooms role into calling stateful client"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "fbfe38ebecbb97f70b8ac17a99da7ae29fd94a29",
+            "comment": "Only export DeclarativeCallAgent in beta build"
+          },
+          {
+            "author": "jinan@microsoft.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "c4fb6aa86817aa302b84094898fc029108d42b32",
+            "comment": "Add TeamsCall and TeamsCallAgent to StatefulClient"
+          }
+        ],
+        "patch": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/chat-component-bindings",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/chat-stateful-client",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/chat-stateful-client",
+            "commit": "4a670785567b2de58b3d78df8aeea77aa1f6173e",
+            "comment": "Fix issue where typingIndicator errors were not being caught by the ChatAdapter."
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/fake-backends",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "29cecd954712376ed4b9a4fe4ed9300f4112672d",
+            "comment": "setting icon definition to undefined if icon is already defined by fluent"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "5e75267b651935b673dba3955878c3bf6231be22",
+            "comment": "Refresh string translations"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "41f8e688e1f277a644a26b8aaef30ac3ffd5798c",
+            "comment": "Bump dependencies to get closer to react 18 support"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "f77ff8331775565f18d85e7d7a317cada2b78e3a",
+            "comment": "Fix a string name and restrict it to beta builds"
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "d303892227d0a98faad54a2cec790800e37f1c77",
+            "comment": "Fix remove participant logic for teams user. Make sure to enforce isRemovable property on participantList participant."
+          },
+          {
+            "author": "edwardlee@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "d7293fca758edb5927f520f36471bd863dc69bb9",
+            "comment": "Focus on participant list when opening people pane"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "anjulgarg@live.com",
+            "package": "@internal/react-composites",
+            "commit": "713f8fffeaf64b3f2ed08ccd86f0b473f5c376d3",
+            "comment": "Config page local preview does not show a black screen when camera devices are removed."
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "4a670785567b2de58b3d78df8aeea77aa1f6173e",
+            "comment": "Fix issue where typingIndicator errors were not being caught by the ChatAdapter"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "41f8e688e1f277a644a26b8aaef30ac3ffd5798c",
+            "comment": "Bump dependencies to get closer to react 18 support"
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "08765a2c32ab5384156bcf706a5939a2808b55c2",
+            "comment": "Fix CallWithChatPane drawer menu that stays open after switching mobile tabs"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "29cecd954712376ed4b9a4fe4ed9300f4112672d",
+            "comment": "setting icon definition to undefined if icon is already defined by fluent"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "5e75267b651935b673dba3955878c3bf6231be22",
+            "comment": "Refresh string translations"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "fe8ac93f7d7404fc1ab2d37b084758aaee3151ba",
+            "comment": "Increase max listener limit to remove warning in console"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "41f8e688e1f277a644a26b8aaef30ac3ffd5798c",
+            "comment": "Bump dependencies to get closer to react 18 support"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/storybook",
+            "commit": "29cecd954712376ed4b9a4fe4ed9300f4112672d",
+            "comment": "Move icon register code to manager to avoid re-register warning on load"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "7244e8add398513a81398441c90b8a07f43ba309",
+            "comment": "Add documentation for minimum typescript and webpack versions."
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "4bc76af77fc4f4e108de10b8a6e4227348b82cdb",
+            "comment": "Filter out devices with blank names"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "anjulgarg@live.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "713f8fffeaf64b3f2ed08ccd86f0b473f5c376d3",
+            "comment": "Filter out camera devices with blank name when declarative device manager is used."
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "5c061a95044751fd8e0f4618cd02a0e63d3027dd",
+            "comment": "Remove DeclarativeCallAgent from stable API"
+          }
+        ],
+        "none": [
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/chat-component-bindings",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/chat-stateful-client",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/fake-backends",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "edwardlee@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "7a94ca460e7e64a3779025825c1d35aeda8946f1",
+            "comment": "Add missing PSTN conditional compilation"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "467ea946e9d58b3accebc4821466afd754eabd7e",
+            "comment": "Create a device ermissions sub directory"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "020102df6028cc4ea61f9c9cfd44839d53b4f14f",
+            "comment": "Add data ui id to device  permission component"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "3421272897067d1e196176deec2f04a4c530d66e",
+            "comment": "Add ability to style a failed chat message (fixes #2257)"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "jinan@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "c4fb6aa86817aa302b84094898fc029108d42b32",
+            "comment": "Add TeamsCall and TeamsCallAgent to StatefulClient"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "363401bdd3c81c42cf776243734740ea8d25390c",
+            "comment": "Update pro based on newer api (no functional change)"
+          },
+          {
+            "author": "edwardlee@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "7a94ca460e7e64a3779025825c1d35aeda8946f1",
+            "comment": "Add missing PSTN conditional compilation"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "d00af9f75b8341762abd708e7b5dd5d043e84b19",
+            "comment": "Add support for conditionally compiled browser tests"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "60540a73e437a99f7af3910e2282b534c37b79a9",
+            "comment": "browser tests: drop runtime test for build flavor environment variable"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "3aab73e61303d02385497dfe6116f4d5f03b4f94",
+            "comment": "Update names"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "6602f6b063057bc3a194d899d3f7b4b192a37615",
+            "comment": "Use permission API to get device permissions "
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "1e0f9b6bb5d2e5c98fc1076160b5b25d03cf3695",
+            "comment": "Clean up storybook quickstart setup page"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "c5efaf6677c46c017e3297a003a1df905f4044f1",
+            "comment": "Update domain permissions story to have checking device permissions type"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "not available",
+            "comment": "xkcd"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "363401bdd3c81c42cf776243734740ea8d25390c",
+            "comment": "Update internal story to have denied vs request domain permission skus"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "3aab73e61303d02385497dfe6116f4d5f03b4f94",
+            "comment": "Add stories for individual camera and mic permission modals in internal folder"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/acs-ui-common",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/acs-ui-common",
+            "commit": "807c931ca9bdc6813b08c1e01bd60f4131be089e",
+            "comment": "Document template of the application ID used for telemetry"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "6b4049475e182608504163b25d62692a6f781e7f",
+            "comment": "Stable release branch hotfix: Fix camera turning back on when turned off on connecting screen (#2458)"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/calling-component-bindings",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/calling-stateful-client",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          }
+        ],
+        "minor": [
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "7244e8add398513a81398441c90b8a07f43ba309",
+            "comment": "Update html-to-react dependency. Note: This change requires Webpack > 4."
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "1ebf2f2e306113c14b59da615a5b2a3ef493e5a4",
+            "comment": "Revert breaking API change in `CallEndedListener` callback"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:01:52 GMT",
       "tag": "@azure/communication-react_v1.4.0",
       "version": "1.4.0",

--- a/packages/fake-backends/CHANGELOG.json
+++ b/packages/fake-backends/CHANGELOG.json
@@ -2,6 +2,43 @@
   "name": "@internal/fake-backends",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:30 GMT",
+      "tag": "@internal/fake-backends_v1.4.1-beta.0",
+      "version": "1.4.1-beta.0",
+      "comments": {
+        "none": [
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/fake-backends",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          }
+        ],
+        "patch": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/fake-backends",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/fake-backends",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ],
+        "prerelease": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/fake-backends",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "gee"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:11 GMT",
       "tag": "@internal/fake-backends_v1.4.0",
       "version": "1.4.0",

--- a/packages/react-components/CHANGELOG.json
+++ b/packages/react-components/CHANGELOG.json
@@ -2,6 +2,153 @@
   "name": "@internal/react-components",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:30 GMT",
+      "tag": "@internal/react-components_v1.4.1-beta.0",
+      "version": "1.4.1-beta.0",
+      "comments": {
+        "minor": [
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "7244e8add398513a81398441c90b8a07f43ba309",
+            "comment": "Update html-to-react dependency. Note: This change requires Webpack > 4."
+          }
+        ],
+        "none": [
+          {
+            "author": "edwardlee@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "7a94ca460e7e64a3779025825c1d35aeda8946f1",
+            "comment": "Add missing PSTN conditional compilation"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "467ea946e9d58b3accebc4821466afd754eabd7e",
+            "comment": "Create a device ermissions sub directory"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "020102df6028cc4ea61f9c9cfd44839d53b4f14f",
+            "comment": "Add data ui id to device  permission component"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "3421272897067d1e196176deec2f04a4c530d66e",
+            "comment": "Add ability to style a failed chat message (fixes #2257)"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          }
+        ],
+        "patch": [
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "29cecd954712376ed4b9a4fe4ed9300f4112672d",
+            "comment": "setting icon definition to undefined if icon is already defined by fluent"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "5e75267b651935b673dba3955878c3bf6231be22",
+            "comment": "Refresh string translations"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "41f8e688e1f277a644a26b8aaef30ac3ffd5798c",
+            "comment": "Bump dependencies to get closer to react 18 support"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/react-components",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ],
+        "prerelease": [
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "7b0e29772ac2e4a8111572fefb43624919e842a9",
+            "comment": "change device permission component string prop to optional"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "jee"
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "a4885ef50b259dc13f864cade5203c8eb2225544",
+            "comment": "Fix dtmf dialpad behavior to allow constant visibility of tone sent last."
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "1b91cc5a3b775c3db0bedd577defeb62e0075a1e",
+            "comment": "Remove padding and margins from base dialpad component."
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "d614a2b2c8f2a7a9a7174f1d7981fde443c986b1",
+            "comment": "Make components string optional"
+          },
+          {
+            "author": "edwardlee@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "2a279a14cc990a9716c96a582931a8b277bbfa34",
+            "comment": "Fix dark mode text for TroubleshootingGuideErrorBar messages"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "363401bdd3c81c42cf776243734740ea8d25390c",
+            "comment": "Add domain permission denied prompt pure UI component"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "3aab73e61303d02385497dfe6116f4d5f03b4f94",
+            "comment": "New individual camera and microphone permission modals"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "d5c6baf76a616d8c3556e0e479da975b6a366305",
+            "comment": "Enabled troubleshooting guide error bar to display network error guide/device error guide based on error type "
+          },
+          {
+            "author": "anjulgarg@live.com",
+            "package": "@internal/react-components",
+            "commit": "1b49a7e17ef1d7c18d2322d01da28b9116074fc3",
+            "comment": "Bugfix mute indicator color not matching display name"
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/react-components",
+            "commit": "3d491b8aa403a607549999607b789da7c13c503f",
+            "comment": "Added role to CallParticipantListParticipant type"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-components",
+            "commit": "c5efaf6677c46c017e3297a003a1df905f4044f1",
+            "comment": "Add checking device permission prompt pure ui component"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:01:58 GMT",
       "tag": "@internal/react-components_v1.4.0",
       "version": "1.4.0",

--- a/packages/react-composites/CHANGELOG.json
+++ b/packages/react-composites/CHANGELOG.json
@@ -2,6 +2,243 @@
   "name": "@internal/react-composites",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:31 GMT",
+      "tag": "@internal/react-composites_v1.4.1-beta.0",
+      "version": "1.4.1-beta.0",
+      "comments": {
+        "patch": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "f77ff8331775565f18d85e7d7a317cada2b78e3a",
+            "comment": "Fix a string name and restrict it to beta builds"
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "d303892227d0a98faad54a2cec790800e37f1c77",
+            "comment": "Fix remove participant logic for teams user. Make sure to enforce isRemovable property on participantList participant."
+          },
+          {
+            "author": "edwardlee@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "d7293fca758edb5927f520f36471bd863dc69bb9",
+            "comment": "Focus on participant list when opening people pane"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "anjulgarg@live.com",
+            "package": "@internal/react-composites",
+            "commit": "713f8fffeaf64b3f2ed08ccd86f0b473f5c376d3",
+            "comment": "Config page local preview does not show a black screen when camera devices are removed."
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "4a670785567b2de58b3d78df8aeea77aa1f6173e",
+            "comment": "Fix issue where typingIndicator errors were not being caught by the ChatAdapter"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "41f8e688e1f277a644a26b8aaef30ac3ffd5798c",
+            "comment": "Bump dependencies to get closer to react 18 support"
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "08765a2c32ab5384156bcf706a5939a2808b55c2",
+            "comment": "Fix CallWithChatPane drawer menu that stays open after switching mobile tabs"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "29cecd954712376ed4b9a4fe4ed9300f4112672d",
+            "comment": "setting icon definition to undefined if icon is already defined by fluent"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "5e75267b651935b673dba3955878c3bf6231be22",
+            "comment": "Refresh string translations"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "fe8ac93f7d7404fc1ab2d37b084758aaee3151ba",
+            "comment": "Increase max listener limit to remove warning in console"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/react-composites",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/react-composites",
+            "comment": "Bump @internal/calling-component-bindings to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/react-composites",
+            "comment": "Bump @internal/calling-stateful-client to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/react-composites",
+            "comment": "Bump @internal/chat-component-bindings to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/react-composites",
+            "comment": "Bump @internal/chat-stateful-client to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/react-composites",
+            "comment": "Bump @internal/react-components to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/react-composites",
+            "comment": "Bump @internal/fake-backends to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ],
+        "none": [
+          {
+            "author": "jinan@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "c4fb6aa86817aa302b84094898fc029108d42b32",
+            "comment": "Add TeamsCall and TeamsCallAgent to StatefulClient"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "363401bdd3c81c42cf776243734740ea8d25390c",
+            "comment": "Update pro based on newer api (no functional change)"
+          },
+          {
+            "author": "edwardlee@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "7a94ca460e7e64a3779025825c1d35aeda8946f1",
+            "comment": "Add missing PSTN conditional compilation"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "d00af9f75b8341762abd708e7b5dd5d043e84b19",
+            "comment": "Add support for conditionally compiled browser tests"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "60540a73e437a99f7af3910e2282b534c37b79a9",
+            "comment": "browser tests: drop runtime test for build flavor environment variable"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "3aab73e61303d02385497dfe6116f4d5f03b4f94",
+            "comment": "Update names"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "6602f6b063057bc3a194d899d3f7b4b192a37615",
+            "comment": "Use permission API to get device permissions "
+          }
+        ],
+        "prerelease": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "zdc"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "d075433a363565a25612db2a26088253fbe3c340",
+            "comment": "Add enable call readiness option for Call and CallWithChat composite"
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "0b60aba0f6c7fe265ac415ce0b077cc52796746a",
+            "comment": "Moved roleHint prop of CallComposite to CallAdapter state."
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "cbde9d2aa633d732f80a0df855d8e4d6ea7cc595",
+            "comment": "Access role from stateful call client in CallComposite and changed CallComposite prop name from role to roleHint."
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "adb2a443098f13b37cdc7bcc032dad0f63224638",
+            "comment": "Introduce e2e tests for lobby screen in calling composite to validate experience for different call types."
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "d5c6baf76a616d8c3556e0e479da975b6a366305",
+            "comment": "Add troubleshooting error bar to call composite config "
+          },
+          {
+            "author": "94866715+dmceachernmsft@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "a4885ef50b259dc13f864cade5203c8eb2225544",
+            "comment": "Fix dtmf dialpad behavior to allow constant visibility of tone sent last."
+          },
+          {
+            "author": "miguelgamis@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "3d491b8aa403a607549999607b789da7c13c503f",
+            "comment": "Added getRole selector"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "d614a2b2c8f2a7a9a7174f1d7981fde443c986b1",
+            "comment": "Add allow access modal to configuration screen"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/react-composites",
+            "commit": "7b0e29772ac2e4a8111572fefb43624919e842a9",
+            "comment": "Add device permission drawer to calling mobile config screen"
+          }
+        ],
+        "minor": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/react-composites",
+            "commit": "1ebf2f2e306113c14b59da615a5b2a3ef493e5a4",
+            "comment": "Revert breaking API change in `CallEndedListener` callback"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:01:53 GMT",
       "tag": "@internal/react-composites_v1.4.0",
       "version": "1.4.0",

--- a/packages/storybook/CHANGELOG.json
+++ b/packages/storybook/CHANGELOG.json
@@ -2,6 +2,97 @@
   "name": "@internal/storybook",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:32 GMT",
+      "tag": "@internal/storybook_v1.4.1-beta.0",
+      "version": "1.4.1-beta.0",
+      "comments": {
+        "none": [
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "1e0f9b6bb5d2e5c98fc1076160b5b25d03cf3695",
+            "comment": "Clean up storybook quickstart setup page"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "c5efaf6677c46c017e3297a003a1df905f4044f1",
+            "comment": "Update domain permissions story to have checking device permissions type"
+          },
+          {
+            "author": "41898282+github-actions[bot]@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "c8e8d74de3f7804e0187538d696bbfe7a37e0248",
+            "comment": "Bumped"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "not available",
+            "comment": "xkcd"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "363401bdd3c81c42cf776243734740ea8d25390c",
+            "comment": "Update internal story to have denied vs request domain permission skus"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "3aab73e61303d02385497dfe6116f4d5f03b4f94",
+            "comment": "Add stories for individual camera and mic permission modals in internal folder"
+          }
+        ],
+        "patch": [
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "41f8e688e1f277a644a26b8aaef30ac3ffd5798c",
+            "comment": "Bump dependencies to get closer to react 18 support"
+          },
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/storybook",
+            "commit": "29cecd954712376ed4b9a4fe4ed9300f4112672d",
+            "comment": "Move icon register code to manager to avoid re-register warning on load"
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "8cb67542c822c72db69c77e223747d55fe5b4d54",
+            "comment": "Allow a range of communication services dependency packages"
+          },
+          {
+            "author": "2684369+JamesBurnside@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "7244e8add398513a81398441c90b8a07f43ba309",
+            "comment": "Add documentation for minimum typescript and webpack versions."
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/storybook",
+            "comment": "Bump @azure/communication-react to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ],
+        "prerelease": [
+          {
+            "author": "carolinecao@microsoft.com",
+            "package": "@internal/storybook",
+            "commit": "d5c6baf76a616d8c3556e0e479da975b6a366305",
+            "comment": "Updated troubleshooting error bar storybook "
+          },
+          {
+            "author": "82062616+prprabhu-ms@users.noreply.github.com",
+            "package": "@internal/storybook",
+            "commit": "d087da7a35600150eb119411c99a6142cc0be829",
+            "comment": "cc"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:01:55 GMT",
       "tag": "@internal/storybook_v1.4.0",
       "version": "1.4.0",

--- a/samples/CallWithChat/CHANGELOG.json
+++ b/samples/CallWithChat/CHANGELOG.json
@@ -2,6 +2,51 @@
   "name": "callwithchat",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:33 GMT",
+      "tag": "callwithchat_v0.0.1",
+      "version": "0.0.1",
+      "comments": {
+        "undefined": [
+          {
+            "author": "beachball",
+            "package": "callwithchat",
+            "comment": "Bump @azure/communication-react to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "callwithchat",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "callwithchat",
+            "comment": "Bump @internal/calling-component-bindings to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "callwithchat",
+            "comment": "Bump @internal/calling-stateful-client to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "callwithchat",
+            "comment": "Bump @internal/react-components to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "callwithchat",
+            "comment": "Bump @internal/react-composites to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:13 GMT",
       "tag": "callwithchat_v0.0.1",
       "version": "0.0.1",

--- a/samples/Calling/CHANGELOG.json
+++ b/samples/Calling/CHANGELOG.json
@@ -2,6 +2,51 @@
   "name": "calling",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:33 GMT",
+      "tag": "calling_v0.0.1",
+      "version": "0.0.1",
+      "comments": {
+        "undefined": [
+          {
+            "author": "beachball",
+            "package": "calling",
+            "comment": "Bump @azure/communication-react to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "calling",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "calling",
+            "comment": "Bump @internal/calling-component-bindings to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "calling",
+            "comment": "Bump @internal/calling-stateful-client to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "calling",
+            "comment": "Bump @internal/react-components to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "calling",
+            "comment": "Bump @internal/react-composites to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:13 GMT",
       "tag": "calling_v0.0.1",
       "version": "0.0.1",

--- a/samples/Chat/CHANGELOG.json
+++ b/samples/Chat/CHANGELOG.json
@@ -2,6 +2,51 @@
   "name": "chat",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:33 GMT",
+      "tag": "chat_v0.0.1",
+      "version": "0.0.1",
+      "comments": {
+        "undefined": [
+          {
+            "author": "beachball",
+            "package": "chat",
+            "comment": "Bump @azure/communication-react to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "chat",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "chat",
+            "comment": "Bump @internal/chat-stateful-client to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "chat",
+            "comment": "Bump @internal/chat-component-bindings to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "chat",
+            "comment": "Bump @internal/react-components to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "chat",
+            "comment": "Bump @internal/react-composites to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:13 GMT",
       "tag": "chat_v0.0.1",
       "version": "0.0.1",

--- a/samples/ComponentExamples/CHANGELOG.json
+++ b/samples/ComponentExamples/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "component-examples",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:33 GMT",
+      "tag": "component-examples_v0.0.1",
+      "version": "0.0.1",
+      "comments": {
+        "undefined": [
+          {
+            "author": "beachball",
+            "package": "component-examples",
+            "comment": "Bump @azure/communication-react to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:13 GMT",
       "tag": "component-examples_v0.0.1",
       "version": "0.0.1",

--- a/samples/StaticHtmlComposites/CHANGELOG.json
+++ b/samples/StaticHtmlComposites/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "sample-static-html-composites",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:33 GMT",
+      "tag": "sample-static-html-composites_v1.0.0",
+      "version": "1.0.0",
+      "comments": {
+        "undefined": [
+          {
+            "author": "beachball",
+            "package": "sample-static-html-composites",
+            "comment": "Bump @azure/communication-react to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:13 GMT",
       "tag": "sample-static-html-composites_v1.0.0",
       "version": "1.0.0",

--- a/tools/check-treeshaking/CHANGELOG.json
+++ b/tools/check-treeshaking/CHANGELOG.json
@@ -2,6 +2,51 @@
   "name": "@internal/check-treeshaking",
   "entries": [
     {
+      "date": "Thu, 10 Nov 2022 07:17:33 GMT",
+      "tag": "@internal/check-treeshaking_v0.1.0",
+      "version": "0.1.0",
+      "comments": {
+        "undefined": [
+          {
+            "author": "beachball",
+            "package": "@internal/check-treeshaking",
+            "comment": "Bump @internal/acs-ui-common to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/check-treeshaking",
+            "comment": "Bump @internal/react-components to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/check-treeshaking",
+            "comment": "Bump @internal/chat-stateful-client to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/check-treeshaking",
+            "comment": "Bump @internal/calling-stateful-client to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/check-treeshaking",
+            "comment": "Bump @internal/chat-component-bindings to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          },
+          {
+            "author": "beachball",
+            "package": "@internal/check-treeshaking",
+            "comment": "Bump @internal/calling-component-bindings to v1.4.1-beta.0",
+            "commit": "c8d3d24cf8d17695a2992940a0fc753f94bf6f9e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 21 Oct 2022 23:02:13 GMT",
       "tag": "@internal/check-treeshaking_v0.1.0",
       "version": "0.1.0",


### PR DESCRIPTION
This PR demonstrates how `CHANGELOG.beta.md` is collected for beta builds via the tooling introduced in #2513 

This PR was generated by running:

```
node common/scripts/changelog/collect.mjs beta
```