### PR TITLE
Revert "Require webpack 5 in our lib... (#2428)" from release/1.4.1-beta.1

### DIFF
--- a/change-beta/@azure-communication-react-a027e775-198b-494f-b12e-924fe099880b.json
+++ b/change-beta/@azure-communication-react-a027e775-198b-494f-b12e-924fe099880b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert Require webpack 5 in our lib... (#2428)",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-a027e775-198b-494f-b12e-924fe099880b.json
+++ b/change/@azure-communication-react-a027e775-198b-494f-b12e-924fe099880b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert Require webpack 5 in our lib... (#2428)",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@internal-react-components-072cc54d-a247-459c-b8a8-8101ff98f2e2.json
+++ b/change/@internal-react-components-072cc54d-a247-459c-b8a8-8101ff98f2e2.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Update html-to-react dependency. Note: This change requires Webpack > 4.",
-  "packageName": "@internal/react-components",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@internal-storybook-f359b390-2a8f-472c-9495-a2bcf93f3068.json
+++ b/change/@internal-storybook-f359b390-2a8f-472c-9495-a2bcf93f3068.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Add documentation for minimum typescript and webpack versions.",
-  "packageName": "@internal/storybook",
-  "email": "2684369+JamesBurnside@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3264,7 +3264,7 @@ packages:
         optional: true
     resolution:
       integrity: sha512-RG/NjsheD9FixZ789RJlNyNccaR2Cuy7CtAwph4oUNi3aDFjtOI8Oe9L+FOT7qtVnZLw/YMjF+pZxoDqJNKLPw==
-  /@storybook/addon-essentials/6.5.13_761a676dff9f1ae99822e050e220b5de:
+  /@storybook/addon-essentials/6.5.13_b57044ac855b5a7fdef2180698b3526c:
     dependencies:
       '@babel/core': 7.16.12
       '@storybook/addon-actions': 6.5.13_react-dom@16.13.1+react@16.14.0
@@ -3277,7 +3277,6 @@ packages:
       '@storybook/addon-viewport': 6.5.13_react-dom@16.13.1+react@16.14.0
       '@storybook/addons': 6.5.13_react-dom@16.13.1+react@16.14.0
       '@storybook/api': 6.5.13_react-dom@16.13.1+react@16.14.0
-      '@storybook/builder-webpack5': 6.5.12_21967b81d2c78d5d5bef666521618933
       '@storybook/core-common': 6.5.13_21967b81d2c78d5d5bef666521618933
       '@storybook/node-logger': 6.5.13
       core-js: 3.26.0
@@ -3420,17 +3419,17 @@ packages:
         optional: true
     resolution:
       integrity: sha512-8d8taPheO/tryflzXbj2QRuxHOIS8CtzRzcaglCcioqHEMhOIDOx9BdXKdheq54gdk/UN94HdGJUoVxYyXwZ4Q==
-  /@storybook/addon-storyshots/6.5.13_c5ec9649494d0885a51f2f047d463419:
+  /@storybook/addon-storyshots/6.5.13_52933b2195c9e8824d33306e195777fc:
     dependencies:
       '@jest/transform': 26.6.2
       '@storybook/addons': 6.5.13_react-dom@16.13.1+react@16.14.0
       '@storybook/babel-plugin-require-context-hook': 1.0.1
       '@storybook/client-api': 6.5.13_react-dom@16.13.1+react@16.14.0
-      '@storybook/core': 6.5.13_922af42a9cba908f0152755603d50927
+      '@storybook/core': 6.5.13_08636f889aa3a8b90638d0b22ccfb490
       '@storybook/core-client': 6.5.13_b472181635e395dce6ccaf19d0dd7e47
       '@storybook/core-common': 6.5.13_21967b81d2c78d5d5bef666521618933
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/react': 6.5.13_71976a75a5e0ecf7b769c460fbb39e3e
+      '@storybook/react': 6.5.13_a0f70ca063c2888268bc94ca80f059e8
       '@types/glob': 7.2.0
       '@types/jest': 26.0.24
       '@types/jest-specific-snapshot': 0.5.6
@@ -3453,8 +3452,6 @@ packages:
       '@angular/core': '>=6.0.0'
       '@angular/platform-browser-dynamic': '>=6.0.0'
       '@storybook/angular': '*'
-      '@storybook/builder-webpack5': '*'
-      '@storybook/manager-webpack5': '*'
       '@storybook/react': '*'
       '@storybook/vue': '*'
       '@storybook/vue3': '*'
@@ -4194,18 +4191,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-kL745tPpRKejzHToA3/CoBNbI+NPRVk186vGxXBmk95OEg0TlwgQExP8BnqEtLlRZMbW08e4+6kilc1M1M4N5w==
-  /@storybook/core-server/6.5.13_dab294bee2e22904295aca95523c7ab9:
+  /@storybook/core-server/6.5.13_21967b81d2c78d5d5bef666521618933:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@storybook/builder-webpack4': 6.5.13_21967b81d2c78d5d5bef666521618933
-      '@storybook/builder-webpack5': 6.5.12_21967b81d2c78d5d5bef666521618933
       '@storybook/core-client': 6.5.13_b96b6ddd746339a36833aef2724144a7
       '@storybook/core-common': 6.5.13_21967b81d2c78d5d5bef666521618933
       '@storybook/core-events': 6.5.13
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.13
       '@storybook/manager-webpack4': 6.5.13_21967b81d2c78d5d5bef666521618933
-      '@storybook/manager-webpack5': 6.5.12_21967b81d2c78d5d5bef666521618933
       '@storybook/node-logger': 6.5.13
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.13_react-dom@16.13.1+react@16.14.0
@@ -4263,12 +4258,10 @@ packages:
         optional: true
     resolution:
       integrity: sha512-vs7tu3kAnFwuINio1p87WyqDNlFyZESmeh9s7vvrZVbe/xS/ElqDscr9DT5seW+jbtxufAaHsx+JUTver1dheQ==
-  /@storybook/core/6.5.13_922af42a9cba908f0152755603d50927:
+  /@storybook/core/6.5.13_08636f889aa3a8b90638d0b22ccfb490:
     dependencies:
-      '@storybook/builder-webpack5': 6.5.12_21967b81d2c78d5d5bef666521618933
       '@storybook/core-client': 6.5.13_b472181635e395dce6ccaf19d0dd7e47
-      '@storybook/core-server': 6.5.13_dab294bee2e22904295aca95523c7ab9
-      '@storybook/manager-webpack5': 6.5.12_21967b81d2c78d5d5bef666521618933
+      '@storybook/core-server': 6.5.13_21967b81d2c78d5d5bef666521618933
       react: 16.14.0
       react-dom: 16.13.1_react@16.14.0
       typescript: 4.3.5
@@ -4548,20 +4541,18 @@ packages:
       webpack: '>= 4'
     resolution:
       integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==
-  /@storybook/react/6.5.13_71976a75a5e0ecf7b769c460fbb39e3e:
+  /@storybook/react/6.5.13_a0f70ca063c2888268bc94ca80f059e8:
     dependencies:
       '@babel/core': 7.16.12
       '@babel/preset-flow': 7.18.6_@babel+core@7.16.12
       '@babel/preset-react': 7.18.6_@babel+core@7.16.12
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.8_f98928d9a7034c7af6cb4973cda31677
       '@storybook/addons': 6.5.13_react-dom@16.13.1+react@16.14.0
-      '@storybook/builder-webpack5': 6.5.12_21967b81d2c78d5d5bef666521618933
       '@storybook/client-logger': 6.5.13
-      '@storybook/core': 6.5.13_922af42a9cba908f0152755603d50927
+      '@storybook/core': 6.5.13_08636f889aa3a8b90638d0b22ccfb490
       '@storybook/core-common': 6.5.13_21967b81d2c78d5d5bef666521618933
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.13_react-dom@16.13.1+react@16.14.0
-      '@storybook/manager-webpack5': 6.5.12_21967b81d2c78d5d5bef666521618933
       '@storybook/node-logger': 6.5.13
       '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_typescript@4.3.5+webpack@5.38.1
       '@storybook/semver': 7.3.2
@@ -8856,6 +8847,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+  /entities/3.0.1:
+    dev: false
+    engines:
+      node: '>=0.12'
+    resolution:
+      integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
   /entities/4.4.0:
     dev: false
     engines:
@@ -11066,14 +11063,18 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==
-  /html-to-react/1.5.0:
+  /html-to-react/1.4.8_react@16.14.0:
     dependencies:
-      domhandler: 5.0.3
-      htmlparser2: 8.0.1
+      domhandler: 4.3.1
+      htmlparser2: 7.2.0
       lodash.camelcase: 4.3.0
+      ramda: 0.28.0
+      react: 16.14.0
     dev: false
+    peerDependencies:
+      react: ^16.0 || ^17.0
     resolution:
-      integrity: sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==
+      integrity: sha512-BDOPUYTej5eiOco0V0wxJ5FS+Zckp2O0kb13X1SxQFzyusIeUmnxAK0Cl5M6692bmGBs1WBjh9qF3oQ2AJUZmg==
   /html-void-elements/1.0.5:
     dev: false
     resolution:
@@ -11136,6 +11137,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  /htmlparser2/7.2.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
+      domutils: 2.8.0
+      entities: 3.0.1
+    dev: false
+    resolution:
+      integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==
   /htmlparser2/8.0.1:
     dependencies:
       domelementtype: 2.3.0
@@ -19376,7 +19386,7 @@ packages:
     dev: false
     name: '@rush-temp/acs-ui-common'
     resolution:
-      integrity: sha512-KPACOf6UMXeUu35S/srV1+9WhgFCb+LjgeCvojn02ANRjImh6Go+0Gc73etf+NWkdSoOk8opoUKEcyZA5Yljzg==
+      integrity: sha512-MK4HDQLksxN07MYChnuMJlUGPR9g6qGKGWtSLq6iJXVUsK37ons08bbyeUlh9WYhcKFRjGDesu4qujsenfZTHQ==
       tarball: file:projects/acs-ui-common.tgz
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
@@ -19415,7 +19425,7 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-2VXp00mIH6VDMufYK88xODhvXaxhIR0c7RrAK30WeeJXRzgsRegldLtyUP6Z+b/qdJrt7CHE0P5Jb3OB+G+dEA==
+      integrity: sha512-4nYw/8vVIZcTG+r/m39rNPAlltFno8y2ssPkgccVvs6yV9n98se0k8Kdz4RHeTvGmY6/HMqqX1yotF3WdGLK1w==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
@@ -19455,7 +19465,7 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-HXhqQbduKs8XOpentYreRtJANubiWkqxEefJ4qR+9919NwLkbhyUY/ECBtNEm5mwnsx7uV90IHCMu6md/+UZWg==
+      integrity: sha512-0YRBNDkf+QSjT29QLiXkHuKRVYqUwwqiuDczcfqdS1boLyGKNSfDftGqjf65HuM4wONLlQ223a0gFMQvRyfn/A==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
@@ -19529,7 +19539,7 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-ukrB/nmsA2FbiMGjhko5EGBohkP+A1XsdBYu6EvEO8czaZ1cYP9ckEtvfpBd90/lk1icCHJxOX9pES2I+Q3i6g==
+      integrity: sha512-885bCEewF3V2gDIU0/SkKvzhBlzEHk1FOmoQ/1monkFhoIXIGGMiw43AjlVV358qUivgCfGD3QnlsokckFcEyg==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
@@ -19602,7 +19612,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-TqkfA4EUNa3hNnYVttjMSO6u1GVBGHuHitEeh5bU3R1/+PG6vijpoRdHjSqa8AxFto4eedT8nl8lo8gZjSZbUw==
+      integrity: sha512-fqLrLsSUSJ3JeFTQa6n6xpINp6Dy0S8LoLtk/9eUPhwCvFGhao/zTlCSyXY2SXmmEL/h3g4ieNUNUk1xO7qzRQ==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19639,7 +19649,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-component-bindings'
     resolution:
-      integrity: sha512-OppeoEHO9pU7raWJWChofIQDUzXAKaE6UC5KHTzJOUNYGDU7d/c8BgQNIa3BbSLlsXCkS8nixtoY6+yuFDnPrg==
+      integrity: sha512-Qzjqz9ZFrvkwYbNkgZaA0vX99jxNkxSR7YoNb+nc/cdX8zpY6GRTl87ZIA5wzGlGhCKHjXrdjlC4oLxfG0TMcg==
       tarball: file:projects/chat-component-bindings.tgz
     version: 0.0.0
   file:projects/chat-stateful-client.tgz:
@@ -19681,7 +19691,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-stateful-client'
     resolution:
-      integrity: sha512-uyzfX2f5YMQUbiWIcJRi7lisznTo5IIuFJYOuV/uUJN1Hsn+UeIQeS8I9x9J8FacYGfN2VLssyTgeSQ07v1F1g==
+      integrity: sha512-x2OZrFryOFpDWRjSYIAI/yUQjEO+13+RLRPciDbpJYAZ+3WUreyNCC5GQIcaJ2vgpA8F42bLCjLPTLWmKd+Btw==
       tarball: file:projects/chat-stateful-client.tgz
     version: 0.0.0
   file:projects/chat.tgz:
@@ -19750,7 +19760,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-bg4Cbzpa8P6n7PkjdvGmh/U0Px5Zrzv/a9yvfTApj/jRNfwReYq38X/cj/3UP4e0bnYwEvMFjI8pAac8IZ0YHQ==
+      integrity: sha512-Il6glNwJbGGy1T0ySy+S6OF3GWphJokQy8q2QJra7IzYGPSZQuGF0vHqibCEDxidkGEynR71v+1G9JKohSHQUg==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19770,7 +19780,7 @@ packages:
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-4mmYbma3PDXmYlGIYtO0L9Ltxxm7RrvERN5H6mA60qKhu+RF8pmc1Ri2Wz8UGvntDOAwh2Q09j9AHWURhkG4Bw==
+      integrity: sha512-E0+j7pCgQtYLVeLK5YNNBcDSpZAMqVo+6mqOYuXZDrOV80/6kSGczOwFcmzk/ow1YVaztPxnIaI5TFhcf+RIrw==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
@@ -19824,7 +19834,7 @@ packages:
       eslint-plugin-react: 7.31.10_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
       events: 3.3.0
-      html-to-react: 1.5.0
+      html-to-react: 1.4.8_react@16.14.0
       if-env: 1.0.4
       immer: 9.0.6
       jest: 26.6.0_ts-node@9.1.1
@@ -19857,7 +19867,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-myxvG0AajmBvTJqbFaHH+kQmyOcrwtzpEICLxM4a0v23m3pAy9th6bBzJAxnXQ17kkb8bbo7Aho4N+oVgVwmQQ==
+      integrity: sha512-81LSo/a0rEEbsjyoFT1P+3RpzsG3tvCpfXs5PyeA4A8utvvv5RsD0gMVPGrm3INH+k4htLzmFT9VSjG0Fz72Gg==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
@@ -19907,7 +19917,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-rxyTzwcn0JxbczNgOV+3xhG6kNTPRp1RC1YQZWWfZQwgUGJtEjyX9RtMHgbUmGuc7oziupAsZMNd/uubEpbcRQ==
+      integrity: sha512-C0gTF4RqjweJ0xfnGT1PoOWJIbtfvUiPB6rI74/DgVZBfsG6WoL0QaA6f5DE4Hg+Wa7x31L32zjFsCyC+ZjIXw==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19966,7 +19976,7 @@ packages:
     dev: false
     name: '@rush-temp/fake-backends'
     resolution:
-      integrity: sha512-OwfTwlz6kBRQSqgDex+joz+sLQOlzOTXXM4NkbSZTIO2gX1yM9DfhwQ9RRPt94LGyvxHYYCiC8C2iZoX8sc30g==
+      integrity: sha512-1JvLszcPfVjGMPVD6dmkrQ/UW1+9pwAGsGKUqsTpvfywr8OZSrd/Q+d3kP1E9IP1iMHsTSTCeKeTq/6rOWmjTQ==
       tarball: file:projects/fake-backends.tgz
     version: 0.0.0
   file:projects/react-components.tgz:
@@ -20018,7 +20028,7 @@ packages:
       eslint-plugin-prettier: 3.4.1_8142a4287e8e8e0691574dfac8adcedb
       eslint-plugin-react: 7.31.10_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
-      html-to-react: 1.5.0
+      html-to-react: 1.4.8_react@16.14.0
       husky: 4.3.8
       if-env: 1.0.4
       jest: 26.6.0_ts-node@9.1.1
@@ -20050,7 +20060,7 @@ packages:
     dev: false
     name: '@rush-temp/react-components'
     resolution:
-      integrity: sha512-N8uxttwHVUbGYpoFirbCMpCs8WzEVahFLXqYx1WCgq9OXOiCgTye9aCgOzVJwe7tSdpUmfpjG+3J3mfZmAQmiA==
+      integrity: sha512-+M/ZcFtpZ/lJ3MqB5PahTGBx519FPIxdvoGipf6AWKul/8Z8eZTxkOLz57m9CG7OESaE8r2GF3OJEF0QmDwyqg==
       tarball: file:projects/react-components.tgz
     version: 0.0.0
   file:projects/react-composites.tgz:
@@ -20160,7 +20170,7 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-LHccBhXGZUZb0j6IjR1kTjpbtmc25jQnqWlvU0VPa3i3KcKEIou/BXwU7eMlj2NqQ/abSj2ReuXFpO+qT5H0ow==
+      integrity: sha512-imjtlVpf6ksYGS4sLJYYZoLZjUfkzJ7cD/E9SiATWhB36mB1CDnnnQbd6U1jVd7+ka756nKgoPTmvooWK3Ew4Q==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
@@ -20223,7 +20233,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-W1Bp5m3eL3Trf99ypfvtcgiIpDuQbLCjOS1tuiA8Sx92mHaSQR6QqNNE3fKB9LdP+nsV/XJPvz6v+AE0/6ANIw==
+      integrity: sha512-wc/7h3pvR9sG7m0+NUhP+ZIgreAj54FaakqRjrp+qVqDvcEkCTsY8Cg//4QI8SGMIIpInxpRU4uPeeEc2myEhA==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -20301,9 +20311,9 @@ packages:
       '@storybook/addon-actions': 6.5.13_react-dom@16.13.1+react@16.14.0
       '@storybook/addon-controls': 6.5.13_21967b81d2c78d5d5bef666521618933
       '@storybook/addon-docs': 6.5.13_b57044ac855b5a7fdef2180698b3526c
-      '@storybook/addon-essentials': 6.5.13_761a676dff9f1ae99822e050e220b5de
+      '@storybook/addon-essentials': 6.5.13_b57044ac855b5a7fdef2180698b3526c
       '@storybook/addon-links': 6.5.13_react-dom@16.13.1+react@16.14.0
-      '@storybook/addon-storyshots': 6.5.13_c5ec9649494d0885a51f2f047d463419
+      '@storybook/addon-storyshots': 6.5.13_52933b2195c9e8824d33306e195777fc
       '@storybook/addons': 6.5.13_react-dom@16.13.1+react@16.14.0
       '@storybook/api': 6.5.13_react-dom@16.13.1+react@16.14.0
       '@storybook/builder-webpack5': 6.5.12_21967b81d2c78d5d5bef666521618933
@@ -20311,7 +20321,7 @@ packages:
       '@storybook/core-events': 6.5.13
       '@storybook/manager-webpack5': 6.5.12_21967b81d2c78d5d5bef666521618933
       '@storybook/node-logger': 6.5.13
-      '@storybook/react': 6.5.13_71976a75a5e0ecf7b769c460fbb39e3e
+      '@storybook/react': 6.5.13_a0f70ca063c2888268bc94ca80f059e8
       '@storybook/storybook-deployer': 2.8.16
       '@storybook/theming': 6.5.13_react-dom@16.13.1+react@16.14.0
       '@testing-library/jest-dom': 5.16.5
@@ -20377,7 +20387,7 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-V6oUqmuzcX9y7Gms4FUsx/pALhixce4UrCUNfmXg0zN6WsZF06Gxz3AtR+J4PdvZNlDllDHjsXNjLfM2L5BJjw==
+      integrity: sha512-LMlpJyL0nmc5CNjr9QrswLgVYnBG20pj75j2ZpiTqJGMw//HNorYk79Y0nK17hxh875+5PC945VKrYiCVpjUqg==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -35,7 +35,7 @@
     "@fluentui/react": "~8.98.3",
     "copy-to-clipboard": "~3.3.1",
     "events": "~3.3.0",
-    "html-to-react": "~1.5.0",
+    "html-to-react": "~1.4.5",
     "immer": "9.0.6",
     "memoize-one": "~5.2.1",
     "nanoid": "3.1.32",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -40,7 +40,7 @@
     "@fluentui/react": "~8.98.3",
     "@internal/acs-ui-common": "1.4.1-beta.1",
     "copy-to-clipboard": "~3.3.1",
-    "html-to-react": "~1.5.0",
+    "html-to-react": "~1.4.5",
     "react-aria-live": "^2.0.5",
     "react-linkify": "^1.0.0-alpha",
     "uuid": "^8.1.0"

--- a/packages/storybook/.storybook/main.js
+++ b/packages/storybook/.storybook/main.js
@@ -21,9 +21,6 @@ module.exports = {
   // Speeds up webpack build time after every code change. Improvements of up
   // to 4-5 seconds can be seen. Comment if components don't render properly.
   typescript: { reactDocgen: 'react-docgen' },
-  core: {
-    builder: 'webpack5',
-  },
   addons: [
     '@storybook/addon-links',
     {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -53,8 +53,6 @@
     "@storybook/addon-essentials": "~6.5.7",
     "@storybook/addon-links": "~6.5.7",
     "@storybook/addon-storyshots": "~6.5.7",
-    "@storybook/builder-webpack5": "6.5.12",
-    "@storybook/manager-webpack5": "6.5.12",
     "@storybook/node-logger": "~6.5.7",
     "@storybook/react": "~6.5.7",
     "@storybook/storybook-deployer": "~2.8.10",

--- a/packages/storybook/stories/Setup.stories.mdx
+++ b/packages/storybook/stories/Setup.stories.mdx
@@ -84,15 +84,6 @@ Should you want to update anything make sure that it is compatible with react ve
 
 ### Installing the Package
 
-#### Package prequiresites
-
-The Azure Communication UI Library supports the following minimum versions:
-
-- `typescript` >= 3.7.0
-- `webpack` >= 5.3.8
-
-#### npm install
-
 Use the `npm install` command to install the Azure Communication Services UI Library for JavaScript.
 
 ```bash

--- a/packages/storybook/stories/Troubleshooting.stories.mdx
+++ b/packages/storybook/stories/Troubleshooting.stories.mdx
@@ -61,22 +61,3 @@ by `npm add`.
 ```
 PS C:\tmp\acs\my-react-app> npm add --legacy-peer-deps @azure/communication-react
 ```
-
-## Project build errors
-
-### Webpack ERROR Unexpected token: `export * as`
-
-```
-ERROR in /.../htmlparser2@8.0.1/node_modules/htmlparser2/lib/esm/index.js 59:9
-Module parse failed: Unexpected token (59:9)
-You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
-|     return getFeed(parseDOM(feed, options));
-| }
-> export * as DomUtils from "domutils";
-| // Old name for DomHandler
-| export { DomHandler as DefaultHandler };
-```
-
-This issue will occur when using `@azure/communication-react` with a webpack version < 5.
-The best course of action is to upgrade your webpack version to 5.
-If this is not possible, take a look at [these workarounds](https://github.com/fb55/htmlparser2/issues/1237#issuecomment-1182522861).

--- a/tools/check-treeshaking/package.json
+++ b/tools/check-treeshaking/package.json
@@ -26,9 +26,6 @@
     "@internal/calling-component-bindings": "1.4.1-beta.1"
   },
   "devDependencies": {
-    "@babel/core": "~7.16.0",
-    "@babel/plugin-proposal-export-namespace-from": "~7.16.0",
-    "babel-loader": "8.1.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-prettier": "^3.1.4",


### PR DESCRIPTION
# What
Revert webpack 5 change.

# Why
No features/functionality is impacted with this revert int his beta release 1.4.1-beta.1

# How Tested
Tested locally. Rebuilt and ran through codespace.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->