### PR TITLE
Memoize local participant in video gallery selector

### DIFF
--- a/change-beta/@azure-communication-react-cc8017a5-5def-4ec4-9a1f-f96bfdc4e907.json
+++ b/change-beta/@azure-communication-react-cc8017a5-5def-4ec4-9a1f-f96bfdc4e907.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Memoize local participant in video gallery selector",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-cc8017a5-5def-4ec4-9a1f-f96bfdc4e907.json
+++ b/change/@azure-communication-react-cc8017a5-5def-4ec4-9a1f-f96bfdc4e907.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Memoize local participant in video gallery selector",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/src/utils/videoGalleryUtils.ts
+++ b/packages/calling-component-bindings/src/utils/videoGalleryUtils.ts
@@ -8,6 +8,7 @@ import {
 import { memoizeFnAll, toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 import { RemoteParticipantState, RemoteVideoStreamState } from '@internal/calling-stateful-client';
 import { VideoGalleryRemoteParticipant, VideoGalleryStream } from '@internal/react-components';
+import memoizeOne from 'memoize-one';
 import { checkIsSpeaking } from './SelectorUtils';
 
 /** @internal */
@@ -113,3 +114,18 @@ const convertRemoteVideoStreamToVideoGalleryStream = (stream: RemoteVideoStreamS
     renderElement: stream.view?.target
   };
 };
+
+/** @private */
+export const memoizeLocalParticipant = memoizeOne(
+  (identifier, displayName, isMuted, isScreenSharingOn, localVideoStream) => ({
+    userId: identifier,
+    displayName: displayName ?? '',
+    isMuted: isMuted,
+    isScreenSharingOn: isScreenSharingOn,
+    videoStream: {
+      isAvailable: !!localVideoStream,
+      isMirrored: localVideoStream?.view?.isMirrored,
+      renderElement: localVideoStream?.view?.target
+    }
+  })
+);

--- a/packages/calling-component-bindings/src/videoGallerySelector.ts
+++ b/packages/calling-component-bindings/src/videoGallerySelector.ts
@@ -4,6 +4,7 @@
 import { toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 import { CallClientState, RemoteParticipantState } from '@internal/calling-stateful-client';
 import { VideoGalleryLocalParticipant, VideoGalleryRemoteParticipant } from '@internal/react-components';
+import memoizeOne from 'memoize-one';
 import { createSelector } from 'reselect';
 import {
   CallingBaseSelectorProps,
@@ -21,7 +22,8 @@ import { checkIsSpeaking } from './utils/SelectorUtils';
 import {
   _videoGalleryRemoteParticipantsMemo,
   _dominantSpeakersWithFlatId,
-  convertRemoteParticipantToVideoGalleryRemoteParticipant
+  convertRemoteParticipantToVideoGalleryRemoteParticipant,
+  memoizeLocalParticipant
 } from './utils/videoGalleryUtils';
 
 /**
@@ -85,17 +87,7 @@ export const videoGallerySelector: VideoGallerySelector = createSelector(
             screenShareRemoteParticipant.displayName
           )
         : undefined,
-      localParticipant: {
-        userId: identifier,
-        displayName: displayName ?? '',
-        isMuted: isMuted,
-        isScreenSharingOn: isScreenSharingOn,
-        videoStream: {
-          isAvailable: !!localVideoStream,
-          isMirrored: localVideoStream?.view?.isMirrored,
-          renderElement: localVideoStream?.view?.target
-        }
-      },
+      localParticipant: memoizeLocalParticipant(identifier, displayName, isMuted, isScreenSharingOn, localVideoStream),
       remoteParticipants: _videoGalleryRemoteParticipantsMemo(
         updateUserDisplayNamesTrampoline(remoteParticipants ? Object.values(remoteParticipants) : noRemoteParticipants)
       ),


### PR DESCRIPTION
# What
Memoize local participant in video gallery selector

# Why
Prevent unnecessary re-renders when other parts of the video gallery changes but the local participant has not changed.
This is mostly to help debugging.