### PR TITLE
[Call Readiness] Environmentstrings api fix

### DIFF
--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -3069,7 +3069,7 @@ export const UnsupportedBrowser: (props: UnsupportedBrowserProps) => JSX.Element
 // @beta
 export interface UnsupportedBrowserProps {
     onTroubleshootingClick?: () => void;
-    strings: UnsupportedBrowserStrings;
+    strings?: UnsupportedBrowserStrings;
 }
 
 // @beta
@@ -3103,7 +3103,7 @@ export const UnsupportedOperatingSystem: (props: UnsupportedOperatingSystemProps
 // @beta
 export interface UnsupportedOperatingSystemProps {
     onTroubleshootingClick?: () => void;
-    strings: UnsupportedOperatingSystemStrings;
+    strings?: UnsupportedOperatingSystemStrings;
 }
 
 // @beta

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1582,7 +1582,7 @@ export const UnsupportedBrowser: (props: UnsupportedBrowserProps) => JSX.Element
 // @beta
 export interface UnsupportedBrowserProps {
     onTroubleshootingClick?: () => void;
-    strings: UnsupportedBrowserStrings;
+    strings?: UnsupportedBrowserStrings;
 }
 
 // @beta
@@ -1616,7 +1616,7 @@ export const UnsupportedOperatingSystem: (props: UnsupportedOperatingSystemProps
 // @beta
 export interface UnsupportedOperatingSystemProps {
     onTroubleshootingClick?: () => void;
-    strings: UnsupportedOperatingSystemStrings;
+    strings?: UnsupportedOperatingSystemStrings;
 }
 
 // @beta

--- a/packages/react-components/src/components/UnsupportedBrowser.tsx
+++ b/packages/react-components/src/components/UnsupportedBrowser.tsx
@@ -29,7 +29,7 @@ export interface UnsupportedBrowserProps {
   /** Handler to perform an action when the help link is actioned */
   onTroubleshootingClick?: () => void;
   /** String overrides for the component */
-  strings: UnsupportedBrowserStrings;
+  strings?: UnsupportedBrowserStrings;
 }
 
 /**

--- a/packages/react-components/src/components/UnsupportedOperatingSystem.tsx
+++ b/packages/react-components/src/components/UnsupportedOperatingSystem.tsx
@@ -29,7 +29,7 @@ export interface UnsupportedOperatingSystemProps {
   /** Handler to perform a action when the help link is actioned */
   onTroubleshootingClick?: () => void;
   /** String overrides for the component */
-  strings: UnsupportedOperatingSystemStrings;
+  strings?: UnsupportedOperatingSystemStrings;
 }
 
 /**

--- a/packages/storybook/stories/INTERNAL/UnsupportedBrowser/snippets/UnsupportedEnvironmentDrawer.snippet.tsx
+++ b/packages/storybook/stories/INTERNAL/UnsupportedBrowser/snippets/UnsupportedEnvironmentDrawer.snippet.tsx
@@ -9,13 +9,9 @@ import {
   UnsupportedOperatingSystem
 } from '@internal/react-components';
 import React, { useState } from 'react';
-import { useLocale } from '../../../../../react-components/src/localization';
 import { MobilePreviewContainer } from '../../../MobileContainer';
 
 export const UnsupportedEnvironmentDrawers: () => JSX.Element = () => {
-  const unsupportedBrowserStrings = useLocale().strings.UnsupportedBrowser;
-  const unsupportedBrowserVersionStrings = useLocale().strings.UnsupportedBrowserVersion;
-  const unsupportedOperatingSystemStrings = useLocale().strings.UnsupportedOperatingSystem;
   const [unsupportedBrowserShowing, setUnsupportedBrowserShowing] = useState(false);
   const [unsupportedBrowserVersionShowing, setUnsupportedBrowserVersionShowing] = useState(false);
   const [unsupportedOperatingSystemShowing, setUnsupportedOperatingSystemShowing] = useState(false);
@@ -38,10 +34,7 @@ export const UnsupportedEnvironmentDrawers: () => JSX.Element = () => {
         )}
         {unsupportedBrowserShowing && (
           <_DrawerSurface onLightDismiss={onLightDismissTriggeredUnsupportedBrowser}>
-            <UnsupportedBrowser
-              onTroubleshootingClick={() => alert('clicked trouble shooting link')}
-              strings={unsupportedBrowserStrings}
-            />
+            <UnsupportedBrowser onTroubleshootingClick={() => alert('clicked trouble shooting link')} />
           </_DrawerSurface>
         )}
       </MobilePreviewContainer>
@@ -61,7 +54,6 @@ export const UnsupportedEnvironmentDrawers: () => JSX.Element = () => {
           <_DrawerSurface onLightDismiss={onLightDismissTriggeredUnsupportedBrowserVersion}>
             <UnsupportedBrowserVersion
               onTroubleshootingClick={() => alert('clicked compatibility link')}
-              strings={unsupportedBrowserVersionStrings}
               onContinueAnywayClick={() => alert('you are brave arent you?')}
             />
           </_DrawerSurface>
@@ -81,10 +73,7 @@ export const UnsupportedEnvironmentDrawers: () => JSX.Element = () => {
         )}
         {unsupportedOperatingSystemShowing && (
           <_DrawerSurface onLightDismiss={onLightDismissTriggeredUnsupportedOperatingSystem}>
-            <UnsupportedOperatingSystem
-              onTroubleshootingClick={() => alert('clicked compatibility link')}
-              strings={unsupportedOperatingSystemStrings}
-            />
+            <UnsupportedOperatingSystem onTroubleshootingClick={() => alert('clicked compatibility link')} />
           </_DrawerSurface>
         )}
       </MobilePreviewContainer>

--- a/packages/storybook/stories/INTERNAL/UnsupportedBrowser/snippets/UnsupportedEnvironmentModal.snippet.tsx
+++ b/packages/storybook/stories/INTERNAL/UnsupportedBrowser/snippets/UnsupportedEnvironmentModal.snippet.tsx
@@ -5,12 +5,7 @@ import { Modal, PrimaryButton, Stack } from '@fluentui/react';
 import { UnsupportedBrowser, UnsupportedBrowserVersion, UnsupportedOperatingSystem } from '@internal/react-components';
 import React, { useState } from 'react';
 
-import { useLocale } from '../../../../../react-components/src/localization';
-
 export const UnsupportedEnvironmentModals: () => JSX.Element = () => {
-  const unsupportedBrowserStrings = useLocale().strings.UnsupportedBrowser;
-  const unsupportedBrowserVersionStrings = useLocale().strings.UnsupportedBrowserVersion;
-  const unsupportedBrowserOperatingSystem = useLocale().strings.UnsupportedOperatingSystem;
   const [unsupportedBrowserModalOpen, setUnsupportedBrowserModalOpen] = useState<boolean>(false);
   const [unsupportedBrowserVersionModalOpen, setUnsupportedBrowserVersionModalOpen] = useState<boolean>(false);
   const [unsupportedOperatingSystemModalOpen, setUnsupportedOperatingSystemModalOpen] = useState<boolean>(false);
@@ -42,7 +37,6 @@ export const UnsupportedEnvironmentModals: () => JSX.Element = () => {
       </PrimaryButton>
       <Modal isOpen={unsupportedBrowserModalOpen} onDismiss={() => setUnsupportedBrowserModalOpen(false)}>
         <UnsupportedBrowser
-          strings={unsupportedBrowserStrings}
           onTroubleshootingClick={() => {
             alert('clicked help link');
           }}
@@ -50,7 +44,6 @@ export const UnsupportedEnvironmentModals: () => JSX.Element = () => {
       </Modal>
       <Modal isOpen={unsupportedBrowserVersionModalOpen} onDismiss={() => setUnsupportedBrowserVersionModalOpen(false)}>
         <UnsupportedBrowserVersion
-          strings={unsupportedBrowserVersionStrings}
           onTroubleshootingClick={() => {
             alert('clicked help link');
           }}
@@ -62,7 +55,6 @@ export const UnsupportedEnvironmentModals: () => JSX.Element = () => {
         onDismiss={() => setUnsupportedOperatingSystemModalOpen(false)}
       >
         <UnsupportedOperatingSystem
-          strings={unsupportedBrowserOperatingSystem}
           onTroubleshootingClick={() => {
             alert('clicked help link');
           }}


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
updates strings to be optional for Environment modals
# Why
<!--- What problem does this change solve? -->
allows default strings to be used by Contoso
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Removed provided strings in storybook to validate components render with strings.