### PR TITLE
Add a userProfileProvider to fetch displayName

### DIFF
--- a/packages/acs-ui-common/review/beta/acs-ui-common.api.md
+++ b/packages/acs-ui-common/review/beta/acs-ui-common.api.md
@@ -58,6 +58,9 @@ export const _logEvent: (logger: AzureLogger, event: TelemetryEvent) => void;
 export const _MAX_EVENT_LISTENERS = 50;
 
 // @public
+export const memoizeAllRet: <ArgsT extends unknown[], FnRetT>(fnToMemoize: (...args: ArgsT) => FnRetT) => (...args: ArgsT) => FnRetT;
+
+// @public
 export const memoizeFnAll: <KeyT, ArgsT extends unknown[], FnRetT, CallBackT extends CallbackType<KeyT, ArgsT, FnRetT>>(fnToMemoize: FunctionWithKey<KeyT, ArgsT, FnRetT>, shouldCacheUpdate?: (args1: unknown, args2: unknown) => boolean) => (callback: CallBackT) => FnRetT[];
 
 // @public

--- a/packages/acs-ui-common/src/index.ts
+++ b/packages/acs-ui-common/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 export { memoizeFnAll } from './memoizeFnAll';
+export { memoizeAllRet } from './memoizeAllRet';
 export {
   fromFlatCommunicationIdentifier,
   toFlatCommunicationIdentifier,

--- a/packages/acs-ui-common/src/memoizeAllRet.ts
+++ b/packages/acs-ui-common/src/memoizeAllRet.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { _safeJSONStringify } from './safeStringify';
+
+/**
+ * The function memoize is to cache all results return by the same function args
+ * It will compare function args to determine whether to return previous value or return a new one
+ * @param  fnToMemoize - the function needs to be memorized
+ * @public
+ */
+export const memoizeAllRet = <ArgsT extends unknown[], FnRetT>(
+  fnToMemoize: (...args: ArgsT) => FnRetT
+): ((...args: ArgsT) => FnRetT) => {
+  const cache = new Map<string, FnRetT>();
+
+  return (...args: ArgsT): FnRetT => {
+    const key = _safeJSONStringify(args);
+    if (!key) {
+      throw new Error('Get undefined key from args, please check args');
+    }
+    const value = cache.get(key);
+    if (value) {
+      return value;
+    }
+    const ret = fnToMemoize(...args);
+    cache.set(key, ret);
+    return ret;
+  };
+};

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1640,6 +1640,23 @@ export const _useContainerWidth: (containerRef: RefObject<HTMLElement>) => numbe
 // @internal
 export const _usePermissions: () => _Permissions;
 
+// Warning: (ae-internal-missing-underscore) The name "UserProfile" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export type UserProfile = {
+    userId: string;
+    displayName?: string;
+};
+
+// @internal (undocumented)
+export const _UserProfileProvider: (props: _UserProfileProviderProps) => JSX.Element;
+
+// @internal
+export type _UserProfileProviderProps = {
+    onFetchProfile?: (userId: string) => Promise<UserProfile | undefined>;
+    children: React_2.ReactNode;
+};
+
 // @public
 export const useTheme: () => Theme;
 

--- a/packages/react-components/src/components/ParticipantList.tsx
+++ b/packages/react-components/src/components/ParticipantList.tsx
@@ -15,6 +15,7 @@ import { useIdentifiers } from '../identifiers';
 import { useLocale } from '../localization';
 /* @conditional-compile-remove(rooms) */
 import { _usePermissions } from '../permissions';
+import { _useUserProfile } from '../profile/ProfileProvider';
 import {
   BaseCustomStyles,
   CallParticipantListParticipant,
@@ -108,6 +109,8 @@ const onRenderParticipantDefault = (
     }
   }
 
+  const profileDisplayName = participant.userId ? _useUserProfile(participant.userId)?.displayName : undefined;
+
   const menuItems = createParticipantMenuItems && createParticipantMenuItems(participant);
 
   const onRenderIcon =
@@ -133,7 +136,7 @@ const onRenderParticipantDefault = (
       styles={styles}
       key={participant.userId}
       userId={participant.userId}
-      displayName={participant.displayName}
+      displayName={profileDisplayName ?? participant.displayName}
       me={myUserId ? participant.userId === myUserId : false}
       menuItems={menuItems}
       presence={presence}

--- a/packages/react-components/src/components/RemoteVideoTile.tsx
+++ b/packages/react-components/src/components/RemoteVideoTile.tsx
@@ -3,6 +3,7 @@
 
 import { IContextualMenuProps, Layer, Stack } from '@fluentui/react';
 import React, { useMemo } from 'react';
+import { _useUserProfile } from '../profile/ProfileProvider';
 import {
   CreateVideoStreamViewResult,
   OnRenderAvatarCallback,
@@ -98,6 +99,8 @@ export const _RemoteVideoTile = React.memo(
       ]
     );
 
+    const profileDisplayName = _useUserProfile(userId)?.displayName;
+
     // Handle creating, destroying and updating the video stream as necessary
     const createVideoStreamResult = useRemoteVideoStreamLifecycleMaintainer(remoteVideoStreamProps);
 
@@ -141,7 +144,7 @@ export const _RemoteVideoTile = React.memo(
           key={userId}
           userId={userId}
           renderElement={renderVideoStreamElement}
-          displayName={remoteParticipant.displayName}
+          displayName={profileDisplayName ?? remoteParticipant.displayName}
           onRenderPlaceholder={onRenderAvatar}
           isMuted={remoteParticipant.isMuted}
           isSpeaking={remoteParticipant.isSpeaking}

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -33,6 +33,7 @@ import { floatingLocalVideoTileStyle } from './VideoGallery/styles/FloatingLocal
 import { useId } from '@fluentui/react-hooks';
 /* @conditional-compile-remove(pinned-participants) */
 import { PinnedParticipantsLayout } from './VideoGallery/PinnedParticipantsLayout';
+import { _useUserProfile } from '../profile/ProfileProvider';
 
 /**
  * @private
@@ -261,7 +262,11 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
       styles?.localVideo
     );
 
-    const initialsName = !localParticipant.displayName ? '' : localParticipant.displayName;
+    const profileDisplayName = localParticipant.userId
+      ? _useUserProfile(localParticipant.userId)?.displayName
+      : undefined;
+    const displayName = profileDisplayName ?? localParticipant.displayName;
+    const initialsName = !displayName ? '' : displayName;
 
     return (
       <Stack key="local-video-tile-key" tabIndex={0} aria-label={strings.localVideoMovementLabel} role={'dialog'}>

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -32,6 +32,7 @@ import { DirectionalHint, IContextualMenuProps } from '@fluentui/react';
 import useLongPress from './utils/useLongPress';
 /* @conditional-compile-remove(pinned-participants) */
 import { moreButtonStyles } from './styles/VideoTile.styles';
+import { _useUserProfile } from '../profile/ProfileProvider';
 
 /**
  * Strings of {@link VideoTile} that can be overridden.
@@ -303,7 +304,10 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
 
   const ids = useIdentifiers();
 
-  const canShowLabel = showLabel && (displayName || (showMuteIndicator && isMuted));
+  const profileDisplayName = userId ? _useUserProfile(userId)?.displayName : undefined;
+  const displayNameToRender = profileDisplayName ?? displayName;
+
+  const canShowLabel = (showLabel && displayNameToRender) || (showMuteIndicator && isMuted);
   const participantStateString = participantStateStringTrampoline(props, locale);
   return (
     <Stack
@@ -356,10 +360,10 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
               {canShowLabel && (
                 <Text
                   className={mergeStyles(displayNameStyle)}
-                  title={displayName}
+                  title={displayNameToRender}
                   style={{ color: participantStateString ? theme.palette.neutralSecondary : 'inherit' }}
                 >
-                  {displayName}
+                  {displayNameToRender}
                 </Text>
               )}
               {participantStateString && (

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -49,3 +49,7 @@ export type {
   VideoStreamOptions,
   ViewScalingMode
 } from './types';
+
+export { _UserProfileProvider } from './profile/ProfileProvider';
+
+export type { _UserProfileProviderProps, UserProfile } from './profile/ProfileProvider';

--- a/packages/react-components/src/profile/ProfileProvider.tsx
+++ b/packages/react-components/src/profile/ProfileProvider.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+/**
+ * @internal
+ */
+export type _UserProfileFunction = {
+  onFetchProfile?: (userId: string) => Promise<UserProfile | undefined>;
+};
+
+/**
+ * @internal
+ */
+export type UserProfile = {
+  userId: string;
+  displayName?: string;
+};
+
+/**
+ * @internal
+ */
+export const UserProfileContext = createContext<_UserProfileFunction>({
+  onFetchProfile: undefined
+});
+
+/**
+ * Props for {@link _PermissionsProviderProps}.
+ *
+ * @internal
+ */
+export type _UserProfileProviderProps = {
+  /** Permission context to provide components */
+  onFetchProfile?: (userId: string) => Promise<UserProfile | undefined>;
+  /** Children to provide locale context. */
+  children: React.ReactNode;
+};
+
+/**
+ * @internal
+ */
+export const _UserProfileProvider = (props: _UserProfileProviderProps): JSX.Element => {
+  const { onFetchProfile, children } = props;
+  return <UserProfileContext.Provider value={{ onFetchProfile }}>{children}</UserProfileContext.Provider>;
+};
+
+/**
+ * @internal
+ * React hook to access permissions
+ */
+export const _useUserProfile = (userId: string): UserProfile | undefined => {
+  const onFetchUserProfile = useContext(UserProfileContext).onFetchProfile;
+  const [profile, setProfile] = useState<UserProfile | undefined>(undefined);
+
+  useEffect(() => {
+    if (!onFetchUserProfile) {
+      return;
+    }
+    onFetchUserProfile(userId).then((profile) => setProfile(profile));
+  }, [onFetchUserProfile, userId]);
+
+  return profile;
+};

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -139,6 +139,7 @@ export interface BaseCompositeProps<TIcons extends Record<string, JSX.Element>> 
     locale?: CompositeLocale;
     onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
     onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
+    onFetchProfile?: OnFetchProfileCallback;
     rtl?: boolean;
 }
 
@@ -1248,6 +1249,9 @@ export type NetworkDiagnosticChangedEvent = NetworkDiagnosticChangedEventArgs & 
 };
 
 // @public
+export type OnFetchProfileCallback = (userId: string) => Promise<Profile | undefined>;
+
+// @public
 export type ParticipantsAddedListener = (event: {
     participantsAdded: ChatParticipant[];
     addedBy: ChatParticipant;
@@ -1268,6 +1272,12 @@ export type ParticipantsRemovedListener = (event: {
     participantsRemoved: ChatParticipant[];
     removedBy: ChatParticipant;
 }) => void;
+
+// @public
+export type Profile = {
+    displayName?: string;
+    avatarPersonaData?: AvatarPersonaData;
+};
 
 // @beta
 export interface TeamsCallAdapter extends CommonCallAdapter {

--- a/packages/react-composites/src/composites/common/BaseComposite.tsx
+++ b/packages/react-composites/src/composites/common/BaseComposite.tsx
@@ -18,6 +18,7 @@ import { AvatarPersonaDataCallback } from './AvatarPersona';
 import { CallCompositeIcons, CallWithChatCompositeIcons, ChatCompositeIcons, DEFAULT_COMPOSITE_ICONS } from './icons';
 import { globalLayerHostStyle } from './styles/GlobalHostLayer.styles';
 import { useId } from '@fluentui/react-hooks';
+import { OnFetchProfileCallback } from './Profile';
 /**
  * Properties common to all composites exported from this library.
  *
@@ -56,6 +57,12 @@ export interface BaseCompositeProps<TIcons extends Record<string, JSX.Element>> 
    * will be what is provided to the adapter when the adapter is created.
    */
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
+
+  /**
+   * A callback function that can be used to provide custom data to a user profile including
+   * display name and avatar in Composite.
+   */
+  onFetchProfile?: OnFetchProfileCallback;
 
   /**
    * A callback function that can be used to provide custom menu items for a participant in

--- a/packages/react-composites/src/composites/common/Profile.tsx
+++ b/packages/react-composites/src/composites/common/Profile.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AvatarPersonaData } from './AvatarPersona';
+
+/**
+ * Custom data attributes for displaying avatar for a user.
+ *
+ * @public
+ */
+export type Profile = {
+  /**
+   * Primary text to display, usually the name of the person.
+   */
+  displayName?: string;
+  avatarPersonaData?: AvatarPersonaData;
+};
+
+/**
+ * Callback function used to provide custom data to build profile for a user.
+ *
+ * @public
+ */
+export type OnFetchProfileCallback = (userId: string) => Promise<Profile | undefined>;

--- a/packages/react-composites/src/composites/index.ts
+++ b/packages/react-composites/src/composites/index.ts
@@ -8,6 +8,7 @@ export * from './CallComposite';
 export * from './CallWithChatComposite';
 
 export type { AvatarPersonaData, AvatarPersonaDataCallback } from './common/AvatarPersona';
+export type { OnFetchProfileCallback, Profile } from './common/Profile';
 export { COMPOSITE_ONLY_ICONS, DEFAULT_COMPOSITE_ICONS } from './common/icons';
 export type {
   CompositeIcons,


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add a userProfileProvider to fetch displayName

Usage:

For composite - pass a fetchProfile function and it will memorize the first return value of specific params and never update (which means can't live update user name)

For component - wrap components with UserProfileProvider, and provide the function to it

For future design - could be onShowPeopleCard or onHover and trigger some actions to render people card for users in the Profile object
# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->