### PR TITLE
Add onFetchProfile to teams adapter option (#2680)

### DIFF
--- a/GROOMME.md
+++ b/GROOMME.md
@@ -1,1 +1,0 @@
-Please groom the changelog and then delete me.

--- a/GROOMME.md
+++ b/GROOMME.md
@@ -1,0 +1,1 @@
+Please groom the changelog and then delete me.

--- a/change-beta/@azure-communication-react-ab927468-a366-4193-a41d-c668b780b10b.json
+++ b/change-beta/@azure-communication-react-ab927468-a366-4193-a41d-c668b780b10b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add onFetchProfile to adapter",
+  "packageName": "@azure/communication-react",
+  "email": "jiangnanhello@live.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-cebf8018-dd7a-415e-b1d1-130b8ac927d7.json
+++ b/change-beta/@azure-communication-react-cebf8018-dd7a-415e-b1d1-130b8ac927d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bumped",
+  "packageName": "@azure/communication-react",
+  "email": "41898282+github-actions[bot]@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-ab927468-a366-4193-a41d-c668b780b10b.json
+++ b/change/@azure-communication-react-ab927468-a366-4193-a41d-c668b780b10b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add onFetchProfile to adapter",
+  "packageName": "@azure/communication-react",
+  "email": "jiangnanhello@live.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-cebf8018-dd7a-415e-b1d1-130b8ac927d7.json
+++ b/change/@azure-communication-react-cebf8018-dd7a-415e-b1d1-130b8ac927d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bumped",
+  "packageName": "@azure/communication-react",
+  "email": "41898282+github-actions[bot]@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1668,10 +1668,10 @@ export const createStatefulCallClient: (args: StatefulCallClientArgs, options?: 
 export const createStatefulChatClient: (args: StatefulChatClientArgs, options?: StatefulChatClientOptions | undefined) => StatefulChatClient;
 
 // @beta (undocumented)
-export const createTeamsCallAdapter: ({ userId, credential, locator }: TeamsCallAdapterArgs) => Promise<TeamsCallAdapter>;
+export const createTeamsCallAdapter: ({ userId, credential, locator, options }: TeamsCallAdapterArgs) => Promise<TeamsCallAdapter>;
 
 // @beta
-export const createTeamsCallAdapterFromClient: (callClient: StatefulCallClient, callAgent: TeamsCallAgent, locator: CallAdapterLocator) => Promise<TeamsCallAdapter>;
+export const createTeamsCallAdapterFromClient: (callClient: StatefulCallClient, callAgent: TeamsCallAgent, locator: CallAdapterLocator, options?: TeamsAdapterOptions | undefined) => Promise<TeamsCallAdapter>;
 
 // @public
 export interface CreateVideoStreamViewResult {
@@ -2607,6 +2607,9 @@ export interface NetworkDiagnosticsState {
     latest: LatestNetworkDiagnostics;
 }
 
+// @beta
+export type OnFetchProfileCallback = (userId: string) => Promise<Profile | undefined>;
+
 // @public
 export type OnRenderAvatarCallback = (
 userId?: string, options?: CustomAvatarOptions,
@@ -2786,6 +2789,11 @@ export type ParticipantsRemovedListener = (event: {
 
 // @public
 export type ParticipantState = 'Idle' | 'Connecting' | 'Ringing' | 'Connected' | 'Hold' | 'InLobby' | 'EarlyMedia' | 'Disconnected';
+
+// @beta
+export type Profile = {
+    displayName?: string;
+};
 
 // @public
 export type ReadReceiptsBySenderId = {
@@ -3000,6 +3008,11 @@ export interface SystemMessageCommon extends MessageCommon {
 }
 
 // @beta
+export type TeamsAdapterOptions = {
+    onFetchProfile?: OnFetchProfileCallback;
+};
+
+// @beta
 export interface TeamsCallAdapter extends CommonCallAdapter {
     joinCall(microphoneOn?: boolean): TeamsCall | undefined;
     startCall(participants: string[], options?: StartCallOptions): TeamsCall | undefined;
@@ -3011,6 +3024,7 @@ export type TeamsCallAdapterArgs = {
     userId: MicrosoftTeamsUserIdentifier;
     credential: CommunicationTokenCredential;
     locator: TeamsMeetingLinkLocator;
+    options?: TeamsAdapterOptions;
 };
 
 // @beta

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -988,10 +988,10 @@ export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, user
 export const createAzureCommunicationChatAdapterFromClient: (chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient) => Promise<ChatAdapter>;
 
 // @beta (undocumented)
-export const createTeamsCallAdapter: ({ userId, credential, locator }: TeamsCallAdapterArgs) => Promise<TeamsCallAdapter>;
+export const createTeamsCallAdapter: ({ userId, credential, locator, options }: TeamsCallAdapterArgs) => Promise<TeamsCallAdapter>;
 
 // @beta
-export const createTeamsCallAdapterFromClient: (callClient: StatefulCallClient, callAgent: TeamsCallAgent, locator: CallAdapterLocator) => Promise<TeamsCallAdapter>;
+export const createTeamsCallAdapterFromClient: (callClient: StatefulCallClient, callAgent: TeamsCallAgent, locator: CallAdapterLocator, options?: TeamsAdapterOptions | undefined) => Promise<TeamsCallAdapter>;
 
 // @beta
 export type CustomCallControlButtonCallback = (args: CustomCallControlButtonCallbackArgs) => CustomCallControlButtonProps;
@@ -1249,6 +1249,9 @@ export type NetworkDiagnosticChangedEvent = NetworkDiagnosticChangedEventArgs & 
     type: 'network';
 };
 
+// @beta
+export type OnFetchProfileCallback = (userId: string) => Promise<Profile | undefined>;
+
 // @public
 export type ParticipantsAddedListener = (event: {
     participantsAdded: ChatParticipant[];
@@ -1272,9 +1275,19 @@ export type ParticipantsRemovedListener = (event: {
 }) => void;
 
 // @beta
+export type Profile = {
+    displayName?: string;
+};
+
+// @beta
 export interface RemoteVideoTileMenuOptions {
     isHidden?: boolean;
 }
+
+// @beta
+export type TeamsAdapterOptions = {
+    onFetchProfile?: OnFetchProfileCallback;
+};
 
 // @beta
 export interface TeamsCallAdapter extends CommonCallAdapter {
@@ -1288,6 +1301,7 @@ export type TeamsCallAdapterArgs = {
     userId: MicrosoftTeamsUserIdentifier;
     credential: CommunicationTokenCredential;
     locator: TeamsMeetingLinkLocator;
+    options?: TeamsAdapterOptions;
 };
 
 // @public

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -76,6 +76,7 @@ import { AdapterError } from '../../common/adapters';
 import { DiagnosticsForwarder } from './DiagnosticsForwarder';
 import { useEffect, useRef, useState } from 'react';
 import { CallHandlersOf, createHandlers } from './createHandlers';
+import { createProfileStateModifier, OnFetchProfileCallback } from './OnFetchProfileCallback';
 
 type CallTypeOf<AgentType extends CallAgent | BetaTeamsCallAgent> = AgentType extends CallAgent ? Call : TeamsCall;
 
@@ -84,6 +85,7 @@ class CallContext {
   private emitter: EventEmitter = new EventEmitter();
   private state: CallAdapterState;
   private callId: string | undefined;
+  private displayNameModifier: AdapterStateModifier | undefined;
 
   constructor(
     clientState: CallClientState,
@@ -91,6 +93,7 @@ class CallContext {
     options?: {
       /* @conditional-compile-remove(rooms) */ roleHint?: Role;
       maxListeners?: number;
+      onFetchProfile?: OnFetchProfileCallback;
     }
   ) {
     this.state = {
@@ -110,6 +113,11 @@ class CallContext {
     };
     this.emitter.setMaxListeners(options?.maxListeners ?? 50);
     this.bindPublicMethods();
+    this.displayNameModifier = options?.onFetchProfile
+      ? createProfileStateModifier(options.onFetchProfile, () => {
+          this.setState(this.getState());
+        })
+      : undefined;
   }
 
   private bindPublicMethods(): void {
@@ -126,7 +134,7 @@ class CallContext {
   }
 
   public setState(state: CallAdapterState): void {
-    this.state = state;
+    this.state = this.displayNameModifier ? this.displayNameModifier(state) : state;
     this.emitter.emit('stateChanged', this.state);
   }
 
@@ -216,6 +224,11 @@ const findLatestEndedCall = (calls: { [key: string]: CallState }): CallState | u
 /**
  * @private
  */
+export type AdapterStateModifier = (state: CallAdapterState) => CallAdapterState;
+
+/**
+ * @private
+ */
 export class AzureCommunicationCallAdapter<AgentType extends CallAgent | BetaTeamsCallAgent = CallAgent>
   implements CommonCallAdapter
 {
@@ -247,7 +260,7 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | BetaTea
     locator: CallAdapterLocator,
     callAgent: AgentType,
     deviceManager: StatefulDeviceManager,
-    options?: AzureCommunicationCallAdapterOptions
+    options?: AzureCommunicationCallAdapterOptions & TeamsAdapterOptions
   ) {
     this.bindPublicMethods();
     this.callClient = callClient;
@@ -831,6 +844,20 @@ export type AzureCommunicationCallAdapterArgs = {
 };
 
 /**
+ * Optional parameters to create {@link AzureCommunicationCallAdapter}
+ *
+ * @beta
+ */
+export type TeamsAdapterOptions = {
+  /**
+   * Use this to fetch profile information which will override data in {@link CallAdapterState} like display name
+   * The onFetchProfile is fetch-and-forget one time action for each user, once a user profile is updated, the value will be cached
+   * and would not be updated again within the lifecycle of adapter.
+   */
+  onFetchProfile?: OnFetchProfileCallback;
+};
+
+/**
  * Arguments for creating the Azure Communication Services implementation of {@link TeamsCallAdapter}.
  *
  * @beta
@@ -839,6 +866,10 @@ export type TeamsCallAdapterArgs = {
   userId: MicrosoftTeamsUserIdentifier;
   credential: CommunicationTokenCredential;
   locator: TeamsMeetingLinkLocator;
+  /**
+   * Optional parameters for the {@link TeamsCallAdapter} created
+   */
+  options?: TeamsAdapterOptions;
 };
 
 /**
@@ -879,7 +910,8 @@ export const createAzureCommunicationCallAdapter = async ({
 export const createTeamsCallAdapter = async ({
   userId,
   credential,
-  locator
+  locator,
+  options
 }: TeamsCallAdapterArgs): Promise<TeamsCallAdapter> => {
   const callClient = createStatefulCallClient({
     userId
@@ -887,7 +919,7 @@ export const createTeamsCallAdapter = async ({
   const callAgent = await callClient.createTeamsCallAgent(credential, {
     undefined
   });
-  const adapter = createTeamsCallAdapterFromClient(callClient, callAgent, locator);
+  const adapter = createTeamsCallAdapterFromClient(callClient, callAgent, locator, options);
   return adapter;
 };
 
@@ -961,6 +993,11 @@ const useAzureCommunicationCallAdapterGeneric = <
           if (!displayName) {
             throw new Error('Unreachable code, displayName already checked above.');
           }
+          // This is just the type check to ensure that roleHint is defined.
+          /* @conditional-compile-remove(rooms) */
+          if (options && !('roleHint' in options)) {
+            throw new Error('Unreachable code, provided a options without roleHint.');
+          }
           newAdapter = (await createAzureCommunicationCallAdapter({
             credential,
             displayName: displayName,
@@ -970,11 +1007,17 @@ const useAzureCommunicationCallAdapterGeneric = <
             /* @conditional-compile-remove(rooms) */ options
           })) as Adapter;
         } else if (adapterKind === 'Teams') {
+          // This is just the type check to ensure that roleHint is defined.
+          /* @conditional-compile-remove(teams-identity-support)) */
+          if (options && !('onFetchProfile' in options)) {
+            throw new Error('Unreachable code, provided a options without roleHint.');
+          }
           /* @conditional-compile-remove(teams-identity-support) */
           newAdapter = (await createTeamsCallAdapter({
             credential,
             locator: locator as TeamsMeetingLinkLocator,
-            userId: userId as MicrosoftTeamsUserIdentifier
+            userId: userId as MicrosoftTeamsUserIdentifier,
+            options
           })) as Adapter;
         } else {
           throw new Error('Unreachable code, unknown adapterKind');
@@ -1004,6 +1047,7 @@ const useAzureCommunicationCallAdapterGeneric = <
       /* @conditional-compile-remove(PSTN-calls) */
       alternateCallerId,
       /* @conditional-compile-remove(rooms) */
+      /* @conditional-compile-remove(teams-identity-support) */
       options
     ]
   );
@@ -1146,12 +1190,13 @@ export const createAzureCommunicationCallAdapterFromClient: (
 export const createTeamsCallAdapterFromClient = async (
   callClient: StatefulCallClient,
   callAgent: TeamsCallAgent,
-  locator: CallAdapterLocator
+  locator: CallAdapterLocator,
+  options?: TeamsAdapterOptions
 ): Promise<TeamsCallAdapter> => {
   const deviceManager = (await callClient.getDeviceManager()) as StatefulDeviceManager;
   /* @conditional-compile-remove(unsupported-browser) */
   await callClient.feature(Features.DebugInfo).getEnvironmentInfo();
-  return new AzureCommunicationCallAdapter(callClient, locator, callAgent, deviceManager);
+  return new AzureCommunicationCallAdapter(callClient, locator, callAgent, deviceManager, options);
 };
 
 const isCallError = (e: Error): e is CallError => {

--- a/packages/react-composites/src/composites/CallComposite/adapter/OnFetchProfileCallback.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/OnFetchProfileCallback.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { CallAdapterState } from './CallAdapter';
+import { RemoteParticipantState } from '@internal/calling-stateful-client';
+import { AdapterStateModifier } from './AzureCommunicationCallAdapter';
+import { createParticipantModifier } from '../utils';
+
+/**
+ * Callback function used to provide custom data to build profile for a user.
+ *
+ * @beta
+ */
+export type OnFetchProfileCallback = (userId: string) => Promise<Profile | undefined>;
+
+/**
+ * The profile of a user.
+ *
+ * @beta
+ */
+export type Profile = {
+  /**
+   * Primary text to display, usually the name of the person.
+   */
+  displayName?: string;
+};
+
+/**
+ * @private
+ */
+export const createProfileStateModifier = (
+  onFetchProfile: OnFetchProfileCallback,
+  notifyUpdate: () => void
+): AdapterStateModifier => {
+  const cachedDisplayName: {
+    [id: string]: string;
+  } = {};
+
+  return (state: CallAdapterState) => {
+    const originalParticipants = state.call?.remoteParticipants;
+    (async () => {
+      let shouldNotifyUpdates = false;
+      for (const key in originalParticipants) {
+        if (cachedDisplayName[key]) {
+          continue;
+        }
+        const profile = await onFetchProfile(key);
+        if (profile?.displayName && originalParticipants[key].displayName !== profile?.displayName) {
+          cachedDisplayName[key] = profile?.displayName;
+        }
+        shouldNotifyUpdates = true;
+      }
+      // notify update only when there is a change, which most likely will trigger modifier and setState again
+      shouldNotifyUpdates && notifyUpdate();
+    })();
+
+    const participantsModifier = createParticipantModifier(
+      (id: string, participant: RemoteParticipantState): RemoteParticipantState | undefined => {
+        if (cachedDisplayName[id]) {
+          return { ...participant, displayName: cachedDisplayName[id] };
+        }
+        return undefined;
+      }
+    );
+
+    return participantsModifier(state);
+  };
+};

--- a/packages/react-composites/src/composites/CallComposite/adapter/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/index.ts
@@ -14,7 +14,9 @@ export {
   useTeamsCallAdapter
 } from './AzureCommunicationCallAdapter';
 /* @conditional-compile-remove(teams-identity-support) */
-export type { TeamsCallAdapterArgs } from './AzureCommunicationCallAdapter';
+export type { TeamsCallAdapterArgs, TeamsAdapterOptions } from './AzureCommunicationCallAdapter';
+/* @conditional-compile-remove(teams-identity-support) */
+export type { OnFetchProfileCallback, Profile } from './OnFetchProfileCallback';
 export type { AzureCommunicationCallAdapterArgs, CallAdapterLocator } from './AzureCommunicationCallAdapter';
 /* @conditional-compile-remove(rooms) */
 export type { AzureCommunicationCallAdapterOptions } from './AzureCommunicationCallAdapter';

--- a/packages/react-composites/src/composites/CallComposite/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/index.ts
@@ -29,7 +29,13 @@ export {
 export { createTeamsCallAdapter, createTeamsCallAdapterFromClient, useTeamsCallAdapter } from './adapter';
 
 /* @conditional-compile-remove(teams-identity-support) */
-export type { TeamsCallAdapter, TeamsCallAdapterArgs } from './adapter';
+export type {
+  TeamsCallAdapter,
+  TeamsCallAdapterArgs,
+  TeamsAdapterOptions,
+  OnFetchProfileCallback,
+  Profile
+} from './adapter';
 
 export type {
   AzureCommunicationCallAdapterArgs,


### PR DESCRIPTION
Cherry pick from #2680

* Add onFetchProfile to teams adapter

---------

Co-authored-by: Nan Jiang <jinan@microsoft.com>

# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->