### PR TITLE
prototype snippet component code

### DIFF
--- a/packages/storybook/stories/SendBox/SendBox.stories.tsx
+++ b/packages/storybook/stories/SendBox/SendBox.stories.tsx
@@ -9,11 +9,12 @@ import { DetailedBetaBanner } from '../BetaBanners/DetailedBetaBanner';
 
 import { COMPONENT_FOLDER_PREFIX } from '../constants';
 import { controlsToAdd, hiddenControl } from '../controlsUtils';
+import { Snippet } from '../Snippet';
 import { CustomIconExample } from './snippets/CustomIcon.snippet';
 import { CustomStylingExample } from './snippets/CustomStyling.snippet';
 import { FileUploadsExample } from './snippets/FileUploads.snippet';
 import { SendBoxExample } from './snippets/SendBox.snippet';
-import { SendBoxWithSystemMessageExample } from './snippets/SendBoxWithSystemMessage.snippet';
+// import { SendBoxWithSystemMessageExample } from './snippets/SendBoxWithSystemMessage.snippet';
 
 const CustomIconExampleText = require('!!raw-loader!./snippets/CustomIcon.snippet.tsx').default;
 const CustomStylingExampleText = require('!!raw-loader!./snippets/CustomStyling.snippet.tsx').default;
@@ -21,7 +22,6 @@ const FileUploadsExampleText = require('!!raw-loader!./snippets/FileUploads.snip
 const SendBoxExampleText = require('!!raw-loader!./snippets/SendBox.snippet.tsx').default;
 const SendBoxWithSystemMessageExampleText =
   require('!!raw-loader!./snippets/SendBoxWithSystemMessage.snippet.tsx').default;
-
 const importStatement = `import { SendBox } from '@azure/communication-react';`;
 
 const getDocs: () => JSX.Element = () => {
@@ -43,9 +43,18 @@ const getDocs: () => JSX.Element = () => {
 
       <Heading>Add a system message</Heading>
       <Description>To add a system message, use the systemMessage property like in the example below.</Description>
-      <Canvas mdxSource={SendBoxWithSystemMessageExampleText}>
+      <Snippet
+        key="sendBoxWithSystemMessageSnippet"
+        code={SendBoxWithSystemMessageExampleText}
+        startLine={7}
+        endLine={15}
+        githubUrl={
+          'https://github.com/Azure/communication-ui-library/blob/main/packages/storybook/stories/SendBox/snippets/SendBoxWithSystemMessage.snippet.tsx#L7-L15'
+        }
+      />
+      {/* <Canvas mdxSource={SendBoxWithSystemMessageExampleText}>
         <SendBoxWithSystemMessageExample />
-      </Canvas>
+      </Canvas> */}
 
       <Heading>Customize send icon</Heading>
       <Description>

--- a/packages/storybook/stories/Snippet.tsx
+++ b/packages/storybook/stories/Snippet.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Source } from '@storybook/addon-docs';
+
+type Args = {
+  key: string;
+  code: string;
+  startLine: number;
+  endLine: number;
+  githubUrl: string;
+};
+
+const extractSnippet = (exampleAsText: string, startLine: number, endLine: number) => {
+  const exampleAsArr = exampleAsText.split('\n');
+  let snippetAsArr = new Array();
+  for (var i = startLine - 1; i < endLine; i++) {
+    snippetAsArr.push(exampleAsArr[i]);
+  }
+  return snippetAsArr.join('\n');
+};
+export const Snippet = (args: Args) => {
+  const snippet = extractSnippet(args.code, args.startLine, args.endLine);
+  return (
+    <div>
+      <Source code={snippet} key={args.key} language={'tsx'}></Source>
+      See this snippet in a working example in Github <a href={args.githubUrl}>click</a>
+    </div>
+  );
+};


### PR DESCRIPTION
Creating a new wrapper component for our <Source> tag usage when showing snippets.

type Args = {
  key: string;
  code: string;
  startLine: number;
  endLine: number;
  githubUrl: string;
};

we take in these args into our new "snippet" component.

We still pass in the code similar to the Source component. The difference is that we can pass in a start/end line to constrain our code to a specific set of lines in the snippet. Also including a githubUrl where we would link to the snippet in github with the specific lines hightlighted to show where the lines in the snippet fit in the overall working code