### PR TITLE
Run `force-build-versions` in CI at all times when switching to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,9 @@ jobs:
         id: switch-flavor
         if: ${{ matrix.flavor == 'stable' }}
         run: |
-          node ./common/scripts/force-build-flavor.mjs stable
           rush switch-flavor:stable
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush update:stable
       - name: Check result of flavor switch
         if: ${{ always() && steps.switch-flavor.outcome == 'failure' }}
         run: echo "Failed to switch to stable flavor, please make sure you run 'rush update:stable' if dependencies were updated." && exit 1
@@ -144,8 +145,9 @@ jobs:
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: |
-          node ./common/scripts/force-build-flavor.mjs stable
           rush switch-flavor:stable
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush update:stable
       - name: Build Call Composite Test App
         run: |
           cd packages/react-composites
@@ -212,7 +214,10 @@ jobs:
         run: rush install
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
-        run: rush switch-flavor:stable
+        run: |
+          rush switch-flavor:stable
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush update:stable
       - name: Build Chat Composite Test App
         run: |
           cd packages/react-composites
@@ -280,8 +285,9 @@ jobs:
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: |
-          node ./common/scripts/force-build-flavor.mjs stable
           rush switch-flavor:stable
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush update:stable
       - name: Build CallWithChatComposite Test App
         run: |
           cd packages/react-composites
@@ -376,8 +382,9 @@ jobs:
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: |
-          node ./common/scripts/force-build-flavor.mjs stable
           rush switch-flavor:stable
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush update:stable
       - name: Build
         run: rush build -o calling
       - name: Tests
@@ -416,8 +423,9 @@ jobs:
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: |
-          node ./common/scripts/force-build-flavor.mjs stable
           rush switch-flavor:stable
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush update:stable
       - name: Build
         run: rush build -o chat
       - name: Tests
@@ -456,8 +464,9 @@ jobs:
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: |
-          node ./common/scripts/force-build-flavor.mjs stable
           rush switch-flavor:stable
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush update:stable
       - name: Build
         run: rush build -o callwithchat
       - name: Tests
@@ -491,8 +500,9 @@ jobs:
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: |
-          node ./common/scripts/force-build-flavor.mjs stable
           rush switch-flavor:stable
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush update:stable
       - name: Build
         run: rush build -t sample-static-html-composites
       - name: Visual Regression Tests
@@ -543,8 +553,9 @@ jobs:
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
         run: |
-          node ./common/scripts/force-build-flavor.mjs stable
           rush switch-flavor:stable
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush update:stable
       - name: Build
         run: rush build -t component-examples
       - name: Visual Regression Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
       - name: Switch flavor for stable build
         id: switch-flavor
         if: ${{ matrix.flavor == 'stable' }}
-        run: rush switch-flavor:stable
+        run: |
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush switch-flavor:stable
       - name: Check result of flavor switch
         if: ${{ always() && steps.switch-flavor.outcome == 'failure' }}
         run: echo "Failed to switch to stable flavor, please make sure you run 'rush update:stable' if dependencies were updated." && exit 1
@@ -141,7 +143,9 @@ jobs:
         run: rush install
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
-        run: rush switch-flavor:stable
+        run: |
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush switch-flavor:stable
       - name: Build Call Composite Test App
         run: |
           cd packages/react-composites
@@ -275,7 +279,9 @@ jobs:
         run: rush install
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
-        run: rush switch-flavor:stable
+        run: |
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush switch-flavor:stable
       - name: Build CallWithChatComposite Test App
         run: |
           cd packages/react-composites
@@ -369,7 +375,9 @@ jobs:
       # Switch flavor if necessary
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
-        run: rush switch-flavor:stable
+        run: |
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush switch-flavor:stable
       - name: Build
         run: rush build -o calling
       - name: Tests
@@ -407,7 +415,9 @@ jobs:
       # Switch flavor if necessary
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
-        run: rush switch-flavor:stable
+        run: |
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush switch-flavor:stable
       - name: Build
         run: rush build -o chat
       - name: Tests
@@ -445,7 +455,9 @@ jobs:
       # Switch flavor if necessary
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
-        run: rush switch-flavor:stable
+        run: |
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush switch-flavor:stable
       - name: Build
         run: rush build -o callwithchat
       - name: Tests
@@ -478,7 +490,9 @@ jobs:
       # Switch flavor if necessary
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
-        run: rush switch-flavor:stable
+        run: |
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush switch-flavor:stable
       - name: Build
         run: rush build -t sample-static-html-composites
       - name: Visual Regression Tests
@@ -528,7 +542,9 @@ jobs:
       # Switch flavor when necessary
       - name: Switch flavor for stable build
         if: ${{ matrix.flavor == 'stable' }}
-        run: rush switch-flavor:stable
+        run: |
+          node ./common/scripts/force-build-flavor.mjs stable
+          rush switch-flavor:stable
       - name: Build
         run: rush build -t component-examples
       - name: Visual Regression Tests

--- a/change-beta/@azure-communication-react-9715359a-9ad3-42e2-b63f-b145d60cf9a1.json
+++ b/change-beta/@azure-communication-react-9715359a-9ad3-42e2-b63f-b145d60cf9a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Ensure force-build-versions is run in CI",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-9715359a-9ad3-42e2-b63f-b145d60cf9a1.json
+++ b/change/@azure-communication-react-9715359a-9ad3-42e2-b63f-b145d60cf9a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Ensure force-build-versions is run in CI",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
# What
* Run `force-build-versions` in CI at all times when switching to stable
* Run `rush update:stable` to ensure the new version definitions are picked up

# Why
`force-build-versions` ensures the crafted package.json only has the required versions.
This is only run on creating a release branch, we should be running it on all CI.

Related, this ensures the remove of #2689 from stable builds will be tested at CI time.

# How Tested
CI runs
Also ran these commands locally

```sh
rush install
node ./common/scripts/force-build-flavor.mjs stable
rush switch-flavor:stable
```

And confirmed `@azure/communication-calling-effects` was removed in the node_modules:
![image](https://user-images.githubusercontent.com/2684369/215616453-5e7e26fd-d74f-4932-9cd6-6fb76e10d54a.png)

