### PR TITLE
[Bugfix] Fix video tile strict mode findDOMNode warning

### DIFF
--- a/change-beta/@azure-communication-react-cbefab17-73bb-4853-9e8f-9d7a6cc4ab87.json
+++ b/change-beta/@azure-communication-react-cbefab17-73bb-4853-9e8f-9d7a6cc4ab87.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix findDOMNode warning caused by react.strictmode.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-cbefab17-73bb-4853-9e8f-9d7a6cc4ab87.json
+++ b/change/@azure-communication-react-cbefab17-73bb-4853-9e8f-9d7a6cc4ab87.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix findDOMNode warning caused by react.strictmode.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -246,7 +246,6 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
   const observer = useRef(
     new ResizeObserver((entries): void => {
       const { width, height } = entries[0].contentRect;
-      console.log(entries);
       const personaSize = Math.min(width, height) / 3;
       setPersonaSize(Math.max(Math.min(personaSize, personaMaxSize), personaMinSize));
     })

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -4,7 +4,6 @@
 import { Icon, IStyle, mergeStyles, Persona, Stack, Text } from '@fluentui/react';
 /* @conditional-compile-remove(pinned-participants) */
 import { IconButton } from '@fluentui/react';
-import { Ref } from '@fluentui/react-northstar';
 import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useIdentifiers } from '../identifiers';
 import { ComponentLocale, useLocale } from '../localization';
@@ -237,7 +236,7 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
   } = props;
 
   const [personaSize, setPersonaSize] = useState(100);
-  const videoTileRef = useRef<HTMLElement>(null);
+  const videoTileRef = useRef<HTMLDivElement>(null);
 
   const locale = useLocale();
   const theme = useTheme();
@@ -307,7 +306,7 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
   const canShowLabel = showLabel && (displayName || (showMuteIndicator && isMuted));
   const participantStateString = participantStateStringTrampoline(props, locale);
   return (
-    <Ref innerRef={videoTileRef}>
+    <div ref={videoTileRef} style={{ width: '100%', height: '100%' }}>
       <Stack
         data-ui-id={ids.videoTile}
         className={mergeStyles(
@@ -393,7 +392,7 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
           <Stack className={mergeStyles(overlayContainerStyles, styles?.overlayContainer)}>{children}</Stack>
         )}
       </Stack>
-    </Ref>
+    </div>
   );
 };
 

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -246,6 +246,7 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
   const observer = useRef(
     new ResizeObserver((entries): void => {
       const { width, height } = entries[0].contentRect;
+      console.log(entries);
       const personaSize = Math.min(width, height) / 3;
       setPersonaSize(Math.max(Math.min(personaSize, personaMaxSize), personaMinSize));
     })
@@ -306,30 +307,30 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
   const canShowLabel = showLabel && (displayName || (showMuteIndicator && isMuted));
   const participantStateString = participantStateStringTrampoline(props, locale);
   return (
-    <div ref={videoTileRef} style={{ width: '100%', height: '100%' }}>
-      <Stack
-        data-ui-id={ids.videoTile}
-        className={mergeStyles(
-          rootStyles,
-          {
-            background: theme.palette.neutralLighter,
-            borderRadius: theme.effects.roundedCorner4
-          },
-          isSpeaking && {
-            '&::before': {
-              content: `''`,
-              position: 'absolute',
-              zIndex: 1,
-              border: `0.25rem solid ${theme.palette.themePrimary}`,
-              borderRadius: theme.effects.roundedCorner4,
-              width: '100%',
-              height: '100%'
-            }
-          },
-          styles?.root
-        )}
-        {...longPressHandlersTrampoline}
-      >
+    <Stack
+      data-ui-id={ids.videoTile}
+      className={mergeStyles(
+        rootStyles,
+        {
+          background: theme.palette.neutralLighter,
+          borderRadius: theme.effects.roundedCorner4
+        },
+        isSpeaking && {
+          '&::before': {
+            content: `''`,
+            position: 'absolute',
+            zIndex: 1,
+            border: `0.25rem solid ${theme.palette.themePrimary}`,
+            borderRadius: theme.effects.roundedCorner4,
+            width: '100%',
+            height: '100%'
+          }
+        },
+        styles?.root
+      )}
+      {...longPressHandlersTrampoline}
+    >
+      <div ref={videoTileRef} style={{ width: '100%', height: '100%' }}>
         {isVideoRendered ? (
           <Stack
             className={mergeStyles(
@@ -391,8 +392,8 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
         {children && (
           <Stack className={mergeStyles(overlayContainerStyles, styles?.overlayContainer)}>{children}</Stack>
         )}
-      </Stack>
-    </div>
+      </div>
+    </Stack>
   );
 };
 

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -191,18 +191,20 @@ const App = (): JSX.Element => {
         return <Spinner label={'Getting user credentials from server'} ariaLive="assertive" labelPosition="top" />;
       }
       return (
-        <CallScreen
-          token={token}
-          userId={userId}
-          displayName={displayName}
-          callLocator={callLocator}
-          /* @conditional-compile-remove(PSTN-calls) */
-          alternateCallerId={alternateCallerId}
-          /* @conditional-compile-remove(rooms) */
-          roleHint={role}
-          /* @conditional-compile-remove(teams-identity-support) */
-          isTeamsIdentityCall={isTeamsCall}
-        />
+        <React.StrictMode>
+          <CallScreen
+            token={token}
+            userId={userId}
+            displayName={displayName}
+            callLocator={callLocator}
+            /* @conditional-compile-remove(PSTN-calls) */
+            alternateCallerId={alternateCallerId}
+            /* @conditional-compile-remove(rooms) */
+            roleHint={role}
+            /* @conditional-compile-remove(teams-identity-support) */
+            isTeamsIdentityCall={isTeamsCall}
+          />
+        </React.StrictMode>
       );
     }
     default:


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Remove use of `<Ref>` tag from fluent nothstar
# Why
<!--- What problem does this change solve? -->
fixes findDOMNode warning caused by strict mode in the video tile. Under the hood the `<Ref>` tag probably uses `findDOMNode()`. According to react's documentation about the function it should not be used with React.FunctionalComponents. `<Ref>` is a React.FunctionalComponent according the the api file provided by fluent-northstar.
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3090254
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran app locally with new reference structure to make sure the video gallery still works