### PR TITLE
Release/1.4.1 beta.1 update cherrypick changelog for bumping Calling SDK

### DIFF
--- a/change-beta/@azure-communication-react-d695a8c5-053e-460b-981d-869bb36383bb.json
+++ b/change-beta/@azure-communication-react-d695a8c5-053e-460b-981d-869bb36383bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update beta changelogs",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-d695a8c5-053e-460b-981d-869bb36383bb.json
+++ b/change/@azure-communication-react-d695a8c5-053e-460b-981d-869bb36383bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update beta changelogs",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/communication-react/CHANGELOG.beta.md
+++ b/packages/communication-react/CHANGELOG.beta.md
@@ -49,6 +49,7 @@ Tue, 15 Nov 2022 21:12:22 GMT
 - Bump dependencies to get closer to react 18 support ([PR #2427](https://github.com/azure/communication-ui-library/pull/2427) by 2684369+JamesBurnside@users.noreply.github.com)
 - Focus on participant list when opening people pane ([PR #2492](https://github.com/azure/communication-ui-library/pull/2492) by edwardlee@microsoft.com)
 - Config page local preview does not show a black screen when camera devices are removed ([PR #2456](https://github.com/azure/communication-ui-library/pull/2456) by anjulgarg@live.com)
+- Bumped calling SDK beta version to 1.9.1-beta.1 ([PR #2475](https://github.com/azure/communication-ui-library/pull/2475) by 94866715+dmceachernmsft@users.noreply.github.com)
 
 ## [1.3.2-beta.1](https://github.com/azure/communication-ui-library/tree/1.3.2-beta.1)
 


### PR DESCRIPTION
# What
Update Changelog for bumping Calling sdk to 1.9.1-beta.1 

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->