### PR TITLE
Add type cast to support latest lib.dom version

### DIFF
--- a/change/@internal-react-composites-6ab13215-de2b-44fb-8e89-a21bd5e62667.json
+++ b/change/@internal-react-composites-6ab13215-de2b-44fb-8e89-a21bd5e62667.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add type cast to support latest lib.dom version",
+  "packageName": "@internal/react-composites",
+  "email": "jinan@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
+++ b/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
@@ -263,7 +263,7 @@ export const getDevicePermissionState = (
   setAudioState: (state: PermissionState) => void
 ): void => {
   navigator.permissions
-    .query({ name: 'camera' })
+    .query({ name: 'camera' as PermissionName })
     .then((result) => {
       setVideoState(result.state);
     })
@@ -272,7 +272,7 @@ export const getDevicePermissionState = (
     });
 
   navigator.permissions
-    .query({ name: 'microphone' })
+    .query({ name: 'microphone' as PermissionName })
     .then((result) => {
       setAudioState(result.state);
     })

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -384,7 +384,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
     try {
       return await f();
     } catch (error) {
-      if (isChatError(error)) {
+      if (isChatError(error as Error)) {
         this.emitter.emit('error', error as AdapterError);
       }
       throw error;


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
There are 3 warnings popping up after doing a `rush update` and it seems because of lib.dom update, which changes some type definition, this PR is to do the right type cast for bypass warnings

Check this build for those 3 warnings: https://github.com/Azure/communication-ui-library/actions/runs/3434222284/jobs/5725340021

![image](https://user-images.githubusercontent.com/11863655/201247880-474cda90-791d-4be7-bcc8-b8f877b7ac48.png)

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->