### PR TITLE
Cursor should show at the end when clicking in dialpad textfield

### DIFF
--- a/change-beta/@azure-communication-react-d3be0530-f540-4d98-a572-ddfc67367bbb.json
+++ b/change-beta/@azure-communication-react-d3be0530-f540-4d98-a572-ddfc67367bbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move cursor to the end of input when clicking on dialpad text field",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-d3be0530-f540-4d98-a572-ddfc67367bbb.json
+++ b/change/@azure-communication-react-d3be0530-f540-4d98-a572-ddfc67367bbb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Move cursor to the end of input when clicking on dialpad text field",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -267,6 +267,7 @@ const DialpadContainer = (props: {
         onChange={(e: any) => {
           setText(e.target.value);
         }}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onClick={(e: any) => {
           const input = e.target;
           const end = input.value.length;

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -267,6 +267,14 @@ const DialpadContainer = (props: {
         onChange={(e: any) => {
           setText(e.target.value);
         }}
+        onClick={(e: any) => {
+          const input = e.target;
+          const end = input.value.length;
+
+          // Move focus to end of input field
+          input.setSelectionRange(end, end);
+          input.focus();
+        }}
         placeholder={props.strings.placeholderText}
         data-test-id="dialpad-input"
         onRenderSuffix={(): JSX.Element => (


### PR DESCRIPTION
# What
Cursor should show at the end when clicking in dialpad textfield

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3015832

# How Tested


https://user-images.githubusercontent.com/96077406/205985140-f02ec960-c9a2-4559-ad58-688e3cfd3e73.mov


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->