### PR TITLE
Update chat stateful client state and adapter to be readonly

### DIFF
--- a/change-beta/@azure-communication-react-f334d317-6709-47c4-8a01-103601c901ed.json
+++ b/change-beta/@azure-communication-react-f334d317-6709-47c4-8a01-103601c901ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update chat stateful client and ChatAdapter to have their states readonly.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-f334d317-6709-47c4-8a01-103601c901ed.json
+++ b/change/@azure-communication-react-f334d317-6709-47c4-8a01-103601c901ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update chat stateful client and ChatAdapter to have their states readonly.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-stateful-client/review/beta/chat-stateful-client.api.md
+++ b/packages/chat-stateful-client/review/beta/chat-stateful-client.api.md
@@ -17,12 +17,12 @@ import { TypingIndicatorReceivedEvent } from '@azure/communication-chat';
 
 // @public
 export type ChatClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName: string;
-    threads: {
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName: string;
+    readonly threads: {
         [key: string]: ChatThreadClientState;
     };
-    latestErrors: ChatErrors;
+    readonly latestErrors: ChatErrors;
 };
 
 // @public
@@ -49,17 +49,17 @@ export type ChatMessageWithStatus = ChatMessage & {
 
 // @public
 export type ChatThreadClientState = {
-    chatMessages: {
+    readonly chatMessages: {
         [key: string]: ChatMessageWithStatus;
     };
-    participants: {
+    readonly participants: {
         [key: string]: ChatParticipant;
     };
-    threadId: string;
-    properties?: ChatThreadProperties;
-    readReceipts: ChatMessageReadReceipt[];
-    typingIndicators: TypingIndicatorReceivedEvent[];
-    latestReadTime: Date;
+    readonly threadId: string;
+    readonly properties?: ChatThreadProperties;
+    readonly readReceipts: ChatMessageReadReceipt[];
+    readonly typingIndicators: TypingIndicatorReceivedEvent[];
+    readonly latestReadTime: Date;
 };
 
 // @public

--- a/packages/chat-stateful-client/review/stable/chat-stateful-client.api.md
+++ b/packages/chat-stateful-client/review/stable/chat-stateful-client.api.md
@@ -17,12 +17,12 @@ import { TypingIndicatorReceivedEvent } from '@azure/communication-chat';
 
 // @public
 export type ChatClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName: string;
-    threads: {
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName: string;
+    readonly threads: {
         [key: string]: ChatThreadClientState;
     };
-    latestErrors: ChatErrors;
+    readonly latestErrors: ChatErrors;
 };
 
 // @public
@@ -49,17 +49,17 @@ export type ChatMessageWithStatus = ChatMessage & {
 
 // @public
 export type ChatThreadClientState = {
-    chatMessages: {
+    readonly chatMessages: {
         [key: string]: ChatMessageWithStatus;
     };
-    participants: {
+    readonly participants: {
         [key: string]: ChatParticipant;
     };
-    threadId: string;
-    properties?: ChatThreadProperties;
-    readReceipts: ChatMessageReadReceipt[];
-    typingIndicators: TypingIndicatorReceivedEvent[];
-    latestReadTime: Date;
+    readonly threadId: string;
+    readonly properties?: ChatThreadProperties;
+    readonly readReceipts: ChatMessageReadReceipt[];
+    readonly typingIndicators: TypingIndicatorReceivedEvent[];
+    readonly latestReadTime: Date;
 };
 
 // @public

--- a/packages/chat-stateful-client/src/ChatClientState.ts
+++ b/packages/chat-stateful-client/src/ChatClientState.ts
@@ -15,23 +15,23 @@ export type ChatClientState = {
   /**
    * Identifier of the current user.
    */
-  userId: CommunicationIdentifierKind;
+  readonly userId: CommunicationIdentifierKind;
   /**
    * DisplayName of the current user.
    * The same value as what others see in {@link @azure/communication-chat#ChatParticipant.displayName}
    */
-  displayName: string;
+  readonly displayName: string;
   /**
    * Chat threads joined by the current user.
    * Object with {@link ChatThreadClientState} fields, keyed by {@link ChatThreadClientState.threadId}.
    */
-  threads: { [key: string]: ChatThreadClientState };
+  readonly threads: { [key: string]: ChatThreadClientState };
   /**
    * Stores the latest error for each API method.
    *
    * See documentation of {@link ChatErrors} for details.
    */
-  latestErrors: ChatErrors;
+  readonly latestErrors: ChatErrors;
 };
 
 /**
@@ -46,35 +46,35 @@ export type ChatThreadClientState = {
    * Local messages are keyed by keyed by {@link ChatMessageWithStatus.clientMessageId}.
    * Remote messages are keyed by {@link @azure/communication-chat#ChatMessage.id}.
    */
-  chatMessages: { [key: string]: ChatMessageWithStatus };
+  readonly chatMessages: { [key: string]: ChatMessageWithStatus };
   /**
    * Participants of this chat thread.
    *
    * Object with {@link @azure/communication-chat#ChatParticipant} fields,
    * keyed by {@link @azure/communication-chat#ChatParticipant.id}.
    */
-  participants: { [key: string]: ChatParticipant };
+  readonly participants: { [key: string]: ChatParticipant };
   /**
    * Id of this chat thread. Returned from {@link @azure/communication-chat#ChatThreadClient.threadId}
    */
-  threadId: string;
+  readonly threadId: string;
   /**
    * An object containing properties of this chat thread.
    */
-  properties?: ChatThreadProperties;
+  readonly properties?: ChatThreadProperties;
   /**
    * An array of ReadReceipts of this chat thread. Returned from {@link @azure/communication-chat#ChatThreadClient.listReadReceipts}
    */
-  readReceipts: ChatMessageReadReceipt[];
+  readonly readReceipts: ChatMessageReadReceipt[];
   /**
    * An array of typingIndicators of this chat thread. Captured from event listener of {@link @azure/communication-chat#ChatClient}
    * Stateful client only stores recent 8000ms real-time typing indicators data.
    */
-  typingIndicators: TypingIndicatorReceivedEvent[];
+  readonly typingIndicators: TypingIndicatorReceivedEvent[];
   /**
    * Latest timestamp when other users read messages sent by current user.
    */
-  latestReadTime: Date;
+  readonly latestReadTime: Date;
 };
 
 /**

--- a/packages/chat-stateful-client/src/ChatContext.ts
+++ b/packages/chat-stateful-client/src/ChatContext.ts
@@ -85,10 +85,11 @@ export class ChatContext {
   }
 
   public updateChatConfig(userId: CommunicationIdentifierKind, displayName: string): void {
-    this.modifyState((draft: ChatClientState) => {
-      draft.displayName = displayName;
-      draft.userId = userId;
-    });
+    this.modifyState((draft: ChatClientState) => ({
+      ...draft,
+      displayName: displayName,
+      userId: userId
+    }));
   }
 
   public createThreadIfNotExist(threadId: string, properties?: ChatThreadProperties): boolean {
@@ -102,9 +103,9 @@ export class ChatContext {
 
   public updateThread(threadId: string, properties?: ChatThreadProperties): void {
     this.modifyState((draft: ChatClientState) => {
-      const thread = draft.threads[threadId];
+      let thread = draft.threads[threadId];
       if (thread) {
-        thread.properties = properties;
+        thread = { ...thread, properties: properties };
       }
     });
   }
@@ -114,9 +115,9 @@ export class ChatContext {
       if (topic === undefined) {
         return;
       }
-      const thread = draft.threads[threadId];
+      let thread = draft.threads[threadId];
       if (thread && !thread.properties) {
-        thread.properties = { topic: topic };
+        thread = { ...thread, properties: { topic: topic } };
       } else if (thread && thread.properties) {
         thread.properties.topic = topic;
       }
@@ -134,9 +135,9 @@ export class ChatContext {
 
   public setChatMessages(threadId: string, messages: { [key: string]: ChatMessageWithStatus }): void {
     this.modifyState((draft: ChatClientState) => {
-      const threadState = draft.threads[threadId];
+      let threadState = draft.threads[threadId];
       if (threadState) {
-        threadState.chatMessages = messages;
+        threadState = { ...threadState, chatMessages: messages };
       }
 
       // remove typing indicator when receive messages
@@ -225,12 +226,12 @@ export class ChatContext {
 
   public addReadReceipt(threadId: string, readReceipt: ChatMessageReadReceipt): void {
     this.modifyState((draft: ChatClientState) => {
-      const thread = draft.threads[threadId];
+      let thread = draft.threads[threadId];
       const readReceipts = thread?.readReceipts;
       if (thread && readReceipts) {
         // TODO(prprabhu): Replace `this.getState()` with `draft`?
         if (readReceipt.sender !== this.getState().userId && thread.latestReadTime < readReceipt.readOn) {
-          thread.latestReadTime = readReceipt.readOn;
+          thread = { ...thread, latestReadTime: readReceipt.readOn };
         }
         readReceipts.push(readReceipt);
       }
@@ -251,7 +252,7 @@ export class ChatContext {
           });
 
           if (thread.typingIndicators.length !== filteredTypingIndicators.length) {
-            thread.typingIndicators = filteredTypingIndicators;
+            ({ ...thread, typingIndicators: filteredTypingIndicators });
           }
           if (thread.typingIndicators.length > 0) {
             isTypingActive = true;
@@ -364,7 +365,7 @@ export class ChatContext {
       (typingIndicator) => toFlatCommunicationIdentifier(typingIndicator.sender) !== userIdAsKey
     );
     if (filteredTypingIndicators.length !== typingIndicators.length) {
-      thread.typingIndicators = filteredTypingIndicators;
+      ({ ...thread, typingIndicators: filteredTypingIndicators });
     }
   }
 

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1157,8 +1157,8 @@ export interface ChatAdapterThreadManagement {
 
 // @public
 export type ChatAdapterUiState = {
-    error?: Error;
-    fileUploads?: FileUploadsUiState;
+    readonly error?: Error;
+    readonly fileUploads?: FileUploadsUiState;
 };
 
 // @public
@@ -1177,12 +1177,12 @@ export type ChatClientProviderProps = {
 
 // @public
 export type ChatClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName: string;
-    threads: {
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName: string;
+    readonly threads: {
         [key: string]: ChatThreadClientState;
     };
-    latestErrors: ChatErrors;
+    readonly latestErrors: ChatErrors;
 };
 
 // @public
@@ -1190,10 +1190,10 @@ export const ChatComposite: (props: ChatCompositeProps) => JSX.Element;
 
 // @public
 export type ChatCompositeClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName: string;
-    thread: ChatThreadClientState;
-    latestErrors: AdapterErrors;
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName: string;
+    readonly thread: ChatThreadClientState;
+    readonly latestErrors: AdapterErrors;
 };
 
 // @public
@@ -1327,17 +1327,17 @@ export type ChatThreadClientProviderProps = {
 
 // @public
 export type ChatThreadClientState = {
-    chatMessages: {
+    readonly chatMessages: {
         [key: string]: ChatMessageWithStatus;
     };
-    participants: {
+    readonly participants: {
         [key: string]: ChatParticipant;
     };
-    threadId: string;
-    properties?: ChatThreadProperties;
-    readReceipts: ChatMessageReadReceipt[];
-    typingIndicators: TypingIndicatorReceivedEvent[];
-    latestReadTime: Date;
+    readonly threadId: string;
+    readonly properties?: ChatThreadProperties;
+    readonly readReceipts: ChatMessageReadReceipt[];
+    readonly typingIndicators: TypingIndicatorReceivedEvent[];
+    readonly latestReadTime: Date;
 };
 
 // @public

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -904,7 +904,7 @@ export interface ChatAdapterThreadManagement {
 
 // @public
 export type ChatAdapterUiState = {
-    error?: Error;
+    readonly error?: Error;
 };
 
 // @public
@@ -923,12 +923,12 @@ export type ChatClientProviderProps = {
 
 // @public
 export type ChatClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName: string;
-    threads: {
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName: string;
+    readonly threads: {
         [key: string]: ChatThreadClientState;
     };
-    latestErrors: ChatErrors;
+    readonly latestErrors: ChatErrors;
 };
 
 // @public
@@ -936,10 +936,10 @@ export const ChatComposite: (props: ChatCompositeProps) => JSX.Element;
 
 // @public
 export type ChatCompositeClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName: string;
-    thread: ChatThreadClientState;
-    latestErrors: AdapterErrors;
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName: string;
+    readonly thread: ChatThreadClientState;
+    readonly latestErrors: AdapterErrors;
 };
 
 // @public
@@ -1064,17 +1064,17 @@ export type ChatThreadClientProviderProps = {
 
 // @public
 export type ChatThreadClientState = {
-    chatMessages: {
+    readonly chatMessages: {
         [key: string]: ChatMessageWithStatus;
     };
-    participants: {
+    readonly participants: {
         [key: string]: ChatParticipant;
     };
-    threadId: string;
-    properties?: ChatThreadProperties;
-    readReceipts: ChatMessageReadReceipt[];
-    typingIndicators: TypingIndicatorReceivedEvent[];
-    latestReadTime: Date;
+    readonly threadId: string;
+    readonly properties?: ChatThreadProperties;
+    readonly readReceipts: ChatMessageReadReceipt[];
+    readonly typingIndicators: TypingIndicatorReceivedEvent[];
+    readonly latestReadTime: Date;
 };
 
 // @public

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -839,8 +839,8 @@ export interface ChatAdapterThreadManagement {
 
 // @public
 export type ChatAdapterUiState = {
-    error?: Error;
-    fileUploads?: FileUploadsUiState;
+    readonly error?: Error;
+    readonly fileUploads?: FileUploadsUiState;
 };
 
 // @public
@@ -848,10 +848,10 @@ export const ChatComposite: (props: ChatCompositeProps) => JSX.Element;
 
 // @public
 export type ChatCompositeClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName: string;
-    thread: ChatThreadClientState;
-    latestErrors: AdapterErrors;
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName: string;
+    readonly thread: ChatThreadClientState;
+    readonly latestErrors: AdapterErrors;
 };
 
 // @public

--- a/packages/react-composites/review/stable/react-composites.api.md
+++ b/packages/react-composites/review/stable/react-composites.api.md
@@ -667,7 +667,7 @@ export interface ChatAdapterThreadManagement {
 
 // @public
 export type ChatAdapterUiState = {
-    error?: Error;
+    readonly error?: Error;
 };
 
 // @public
@@ -675,10 +675,10 @@ export const ChatComposite: (props: ChatCompositeProps) => JSX.Element;
 
 // @public
 export type ChatCompositeClientState = {
-    userId: CommunicationIdentifierKind;
-    displayName: string;
-    thread: ChatThreadClientState;
-    latestErrors: AdapterErrors;
+    readonly userId: CommunicationIdentifierKind;
+    readonly displayName: string;
+    readonly thread: ChatThreadClientState;
+    readonly latestErrors: AdapterErrors;
 };
 
 // @public

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationFileUploadAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationFileUploadAdapter.ts
@@ -58,9 +58,10 @@ class FileUploadContext {
 
   public clearFileUploads(): void {
     this.chatContext.setState(
-      produce(this.chatContext.getState(), (draft: ChatAdapterState) => {
-        draft.fileUploads = {};
-      })
+      produce(this.chatContext.getState(), (draft: ChatAdapterState) => ({
+        ...draft,
+        fileUploads: {}
+      }))
     );
   }
 

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
@@ -18,7 +18,7 @@ import { FileMetadata } from '@internal/react-components';
 export type ChatAdapterUiState = {
   // FIXME(Delete?)
   // Self-contained state for composite
-  error?: Error;
+  readonly error?: Error;
   /* @conditional-compile-remove(file-sharing) */
   /**
    * Files being uploaded by a user in the current thread.
@@ -26,7 +26,7 @@ export type ChatAdapterUiState = {
    * Array of type {@link FileUploadsUiState}
    * @beta
    */
-  fileUploads?: FileUploadsUiState;
+  readonly fileUploads?: FileUploadsUiState;
 };
 
 /**
@@ -35,13 +35,13 @@ export type ChatAdapterUiState = {
  * @public
  */
 export type ChatCompositeClientState = {
-  userId: CommunicationIdentifierKind;
-  displayName: string;
-  thread: ChatThreadClientState;
+  readonly userId: CommunicationIdentifierKind;
+  readonly displayName: string;
+  readonly thread: ChatThreadClientState;
   /**
    * Latest error encountered for each operation performed via the adapter.
    */
-  latestErrors: AdapterErrors;
+  readonly latestErrors: AdapterErrors;
 };
 
 /**


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Make state readonly in the Adapter and Chat statefulClient
# Why
<!--- What problem does this change solve? -->
Makes the state of the two levels immutable
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/2981275
related: https://github.com/Azure/communication-ui-library/pull/2615
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran apps locally to verify client and adapters are still working