### PR TITLE
Update calling stateful client and CallAdapter state to be readonly

### DIFF
--- a/change-beta/@azure-communication-react-7c223640-78e5-4496-8384-959788cc5a1a.json
+++ b/change-beta/@azure-communication-react-7c223640-78e5-4496-8384-959788cc5a1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update CallAdapter state to be readonly.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-7c223640-78e5-4496-8384-959788cc5a1a.json
+++ b/change/@azure-communication-react-7c223640-78e5-4496-8384-959788cc5a1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update CallAdapter state to be readonly.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/review/beta/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/beta/calling-stateful-client.api.md
@@ -52,7 +52,7 @@ export interface CallAgentState {
 
 // @public
 export interface CallClientState {
-    alternateCallerId?: string;
+    alternateCallerId?: Readonly<string>;
     callAgent?: CallAgentState;
     calls: {
         [key: string]: CallState;
@@ -61,7 +61,7 @@ export interface CallClientState {
         [key: string]: CallState;
     };
     deviceManager: DeviceManagerState;
-    environmentInfo?: EnvironmentInfo;
+    environmentInfo?: Readonly<EnvironmentInfo>;
     incomingCalls: {
         [key: string]: IncomingCallState;
     };
@@ -69,7 +69,7 @@ export interface CallClientState {
         [key: string]: IncomingCallState;
     };
     latestErrors: CallErrors;
-    userId: CommunicationIdentifierKind;
+    userId: Readonly<CommunicationIdentifierKind>;
 }
 
 // @public

--- a/packages/calling-stateful-client/review/beta/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/beta/calling-stateful-client.api.md
@@ -53,22 +53,22 @@ export interface CallAgentState {
 // @public
 export interface CallClientState {
     readonly alternateCallerId?: string;
-    callAgent?: CallAgentState;
-    calls: {
+    readonly callAgent?: CallAgentState;
+    readonly calls: {
         [key: string]: CallState;
     };
-    callsEnded: {
+    readonly callsEnded: {
         [key: string]: CallState;
     };
-    deviceManager: DeviceManagerState;
+    readonly deviceManager: DeviceManagerState;
     readonly environmentInfo?: EnvironmentInfo;
-    incomingCalls: {
+    readonly incomingCalls: {
         [key: string]: IncomingCallState;
     };
-    incomingCallsEnded: {
+    readonly incomingCallsEnded: {
         [key: string]: IncomingCallState;
     };
-    latestErrors: CallErrors;
+    readonly latestErrors: CallErrors;
     readonly userId: CommunicationIdentifierKind;
 }
 

--- a/packages/calling-stateful-client/review/beta/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/beta/calling-stateful-client.api.md
@@ -54,13 +54,13 @@ export interface CallAgentState {
 export interface CallClientState {
     readonly alternateCallerId?: string;
     readonly callAgent?: CallAgentState;
-    readonly calls: {
+    calls: {
         [key: string]: CallState;
     };
     readonly callsEnded: {
         [key: string]: CallState;
     };
-    readonly deviceManager: DeviceManagerState;
+    deviceManager: DeviceManagerState;
     readonly environmentInfo?: EnvironmentInfo;
     readonly incomingCalls: {
         [key: string]: IncomingCallState;

--- a/packages/calling-stateful-client/review/beta/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/beta/calling-stateful-client.api.md
@@ -52,7 +52,7 @@ export interface CallAgentState {
 
 // @public
 export interface CallClientState {
-    alternateCallerId?: Readonly<string>;
+    readonly alternateCallerId?: string;
     callAgent?: CallAgentState;
     calls: {
         [key: string]: CallState;
@@ -61,7 +61,7 @@ export interface CallClientState {
         [key: string]: CallState;
     };
     deviceManager: DeviceManagerState;
-    environmentInfo?: Readonly<EnvironmentInfo>;
+    readonly environmentInfo?: EnvironmentInfo;
     incomingCalls: {
         [key: string]: IncomingCallState;
     };
@@ -69,7 +69,7 @@ export interface CallClientState {
         [key: string]: IncomingCallState;
     };
     latestErrors: CallErrors;
-    userId: Readonly<CommunicationIdentifierKind>;
+    readonly userId: CommunicationIdentifierKind;
 }
 
 // @public

--- a/packages/calling-stateful-client/review/stable/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/stable/calling-stateful-client.api.md
@@ -59,7 +59,7 @@ export interface CallClientState {
         [key: string]: IncomingCallState;
     };
     latestErrors: CallErrors;
-    userId: CommunicationIdentifierKind;
+    readonly userId: CommunicationIdentifierKind;
 }
 
 // @public

--- a/packages/calling-stateful-client/review/stable/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/stable/calling-stateful-client.api.md
@@ -44,21 +44,21 @@ export interface CallAgentState {
 
 // @public
 export interface CallClientState {
-    callAgent?: CallAgentState;
+    readonly callAgent?: CallAgentState;
     calls: {
         [key: string]: CallState;
     };
-    callsEnded: {
+    readonly callsEnded: {
         [key: string]: CallState;
     };
     deviceManager: DeviceManagerState;
-    incomingCalls: {
+    readonly incomingCalls: {
         [key: string]: IncomingCallState;
     };
-    incomingCallsEnded: {
+    readonly incomingCallsEnded: {
         [key: string]: IncomingCallState;
     };
-    latestErrors: CallErrors;
+    readonly latestErrors: CallErrors;
     readonly userId: CommunicationIdentifierKind;
 }
 

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -397,19 +397,19 @@ export interface CallClientState {
    *
    * Only {@link MAX_CALL_HISTORY_LENGTH} Calls are kept in the history. Oldest calls are evicted if required.
    */
-  callsEnded: { [key: string]: CallState };
+  readonly callsEnded: { [key: string]: CallState };
   /**
    * Proxy of {@link @azure/communication-calling#IncomingCall} as an object with {@link IncomingCall} fields.
    * It is keyed by {@link @azure/communication-calling#IncomingCall.id}.
    */
-  incomingCalls: { [key: string]: IncomingCallState };
+  readonly incomingCalls: { [key: string]: IncomingCallState };
   /**
    * Incoming Calls that have ended are stored here so the callEndReason could be checked.
    * It is an as an object with {@link @azure/communication-calling#Call.id} keys and {@link IncomingCall} values.
    *
    * Only {@link MAX_CALL_HISTORY_LENGTH} Calls are kept in the history. Oldest calls are evicted if required.
    */
-  incomingCallsEnded: { [key: string]: IncomingCallState };
+  readonly incomingCallsEnded: { [key: string]: IncomingCallState };
   /**
    * Proxy of {@link @azure/communication-calling#DeviceManager}. Please review {@link DeviceManagerState}.
    */
@@ -417,7 +417,7 @@ export interface CallClientState {
   /**
    * Proxy of {@link @azure/communication-calling#CallAgent}. Please review {@link CallAgentState}.
    */
-  callAgent?: CallAgentState;
+  readonly callAgent?: CallAgentState;
   /**
    * Stores a userId. This is not used by the {@link StatefulCallClient} and is provided here as a convenience for the
    * developer for easier access to userId. Must be passed in at initialization of the {@link StatefulCallClient}.
@@ -429,7 +429,7 @@ export interface CallClientState {
    *
    * See documentation of {@Link CallErrors} for details.
    */
-  latestErrors: CallErrors;
+  readonly latestErrors: CallErrors;
   /* @conditional-compile-remove(PSTN-calls) */
   /**
    * A phone number in E.164 format that will be used to represent callers identity.

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -423,25 +423,25 @@ export interface CallClientState {
    * developer for easier access to userId. Must be passed in at initialization of the {@link StatefulCallClient}.
    * Completely controlled by the developer.
    */
-  userId: Readonly<CommunicationIdentifierKind>;
+  readonly userId: CommunicationIdentifierKind;
   /**
    * Stores the latest error for each API method.
    *
    * See documentation of {@Link CallErrors} for details.
    */
-  latestErrors: Readonly<CallErrors>;
+  latestErrors: CallErrors;
   /* @conditional-compile-remove(PSTN-calls) */
   /**
    * A phone number in E.164 format that will be used to represent callers identity.
    * For example, using the alternateCallerId to add a participant using PSTN, this number will
    * be used as the caller id in the PSTN call.
    */
-  alternateCallerId?: Readonly<string>;
+  readonly alternateCallerId?: string;
   /* @conditional-compile-remove(unsupported-browser) */
   /**
    * state to track the environment that the stateful client was made in is supported
    */
-  environmentInfo?: Readonly<EnvironmentInfo>;
+  readonly environmentInfo?: EnvironmentInfo;
 }
 
 /**

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -423,25 +423,25 @@ export interface CallClientState {
    * developer for easier access to userId. Must be passed in at initialization of the {@link StatefulCallClient}.
    * Completely controlled by the developer.
    */
-  userId: CommunicationIdentifierKind;
+  userId: Readonly<CommunicationIdentifierKind>;
   /**
    * Stores the latest error for each API method.
    *
    * See documentation of {@Link CallErrors} for details.
    */
-  latestErrors: CallErrors;
+  latestErrors: Readonly<CallErrors>;
   /* @conditional-compile-remove(PSTN-calls) */
   /**
    * A phone number in E.164 format that will be used to represent callers identity.
    * For example, using the alternateCallerId to add a participant using PSTN, this number will
    * be used as the caller id in the PSTN call.
    */
-  alternateCallerId?: string;
+  alternateCallerId?: Readonly<string>;
   /* @conditional-compile-remove(unsupported-browser) */
   /**
    * state to track the environment that the stateful client was made in is supported
    */
-  environmentInfo?: EnvironmentInfo;
+  environmentInfo?: Readonly<EnvironmentInfo>;
 }
 
 /**

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -200,10 +200,11 @@ export class CallContext {
   }
 
   /* @conditional-compile-remove(unsupported-browser) */
-  public setEnvironmentInfo(envInfo: EnvironmentInfo): void {
-    this.modifyState((draft: CallClientState) => {
-      draft.environmentInfo = envInfo;
-    });
+  public setEnvironmentInfo(environmentInfo: EnvironmentInfo): void {
+    this.modifyState((draft: CallClientState) => ({
+      ...draft,
+      environmentInfo
+    }));
   }
 
   public setCallIsScreenSharingOn(callId: string, isScreenSharingOn: boolean): void {

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -116,18 +116,20 @@ export class CallContext {
   // make sure the state is clean because any left over state (if previous CallAgentDeclarative was disposed) may be
   // invalid.
   public clearCallRelatedState(): void {
-    this.modifyState((draft: CallClientState) => {
-      draft.calls = {};
-      draft.incomingCalls = {};
-      draft.callsEnded = {};
-      draft.incomingCallsEnded = {};
-    });
+    this.modifyState((draft: CallClientState) => ({
+      ...draft,
+      calls: {},
+      incomingCalls: {},
+      callsEnded: {},
+      incomingCallsEnded: {}
+    }));
   }
 
   public setCallAgent(callAgent: CallAgentState): void {
-    this.modifyState((draft: CallClientState) => {
-      draft.callAgent = callAgent;
-    });
+    this.modifyState((draft: CallClientState) => ({
+      ...draft,
+      callAgent: callAgent
+    }));
   }
 
   public setCall(call: CallState): void {

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -292,15 +292,15 @@ export interface CallAdapterCallOperations {
 
 // @public
 export type CallAdapterClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName?: string;
-    call?: CallState;
+    userId: Readonly<CommunicationIdentifierKind>;
+    displayName?: Readonly<string>;
+    call?: Readonly<CallState>;
     devices: DeviceManagerState;
-    endedCall?: CallState;
-    isTeamsCall: boolean;
+    endedCall?: Readonly<CallState>;
+    isTeamsCall: Readonly<boolean>;
     latestErrors: AdapterErrors;
-    alternateCallerId?: string;
-    environmentInfo?: EnvironmentInfo;
+    alternateCallerId?: Readonly<string>;
+    environmentInfo?: Readonly<EnvironmentInfo>;
     roleHint?: Role;
 };
 
@@ -352,7 +352,7 @@ export interface CallAdapterSubscribers {
 // @public
 export type CallAdapterUiState = {
     isLocalPreviewMicrophoneEnabled: boolean;
-    page: CallCompositePage;
+    page: Readonly<CallCompositePage>;
     unsupportedBrowserVersionsAllowed?: boolean;
 };
 
@@ -391,7 +391,7 @@ export interface CallClientProviderProps {
 
 // @public
 export interface CallClientState {
-    alternateCallerId?: string;
+    alternateCallerId?: Readonly<string>;
     callAgent?: CallAgentState;
     calls: {
         [key: string]: CallState;
@@ -400,7 +400,7 @@ export interface CallClientState {
         [key: string]: CallState;
     };
     deviceManager: DeviceManagerState;
-    environmentInfo?: EnvironmentInfo;
+    environmentInfo?: Readonly<EnvironmentInfo>;
     incomingCalls: {
         [key: string]: IncomingCallState;
     };
@@ -408,7 +408,7 @@ export interface CallClientState {
         [key: string]: IncomingCallState;
     };
     latestErrors: CallErrors;
-    userId: CommunicationIdentifierKind;
+    userId: Readonly<CommunicationIdentifierKind>;
 }
 
 // @public

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -393,13 +393,13 @@ export interface CallClientProviderProps {
 export interface CallClientState {
     readonly alternateCallerId?: string;
     readonly callAgent?: CallAgentState;
-    readonly calls: {
+    calls: {
         [key: string]: CallState;
     };
     readonly callsEnded: {
         [key: string]: CallState;
     };
-    readonly deviceManager: DeviceManagerState;
+    deviceManager: DeviceManagerState;
     readonly environmentInfo?: EnvironmentInfo;
     readonly incomingCalls: {
         [key: string]: IncomingCallState;

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -292,16 +292,16 @@ export interface CallAdapterCallOperations {
 
 // @public
 export type CallAdapterClientState = {
-    userId: Readonly<CommunicationIdentifierKind>;
-    displayName?: Readonly<string>;
-    call?: Readonly<CallState>;
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName?: string;
+    readonly call?: CallState;
     devices: DeviceManagerState;
-    endedCall?: Readonly<CallState>;
-    isTeamsCall: Readonly<boolean>;
+    readonly endedCall?: CallState;
+    readonly isTeamsCall: boolean;
     latestErrors: AdapterErrors;
-    alternateCallerId?: Readonly<string>;
-    environmentInfo?: Readonly<EnvironmentInfo>;
-    roleHint?: Role;
+    readonly alternateCallerId?: string;
+    readonly environmentInfo?: EnvironmentInfo;
+    readonly roleHint?: Role;
 };
 
 // @public
@@ -352,8 +352,8 @@ export interface CallAdapterSubscribers {
 // @public
 export type CallAdapterUiState = {
     isLocalPreviewMicrophoneEnabled: boolean;
-    page: Readonly<CallCompositePage>;
-    unsupportedBrowserVersionsAllowed?: boolean;
+    readonly page: CallCompositePage;
+    readonly unsupportedBrowserVersionsAllowed?: boolean;
 };
 
 // @public
@@ -391,7 +391,7 @@ export interface CallClientProviderProps {
 
 // @public
 export interface CallClientState {
-    alternateCallerId?: Readonly<string>;
+    readonly alternateCallerId?: string;
     callAgent?: CallAgentState;
     calls: {
         [key: string]: CallState;
@@ -400,7 +400,7 @@ export interface CallClientState {
         [key: string]: CallState;
     };
     deviceManager: DeviceManagerState;
-    environmentInfo?: Readonly<EnvironmentInfo>;
+    readonly environmentInfo?: EnvironmentInfo;
     incomingCalls: {
         [key: string]: IncomingCallState;
     };
@@ -408,7 +408,7 @@ export interface CallClientState {
         [key: string]: IncomingCallState;
     };
     latestErrors: CallErrors;
-    userId: Readonly<CommunicationIdentifierKind>;
+    readonly userId: CommunicationIdentifierKind;
 }
 
 // @public

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -295,10 +295,10 @@ export type CallAdapterClientState = {
     readonly userId: CommunicationIdentifierKind;
     readonly displayName?: string;
     readonly call?: CallState;
-    devices: DeviceManagerState;
+    readonly devices: DeviceManagerState;
     readonly endedCall?: CallState;
     readonly isTeamsCall: boolean;
-    latestErrors: AdapterErrors;
+    readonly latestErrors: AdapterErrors;
     readonly alternateCallerId?: string;
     readonly environmentInfo?: EnvironmentInfo;
     readonly roleHint?: Role;
@@ -351,7 +351,7 @@ export interface CallAdapterSubscribers {
 
 // @public
 export type CallAdapterUiState = {
-    isLocalPreviewMicrophoneEnabled: boolean;
+    readonly isLocalPreviewMicrophoneEnabled: boolean;
     readonly page: CallCompositePage;
     readonly unsupportedBrowserVersionsAllowed?: boolean;
 };
@@ -392,22 +392,22 @@ export interface CallClientProviderProps {
 // @public
 export interface CallClientState {
     readonly alternateCallerId?: string;
-    callAgent?: CallAgentState;
-    calls: {
+    readonly callAgent?: CallAgentState;
+    readonly calls: {
         [key: string]: CallState;
     };
-    callsEnded: {
+    readonly callsEnded: {
         [key: string]: CallState;
     };
-    deviceManager: DeviceManagerState;
+    readonly deviceManager: DeviceManagerState;
     readonly environmentInfo?: EnvironmentInfo;
-    incomingCalls: {
+    readonly incomingCalls: {
         [key: string]: IncomingCallState;
     };
-    incomingCallsEnded: {
+    readonly incomingCallsEnded: {
         [key: string]: IncomingCallState;
     };
-    latestErrors: CallErrors;
+    readonly latestErrors: CallErrors;
     readonly userId: CommunicationIdentifierKind;
 }
 

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -204,10 +204,10 @@ export type CallAdapterClientState = {
     readonly userId: CommunicationIdentifierKind;
     readonly displayName?: string;
     readonly call?: CallState;
-    devices: DeviceManagerState;
+    readonly devices: DeviceManagerState;
     readonly endedCall?: CallState;
     readonly isTeamsCall: boolean;
-    latestErrors: AdapterErrors;
+    readonly latestErrors: AdapterErrors;
 };
 
 // @public
@@ -257,7 +257,7 @@ export interface CallAdapterSubscribers {
 
 // @public
 export type CallAdapterUiState = {
-    isLocalPreviewMicrophoneEnabled: boolean;
+    readonly isLocalPreviewMicrophoneEnabled: boolean;
     readonly page: CallCompositePage;
 };
 
@@ -296,21 +296,21 @@ export interface CallClientProviderProps {
 
 // @public
 export interface CallClientState {
-    callAgent?: CallAgentState;
+    readonly callAgent?: CallAgentState;
     calls: {
         [key: string]: CallState;
     };
-    callsEnded: {
+    readonly callsEnded: {
         [key: string]: CallState;
     };
     deviceManager: DeviceManagerState;
-    incomingCalls: {
+    readonly incomingCalls: {
         [key: string]: IncomingCallState;
     };
-    incomingCallsEnded: {
+    readonly incomingCallsEnded: {
         [key: string]: IncomingCallState;
     };
-    latestErrors: CallErrors;
+    readonly latestErrors: CallErrors;
     readonly userId: CommunicationIdentifierKind;
 }
 

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -201,12 +201,12 @@ export interface CallAdapterCallOperations {
 
 // @public
 export type CallAdapterClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName?: string;
-    call?: CallState;
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName?: string;
+    readonly call?: CallState;
     devices: DeviceManagerState;
-    endedCall?: CallState;
-    isTeamsCall: boolean;
+    readonly endedCall?: CallState;
+    readonly isTeamsCall: boolean;
     latestErrors: AdapterErrors;
 };
 
@@ -258,7 +258,7 @@ export interface CallAdapterSubscribers {
 // @public
 export type CallAdapterUiState = {
     isLocalPreviewMicrophoneEnabled: boolean;
-    page: CallCompositePage;
+    readonly page: CallCompositePage;
 };
 
 // @public
@@ -311,7 +311,7 @@ export interface CallClientState {
         [key: string]: IncomingCallState;
     };
     latestErrors: CallErrors;
-    userId: CommunicationIdentifierKind;
+    readonly userId: CommunicationIdentifierKind;
 }
 
 // @public

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -195,10 +195,10 @@ export type CallAdapterClientState = {
     readonly userId: CommunicationIdentifierKind;
     readonly displayName?: string;
     readonly call?: CallState;
-    devices: DeviceManagerState;
+    readonly devices: DeviceManagerState;
     readonly endedCall?: CallState;
     readonly isTeamsCall: boolean;
-    latestErrors: AdapterErrors;
+    readonly latestErrors: AdapterErrors;
     readonly alternateCallerId?: string;
     readonly environmentInfo?: EnvironmentInfo;
     readonly roleHint?: Role;
@@ -251,7 +251,7 @@ export interface CallAdapterSubscribers {
 
 // @public
 export type CallAdapterUiState = {
-    isLocalPreviewMicrophoneEnabled: boolean;
+    readonly isLocalPreviewMicrophoneEnabled: boolean;
     readonly page: CallCompositePage;
     readonly unsupportedBrowserVersionsAllowed?: boolean;
 };

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -192,15 +192,15 @@ export interface CallAdapterCallOperations {
 
 // @public
 export type CallAdapterClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName?: string;
-    call?: CallState;
+    userId: Readonly<CommunicationIdentifierKind>;
+    displayName?: Readonly<string>;
+    call?: Readonly<CallState>;
     devices: DeviceManagerState;
-    endedCall?: CallState;
-    isTeamsCall: boolean;
+    endedCall?: Readonly<CallState>;
+    isTeamsCall: Readonly<boolean>;
     latestErrors: AdapterErrors;
-    alternateCallerId?: string;
-    environmentInfo?: EnvironmentInfo;
+    alternateCallerId?: Readonly<string>;
+    environmentInfo?: Readonly<EnvironmentInfo>;
     roleHint?: Role;
 };
 
@@ -252,7 +252,7 @@ export interface CallAdapterSubscribers {
 // @public
 export type CallAdapterUiState = {
     isLocalPreviewMicrophoneEnabled: boolean;
-    page: CallCompositePage;
+    page: Readonly<CallCompositePage>;
     unsupportedBrowserVersionsAllowed?: boolean;
 };
 

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -192,16 +192,16 @@ export interface CallAdapterCallOperations {
 
 // @public
 export type CallAdapterClientState = {
-    userId: Readonly<CommunicationIdentifierKind>;
-    displayName?: Readonly<string>;
-    call?: Readonly<CallState>;
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName?: string;
+    readonly call?: CallState;
     devices: DeviceManagerState;
-    endedCall?: Readonly<CallState>;
-    isTeamsCall: Readonly<boolean>;
+    readonly endedCall?: CallState;
+    readonly isTeamsCall: boolean;
     latestErrors: AdapterErrors;
-    alternateCallerId?: Readonly<string>;
-    environmentInfo?: Readonly<EnvironmentInfo>;
-    roleHint?: Role;
+    readonly alternateCallerId?: string;
+    readonly environmentInfo?: EnvironmentInfo;
+    readonly roleHint?: Role;
 };
 
 // @public
@@ -252,8 +252,8 @@ export interface CallAdapterSubscribers {
 // @public
 export type CallAdapterUiState = {
     isLocalPreviewMicrophoneEnabled: boolean;
-    page: Readonly<CallCompositePage>;
-    unsupportedBrowserVersionsAllowed?: boolean;
+    readonly page: CallCompositePage;
+    readonly unsupportedBrowserVersionsAllowed?: boolean;
 };
 
 // @public

--- a/packages/react-composites/review/stable/react-composites.api.md
+++ b/packages/react-composites/review/stable/react-composites.api.md
@@ -154,10 +154,10 @@ export type CallAdapterClientState = {
     readonly userId: CommunicationIdentifierKind;
     readonly displayName?: string;
     readonly call?: CallState;
-    devices: DeviceManagerState;
+    readonly devices: DeviceManagerState;
     readonly endedCall?: CallState;
     readonly isTeamsCall: boolean;
-    latestErrors: AdapterErrors;
+    readonly latestErrors: AdapterErrors;
 };
 
 // @public
@@ -207,7 +207,7 @@ export interface CallAdapterSubscribers {
 
 // @public
 export type CallAdapterUiState = {
-    isLocalPreviewMicrophoneEnabled: boolean;
+    readonly isLocalPreviewMicrophoneEnabled: boolean;
     readonly page: CallCompositePage;
 };
 

--- a/packages/react-composites/review/stable/react-composites.api.md
+++ b/packages/react-composites/review/stable/react-composites.api.md
@@ -151,12 +151,12 @@ export interface CallAdapterCallOperations {
 
 // @public
 export type CallAdapterClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName?: string;
-    call?: CallState;
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName?: string;
+    readonly call?: CallState;
     devices: DeviceManagerState;
-    endedCall?: CallState;
-    isTeamsCall: boolean;
+    readonly endedCall?: CallState;
+    readonly isTeamsCall: boolean;
     latestErrors: AdapterErrors;
 };
 
@@ -208,7 +208,7 @@ export interface CallAdapterSubscribers {
 // @public
 export type CallAdapterUiState = {
     isLocalPreviewMicrophoneEnabled: boolean;
-    page: CallCompositePage;
+    readonly page: CallCompositePage;
 };
 
 // @public

--- a/packages/react-composites/src/composites/CallComposite/MockCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/MockCallAdapter.ts
@@ -25,7 +25,7 @@ export class MockCallAdapter implements CallAdapter {
     }
     /* @conditional-compile-remove(rooms) */
     if (testState.options?.roleHint) {
-      this.state.roleHint = testState.options.roleHint;
+      ({ ...this.state, roleHint: testState.options.roleHint });
     }
   }
 

--- a/packages/react-composites/src/composites/CallComposite/MockCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/MockCallAdapter.ts
@@ -25,7 +25,7 @@ export class MockCallAdapter implements CallAdapter {
     }
     /* @conditional-compile-remove(rooms) */
     if (testState.options?.roleHint) {
-      ({ ...this.state, roleHint: testState.options.roleHint });
+      this.setState({ ...this.state, roleHint: testState.options.roleHint });
     }
   }
 

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -76,14 +76,13 @@ import { AdapterError } from '../../common/adapters';
 import { DiagnosticsForwarder } from './DiagnosticsForwarder';
 import { useEffect, useRef, useState } from 'react';
 import { CallHandlersOf, createHandlers } from './createHandlers';
-import { Mutable } from 'type-fest';
 
 type CallTypeOf<AgentType extends CallAgent | BetaTeamsCallAgent> = AgentType extends CallAgent ? Call : TeamsCall;
 
 /** Context of call, which is a centralized context for all state updates */
 class CallContext {
   private emitter: EventEmitter = new EventEmitter();
-  private readonly state: CallAdapterState;
+  private state: CallAdapterState;
   private callId: string | undefined;
 
   constructor(
@@ -126,9 +125,8 @@ class CallContext {
   }
 
   public setState(state: CallAdapterState): void {
-    let oldState = this.state as Mutable<CallAdapterState>;
-    oldState = state;
-    this.emitter.emit('stateChanged', oldState);
+    this.state = state;
+    this.emitter.emit('stateChanged', this.state);
   }
 
   public getState(): CallAdapterState {

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -220,7 +220,7 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | BetaTea
   private locator: CallAdapterLocator;
   // Never use directly, even internally. Use `call` property instead.
   private _call?: CallCommon;
-  private context: CallContext;
+  private readonly context: CallContext;
   private diagnosticsForwarder?: DiagnosticsForwarder;
   private handlers: CallHandlersOf<AgentType>;
   private participantSubscribers = new Map<string, ParticipantSubscriber>();

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -76,13 +76,14 @@ import { AdapterError } from '../../common/adapters';
 import { DiagnosticsForwarder } from './DiagnosticsForwarder';
 import { useEffect, useRef, useState } from 'react';
 import { CallHandlersOf, createHandlers } from './createHandlers';
+import { Mutable } from 'type-fest';
 
 type CallTypeOf<AgentType extends CallAgent | BetaTeamsCallAgent> = AgentType extends CallAgent ? Call : TeamsCall;
 
 /** Context of call, which is a centralized context for all state updates */
 class CallContext {
   private emitter: EventEmitter = new EventEmitter();
-  private state: CallAdapterState;
+  private readonly state: CallAdapterState;
   private callId: string | undefined;
 
   constructor(
@@ -125,8 +126,9 @@ class CallContext {
   }
 
   public setState(state: CallAdapterState): void {
-    this.state = state;
-    this.emitter.emit('stateChanged', this.state);
+    let oldState = this.state as Mutable<CallAdapterState>;
+    oldState = state;
+    this.emitter.emit('stateChanged', oldState);
   }
 
   public getState(): CallAdapterState {

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -69,9 +69,9 @@ export const END_CALL_PAGES: CallCompositePage[] = [
  */
 export type CallAdapterUiState = {
   isLocalPreviewMicrophoneEnabled: boolean;
-  page: Readonly<CallCompositePage>;
+  readonly page: CallCompositePage;
   /* @conditional-compile-remove(unsupported-browser) */
-  unsupportedBrowserVersionsAllowed?: boolean;
+  readonly unsupportedBrowserVersionsAllowed?: boolean;
 };
 
 /**
@@ -80,12 +80,12 @@ export type CallAdapterUiState = {
  * @public
  */
 export type CallAdapterClientState = {
-  userId: Readonly<CommunicationIdentifierKind>;
-  displayName?: Readonly<string>;
-  call?: Readonly<CallState>;
+  readonly userId: CommunicationIdentifierKind;
+  readonly displayName?: string;
+  readonly call?: CallState;
   devices: DeviceManagerState;
-  endedCall?: Readonly<CallState>;
-  isTeamsCall: Readonly<boolean>;
+  readonly endedCall?: CallState;
+  readonly isTeamsCall: boolean;
   /**
    * Latest error encountered for each operation performed via the adapter.
    */
@@ -94,19 +94,19 @@ export type CallAdapterClientState = {
   /**
    * Azure communications Phone number to make PSTN calls with.
    */
-  alternateCallerId?: Readonly<string>;
+  readonly alternateCallerId?: string;
   /* @conditional-compile-remove(unsupported-browser) */
   /**
    * Environment information about system the adapter is made on
    */
-  environmentInfo?: Readonly<EnvironmentInfo>;
+  readonly environmentInfo?: EnvironmentInfo;
   /* @conditional-compile-remove(rooms) */
   /**
    * Use this to hint the role of the user when the role is not available before a Rooms call is started. This value
    * should be obtained using the Rooms API. This role will determine permissions in the configuration page of the
    * {@link CallComposite}. The true role of the user will be synced with ACS services when a Rooms call starts.
    */
-  roleHint?: Role;
+  readonly roleHint?: Role;
 };
 
 /**

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -69,7 +69,7 @@ export const END_CALL_PAGES: CallCompositePage[] = [
  */
 export type CallAdapterUiState = {
   isLocalPreviewMicrophoneEnabled: boolean;
-  page: CallCompositePage;
+  page: Readonly<CallCompositePage>;
   /* @conditional-compile-remove(unsupported-browser) */
   unsupportedBrowserVersionsAllowed?: boolean;
 };
@@ -80,12 +80,12 @@ export type CallAdapterUiState = {
  * @public
  */
 export type CallAdapterClientState = {
-  userId: CommunicationIdentifierKind;
-  displayName?: string;
-  call?: CallState;
+  userId: Readonly<CommunicationIdentifierKind>;
+  displayName?: Readonly<string>;
+  call?: Readonly<CallState>;
   devices: DeviceManagerState;
-  endedCall?: CallState;
-  isTeamsCall: boolean;
+  endedCall?: Readonly<CallState>;
+  isTeamsCall: Readonly<boolean>;
   /**
    * Latest error encountered for each operation performed via the adapter.
    */
@@ -94,12 +94,12 @@ export type CallAdapterClientState = {
   /**
    * Azure communications Phone number to make PSTN calls with.
    */
-  alternateCallerId?: string;
+  alternateCallerId?: Readonly<string>;
   /* @conditional-compile-remove(unsupported-browser) */
   /**
    * Environment information about system the adapter is made on
    */
-  environmentInfo?: EnvironmentInfo;
+  environmentInfo?: Readonly<EnvironmentInfo>;
   /* @conditional-compile-remove(rooms) */
   /**
    * Use this to hint the role of the user when the role is not available before a Rooms call is started. This value

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -68,7 +68,7 @@ export const END_CALL_PAGES: CallCompositePage[] = [
  * @public
  */
 export type CallAdapterUiState = {
-  isLocalPreviewMicrophoneEnabled: boolean;
+  readonly isLocalPreviewMicrophoneEnabled: boolean;
   readonly page: CallCompositePage;
   /* @conditional-compile-remove(unsupported-browser) */
   readonly unsupportedBrowserVersionsAllowed?: boolean;
@@ -83,13 +83,13 @@ export type CallAdapterClientState = {
   readonly userId: CommunicationIdentifierKind;
   readonly displayName?: string;
   readonly call?: CallState;
-  devices: DeviceManagerState;
+  readonly devices: DeviceManagerState;
   readonly endedCall?: CallState;
   readonly isTeamsCall: boolean;
   /**
    * Latest error encountered for each operation performed via the adapter.
    */
-  latestErrors: AdapterErrors;
+  readonly latestErrors: AdapterErrors;
   /* @conditional-compile-remove(PSTN-calls) */
   /**
    * Azure communications Phone number to make PSTN calls with.

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -102,7 +102,7 @@ class CallWithChatContext {
 
   public setState(state: CallWithChatAdapterState): void {
     this.state = state;
-    this.emitter.emit('stateChanged', oldState);
+    this.emitter.emit('stateChanged', this.state);
   }
 
   public getState(): CallWithChatAdapterState {

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -79,14 +79,13 @@ import { useEffect, useRef, useState } from 'react';
 import { _toCommunicationIdentifier } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(unsupported-browser) */
 import { AzureCommunicationCallAdapterOptions } from '../../CallComposite/adapter/AzureCommunicationCallAdapter';
-import { Mutable } from 'type-fest';
 
 type CallWithChatAdapterStateChangedHandler = (newState: CallWithChatAdapterState) => void;
 
 /** Context of Call with Chat, which is a centralized context for all state updates */
 class CallWithChatContext {
   private emitter = new EventEmitter();
-  private readonly state: CallWithChatAdapterState;
+  private state: CallWithChatAdapterState;
 
   constructor(clientState: CallWithChatAdapterState, maxListeners = 50) {
     this.state = clientState;
@@ -102,8 +101,7 @@ class CallWithChatContext {
   }
 
   public setState(state: CallWithChatAdapterState): void {
-    let oldState = this.state as Mutable<CallWithChatAdapterState>;
-    oldState = state;
+    this.state = state;
     this.emitter.emit('stateChanged', oldState);
   }
 

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -79,13 +79,14 @@ import { useEffect, useRef, useState } from 'react';
 import { _toCommunicationIdentifier } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(unsupported-browser) */
 import { AzureCommunicationCallAdapterOptions } from '../../CallComposite/adapter/AzureCommunicationCallAdapter';
+import { Mutable } from 'type-fest';
 
 type CallWithChatAdapterStateChangedHandler = (newState: CallWithChatAdapterState) => void;
 
 /** Context of Call with Chat, which is a centralized context for all state updates */
 class CallWithChatContext {
   private emitter = new EventEmitter();
-  private state: CallWithChatAdapterState;
+  private readonly state: CallWithChatAdapterState;
 
   constructor(clientState: CallWithChatAdapterState, maxListeners = 50) {
     this.state = clientState;
@@ -101,8 +102,9 @@ class CallWithChatContext {
   }
 
   public setState(state: CallWithChatAdapterState): void {
-    this.state = state;
-    this.emitter.emit('stateChanged', this.state);
+    let oldState = this.state as Mutable<CallWithChatAdapterState>;
+    oldState = state;
+    this.emitter.emit('stateChanged', oldState);
   }
 
   public getState(): CallWithChatAdapterState {

--- a/packages/react-composites/tests/browser/call/hermetic/CallReadiness.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/CallReadiness.test.ts
@@ -84,9 +84,8 @@ test.describe('Tests for guidance UI on config page to guide users through enabl
     page,
     serverUrl
   }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.page = 'configuration';
-    initialState.call = undefined;
+    let initialState = defaultMockCallAdapterState();
+    initialState = { ...initialState, page: 'configuration', call: undefined };
     await page.goto(
       buildUrlWithMockAdapter(serverUrl, initialState, {
         usePermissionTroubleshootingActions: 'true'
@@ -102,9 +101,8 @@ test.describe('Tests for guidance UI on config page to guide users through enabl
 });
 
 function defaultMockConfigPageStateDeviceDisabled(): MockCallAdapterState {
-  const state = defaultMockCallAdapterState();
-  state.page = 'configuration';
-  state.call = undefined;
+  let state = defaultMockCallAdapterState();
+  state = { ...state, page: 'configuration', call: undefined };
   state.devices = {
     isSpeakerSelectionAvailable: true,
     cameras: [],

--- a/packages/react-composites/tests/browser/call/hermetic/CallReadiness.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/CallReadiness.test.ts
@@ -102,31 +102,35 @@ test.describe('Tests for guidance UI on config page to guide users through enabl
 
 function defaultMockConfigPageStateDeviceDisabled(): MockCallAdapterState {
   let state = defaultMockCallAdapterState();
-  state = { ...state, page: 'configuration', call: undefined };
-  state.devices = {
-    isSpeakerSelectionAvailable: true,
-    cameras: [],
-    microphones: [],
-    speakers: [
-      {
+  state = {
+    ...state,
+    page: 'configuration',
+    call: undefined,
+    devices: {
+      isSpeakerSelectionAvailable: true,
+      cameras: [],
+      microphones: [],
+      speakers: [
+        {
+          name: '',
+          id: 'speaker:',
+          isSystemDefault: true,
+          deviceType: 'Speaker'
+        }
+      ],
+      unparentedViews: [],
+      selectedMicrophone: {
+        name: '',
+        id: 'microphone:',
+        isSystemDefault: true,
+        deviceType: 'Microphone'
+      },
+      selectedSpeaker: {
         name: '',
         id: 'speaker:',
         isSystemDefault: true,
         deviceType: 'Speaker'
       }
-    ],
-    unparentedViews: [],
-    selectedMicrophone: {
-      name: '',
-      id: 'microphone:',
-      isSystemDefault: true,
-      deviceType: 'Microphone'
-    },
-    selectedSpeaker: {
-      name: '',
-      id: 'speaker:',
-      isSystemDefault: true,
-      deviceType: 'Speaker'
     }
   };
 

--- a/packages/react-composites/tests/browser/call/hermetic/ConfigurationPage.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/ConfigurationPage.test.ts
@@ -82,9 +82,8 @@ test.describe('Call Composite E2E Configuration Screen Tests', () => {
 });
 
 function defaultMockConfigurationPageState(): MockCallAdapterState {
-  const state = defaultMockCallAdapterState();
-  state.page = 'configuration';
-  state.call = undefined;
+  let state = defaultMockCallAdapterState();
+  state = { ...state, page: 'configuration', call: undefined };
   return state;
 }
 

--- a/packages/react-composites/tests/browser/call/hermetic/ConfigurationPage.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/ConfigurationPage.test.ts
@@ -44,16 +44,16 @@ test.describe('Call Composite E2E Configuration Screen Tests', () => {
 
   test('Configuration screen desktop should show no devices available', async ({ page, serverUrl }, testInfo) => {
     test.skip(isTestProfileMobile(testInfo));
-    const state = defaultMockConfigurationPageState();
-    state.devices = deviceManagerWithNoDevicesState();
+    let state = defaultMockConfigurationPageState();
+    state = { ...state, devices: deviceManagerWithNoDevicesState() };
     await page.goto(buildUrlWithMockAdapter(serverUrl, state));
     expect(await stableScreenshot(page)).toMatchSnapshot(`desktop-call-configuration-page-no-devices.png`);
   });
 
   test('Configuration screen mobile buttons disabled because no devices', async ({ page, serverUrl }, testInfo) => {
     test.skip(isTestProfileDesktop(testInfo));
-    const state = defaultMockConfigurationPageState();
-    state.devices = deviceManagerWithNoDevicesState();
+    let state = defaultMockConfigurationPageState();
+    state = { ...state, devices: deviceManagerWithNoDevicesState() };
 
     await page.goto(buildUrlWithMockAdapter(serverUrl, state));
 
@@ -63,14 +63,17 @@ test.describe('Call Composite E2E Configuration Screen Tests', () => {
   });
 
   test('Configuration screen shows error when camera is turned on but in use', async ({ page, serverUrl }) => {
-    const initialState = defaultMockConfigurationPageState();
-    initialState.latestErrors = {
-      'Call.startVideo': {
-        timestamp: new Date(),
-        name: 'ERROR: VIDEO WAS IN USE BY ANOTHER APPLICATION', // dummy error message emulating the error thrown by the browser
-        message: 'Browser was unable to start video as it was in use by another application',
-        target: 'Call.startVideo',
-        innerError: new Error('Inner error of failure to stop video')
+    let initialState = defaultMockConfigurationPageState();
+    initialState = {
+      ...initialState,
+      latestErrors: {
+        'Call.startVideo': {
+          timestamp: new Date(),
+          name: 'ERROR: VIDEO WAS IN USE BY ANOTHER APPLICATION', // dummy error message emulating the error thrown by the browser
+          message: 'Browser was unable to start video as it was in use by another application',
+          target: 'Call.startVideo',
+          innerError: new Error('Inner error of failure to stop video')
+        }
       }
     };
 

--- a/packages/react-composites/tests/browser/call/hermetic/DtmfDialpad.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/DtmfDialpad.test.ts
@@ -11,10 +11,10 @@ test.describe('Dtmf dialpad tests', async () => {
     const paul = defaultMockRemoteParticipant('Paul Bridges');
 
     const participant = [paul];
-    const initialState = defaultMockCallAdapterState(participant);
+    let initialState = defaultMockCallAdapterState(participant);
 
     //PSTN call has alternate caller id
-    initialState.alternateCallerId = '+1676568678999';
+    initialState = { ...initialState, alternateCallerId: '+1676568678999' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId('call-with-chat-composite-more-button'));

--- a/packages/react-composites/tests/browser/call/hermetic/ErrorBar.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/ErrorBar.test.ts
@@ -8,14 +8,17 @@ import { IDS } from '../../common/constants';
 
 test.describe('Error bar tests', async () => {
   test('Failure to start video should be shown on error bar', async ({ page, serverUrl }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.latestErrors = {
-      'Call.startVideo': {
-        timestamp: new Date(),
-        name: 'Failure to start video',
-        message: 'Could not start video',
-        target: 'Call.startVideo',
-        innerError: new Error('Inner error of failure to start video')
+    let initialState = defaultMockCallAdapterState();
+    initialState = {
+      ...initialState,
+      latestErrors: {
+        'Call.startVideo': {
+          timestamp: new Date(),
+          name: 'Failure to start video',
+          message: 'Could not start video',
+          target: 'Call.startVideo',
+          innerError: new Error('Inner error of failure to start video')
+        }
       }
     };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
@@ -25,21 +28,24 @@ test.describe('Error bar tests', async () => {
   });
 
   test('Multiple errors should be shown on error bar', async ({ page, serverUrl }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.latestErrors = {
-      'Call.unmute': {
-        timestamp: new Date(),
-        name: 'Failure to unmute',
-        message: 'Could not unmute',
-        target: 'Call.unmute',
-        innerError: new Error('Inner error of failure to unmute')
-      },
-      'Call.stopVideo': {
-        timestamp: new Date(),
-        name: 'Failure to stop video',
-        message: 'Could not stop video',
-        target: 'Call.stopVideo',
-        innerError: new Error('Inner error of failure to stop video')
+    let initialState = defaultMockCallAdapterState();
+    initialState = {
+      ...initialState,
+      latestErrors: {
+        'Call.unmute': {
+          timestamp: new Date(),
+          name: 'Failure to unmute',
+          message: 'Could not unmute',
+          target: 'Call.unmute',
+          innerError: new Error('Inner error of failure to unmute')
+        },
+        'Call.stopVideo': {
+          timestamp: new Date(),
+          name: 'Failure to stop video',
+          message: 'Could not stop video',
+          target: 'Call.stopVideo',
+          innerError: new Error('Inner error of failure to stop video')
+        }
       }
     };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));

--- a/packages/react-composites/tests/browser/call/hermetic/HoldScreen.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/HoldScreen.test.ts
@@ -13,7 +13,7 @@ test.describe('Hold screen tests', async () => {
     const vasily = defaultMockRemoteParticipant('Vasily Podkolzin');
 
     const participants = [paul, vasily];
-    const initialState = defaultMockCallAdapterState(participants);
+    let initialState = defaultMockCallAdapterState(participants);
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId(IDS.moreButton));
     await pageClick(page, dataUiId(IDS.moreButton));
@@ -22,7 +22,7 @@ test.describe('Hold screen tests', async () => {
 
     await waitForSelector(page, dataUiId(IDS.holdButton));
     await pageClick(page, dataUiId(IDS.holdButton));
-    initialState.page = 'hold';
+    initialState = { ...initialState, page: 'hold' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId(IDS.holdPage));
 
@@ -34,7 +34,7 @@ test.describe('Hold screen tests', async () => {
     const vasily = defaultMockRemoteParticipant('Vasily Podkolzin');
 
     const participants = [paul, vasily];
-    const initialState = defaultMockCallAdapterState(participants);
+    let initialState = defaultMockCallAdapterState(participants);
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId(IDS.moreButton));
     await pageClick(page, dataUiId(IDS.moreButton));
@@ -43,7 +43,7 @@ test.describe('Hold screen tests', async () => {
 
     await waitForSelector(page, dataUiId(IDS.holdButton));
     await pageClick(page, dataUiId(IDS.holdButton));
-    initialState.page = 'hold';
+    initialState = { ...initialState, page: 'hold' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId(IDS.holdPage));
 
@@ -52,7 +52,7 @@ test.describe('Hold screen tests', async () => {
     await waitForSelector(page, dataUiId(IDS.resumeCallButton));
     await pageClick(page, dataUiId(IDS.resumeCallButton));
 
-    initialState.page = 'call';
+    initialState = { ...initialState, page: 'call' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId(IDS.callPage));
 

--- a/packages/react-composites/tests/browser/call/hermetic/LobbyScreen.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/LobbyScreen.test.ts
@@ -22,12 +22,12 @@ test.describe('Lobby page tests', async () => {
      */
     dina.state = 'Idle';
     const participants = [dina];
-    const initialState = defaultMockCallAdapterState(participants);
+    let initialState = defaultMockCallAdapterState(participants);
 
     if (initialState.call) {
       initialState.call.state = 'Connecting';
     }
-    initialState.page = 'lobby';
+    initialState = { ...initialState, page: 'lobby' };
 
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
@@ -41,12 +41,12 @@ test.describe('Lobby page tests', async () => {
     const joel = defaultMockRemoteParticipant('Joel');
     joel.state = 'Connecting';
     const participants = [joel];
-    const initialState = defaultMockCallAdapterState(participants);
+    let initialState = defaultMockCallAdapterState(participants);
 
     if (initialState.call) {
       initialState.call.state = 'Connecting';
     }
-    initialState.page = 'lobby';
+    initialState = { ...initialState, page: 'lobby' };
 
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
@@ -60,12 +60,12 @@ test.describe('Lobby page tests', async () => {
     const ellie = defaultMockRemotePSTNParticipant('15556667777');
     ellie.state = 'Ringing';
     const participants = [ellie];
-    const initialState = defaultMockCallAdapterState(participants);
+    let initialState = defaultMockCallAdapterState(participants);
 
     if (initialState.call) {
       initialState.call.state = 'Connecting';
     }
-    initialState.page = 'lobby';
+    initialState = { ...initialState, page: 'lobby' };
 
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 

--- a/packages/react-composites/tests/browser/call/hermetic/Localization.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/Localization.test.ts
@@ -8,8 +8,8 @@ import { IDS } from '../../common/constants';
 
 test.describe('Localization tests', async () => {
   test('Configuration page title and participant button in call should be localized', async ({ page, serverUrl }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.page = 'configuration';
+    let initialState = defaultMockCallAdapterState();
+    initialState = { ...initialState, page: 'configuration' };
     initialState.call = undefined;
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState, { useFrLocale: 'true' }));
     await waitForCallCompositeToLoad(page);

--- a/packages/react-composites/tests/browser/call/hermetic/PageState.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/PageState.test.ts
@@ -7,36 +7,36 @@ import { buildUrlWithMockAdapter, defaultMockCallAdapterState, test } from './fi
 
 test.describe('Page state tests', async () => {
   test('Page when waiting in lobby', async ({ page, serverUrl }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.page = 'lobby';
+    let initialState = defaultMockCallAdapterState();
+    initialState = { ...initialState, page: 'lobby' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId('call-composite-hangup-button'));
     expect(await stableScreenshot(page)).toMatchSnapshot('lobby-page.png');
   });
   test('Page when access is denied', async ({ page, serverUrl }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.page = 'accessDeniedTeamsMeeting';
+    let initialState = defaultMockCallAdapterState();
+    initialState = { ...initialState, page: 'accessDeniedTeamsMeeting' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
     expect(await stableScreenshot(page)).toMatchSnapshot('access-denied-page.png');
   });
   test('Page when join call failed due to network', async ({ page, serverUrl }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.page = 'joinCallFailedDueToNoNetwork';
+    let initialState = defaultMockCallAdapterState();
+    initialState = { ...initialState, page: 'joinCallFailedDueToNoNetwork' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
     expect(await stableScreenshot(page)).toMatchSnapshot('call-failed-due-to-network-page.png');
   });
   test('Page when local participant left call', async ({ page, serverUrl }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.page = 'leftCall';
+    let initialState = defaultMockCallAdapterState();
+    initialState = { ...initialState, page: 'leftCall' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
     expect(await stableScreenshot(page)).toMatchSnapshot('left-call-page.png');
   });
   test('Page when local participant is removed from call', async ({ page, serverUrl }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.page = 'removedFromCall';
+    let initialState = defaultMockCallAdapterState();
+    initialState = { ...initialState, page: 'removedFromCall' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForPageFontsLoaded(page);
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
@@ -45,8 +45,8 @@ test.describe('Page state tests', async () => {
 
   /* @conditional-compile-remove(rooms) */
   test('Page when local participant tries to join a room that cannot be not found', async ({ page, serverUrl }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.page = 'roomNotFound';
+    let initialState = defaultMockCallAdapterState();
+    initialState = { ...initialState, page: 'roomNotFound' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForPageFontsLoaded(page);
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));
@@ -55,8 +55,8 @@ test.describe('Page state tests', async () => {
 
   /* @conditional-compile-remove(rooms) */
   test('Page when local participant tries to join a room that they are not invited to', async ({ page, serverUrl }) => {
-    const initialState = defaultMockCallAdapterState();
-    initialState.page = 'deniedPermissionToRoom';
+    let initialState = defaultMockCallAdapterState();
+    initialState = { ...initialState, page: 'deniedPermissionToRoom' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForPageFontsLoaded(page);
     await waitForSelector(page, dataUiId('call-composite-start-call-button'));

--- a/packages/react-composites/tests/browser/call/hermetic/ParticipantPane.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/ParticipantPane.test.ts
@@ -58,9 +58,9 @@ test.describe('Participant pane tests', async () => {
 
   /* @conditional-compile-remove(PSTN-calls) */
   test('click on add people button will show dialpad option for PSTN call', async ({ page, serverUrl }, testInfo) => {
-    const initialState = defaultMockCallAdapterState();
+    let initialState = defaultMockCallAdapterState();
     //PSTN call has alternate caller id
-    initialState.alternateCallerId = '+1676568678999';
+    initialState = { ...initialState, alternateCallerId: '+1676568678999' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId(IDS.videoGallery));
@@ -82,9 +82,9 @@ test.describe('Participant pane tests', async () => {
 
   /* @conditional-compile-remove(PSTN-calls) */
   test('click on dial phone number will open dialpad in PTSN call', async ({ page, serverUrl }, testInfo) => {
-    const initialState = defaultMockCallAdapterState();
+    let initialState = defaultMockCallAdapterState();
     //PSTN call has alternate caller id
-    initialState.alternateCallerId = '+1676568678999';
+    initialState = { ...initialState, alternateCallerId: '+1676568678999' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
 
     await waitForSelector(page, dataUiId(IDS.videoGallery));
@@ -118,9 +118,9 @@ test.describe('Participant pane tests', async () => {
     const paul = defaultMockRemoteParticipant('Paul Bridges');
     paul.state = 'Connecting';
     const participants = [paul];
-    const initialState = defaultMockCallAdapterState(participants);
+    let initialState = defaultMockCallAdapterState(participants);
     //PSTN call has alternate caller id
-    initialState.alternateCallerId = '+1676568678999';
+    initialState = { ...initialState, alternateCallerId: '+1676568678999' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     if (!isTestProfileDesktop(testInfo)) {
@@ -142,9 +142,9 @@ test.describe('Participant pane tests', async () => {
     );
     longPaul.state = 'Connecting';
     const participants = [longPaul];
-    const initialState = defaultMockCallAdapterState(participants);
+    let initialState = defaultMockCallAdapterState(participants);
     //PSTN call has alternate caller id
-    initialState.alternateCallerId = '+1676568678999';
+    initialState = { ...initialState, alternateCallerId: '+1676568678999' };
     await page.goto(buildUrlWithMockAdapter(serverUrl, initialState));
     await waitForSelector(page, dataUiId(IDS.videoGallery));
     if (!isTestProfileDesktop(testInfo)) {

--- a/packages/react-composites/tests/browser/call/hermetic/RoomsConfigurationScreen.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/RoomsConfigurationScreen.test.ts
@@ -33,8 +33,7 @@ test.describe('Rooms Call Configuration Screen Tests for different roles', () =>
 });
 
 function defaultMockConfigurationPageState(): MockCallAdapterState {
-  const state = defaultMockCallAdapterState();
-  state.page = 'configuration';
-  state.call = undefined;
+  let state = defaultMockCallAdapterState();
+  state = { ...state, call: undefined, page: 'configuration' };
   return state;
 }

--- a/packages/react-composites/tests/browser/call/hermetic/UnsupportedBrowserPage.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/UnsupportedBrowserPage.test.ts
@@ -11,13 +11,13 @@ import { buildUrlWithMockAdapter, defaultMockCallAdapterState, stubLocalCameraNa
 /* @conditional-compile-remove(unsupported-browser) */
 test.describe('unsupportedBrowser page tests', async () => {
   test('unsupportedBrowser displays correctly without a help link', async ({ page, serverUrl }) => {
-    const state = defaultMockUnsupportedBrowserPageState();
+    let state = defaultMockUnsupportedBrowserPageState();
     const envConfig = {
       platform: true,
       browser: false,
       version: false
     };
-    state.environmentInfo = setMockEnvironmentInfo(envConfig);
+    state = { ...state, environmentInfo: setMockEnvironmentInfo(envConfig) };
 
     await page.goto(buildUrlWithMockAdapter(serverUrl, state));
 
@@ -27,13 +27,13 @@ test.describe('unsupportedBrowser page tests', async () => {
   });
 
   test('unsupportedBrowser displays correctly with a help link', async ({ page, serverUrl }) => {
-    const state = defaultMockUnsupportedBrowserPageState();
+    let state = defaultMockUnsupportedBrowserPageState();
     const envConfig = {
       platform: true,
       browser: false,
       version: false
     };
-    state.environmentInfo = setMockEnvironmentInfo(envConfig);
+    state = { ...state, environmentInfo: setMockEnvironmentInfo(envConfig) };
 
     await page.goto(
       buildUrlWithMockAdapter(serverUrl, state, {
@@ -48,13 +48,13 @@ test.describe('unsupportedBrowser page tests', async () => {
   });
 
   test('unsupportedBrowserVersion displays correctly with no help link', async ({ page, serverUrl }) => {
-    const state = defaultMockUnsupportedBrowserPageState();
+    let state = defaultMockUnsupportedBrowserPageState();
     const envConfig = {
       platform: true,
       browser: true,
       version: false
     };
-    state.environmentInfo = setMockEnvironmentInfo(envConfig);
+    state = { ...state, environmentInfo: setMockEnvironmentInfo(envConfig) };
 
     await page.goto(buildUrlWithMockAdapter(serverUrl, state));
 
@@ -64,13 +64,13 @@ test.describe('unsupportedBrowser page tests', async () => {
   });
 
   test('unsupportedBrowserVersion displays correctly with help link', async ({ page, serverUrl }) => {
-    const state = defaultMockUnsupportedBrowserPageState();
+    let state = defaultMockUnsupportedBrowserPageState();
     const envConfig = {
       platform: true,
       browser: true,
       version: false
     };
-    state.environmentInfo = setMockEnvironmentInfo(envConfig);
+    state = { ...state, environmentInfo: setMockEnvironmentInfo(envConfig) };
 
     await page.goto(
       buildUrlWithMockAdapter(serverUrl, state, {
@@ -88,13 +88,13 @@ test.describe('unsupportedBrowser page tests', async () => {
     page,
     serverUrl
   }) => {
-    const state = defaultMockUnsupportedBrowserPageState();
+    let state = defaultMockUnsupportedBrowserPageState();
     const envConfig = {
       platform: true,
       browser: true,
       version: false
     };
-    state.environmentInfo = setMockEnvironmentInfo(envConfig);
+    state = { ...state, environmentInfo: setMockEnvironmentInfo(envConfig) };
 
     await page.goto(
       buildUrlWithMockAdapter(serverUrl, state, {
@@ -109,13 +109,13 @@ test.describe('unsupportedBrowser page tests', async () => {
   });
 
   test('unsupportedBrowserVersion displays correctly with continue button', async ({ page, serverUrl }) => {
-    const state = defaultMockUnsupportedBrowserPageState();
+    let state = defaultMockUnsupportedBrowserPageState();
     const envConfig = {
       platform: true,
       browser: true,
       version: false
     };
-    state.environmentInfo = setMockEnvironmentInfo(envConfig);
+    state = { ...state, environmentInfo: setMockEnvironmentInfo(envConfig) };
 
     await page.goto(buildUrlWithMockAdapter(serverUrl, state));
 
@@ -125,13 +125,13 @@ test.describe('unsupportedBrowser page tests', async () => {
   });
 
   test('unsupportedBrowserVersion with continue button allows user into config screen', async ({ page, serverUrl }) => {
-    const state = defaultMockUnsupportedBrowserPageState();
+    let state = defaultMockUnsupportedBrowserPageState();
     const envConfig = {
       platform: true,
       browser: true,
       version: false
     };
-    state.environmentInfo = setMockEnvironmentInfo(envConfig);
+    state = { ...state, environmentInfo: setMockEnvironmentInfo(envConfig) };
 
     await page.goto(buildUrlWithMockAdapter(serverUrl, state));
 
@@ -140,7 +140,7 @@ test.describe('unsupportedBrowser page tests', async () => {
 
     await pageClick(page, dataUiId(IDS.allowUnsupportedBrowserButton));
 
-    state.page = 'configuration';
+    state = { ...state, page: 'configuration' };
     state.call = undefined;
 
     await page.goto(buildUrlWithMockAdapter(serverUrl, state));
@@ -154,13 +154,13 @@ test.describe('unsupportedBrowser page tests', async () => {
   });
 
   test('unsupportedOperatingSystem displays correctly with no link', async ({ page, serverUrl }) => {
-    const state = defaultMockUnsupportedBrowserPageState();
+    let state = defaultMockUnsupportedBrowserPageState();
     const envConfig = {
       platform: false,
       browser: false,
       version: false
     };
-    state.environmentInfo = setMockEnvironmentInfo(envConfig);
+    state = { ...state, environmentInfo: setMockEnvironmentInfo(envConfig) };
 
     await page.goto(buildUrlWithMockAdapter(serverUrl, state));
 
@@ -170,13 +170,13 @@ test.describe('unsupportedBrowser page tests', async () => {
   });
 
   test('unsupportedOperatingSystem displays correctly with link', async ({ page, serverUrl }) => {
-    const state = defaultMockUnsupportedBrowserPageState();
+    let state = defaultMockUnsupportedBrowserPageState();
     const envConfig = {
       platform: false,
       browser: false,
       version: false
     };
-    state.environmentInfo = setMockEnvironmentInfo(envConfig);
+    state = { ...state, environmentInfo: setMockEnvironmentInfo(envConfig) };
 
     await page.goto(
       buildUrlWithMockAdapter(serverUrl, state, {
@@ -192,8 +192,8 @@ test.describe('unsupportedBrowser page tests', async () => {
 });
 
 const defaultMockUnsupportedBrowserPageState = (): MockCallAdapterState => {
-  const state = defaultMockCallAdapterState();
-  state.page = 'unsupportedEnvironment';
+  let state = defaultMockCallAdapterState();
+  state = { ...state, page: 'unsupportedEnvironment' };
   return state;
 };
 

--- a/packages/react-composites/tests/browser/call/hermetic/fixture.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/fixture.ts
@@ -222,9 +222,8 @@ export const test = base.extend<TestFixture>({
  * Sets up the default state for the configuration screen.
  */
 export const defaultMockConfigurationPageState = (): MockCallAdapterState => {
-  const state = defaultMockCallAdapterState();
-  state.page = 'configuration';
-  state.call = undefined;
+  let state = defaultMockCallAdapterState();
+  state = { ...state, page: 'configuration', call: undefined };
   return state;
 };
 

--- a/packages/react-composites/tests/browser/callwithchat/hermetic/MoreDrawer.test.ts
+++ b/packages/react-composites/tests/browser/callwithchat/hermetic/MoreDrawer.test.ts
@@ -20,13 +20,16 @@ test.describe('CallWithChat Composite CallWithChat Page Tests', () => {
   });
 
   test('Speaker Submenu click on a new audio device displays correctly on mobile', async ({ page, serverUrl }) => {
-    const callState = defaultMockCallAdapterState([defaultMockRemoteParticipant('Paul Bridges')]);
-    callState.devices = {
-      ...callState.devices,
-      speakers: [
-        { id: 'speaker1', name: '1st Speaker', deviceType: 'Speaker', isSystemDefault: true },
-        { id: 'speaker2', name: '2nd Speaker', deviceType: 'Speaker', isSystemDefault: false }
-      ]
+    let callState = defaultMockCallAdapterState([defaultMockRemoteParticipant('Paul Bridges')]);
+    callState = {
+      ...callState,
+      devices: {
+        ...callState.devices,
+        speakers: [
+          { id: 'speaker1', name: '1st Speaker', deviceType: 'Speaker', isSystemDefault: true },
+          { id: 'speaker2', name: '2nd Speaker', deviceType: 'Speaker', isSystemDefault: false }
+        ]
+      }
     };
     await loadCallPage(page, serverUrl, callState);
 
@@ -45,13 +48,16 @@ test.describe('CallWithChat Composite CallWithChat Page Tests', () => {
   });
 
   test('Microphone Submenu click on a new audio device displays correctly on mobile', async ({ page, serverUrl }) => {
-    const callState = defaultMockCallAdapterState([defaultMockRemoteParticipant('Paul Bridges')]);
-    callState.devices = {
-      ...callState.devices,
-      microphones: [
-        { id: 'microphone1', name: '1st Microphone', deviceType: 'Microphone', isSystemDefault: true },
-        { id: 'microphone2', name: '2nd Microphone', deviceType: 'Microphone', isSystemDefault: false }
-      ]
+    let callState = defaultMockCallAdapterState([defaultMockRemoteParticipant('Paul Bridges')]);
+    callState = {
+      ...callState,
+      devices: {
+        ...callState.devices,
+        microphones: [
+          { id: 'microphone1', name: '1st Microphone', deviceType: 'Microphone', isSystemDefault: true },
+          { id: 'microphone2', name: '2nd Microphone', deviceType: 'Microphone', isSystemDefault: false }
+        ]
+      }
     };
     await loadCallPage(page, serverUrl, callState);
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Adds readonly properties to the CallAdapter adapter state
# Why
<!--- What problem does this change solve? -->
Makes adapter state like pages protected from direct assignment.
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2981275
# How Tested
<!--- How did you test your change. What tests have you added. -->
updated tests for readonly state