### PR TITLE
Stable Bugfix - disableEditing not working in MessageThread

### DIFF
--- a/change-beta/@azure-communication-react-7f8aa683-02a2-475e-ac45-d8250c73e05c.json
+++ b/change-beta/@azure-communication-react-7f8aa683-02a2-475e-ac45-d8250c73e05c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bugfix disableEditing not working in MessageThread.",
+  "packageName": "@azure/communication-react",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-7f8aa683-02a2-475e-ac45-d8250c73e05c.json
+++ b/change/@azure-communication-react-7f8aa683-02a2-475e-ac45-d8250c73e05c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bugfix disableEditing not working in MessageThread.",
+  "packageName": "@azure/communication-react",
+  "email": "anjulgarg@live.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -347,7 +347,8 @@ const memoizeAllMessages = memoizeFnAll(
     onRenderMessage?: (message: MessageProps, defaultOnRender?: MessageRenderer) => JSX.Element,
     onUpdateMessage?: UpdateMessageCallback,
     onDeleteMessage?: (messageId: string) => Promise<void>,
-    onSendMessage?: (content: string) => Promise<void>
+    onSendMessage?: (content: string) => Promise<void>,
+    disableEditing?: boolean
   ): ShorthandValue<ChatItemProps> => {
     const messageProps: MessageProps = {
       message,
@@ -355,7 +356,8 @@ const memoizeAllMessages = memoizeFnAll(
       showDate: showMessageDate,
       onUpdateMessage,
       onDeleteMessage,
-      onSendMessage
+      onSendMessage,
+      disableEditing
     };
 
     switch (message.messageType) {
@@ -729,7 +731,7 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
     /* @conditional-compile-remove(date-time-customization) */
     onDisplayDateTimeString
   } = props;
-
+  console.log('MESSAGE THREAD', props.disableEditing);
   const onRenderFileDownloads = onRenderFileDownloadsTrampoline(props);
 
   const [messages, setMessages] = useState<(ChatMessage | SystemMessage | CustomMessage)[]>([]);
@@ -1095,7 +1097,8 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
             onRenderMessage,
             onUpdateMessage,
             onDeleteMessage,
-            onSendMessage
+            onSendMessage,
+            props.disableEditing
           );
         });
       }),
@@ -1118,7 +1121,8 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
       onSendMessage,
       lastSeenChatMessage,
       lastSendingChatMessage,
-      lastDeliveredChatMessage
+      lastDeliveredChatMessage,
+      props.disableEditing
     ]
   );
 


### PR DESCRIPTION
# What
Stable Bugfix - disableEditing not working in MessageThread

# Why
This PR fixes the bug reported here https://github.com/Azure/communication-ui-library/issues/2569

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->