### PR TITLE
`initializeIcons()` in PSTN and 1:N quickstarts

### DIFF
--- a/change/@internal-storybook-a6d95240-9957-4057-a6ce-6d2a50b18088.json
+++ b/change/@internal-storybook-a6d95240-9957-4057-a6ce-6d2a50b18088.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "initializeIcons() in 1:N and PSTN quickstarts",
+  "packageName": "@internal/storybook",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/CallComposite/snippets/Quickstart1ToN.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/Quickstart1ToN.snippet.tsx
@@ -5,6 +5,7 @@ import {
   useAzureCommunicationCallAdapter
 } from '@azure/communication-react';
 import React, { useMemo } from 'react';
+import { initializeIcons } from '@fluentui/react';
 
 /**
  * Authentication information needed for your client application to use
@@ -31,6 +32,8 @@ const DISPLAY_NAME = '<Display Name>';
  * A list of ACS User IDs to call
  */
 const ACS_USER_IDS = ['<ACS User ID>'];
+
+initializeIcons();
 
 /**
  * Entry point of your application.

--- a/packages/storybook/stories/CallComposite/snippets/Quickstart1ToN.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/Quickstart1ToN.snippet.tsx
@@ -4,8 +4,8 @@ import {
   fromFlatCommunicationIdentifier,
   useAzureCommunicationCallAdapter
 } from '@azure/communication-react';
-import React, { useMemo } from 'react';
 import { initializeIcons } from '@fluentui/react';
+import React, { useMemo } from 'react';
 
 /**
  * Authentication information needed for your client application to use

--- a/packages/storybook/stories/CallComposite/snippets/QuickstartPSTN.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/QuickstartPSTN.snippet.tsx
@@ -5,6 +5,7 @@ import {
   useAzureCommunicationCallAdapter
 } from '@azure/communication-react';
 import React, { useMemo } from 'react';
+import { initializeIcons } from '@fluentui/react';
 
 /**
  * Authentication information needed for your client application to use
@@ -40,6 +41,8 @@ const ALTERNATE_CALLER_ID = '<Azure Communication Services Managed Phone Number>
  * A list of phone numbers to call
  */
 const PHONE_NUMBERS = ['<Phone Number>'];
+
+initializeIcons();
 
 /**
  * Entry point of your application.

--- a/packages/storybook/stories/CallComposite/snippets/QuickstartPSTN.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/QuickstartPSTN.snippet.tsx
@@ -4,8 +4,8 @@ import {
   fromFlatCommunicationIdentifier,
   useAzureCommunicationCallAdapter
 } from '@azure/communication-react';
-import React, { useMemo } from 'react';
 import { initializeIcons } from '@fluentui/react';
+import React, { useMemo } from 'react';
 
 /**
  * Authentication information needed for your client application to use


### PR DESCRIPTION
After this PR, the quickstart applications show icons correctly out of the box.