### PR TITLE
Change is Safari prop to browserHint to allow more customization

### DIFF
--- a/change-beta/@azure-communication-react-adc390fc-919f-499c-a08e-e2d69c702a3b.json
+++ b/change-beta/@azure-communication-react-adc390fc-919f-499c-a08e-e2d69c702a3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change domain Permission prop isSafari to browserHint: 'safari' | 'unset' to allow further customization for other browsers",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-adc390fc-919f-499c-a08e-e2d69c702a3b.json
+++ b/change/@azure-communication-react-adc390fc-919f-499c-a08e-e2d69c702a3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change domain Permission prop isSafari to browserHint: 'safari' | 'unset' to allow further customization for other browsers",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1419,7 +1419,7 @@ export interface CommonCallingHandlers {
 // @beta
 export interface CommonDomainPermissionsProps {
     appName: string;
-    isSafari?: boolean;
+    browserHint: 'safari' | 'unset';
     onContinueAnywayClick?: () => void;
     onTroubleshootingClick?: () => void;
     styles?: DomainPermissionsStyles;

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1419,7 +1419,7 @@ export interface CommonCallingHandlers {
 // @beta
 export interface CommonDomainPermissionsProps {
     appName: string;
-    browserHint: 'safari' | 'unset';
+    browserHint?: 'safari' | 'unset';
     onContinueAnywayClick?: () => void;
     onTroubleshootingClick?: () => void;
     styles?: DomainPermissionsStyles;

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -237,7 +237,7 @@ export interface ChatMessage extends MessageCommon {
 // @beta
 export interface CommonDomainPermissionsProps {
     appName: string;
-    isSafari?: boolean;
+    browserHint: 'safari' | 'unset';
     onContinueAnywayClick?: () => void;
     onTroubleshootingClick?: () => void;
     styles?: DomainPermissionsStyles;

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -237,7 +237,7 @@ export interface ChatMessage extends MessageCommon {
 // @beta
 export interface CommonDomainPermissionsProps {
     appName: string;
-    browserHint: 'safari' | 'unset';
+    browserHint?: 'safari' | 'unset';
     onContinueAnywayClick?: () => void;
     onTroubleshootingClick?: () => void;
     styles?: DomainPermissionsStyles;

--- a/packages/react-components/src/components/DevicePermissions/DomainPermissions.tsx
+++ b/packages/react-components/src/components/DevicePermissions/DomainPermissions.tsx
@@ -26,7 +26,7 @@ export interface CommonDomainPermissionsProps {
   /**
    * Type of the browser used, the domain permission component will show different guidance text based on the browser type
    */
-  browserHint: 'safari' | 'unset';
+  browserHint?: 'safari' | 'unset';
   /**
    * Action to be taken by the more help link. Possible to send to external page or show other modal.
    * If this is not provided the button will not be shown.

--- a/packages/react-components/src/components/DevicePermissions/DomainPermissions.tsx
+++ b/packages/react-components/src/components/DevicePermissions/DomainPermissions.tsx
@@ -24,9 +24,9 @@ export interface CommonDomainPermissionsProps {
    */
   type: 'request' | 'denied' | 'check';
   /**
-   * Whether we are using safari browser or not
+   * Type of the browser used, the domain permission component will show different guidance text based on the browser type
    */
-  isSafari?: boolean;
+  browserHint: 'safari' | 'unset';
   /**
    * Action to be taken by the more help link. Possible to send to external page or show other modal.
    * If this is not provided the button will not be shown.
@@ -77,7 +77,7 @@ export const CameraAndMicrophoneDomainPermissions = (props: CameraAndMicrophoneD
   /* @conditional-compile-remove(call-readiness) */
   const strings = useShallowMerge(
     props.type === 'denied'
-      ? props.isSafari
+      ? props.browserHint === 'safari'
         ? locale.CameraAndMicrophoneDomainPermissionsDeniedSafari
         : locale.CameraAndMicrophoneDomainPermissionsDenied
       : props.type === 'request'
@@ -139,7 +139,7 @@ export const MicrophoneDomainPermissions = (props: MicrophoneDomainPermissionsPr
   /* @conditional-compile-remove(call-readiness) */
   const strings = useShallowMerge(
     props.type === 'denied'
-      ? props.isSafari
+      ? props.browserHint === 'safari'
         ? locale.MicrophoneDomainPermissionsDeniedSafari
         : locale.MicrophoneDomainPermissionsDenied
       : props.type === 'request'
@@ -194,7 +194,7 @@ export const CameraDomainPermissions = (props: CameraDomainPermissionsProps): JS
   /* @conditional-compile-remove(call-readiness) */
   const strings = useShallowMerge(
     props.type === 'denied'
-      ? props.isSafari
+      ? props.browserHint === 'safari'
         ? locale.CameraDomainPermissionsDeniedSafari
         : locale.CameraDomainPermissionsDenied
       : props.type === 'request'

--- a/packages/react-composites/src/composites/CallComposite/components/CallReadinessModal.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallReadinessModal.tsx
@@ -71,7 +71,7 @@ export const CallReadinessModal = (props: {
             <CameraAndMicrophoneDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {
@@ -89,7 +89,7 @@ export const CallReadinessModal = (props: {
             <CameraDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {
@@ -110,7 +110,7 @@ export const CallReadinessModal = (props: {
             <MicrophoneDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {
@@ -128,7 +128,7 @@ export const CallReadinessModal = (props: {
             <CameraAndMicrophoneDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {
@@ -146,7 +146,7 @@ export const CallReadinessModal = (props: {
             <CameraDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {
@@ -167,7 +167,7 @@ export const CallReadinessModal = (props: {
             <MicrophoneDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {
@@ -263,7 +263,7 @@ export const CallReadinessModalFallBack = (props: {
             <CameraAndMicrophoneDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {
@@ -279,7 +279,7 @@ export const CallReadinessModalFallBack = (props: {
             <CameraDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {
@@ -298,7 +298,7 @@ export const CallReadinessModalFallBack = (props: {
             <MicrophoneDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {
@@ -320,7 +320,7 @@ export const CallReadinessModalFallBack = (props: {
             <CameraAndMicrophoneDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {
@@ -354,7 +354,7 @@ export const CallReadinessModalFallBack = (props: {
             <CameraAndMicrophoneDomainPermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
-              isSafari={isSafari}
+              browserHint={isSafari ? 'safari' : 'unset'}
               onTroubleshootingClick={
                 onPermissionsTroubleshootingClick
                   ? () => {


### PR DESCRIPTION
# What
Change is Safari prop to browserHint to allow more customization

# Why
In this way if we want to display some specific text for firefox we don't need to add a new prop

# How Tested
Made sure safari is showing the right text
Chrome and firefox is showing the right text 
