### PR TITLE
Device denied screen should show on safari when don't allow is clicked 

### DIFF
--- a/change-beta/@azure-communication-react-d74c9c67-8c1e-4d3c-a629-38ddfa99a3fb.json
+++ b/change-beta/@azure-communication-react-d74c9c67-8c1e-4d3c-a629-38ddfa99a3fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed bug where on safari browser the device denied screen is not showing when don't allow is clicked ",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-d74c9c67-8c1e-4d3c-a629-38ddfa99a3fb.json
+++ b/change-beta/@azure-communication-react-d74c9c67-8c1e-4d3c-a629-38ddfa99a3fb.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "Fixed bug where on safari browser the device denied screen is not showing when don't allow is clicked ",
   "packageName": "@azure/communication-react",
   "email": "carolinecao@microsoft.com",

--- a/change/@azure-communication-react-d74c9c67-8c1e-4d3c-a629-38ddfa99a3fb.json
+++ b/change/@azure-communication-react-d74c9c67-8c1e-4d3c-a629-38ddfa99a3fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed bug where on safari browser the device denied screen is not showing when don't allow is clicked ",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-d74c9c67-8c1e-4d3c-a629-38ddfa99a3fb.json
+++ b/change/@azure-communication-react-d74c9c67-8c1e-4d3c-a629-38ddfa99a3fb.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "Fixed bug where on safari browser the device denied screen is not showing when don't allow is clicked ",
   "packageName": "@azure/communication-react",
   "email": "carolinecao@microsoft.com",

--- a/packages/react-composites/src/composites/CallComposite/components/CallReadinessModal.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallReadinessModal.tsx
@@ -251,7 +251,7 @@ export const CallReadinessModalFallBack = (props: {
   // When permissions are not set, do nothing here
   // When permissions are set to denied, show helper screen
   const showModal = videoState === 'denied' || audioState === 'denied';
-  
+
   /* @conditional-compile-remove(unsupported-browser) */
   const isSafari = _isSafari(environmentInfo);
 

--- a/packages/react-composites/src/composites/CallComposite/components/CallReadinessModal.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallReadinessModal.tsx
@@ -35,13 +35,15 @@ export const CallReadinessModal = (props: {
     camera: PermissionState;
     microphone: PermissionState;
   }) => void;
+  cameraPermissionGranted: boolean | undefined;
+  microphonePermissionGranted: boolean | undefined;
 }): JSX.Element => {
   const {
     mobileView,
-    audioState,
-    videoState,
     permissionsState,
     isPermissionsModalDismissed,
+    cameraPermissionGranted,
+    microphonePermissionGranted,
     setIsPermissionsModalDismissed,
     onPermissionsTroubleshootingClick
   } = props;
@@ -49,6 +51,10 @@ export const CallReadinessModal = (props: {
     // do nothing here
     // only way to dismiss this drawer is clicking on allow access which will leads to device permission prompt
   };
+
+  // On Safari browser with 2 options: don't allow/never for this website again, when don't allow is clicked, permissionAPI returns prompt and PermissionGranted from calling sdk returns false (the right value)
+  const videoState: PermissionState = cameraPermissionGranted === false ? 'denied' : props.videoState;
+  const audioState: PermissionState = microphonePermissionGranted === false ? 'denied' : props.audioState;
 
   const showModal =
     videoState === 'denied' || videoState === 'prompt' || audioState === 'denied' || audioState === 'prompt';

--- a/packages/react-composites/src/composites/CallComposite/components/CallReadinessModal.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallReadinessModal.tsx
@@ -23,8 +23,6 @@ const DRAWER_HIGH_Z_BAND = 99; // setting z index to  99 so that it sit above al
  */
 export const CallReadinessModal = (props: {
   mobileView: boolean;
-  audioState: PermissionState;
-  videoState: PermissionState;
   permissionsState: {
     camera: PermissionState;
     microphone: PermissionState;
@@ -35,15 +33,11 @@ export const CallReadinessModal = (props: {
     camera: PermissionState;
     microphone: PermissionState;
   }) => void;
-  cameraPermissionGranted: boolean | undefined;
-  microphonePermissionGranted: boolean | undefined;
 }): JSX.Element => {
   const {
     mobileView,
     permissionsState,
     isPermissionsModalDismissed,
-    cameraPermissionGranted,
-    microphonePermissionGranted,
     setIsPermissionsModalDismissed,
     onPermissionsTroubleshootingClick
   } = props;
@@ -53,8 +47,8 @@ export const CallReadinessModal = (props: {
   };
 
   // On Safari browser with 2 options: don't allow/never for this website again, when don't allow is clicked, permissionAPI returns prompt and PermissionGranted from calling sdk returns false (the right value)
-  const videoState: PermissionState = cameraPermissionGranted === false ? 'denied' : props.videoState;
-  const audioState: PermissionState = microphonePermissionGranted === false ? 'denied' : props.audioState;
+  const videoState: PermissionState = permissionsState.camera;
+  const audioState: PermissionState = permissionsState.microphone;
 
   const showModal =
     videoState === 'denied' || videoState === 'prompt' || audioState === 'denied' || audioState === 'prompt';
@@ -202,8 +196,6 @@ export const CallReadinessModal = (props: {
  */
 export const CallReadinessModalFallBack = (props: {
   mobileView: boolean;
-  cameraPermissionGranted: boolean | undefined;
-  microphonePermissionGranted: boolean | undefined;
   checkPermissionModalShowing: boolean;
   permissionsState: {
     camera: PermissionState;
@@ -218,8 +210,6 @@ export const CallReadinessModalFallBack = (props: {
 }): JSX.Element => {
   const {
     mobileView,
-    cameraPermissionGranted,
-    microphonePermissionGranted,
     checkPermissionModalShowing,
     permissionsState,
     isPermissionsModalDismissed,
@@ -231,14 +221,17 @@ export const CallReadinessModalFallBack = (props: {
     // only way to dismiss this drawer is clicking on allow access which will leads to device permission prompt
   };
 
-  // When permissions are not set, value is undefined, do nothing here
-  // When permissions are set to denied, value is false, show helper screen
-  const showModal = cameraPermissionGranted === false || microphonePermissionGranted === false;
+  const videoState = permissionsState.camera;
+  const audioState = permissionsState.microphone;
+
+  // When permissions are not set, do nothing here
+  // When permissions are set to denied, show helper screen
+  const showModal = videoState === 'denied' || audioState === 'denied';
 
   const modal: undefined | (() => JSX.Element) = !showModal
     ? undefined
     : () => {
-        if (cameraPermissionGranted === false && microphonePermissionGranted === false) {
+        if (videoState === 'denied' && audioState === 'denied') {
           return (
             <CameraAndMicrophoneDomainPermissions
               appName={'app'}
@@ -252,7 +245,7 @@ export const CallReadinessModalFallBack = (props: {
               type="denied"
             />
           );
-        } else if (cameraPermissionGranted === false && microphonePermissionGranted) {
+        } else if (videoState === 'denied' && audioState === 'granted') {
           return (
             <CameraDomainPermissions
               appName={'app'}
@@ -289,9 +282,7 @@ export const CallReadinessModalFallBack = (props: {
   if (mobileView) {
     return (
       <>
-        {(checkPermissionModalShowing ||
-          microphonePermissionGranted === undefined ||
-          cameraPermissionGranted === undefined) && (
+        {(checkPermissionModalShowing || audioState === 'prompt' || videoState === 'prompt') && (
           <_DrawerSurface onLightDismiss={onLightDismissTriggered} styles={drawerContainerStyles(DRAWER_HIGH_Z_BAND)}>
             <CameraAndMicrophoneDomainPermissions
               appName={'app'}
@@ -316,9 +307,7 @@ export const CallReadinessModalFallBack = (props: {
   } else {
     return (
       <>
-        {(checkPermissionModalShowing ||
-          microphonePermissionGranted === undefined ||
-          cameraPermissionGranted === undefined) && (
+        {(checkPermissionModalShowing || audioState === 'prompt' || videoState === 'prompt') && (
           <Modal
             isOpen={isPermissionsModalDismissed}
             isBlocking={false}

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -150,16 +150,20 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
         ? cameraPermissionGranted !== false
           ? videoState
           : 'denied'
-        : cameraPermissionGranted
-        ? 'granted'
+        : cameraPermissionGranted !== false
+        ? cameraPermissionGranted
+          ? 'granted'
+          : 'prompt'
         : 'denied',
     microphone:
       audioState && audioState !== 'unsupported'
         ? microphonePermissionGranted !== false
           ? audioState
           : 'denied'
-        : microphonePermissionGranted
-        ? 'granted'
+        : microphonePermissionGranted !== false
+        ? microphonePermissionGranted
+          ? 'granted'
+          : 'prompt'
         : 'denied'
   };
   /* @conditional-compile-remove(call-readiness) */
@@ -209,12 +213,8 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
           audioState !== 'unsupported' && (
             <CallReadinessModal
               mobileView={mobileView}
-              audioState={audioState}
-              videoState={videoState}
               permissionsState={permissionsState}
               isPermissionsModalDismissed={isPermissionsModalDismissed}
-              cameraPermissionGranted={cameraPermissionGranted}
-              microphonePermissionGranted={microphonePermissionGranted}
               setIsPermissionsModalDismissed={setIsPermissionsModalDismissed}
               onPermissionsTroubleshootingClick={onPermissionsTroubleshootingClick}
             />
@@ -230,8 +230,6 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
           (videoState === 'unsupported' || audioState === 'unsupported') && (
             <CallReadinessModalFallBack
               mobileView={mobileView}
-              cameraPermissionGranted={cameraPermissionGranted}
-              microphonePermissionGranted={microphonePermissionGranted}
               checkPermissionModalShowing={forceShowingCheckPermissions}
               permissionsState={permissionsState}
               isPermissionsModalDismissed={isPermissionsModalDismissed}

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -200,6 +200,8 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
               videoState={videoState}
               permissionsState={permissionsState}
               isPermissionsModalDismissed={isPermissionsModalDismissed}
+              cameraPermissionGranted={cameraPermissionGranted}
+              microphonePermissionGranted={microphonePermissionGranted}
               setIsPermissionsModalDismissed={setIsPermissionsModalDismissed}
               onPermissionsTroubleshootingClick={onPermissionsTroubleshootingClick}
             />

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -145,9 +145,22 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
     microphone: PermissionState;
   } = {
     // fall back to using cameraPermissionGranted and microphonePermissionGranted if permission API is not supported
-    camera: videoState && videoState !== 'unsupported' ? videoState : cameraPermissionGranted ? 'granted' : 'denied',
+    camera:
+      videoState && videoState !== 'unsupported'
+        ? cameraPermissionGranted !== false
+          ? videoState
+          : 'denied'
+        : cameraPermissionGranted
+        ? 'granted'
+        : 'denied',
     microphone:
-      audioState && audioState !== 'unsupported' ? audioState : microphonePermissionGranted ? 'granted' : 'denied'
+      audioState && audioState !== 'unsupported'
+        ? microphonePermissionGranted !== false
+          ? audioState
+          : 'denied'
+        : microphonePermissionGranted
+        ? 'granted'
+        : 'denied'
   };
   /* @conditional-compile-remove(call-readiness) */
   const networkErrors = errorBarProps.activeErrorMessages.filter((message) => message.type === 'callNetworkQualityLow');


### PR DESCRIPTION
# What
Device denied screen should show on safari when don't allow is clicked 

# Why
When don't allow is clicked on safari, permissionsAPI returns prompt instead of denied (that is because inside safari settings it's still set to ask when don't allow is clicked.) Calling SDK returns false in this case

So we add an extra layer of checking to make sure we always show the denied screen when calling sdk returns false. 

# How Tested


https://user-images.githubusercontent.com/96077406/207913061-04132871-dabb-4ffc-a9ba-1ce46785b40d.mov


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->