### PR TITLE
[bugfix] Update storybook and samples to disable mobile feature "pull-down to refresh"

### DIFF
--- a/change-beta/@azure-communication-react-bfa2f596-77a0-40fd-82ce-dd9beae0b2e2.json
+++ b/change-beta/@azure-communication-react-bfa2f596-77a0-40fd-82ce-dd9beae0b2e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update samples to disable pull down to refresh in chat",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-bfa2f596-77a0-40fd-82ce-dd9beae0b2e2.json
+++ b/change/@azure-communication-react-bfa2f596-77a0-40fd-82ce-dd9beae0b2e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update samples to disable pull down to refresh in chat",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/CallWithChatComposite/CallWithChatCompositeDocs.tsx
+++ b/packages/storybook/stories/CallWithChatComposite/CallWithChatCompositeDocs.tsx
@@ -91,8 +91,8 @@ export const getDocs: () => JSX.Element = () => {
       </Description>
       <Description>
         Mobile devices have a pull-down to refresh feature that may impact users from scrolling through messages in
-        chat. A simple and effective way to disable the pull-down to refresh feature is to set an overflow='hidden' OR
-        touch-action='none' style on the body element for your app.
+        chat. A simple and effective way to disable the pull-down to refresh feature is to set an `overflow='hidden'` OR
+        `touch-action='none'` style on the body element for your app.
       </Description>
 
       <Heading>Theming</Heading>

--- a/packages/storybook/stories/CallWithChatComposite/CallWithChatCompositeDocs.tsx
+++ b/packages/storybook/stories/CallWithChatComposite/CallWithChatCompositeDocs.tsx
@@ -89,6 +89,11 @@ export const getDocs: () => JSX.Element = () => {
         You can try out the form factor property in the [CallWithChatComposite Basic
         Example](./?path=/story/composites-call-with-chat-basicexample--basic-example).
       </Description>
+      <Description>
+        Mobile devices have a pull-down to refresh feature that may impact users from scrolling through messages in
+        chat. A simple and effective way to disable the pull-down to refresh feature is to set an overflow='hidden' OR
+        touch-action='none' style on the body element for your app.
+      </Description>
 
       <Heading>Theming</Heading>
       <Description>

--- a/packages/storybook/stories/ChatComposite/ChatCompositeDocs.tsx
+++ b/packages/storybook/stories/ChatComposite/ChatCompositeDocs.tsx
@@ -123,6 +123,11 @@ export const getDocs: () => JSX.Element = () => {
         composite is responsive to the container it is in and should perform optimally on mobile and desktop
         automatically.
       </Description>
+      <Description>
+        Mobile devices have a pull-down to refresh feature that may impact users from scrolling through messages in
+        chat. A simple and effective way to disable the pull-down to refresh feature is to set an overflow='hidden' OR
+        touch-action='none' style on the body element for your app.
+      </Description>
 
       <Heading>Custom Data Model</Heading>
       <Description>

--- a/packages/storybook/stories/ChatComposite/ChatCompositeDocs.tsx
+++ b/packages/storybook/stories/ChatComposite/ChatCompositeDocs.tsx
@@ -125,8 +125,8 @@ export const getDocs: () => JSX.Element = () => {
       </Description>
       <Description>
         Mobile devices have a pull-down to refresh feature that may impact users from scrolling through messages in
-        chat. A simple and effective way to disable the pull-down to refresh feature is to set an overflow='hidden' OR
-        touch-action='none' style on the body element for your app.
+        chat. A simple and effective way to disable the pull-down to refresh feature is to set an `overflow='hidden'` OR
+        `touch-action='none'` style on the body element for your app.
       </Description>
 
       <Heading>Custom Data Model</Heading>

--- a/samples/CallWithChat/src/app/views/CallScreen.tsx
+++ b/samples/CallWithChat/src/app/views/CallScreen.tsx
@@ -36,6 +36,16 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     locator,
     /* @conditional-compile-remove(PSTN-calls) */ alternateCallerId
   } = props;
+
+  // Disables pull down to refresh. Prevents accidental page refresh when scrolling through chat messages
+  // Another alternative: set body style touch-action to 'none'. Achieves same result.
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'null';
+    };
+  }, []);
+
   const callIdRef = useRef<string>();
   const { currentTheme, currentRtl } = useSwitchableFluentTheme();
   const isMobileSession = useIsMobile();

--- a/samples/Chat/src/app/ChatScreen.tsx
+++ b/samples/Chat/src/app/ChatScreen.tsx
@@ -33,6 +33,15 @@ interface ChatScreenProps {
 export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
   const { displayName, endpointUrl, threadId, token, userId, endChatHandler } = props;
 
+  // Disables pull down to refresh. Prevents accidental page refresh when scrolling through chat messages
+  // Another alternative: set body style touch-action to 'none'. Achieves same result.
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'null';
+    };
+  }, []);
+
   /* @conditional-compile-remove(chat-composite-participant-pane) */
   const [hideParticipants, setHideParticipants] = useState<boolean>(false);
 


### PR DESCRIPTION
# What
Disable pull-down to refresh on samples and document best practice in storybook on how to handle accidental pull down to refresh triggers on mobile

# Why
On IOS Safari Chat and CallWithChat scrolling on chat page can sometimes cause the whole page view to refresh/scroll.
This can cause accidental page refresh.
https://skype.visualstudio.com/SPOOL/_workitems/edit/3069029

# How Tested
Tested on iPhone SE on CallWIthChat and Chat sample.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->