### PR TITLE
Add scalingMode to videoGallerySelector

### DIFF
--- a/change-beta/@azure-communication-react-71abe466-ebd2-4420-b2ea-8f7a9a5a1ee2.json
+++ b/change-beta/@azure-communication-react-71abe466-ebd2-4420-b2ea-8f7a9a5a1ee2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add scalingMode to VideoGalleryStream type",
+  "packageName": "@azure/communication-react",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-71abe466-ebd2-4420-b2ea-8f7a9a5a1ee2.json
+++ b/change/@azure-communication-react-71abe466-ebd2-4420-b2ea-8f7a9a5a1ee2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add scalingMode to VideoGalleryStream type",
+  "packageName": "@azure/communication-react",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/src/utils/videoGalleryUtils.ts
+++ b/packages/calling-component-bindings/src/utils/videoGalleryUtils.ts
@@ -110,6 +110,8 @@ const convertRemoteVideoStreamToVideoGalleryStream = (stream: RemoteVideoStreamS
     /* @conditional-compile-remove(video-stream-is-receiving-flag) */
     isReceiving: stream.isReceiving,
     isMirrored: stream.view?.isMirrored,
-    renderElement: stream.view?.target
+    renderElement: stream.view?.target,
+    /* @conditional-compile-remove(pinned-participants) */
+    scalingMode: stream.view?.scalingMode
   };
 };

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -3214,6 +3214,7 @@ export interface VideoGalleryStream {
     isMirrored?: boolean;
     isReceiving?: boolean;
     renderElement?: HTMLElement;
+    scalingMode?: ViewScalingMode;
 }
 
 // @public

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1665,6 +1665,7 @@ export interface VideoGalleryStream {
     isMirrored?: boolean;
     isReceiving?: boolean;
     renderElement?: HTMLElement;
+    scalingMode?: ViewScalingMode;
 }
 
 // @public

--- a/packages/react-components/src/types/VideoGalleryParticipant.ts
+++ b/packages/react-components/src/types/VideoGalleryParticipant.ts
@@ -58,6 +58,9 @@ export interface VideoGalleryStream {
   isMirrored?: boolean;
   /** Render element of the video stream */
   renderElement?: HTMLElement;
+  /* @conditional-compile-remove(pinned-participants) */
+  /** Scaling mode of the video stream */
+  scalingMode?: ViewScalingMode;
 }
 
 /**


### PR DESCRIPTION
# What
Add scalingMode to videoGallerySelector
This is required to detect the current scaling mode of a remote participant and change the menu item from "Fit" to "Fill" and vice versa in Video Tile contextual menu

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->