### PR TITLE
Bump `@azure/communication-calling` beta dependency to 1.10.0-beta.1

### DIFF
--- a/change-beta/@azure-communication-react-06a5b499-fd64-46e6-a4c7-1826739303fc.json
+++ b/change-beta/@azure-communication-react-06a5b499-fd64-46e6-a4c7-1826739303fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bump `@azure/communication-calling` beta dependency to 1.10.0-beta.1",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-06a5b499-fd64-46e6-a4c7-1826739303fc.json
+++ b/change/@azure-communication-react-06a5b499-fd64-46e6-a4c7-1826739303fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bump `@azure/communication-calling` beta dependency to 1.10.0-beta.1",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -24,7 +24,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "@azure/communication-calling": "1.9.1-beta.1",
+    "@azure/communication-calling": "1.10.0-beta.1",
     "@azure/communication-chat": "1.2.0"
   },
 
@@ -53,7 +53,7 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
-    "@azure/communication-calling": ["1.9.1-beta.1"],
+    "@azure/communication-calling": ["1.10.0-beta.1"],
     "@azure/communication-chat": ["1.2.0"],
     "webpack": [
       // All projects should use this version by default

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,5 +1,5 @@
 dependencies:
-  '@azure/communication-calling': 1.9.1-beta.1
+  '@azure/communication-calling': 1.10.0-beta.1
   '@azure/communication-chat': 1.2.0
   '@rush-temp/acs-ui-common': file:projects/acs-ui-common.tgz
   '@rush-temp/calling': file:projects/calling.tgz
@@ -34,13 +34,20 @@ packages:
       node: '>=12.0.0'
     resolution:
       integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==
-  /@azure/communication-calling/1.9.1-beta.1:
+  /@azure/communication-calling/1.10.0-beta.1:
     dependencies:
       '@azure/communication-common': 2.0.0
       '@azure/logger': 1.0.3
     dev: false
     resolution:
-      integrity: sha512-hnrSami0JU59WDxjpDjZyuMhxItFXnwy0MJ7fnRn+/gNY/3iCgPEZQjAa1DtF09py5W+q9K5C0cJ0Li1Wl+fNg==
+      integrity: sha512-6uw4H13zyc7xolqIKBCV/p2BbXDOByVUdtl0N9KB3B1+7aACO/ARwNzEwhRKBhLXdpEIS7MHCN6q9MA23x4Rlg==
+  /@azure/communication-calling/1.9.1:
+    dependencies:
+      '@azure/communication-common': 2.0.0
+      '@azure/logger': 1.0.3
+    dev: false
+    resolution:
+      integrity: sha512-GV3Uc3HBmzcktawZn1Vwxm6fRcW8HpM/XSNG7dyu8+AgzMqIorGvlRClrlR2RBSXt8ploc/265mG1EW7GKexCg==
   /@azure/communication-chat/1.2.0:
     dependencies:
       '@azure/abort-controller': 1.1.0
@@ -162,8 +169,8 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/core-asynciterator-polyfill': 1.0.2
-      '@azure/core-auth': 1.3.2
-      '@azure/core-rest-pipeline': 1.9.2
+      '@azure/core-auth': 1.4.0
+      '@azure/core-rest-pipeline': 1.10.1
       '@azure/core-tracing': 1.0.0-preview.13
       tslib: 2.4.1
     dev: false
@@ -802,7 +809,7 @@ packages:
   /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.9:
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.12.9
       '@babel/plugin-transform-parameters': 7.20.7_@babel+core@7.12.9
     dev: false
@@ -2176,7 +2183,7 @@ packages:
     dependencies:
       '@fluentui/set-version': 8.2.4
       '@fluentui/theme': 2.6.21_20d09e348401b0c6dd91fc14ba93384f
-      tslib: 2.3.1
+      tslib: 2.4.1
     dev: false
     peerDependencies:
       '@types/react': '*'
@@ -2222,7 +2229,7 @@ packages:
       '@fluentui/react': 8.98.8_be457b8870bd20e1d840272f6132c06f
       '@fluentui/scheme-utilities': 8.3.22_20d09e348401b0c6dd91fc14ba93384f
       '@fluentui/set-version': 8.2.4
-      tslib: 2.3.1
+      tslib: 2.4.1
     dev: false
     peerDependencies:
       '@types/react': '*'
@@ -2520,7 +2527,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       '@types/yargs': 15.0.15
       chalk: 4.1.2
     dev: false
@@ -2975,7 +2982,7 @@ packages:
       integrity: sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==
   /@playwright/test/1.22.2:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       playwright-core: 1.22.2
     dev: false
     engines:
@@ -4551,7 +4558,7 @@ packages:
       flat-cache: 3.0.4
       micromatch: 4.0.5
       react-docgen-typescript: 2.2.2_typescript@4.3.5
-      tslib: 2.3.1
+      tslib: 2.4.1
       typescript: 4.3.5
       webpack: 5.61.0
     dev: false
@@ -4931,19 +4938,19 @@ packages:
   /@types/body-parser/1.19.2:
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
   /@types/bonjour/3.5.10:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==
   /@types/cheerio/0.22.31:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==
@@ -4957,13 +4964,13 @@ packages:
   /@types/connect-history-api-fallback/1.3.5:
     dependencies:
       '@types/express-serve-static-core': 4.17.32
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==
   /@types/connect/3.4.35:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
@@ -4985,7 +4992,7 @@ packages:
       integrity: sha512-yk7QO2/WrtkDLcsqQXfjU3EIYzggNHVl5y6gnxfMtCPB+bxVUIUzwb1BNxlk+78wENoh9ZgkVSNqn80T9rqO8w==
   /@types/cors/2.8.13:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==
@@ -4999,13 +5006,13 @@ packages:
   /@types/eslint-scope/3.7.4:
     dependencies:
       '@types/eslint': 8.4.10
-      '@types/estree': 0.0.50
+      '@types/estree': 1.0.0
     dev: false
     resolution:
       integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==
   /@types/eslint/8.4.10:
     dependencies:
-      '@types/estree': 0.0.50
+      '@types/estree': 1.0.0
       '@types/json-schema': 7.0.11
     dev: false
     resolution:
@@ -5028,7 +5035,7 @@ packages:
       integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
   /@types/express-serve-static-core/4.17.32:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: false
@@ -5046,14 +5053,14 @@ packages:
   /@types/glob/7.2.0:
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
   /@types/glob/8.0.0:
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==
@@ -5083,7 +5090,7 @@ packages:
       integrity: sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==
   /@types/http-proxy/1.17.9:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==
@@ -5160,7 +5167,7 @@ packages:
       integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
   /@types/morgan/1.9.4:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-cXoc4k+6+YAllH3ZHmx4hf7La1dzUk6keTR4bF4b4Sc0mZxU/zK4wO7l+ZzezXm/jkYj/qC+uYGZrarZdIVvyQ==
@@ -5174,7 +5181,7 @@ packages:
   /@types/node-static/0.7.7:
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-Cq3c9lfC9zRrGxe7ox073219Mpy/kmWNsISG0yEG7aUEk33xv/g+uqz/+4b7hM4WN9LsGageBzGuvy09inaGhg==
@@ -5224,7 +5231,7 @@ packages:
       integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
   /@types/puppeteer/5.4.7:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-JdGWZZYL0vKapXF4oQTC5hLVNfOgdPrqeZ1BiQnGk5cB7HeE91EWUiTdVSdQPobRN8rIcdffjiOgCYJ/S8QrnQ==
@@ -5285,13 +5292,13 @@ packages:
   /@types/serve-static/1.15.0:
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
   /@types/sockjs/0.3.33:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==
@@ -5314,7 +5321,7 @@ packages:
   /@types/superagent/4.1.16:
     dependencies:
       '@types/cookiejar': 2.1.2
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-tLfnlJf6A5mB6ddqF159GqcDizfzbMUB1/DeT59/wBNqzRTNNKsaw79A/1TZ84X+f/EwWH8FeuSkjlCLyqS/zQ==
@@ -5366,7 +5373,7 @@ packages:
       integrity: sha512-56/MAlX5WMsPVbOg7tAxnYvNYMMWr/QJiIp6BxVSW3JJXUVzzOn64qW8TzQyMSqSUFM2+PVI4aUHcHOzIz/1tg==
   /@types/webpack-node-externals/2.5.3_webpack-cli@4.10.0:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       webpack: 5.61.0_webpack-cli@4.10.0
     dev: false
     peerDependencies:
@@ -5375,7 +5382,7 @@ packages:
       integrity: sha512-A9JxaR8QXoYT95egET4AmCFuChyTlP8d18ZAnmSHuIMsFdS7QlCQQ8pmN/+FHgLIkm+ViE/VngltT5avLACY9A==
   /@types/webpack-sources/3.2.0:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
     dev: false
@@ -5383,7 +5390,7 @@ packages:
       integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==
   /@types/webpack/4.41.33:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       '@types/tapable': 1.0.8
       '@types/uglify-js': 3.17.1
       '@types/webpack-sources': 3.2.0
@@ -5394,7 +5401,7 @@ packages:
       integrity: sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==
   /@types/ws/8.5.4:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     resolution:
       integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==
@@ -5416,7 +5423,7 @@ packages:
       integrity: sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==
   /@types/yauzl/2.10.0:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
     dev: false
     optional: true
     resolution:
@@ -6412,7 +6419,7 @@ packages:
       integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
   /ast-types/0.14.2:
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.1
     dev: false
     engines:
       node: '>=4'
@@ -6457,7 +6464,7 @@ packages:
       integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
   /autoprefixer/9.8.8:
     dependencies:
-      browserslist: 4.20.4
+      browserslist: 4.21.4
       caniuse-lite: 1.0.30001442
       normalize-range: 0.1.2
       num2fraction: 1.2.2
@@ -9159,7 +9166,7 @@ packages:
       remark-mdx: 1.6.22
       remark-parse: 8.0.3
       remark-stringify: 8.1.1
-      tslib: 2.3.1
+      tslib: 2.4.1
       unified: 9.2.2
     dev: false
     engines:
@@ -9287,7 +9294,7 @@ packages:
       eslint-mdx: 1.17.1_eslint@7.32.0
       eslint-plugin-markdown: 2.2.1_eslint@7.32.0
       synckit: 0.4.1
-      tslib: 2.3.1
+      tslib: 2.4.1
       vfile: 4.2.1
     dev: false
     engines:
@@ -9737,7 +9744,7 @@ packages:
       integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
   /extract-zip/2.0.1:
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.4
       get-stream: 5.2.0
       yauzl: 2.10.0
     dev: false
@@ -11231,7 +11238,7 @@ packages:
   /https-proxy-agent/5.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.1
+      debug: 4.3.4
     dev: false
     engines:
       node: '>= 6'
@@ -12672,7 +12679,7 @@ packages:
       integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
   /jest-worker/27.5.1:
     dependencies:
-      '@types/node': 14.18.36
+      '@types/node': 18.11.18
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -17255,7 +17262,7 @@ packages:
       integrity: sha512-qImOD23aDfnIDNqlG1NOehdB9IYsn1V9oByPjKY1nakv2MQYCEMyX033/q+aEtYCpmYK1cv2+NTmlH+ra6GA5A==
   /synckit/0.4.1:
     dependencies:
-      tslib: 2.3.1
+      tslib: 2.4.1
       uuid: 8.3.2
     dev: false
     engines:
@@ -19320,7 +19327,7 @@ packages:
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
     dependencies:
-      '@azure/communication-calling': 1.9.1-beta.1
+      '@azure/communication-calling': 1.9.1
       '@azure/communication-common': 2.2.0
       '@babel/cli': 7.16.8_@babel+core@7.16.12
       '@babel/core': 7.16.12
@@ -19354,12 +19361,12 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-HvKX2dvAKnuvr58wPlTsJkBe/f5v8QvpcMhlhEt584eGkXHBFkoGTpbWPC37vW3sZrkQACW0yo9qzKwgVmfF/g==
+      integrity: sha512-mVa0B5W4uN3n5Lk3dflsIYsuxvR6uLxzZFOvghuyf0apyWKsHjC111lv5dILCwNhZ+vQ5eEBUNjFQ8iGcIyf/A==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
     dependencies:
-      '@azure/communication-calling': 1.9.1-beta.1
+      '@azure/communication-calling': 1.9.1
       '@azure/communication-common': 2.2.0
       '@azure/core-auth': 1.3.2
       '@azure/logger': 1.0.3
@@ -19394,13 +19401,13 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-tMmvGA+WyBARXFvTT6ztX4QftGsQP44ER4/I7u1FJfPAbMCw7bIyRtCP+jnceiexJ1TfGhHi0Ve8UkUf6SWhHw==
+      integrity: sha512-kqITCgC6c1Ik7d71/b6CEyi+vFjacRsHj4wA1e03tjQ9KKLniaCzgyfsITI+6D8LdBbtNF83Vwn7EWf1Ro3wtA==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.9.1-beta.1
+      '@azure/communication-calling': 1.9.1
       '@azure/communication-common': 2.2.0
       '@azure/communication-identity': 1.1.0
       '@azure/logger': 1.0.3
@@ -19468,13 +19475,13 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-8Pf7FMwTqkXJlR5eYYkfTaIA0D6Xdxrxmi2D77zAzxHtfciwl9qWX9LNgqq/gDUKp4B4YGB1bupA0R43VlbDXg==
+      integrity: sha512-KvnwGCBfmtsRrOfj4lI73N6tVoWtqNYf8pfVzWfhLDoKGN0gvUfW1558u2BhJNyv5L7TWkjY8fy0Kxprnz4b0w==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.9.1-beta.1
+      '@azure/communication-calling': 1.9.1
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.2.0
       '@azure/communication-identity': 1.1.0
@@ -19541,7 +19548,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-Otzaf1dQNHJNvpHdNjRJRZdZDH+b+b/vHBcUyAM5l1B8H/ZCTWb91VsEVUxRA7uVs4D9RUkFZc9/wrgOoZ3xuA==
+      integrity: sha512-kVStSvMhE2waWY2FJfoBnxDZEjYnWu+w6lW3tA93JETJwtCSPNZ1Hz5RTJwcJKKkRoa4M1bALpsodc+25k5FGQ==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19578,7 +19585,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-component-bindings'
     resolution:
-      integrity: sha512-MsdH1c/OLLOBpGhbgtF+LAoTwGTARap2yKn0LCpvVE1S/k75DcIDsoKNdZ7FvPn4vH/QVpqDHsRbartCEf5u7g==
+      integrity: sha512-uCv+zeWydcqyuWuiOIdQhmL/s1FB9Byg3kGtkolBjPY2XIePtJ7ySyvuBmA+3ulvknisggqaepWEA5zNGabaZA==
       tarball: file:projects/chat-component-bindings.tgz
     version: 0.0.0
   file:projects/chat-stateful-client.tgz:
@@ -19620,7 +19627,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-stateful-client'
     resolution:
-      integrity: sha512-uvAi3xoTN9Q7JMswgj7B3MTBBlh3h7t5OFr8UAkk/vAJxkUJTjq8/dIvA7ducWmoeX9ip/p9PfUs+tXVaCbzTw==
+      integrity: sha512-zO+PQVvxl8Nwq3o+O/Esm9X+DQEVKyhDFcpBkJoGvn/ZyGce/++fnfYeQ9J3o4879/fwBqEN/xxZF2W4OGngKw==
       tarball: file:projects/chat-stateful-client.tgz
     version: 0.0.0
   file:projects/chat.tgz:
@@ -19689,7 +19696,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-kqxhuJGMMB7kdOpitaUf4YmSIm6bnu07peqytIvdjpcj+Jm34Fy5qgXrII6HwqH1AKKJSZEBCEDzwse3upSOKA==
+      integrity: sha512-JHxwXZDDXC43PcskvtNMEOXr9cbUEPs766S6aNBUS/5oT8wINBVT0hnRd5QwMl5NMqlt0ssWtXviCslD6SdYtA==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19709,12 +19716,12 @@ packages:
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-MGttIJ/3rUMQLtWvo9mtW/iKXaZNwqBwFOEIugJ47FlbDAMjdh1uXDsUoKOZBHowLrv7VpOgKK7pfDx1WfhGbA==
+      integrity: sha512-yrvNr+AwNcXm1pu41q0GI1kbJfX78yDCUAA6fUWCd/TY7MeKN/0en0hfTS3EwcXLcsJHtYk8FIbjW0xeuJfpvw==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
     dependencies:
-      '@azure/communication-calling': 1.9.1-beta.1
+      '@azure/communication-calling': 1.9.1
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.2.0
       '@azure/core-auth': 1.3.2
@@ -19797,12 +19804,12 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-2wz6sbeGwfnF4CFSwsPj8ZqSZ/oLFOFTkeDImFXA0Z2WNHQmAxu5+eBpDFfz/tSd7zGAykfDGlJ34uJkFO3d3g==
+      integrity: sha512-7G0gLTWB/o5w5r04Avbp+YK4V/Ld8ihSBLoiAq7DO7qVJl/Xh4TVuHmKKofey5hMYdmg1/MVsV4Kuq+lSR9sIA==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
     dependencies:
-      '@azure/communication-calling': 1.9.1-beta.1
+      '@azure/communication-calling': 1.9.1
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.2.0
       '@azure/communication-identity': 1.1.0
@@ -19847,7 +19854,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-E7mY+QySlNZDkxcE5Rh78pgUEsYASy2EPxGlxiXiGOQWsKMVBlCw5Xhi6Rpm1fHC+ijZXVIWtKF9wkyE5hlH5w==
+      integrity: sha512-Nwz5VPQ3GpcLYzPhp6SNr9A+73wRFFHmI7CZZb6u2/ePQWtanA3INKe4XXMri9f7tsXl8mRgsJhvVqD7rVVZDA==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -19906,7 +19913,7 @@ packages:
     dev: false
     name: '@rush-temp/fake-backends'
     resolution:
-      integrity: sha512-8SqfR7KojU1iXPgA090LT2yDHnRe7SbJf7TutjOKls6SS3SvSDkqd/ap9loUvTkKsdDovanCj3pSTNCkSevjRQ==
+      integrity: sha512-p3W1rt/YCdCf+P0/IyOyxd35PiU3R19Zh0Mpk0YvcpFR8TkIVGMdy8LAupZeFoyNCpmHnAfpfPzSTL/H5V9YEQ==
       tarball: file:projects/fake-backends.tgz
     version: 0.0.0
   file:projects/react-components.tgz:
@@ -19991,12 +19998,12 @@ packages:
     dev: false
     name: '@rush-temp/react-components'
     resolution:
-      integrity: sha512-Vw4+jPHGO81Hd+lvodbWbZqlrB7CwWzI6mxiMy1aNdHE6pm6SlosbI672JW9Oh3cTnBBKPSUKihJct6bUzK40g==
+      integrity: sha512-89CDYuUEaO7gEkogdJ17t3LG+ri1kcHGk4Kr6X0rMFAB2f4iDAa5Wrm+H3C9NM30AgNcNW7NBAbuIVGoF1Dn9w==
       tarball: file:projects/react-components.tgz
     version: 0.0.0
   file:projects/react-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.9.1-beta.1
+      '@azure/communication-calling': 1.9.1
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.2.0
       '@azure/communication-identity': 1.1.0
@@ -20101,12 +20108,12 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-kwdwVGTKrR3ZxhgrEuNkcIYsbp6HHObaSlR/g9I5Hq1GuRG3sd/BOQxWOn42F7j6zCgtz/b4kZc8KcwSMw9Tiw==
+      integrity: sha512-eWV96Vhg50wNoUV+i2pEjqzQuzWbde6lI9jrq/YBHIHgwrhwk63VjuRa8l3L83XCt17P2lvbaohWaXP1KmpanA==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
     dependencies:
-      '@azure/communication-calling': 1.9.1-beta.1
+      '@azure/communication-calling': 1.9.1
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.2.0
       '@azure/communication-identity': 1.1.0
@@ -20125,12 +20132,12 @@ packages:
     dev: false
     name: '@rush-temp/sample-automation-tests'
     resolution:
-      integrity: sha512-KxrvauIHStOJGhR8ACZX95D/5amB1HM48nbhg0xhiox3U0HrBZQvc9/JcCl2NzJQcGV2EXrvzHVwmAlytvqQxQ==
+      integrity: sha512-ckuyrAiLY49TZAF8I6Dpba2tzDELJd7NYhwRM6PgXT2Y+5Iwj+WHAs6Kd4SVkw5hVIulFdBHRIBoA+LNvOJc5w==
       tarball: file:projects/sample-automation-tests.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
     dependencies:
-      '@azure/communication-calling': 1.9.1-beta.1
+      '@azure/communication-calling': 1.9.1
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.2.0
       '@azure/communication-identity': 1.1.0
@@ -20164,7 +20171,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-x0ZjIHthpfDtIzccNZBcNvjLDKg+4hGzwtuFBn3/pAfFdmsh2omxzIqZUuGkGyX8wwSSpSYOd8T/vesplM70ow==
+      integrity: sha512-vFDLBel+5lPIuoReUzacEGWH5NCP8PlN3NZztFM1ynbkboTQarlAIqz3ZwQkNoeUcq4PvfBFOPkmTD3FzZaQvA==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -20222,7 +20229,7 @@ packages:
     version: 0.0.0
   file:projects/storybook.tgz:
     dependencies:
-      '@azure/communication-calling': 1.9.1-beta.1
+      '@azure/communication-calling': 1.9.1
       '@azure/communication-chat': 1.2.0
       '@azure/communication-common': 2.2.0
       '@azure/communication-identity': 1.1.0
@@ -20318,11 +20325,11 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-RxonLeojJUYk/kK7CbpFC3S8Y8YKv5xp4pyEhWSdElHE355dcm02OP+xShIXXKzU0jf1BxjK1/Yq/PgU3QhvHg==
+      integrity: sha512-OeF808cLSAjOuG/cH5jlBKAiY44T/MUrHCJTaGk/Rtld3BkQ3YjzriUXZrsohssWj9aIb+yL7dTafDlveW742A==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:
-  '@azure/communication-calling': 1.9.1-beta.1
+  '@azure/communication-calling': 1.10.0-beta.1
   '@azure/communication-chat': 1.2.0
   '@rush-temp/acs-ui-common': file:./projects/acs-ui-common.tgz
   '@rush-temp/calling': file:./projects/calling.tgz

--- a/packages/calling-component-bindings/package.json
+++ b/packages/calling-component-bindings/package.json
@@ -36,12 +36,12 @@
     "reselect": "~4.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+    "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@types/react": ">=16.8.0 <18.0.0",
     "react": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+    "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",
     "@microsoft/api-documenter": "~7.12.11",

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -35,10 +35,10 @@
     "immer": "9.0.6"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4"
+    "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/core-auth": "1.3.2",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -47,7 +47,7 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/communication-chat": "1.2.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
@@ -82,7 +82,7 @@
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/communication-chat": ">=1.2.0",
     "@azure/core-auth": "1.3.2",
     "@babel/cli": "~7.16.0",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -70,7 +70,7 @@
     "uuid": "^8.1.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/communication-chat": ">=1.2.0",
     "@types/react": ">=16.8.0 <18.0.0",
     "@types/react-dom": ">=16.8.0 <18.0.0",
@@ -78,7 +78,7 @@
     "react-dom": ">=16.8.0 <18.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-identity": "~1.1.0",
     "@azure/communication-signaling": "1.0.0-beta.13",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -18,7 +18,7 @@
     "lint:quiet": "rushx lint -- --quiet"
   },
   "dependencies": {
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-common": "2.2.0",
     "@azure/communication-identity": "~1.1.0",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-identity": "~1.1.0",
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-react": "1.5.1-beta.0",
     "@azure/communication-common": "2.2.0",

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/communication-identity": "~1.1.0",
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/communication-react": "1.5.1-beta.0",
     "@azure/communication-common": "2.2.0",
     "@azure/logger": "1.0.3",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@azure/communication-chat": ">=1.2.0",
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/communication-common": "2.2.0",
     "@azure/communication-identity": "~1.1.0",
     "@azure/communication-react": "1.5.1-beta.0",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@azure/communication-react": "1.5.1-beta.0",
     "@azure/communication-common": "2.2.0",
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/communication-chat": ">=1.2.0",
     "react": "~16.14.0",
     "react-dom": "16.13.1",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.9.1-beta.1 || >=1.4.4",
+     "@azure/communication-calling": "1.10.0-beta.1 || >=1.4.4",
     "@azure/communication-chat": ">=1.2.0",
     "@azure/communication-common": "2.2.0",
     "uuid": "^8.1.0",


### PR DESCRIPTION
# What
Bump `@azure/communication-calling` beta dependency to 1.10.0-beta.1

# Why
Calling recently updated their beta version