### PR TITLE
[DO NOT REVIEW] Demonstrate CI validation of changefiles

### DIFF
--- a/change-beta/@azure-communication-react-b258c739-33a4-4528-889d-a7e363b2e679.json
+++ b/change-beta/@azure-communication-react-b258c739-33a4-4528-889d-a7e363b2e679.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "I didn't really have a change so added a none changelog",
+  "packageName": "@azure/communication-react",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-b258c739-33a4-4528-889d-a7e363b2e679.json
+++ b/change/@azure-communication-react-b258c739-33a4-4528-889d-a7e363b2e679.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "I didn't really have a change so added a none changelog",
+  "packageName": "@azure/communication-react",
+  "email": "82062616+prprabhu-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
This is a PR that contains a mandatory changefile. The CI step that checks for changefiles should succeed on this PR.

Changefile was generated with `rush changelog`

e.g.: [This build](https://github.com/Azure/communication-ui-library/actions/runs/3441511529/jobs/5741147647) passed changefile validation.