### PR TITLE
Add beta version option for beta banners in Storybook

### DIFF
--- a/change-beta/@azure-communication-react-aed327b7-449f-4d86-8730-ba8e16d8d2a1.json
+++ b/change-beta/@azure-communication-react-aed327b7-449f-4d86-8730-ba8e16d8d2a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add beta version option for beta banners in Storybook",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-aed327b7-449f-4d86-8730-ba8e16d8d2a1.json
+++ b/change/@azure-communication-react-aed327b7-449f-4d86-8730-ba8e16d8d2a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add beta version option for beta banners in Storybook",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/BetaBanners/DetailedBetaBanner.tsx
+++ b/packages/storybook/stories/BetaBanners/DetailedBetaBanner.tsx
@@ -9,7 +9,7 @@ import { BannerPalette, blueBannerPalette } from './BannerPalettes';
 import { ImportantHeading } from './ImportantBannerHeading';
 
 /** @private */
-export const DetailedBetaBanner = (props: { palette?: BannerPalette }): JSX.Element => {
+export const DetailedBetaBanner = (props: { palette?: BannerPalette; version?: string }): JSX.Element => {
   const palette: BannerPalette = props.palette ?? blueBannerPalette;
   return (
     <Stack className={bannerContainerStyles(palette.background)}>
@@ -18,9 +18,16 @@ export const DetailedBetaBanner = (props: { palette?: BannerPalette }): JSX.Elem
       </Stack.Item>
       <Stack.Item>
         <Text className={mergeStyles({ lineHeight: '1.5rem' })}>
-          This feature is currently in public preview. Public preview APIs may be unstable and are not recommended for
-          production workloads. As such these features are only available in @azure/communication-react npm packages
-          suffixed with -beta. For more information, see:{' '}
+          This feature is currently in public preview {props.version ? 'version' : ''}{' '}
+          {props.version ? (
+            <b>
+              {'>'}={props.version}
+            </b>
+          ) : (
+            ''
+          )}
+          . Public preview APIs may be unstable and are not recommended for production workloads. As such these features
+          are only available in @azure/communication-react npm packages suffixed with -beta. For more information, see:{' '}
           <Link
             className={mergeStyles({ color: palette.link, fontWeight: '600' })}
             href={MICROSOFT_AZURE_PREVIEWS_URL}

--- a/packages/storybook/stories/BetaBanners/SingleLineBetaBanner.tsx
+++ b/packages/storybook/stories/BetaBanners/SingleLineBetaBanner.tsx
@@ -10,22 +10,34 @@ import { StorybookBanner, StorybookBannerProps } from './StorybookBanner';
 /**
  * @private
  */
-export const SingleLineBetaBanner = (): JSX.Element => {
+export const SingleLineBetaBanner = (props: { version?: string; topOfPage?: boolean }): JSX.Element => {
   const palette = blueBannerPalette;
   return (
-    <StorybookBanner>
-      <Stack style={{ display: 'inline-block' }}>
-        <Text>This feature is currently in public preview and not recommended for production use. </Text>
-        <Link
-          className={mergeStyles({ color: palette.link })}
-          underline={true}
-          href={MICROSOFT_AZURE_PREVIEWS_URL}
-          target="_blank"
-        >
-          More info.
-        </Link>
-      </Stack>
-    </StorybookBanner>
+    <Stack styles={props.topOfPage ? { root: { paddingTop: '1rem' } } : {}}>
+      <StorybookBanner>
+        <Stack style={{ display: 'inline-block' }}>
+          <Text>
+            This feature is currently in public preview {props.version ? 'version' : ''}{' '}
+            {props.version ? (
+              <b>
+                {'>'}={props.version}
+              </b>
+            ) : (
+              ''
+            )}{' '}
+            and not recommended for production use.{' '}
+          </Text>
+          <Link
+            className={mergeStyles({ color: palette.link })}
+            underline={true}
+            href={MICROSOFT_AZURE_PREVIEWS_URL}
+            target="_blank"
+          >
+            More info.
+          </Link>
+        </Stack>
+      </StorybookBanner>
+    </Stack>
   );
 };
 

--- a/packages/storybook/stories/CallComposite/CallCompositeDocs.tsx
+++ b/packages/storybook/stories/CallComposite/CallCompositeDocs.tsx
@@ -210,7 +210,7 @@ export const getDocs: () => JSX.Element = () => {
       </Description>
 
       <Heading>PSTN and 1:N Calling</Heading>
-      <SingleLineBetaBanner />
+      <SingleLineBetaBanner version={'1.3.2-beta.1'} />
       <Description>
         The CallComposite supports making outbound PSTN and 1:N calls. 1:N is a call either between just Azure
         Communication Users or, a mix between ACS and PSTN users. To make these outbound calls you need to provide a
@@ -229,7 +229,7 @@ export const getDocs: () => JSX.Element = () => {
       </Description>
 
       <Heading>Rooms</Heading>
-      <SingleLineBetaBanner />
+      <SingleLineBetaBanner version={'1.3.2-beta.1'} />
       <Description>
         The CallComposite supports [Rooms](./?path=/docs/rooms--page). To join a room call you need to provide a
         `locator` that contains the roomId of the room call you want to join to the

--- a/packages/storybook/stories/CallComposite/Quickstart1ToNDocs.stories.mdx
+++ b/packages/storybook/stories/CallComposite/Quickstart1ToNDocs.stories.mdx
@@ -10,7 +10,7 @@ import Quickstart1TonSnippet from '!!raw-loader!./snippets/Quickstart1ToN.snippe
 
 # Getting Started With 1:N
 
-<DetailedBetaBanner />
+<DetailedBetaBanner version={'1.3.2-beta.1'} />
 
 The UI Library CallWithChat Composite and Calling Composite supports 1:N by enabling developers to perform outbound calls through
 Azure Communication Services call service. Currently, Inbound scenarios (receiving calls from outbound ACS calls) are not supported by our composite level offerings calls.

--- a/packages/storybook/stories/CallComposite/QuickstartPSTNDocs.stories.mdx
+++ b/packages/storybook/stories/CallComposite/QuickstartPSTNDocs.stories.mdx
@@ -10,7 +10,7 @@ import QuickstartPSTNSnippet from '!!raw-loader!./snippets/QuickstartPSTN.snippe
 
 # Getting Started With PSTN
 
-<DetailedBetaBanner />
+<DetailedBetaBanner version={'1.3.2-beta.1'} />
 
 The UI Library CallWithChat Composite and Calling Composite supports PSTN by enabling developers to dial and call phone numbers through
 Azure Communication Services call service. The UI Library renders a dialpad that supports DTMF (dual tone multi-frequency) and other

--- a/packages/storybook/stories/Dialpad/Dialpad.stories.tsx
+++ b/packages/storybook/stories/Dialpad/Dialpad.stories.tsx
@@ -19,7 +19,7 @@ const getDocs: () => JSX.Element = () => {
   /* eslint-disable react/no-unescaped-entities */
   return (
     <>
-      <SingleLineBetaBanner />
+      <SingleLineBetaBanner version={'1.3.2-beta.1'} topOfPage={true} />
       <Title>Dialpad</Title>
       <Description>
         Component to render a Dialpad. This component allows numbers and +, *, # input by clicking on dialpad or using

--- a/packages/storybook/stories/Rooms.stories.mdx
+++ b/packages/storybook/stories/Rooms.stories.mdx
@@ -1,9 +1,12 @@
 import { Meta, Source } from '@storybook/addon-docs';
+import { DetailedBetaBanner } from './BetaBanners/DetailedBetaBanner';
 import RoomsCallSnippetText from '!!raw-loader!./snippets/RoomsCall.snippet.tsx';
 
 <Meta id="rooms" title="Concepts/Rooms" parameters={{ previewTabs: { canvas: { disable: true, hidden: true } } }} />
 
 # Rooms
+
+<DetailedBetaBanner version={'1.3.2-beta.1'} />
 
 Rooms secures which users can join an ACS call. Rooms also assigns roles to users to limit their access in an ACS call.
 


### PR DESCRIPTION
# What
Add beta banner version options for storybook.

# Why
Customers need clarity on which @azure/communication-react version public preview features are available in.
https://github.com/Azure/communication-ui-library/issues/2521

# How Tested
Locally ran storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->