### PR TITLE
[Cherry pick] update errorbar selector to no longer incorrectly indicate u…

### DIFF
--- a/change-beta/@azure-communication-react-805378b6-b850-478d-a814-e875c976b34e.json
+++ b/change-beta/@azure-communication-react-805378b6-b850-478d-a814-e875c976b34e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update the Errorbar selector to check environmentInfo for mac specific warnings.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-805378b6-b850-478d-a814-e875c976b34e.json
+++ b/change/@azure-communication-react-805378b6-b850-478d-a814-e875c976b34e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update the Errorbar selector to check environmentInfo for mac specific warnings.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/babel/.babelrc.js
+++ b/common/config/babel/.babelrc.js
@@ -42,7 +42,9 @@ process.env['COMMUNICATION_REACT_FLAVOR'] === 'stable' &&
         // Pinned Participants
         'pinned-participants',
         // Feature to show the total number of participants in a call (currently in beta in calling SDK, hence this must be conditionally compiled)
-        'total-participant-count'
+        'total-participant-count',
+        // feature for tracking environment info API different than unsupported browser. stable use of environment info affects other components possibly sooner
+        'calling-environment-info'
       ],
       // A list of stabilized features.
       // These features can be listed in the conditional compilation directives without

--- a/packages/calling-component-bindings/src/errorBarSelector.ts
+++ b/packages/calling-component-bindings/src/errorBarSelector.ts
@@ -54,9 +54,15 @@ export const errorBarSelector: ErrorBarSelector = createSelector(
     const activeErrorMessages: ActiveErrorMessage[] = [];
 
     const isSafari = (): boolean => {
-      /* @conditional-compile-remove(unsupported-browser) */
+      /* @conditional-compile-remove(calling-environment-info) */
       return environmentInfo?.environment.browser === 'safari';
       return /^((?!chrome|android|crios|fxios).)*safari/i.test(navigator.userAgent);
+    };
+
+    const isMacOS = (): boolean => {
+      /* @conditional-compile-remove(calling-environment-info) */
+      return environmentInfo?.environment.platform === 'mac';
+      return false;
     };
 
     // Errors reported via diagnostics are more reliable than from API method failures, so process those first.
@@ -78,8 +84,11 @@ export const errorBarSelector: ErrorBarSelector = createSelector(
     if (deviceManager.deviceAccess?.audio === false && !isSafari()) {
       activeErrorMessages.push({ type: 'callMicrophoneAccessDenied' });
     }
-    if (diagnostics?.media.latest.microphonePermissionDenied?.value === true) {
+
+    if (diagnostics?.media.latest.microphonePermissionDenied?.value === true && isMacOS()) {
       activeErrorMessages.push({ type: 'callMacOsMicrophoneAccessDenied' });
+    } else if (diagnostics?.media.latest.microphonePermissionDenied?.value === true) {
+      activeErrorMessages.push({ type: 'callMicrophoneAccessDenied' });
     }
 
     const microphoneMuteUnexpectedlyDiagnostic =
@@ -114,11 +123,20 @@ export const errorBarSelector: ErrorBarSelector = createSelector(
       }
     }
 
-    if (diagnostics?.media.latest.cameraPermissionDenied?.value === true) {
+    /**
+     * show the Mac specific strings if the platform is detected as mac
+     */
+    if (diagnostics?.media.latest.cameraPermissionDenied?.value === true && isMacOS()) {
       activeErrorMessages.push({ type: 'callMacOsCameraAccessDenied' });
     }
-    if (diagnostics?.media.latest.screenshareRecordingDisabled?.value === true) {
+
+    /**
+     * This UFD only works on mac still so we should only see it fire on mac.
+     */
+    if (diagnostics?.media.latest.screenshareRecordingDisabled?.value === true && isMacOS()) {
       activeErrorMessages.push({ type: 'callMacOsScreenShareAccessDenied' });
+    } else if (diagnostics?.media.latest.screenshareRecordingDisabled?.value === true) {
+      activeErrorMessages.push({ type: 'startScreenSharingGeneric' });
     }
 
     // Prefer to show errors with privacy implications.

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2112,6 +2112,7 @@ export interface ErrorBarStrings {
     sendMessageGeneric: string;
     sendMessageNotInChatThread: string;
     startScreenShareGeneric: string;
+    startScreenSharingGeneric?: string;
     startVideoGeneric: string;
     stopScreenShareGeneric: string;
     stopVideoGeneric: string;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -1647,6 +1647,7 @@ export interface ErrorBarStrings {
     sendMessageGeneric: string;
     sendMessageNotInChatThread: string;
     startScreenShareGeneric: string;
+    startScreenSharingGeneric?: string;
     startVideoGeneric: string;
     stopScreenShareGeneric: string;
     stopVideoGeneric: string;

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -748,6 +748,7 @@ export interface ErrorBarStrings {
     sendMessageGeneric: string;
     sendMessageNotInChatThread: string;
     startScreenShareGeneric: string;
+    startScreenSharingGeneric?: string;
     startVideoGeneric: string;
     stopScreenShareGeneric: string;
     stopVideoGeneric: string;

--- a/packages/react-components/review/stable/react-components.api.md
+++ b/packages/react-components/review/stable/react-components.api.md
@@ -600,6 +600,7 @@ export interface ErrorBarStrings {
     sendMessageGeneric: string;
     sendMessageNotInChatThread: string;
     startScreenShareGeneric: string;
+    startScreenSharingGeneric?: string;
     startVideoGeneric: string;
     stopScreenShareGeneric: string;
     stopVideoGeneric: string;

--- a/packages/react-components/src/components/ErrorBar.tsx
+++ b/packages/react-components/src/components/ErrorBar.tsx
@@ -209,6 +209,10 @@ export interface ErrorBarStrings {
    * An error message when joining a call fails specifically due to an invalid meeting link.
    */
   failedToJoinCallInvalidMeetingLink?: string;
+  /**
+   * Generic message for when screen sharing fails
+   */
+  startScreenSharingGeneric?: string;
 }
 
 /**

--- a/packages/react-components/src/components/utils.ts
+++ b/packages/react-components/src/components/utils.ts
@@ -151,6 +151,7 @@ export const messageBarType = (errorType: ErrorType): MessageBarType => {
     case 'callVideoRecoveredBySystem':
     case 'callMacOsCameraAccessDenied':
     case 'callMacOsScreenShareAccessDenied':
+    case 'startScreenSharingGeneric':
       return MessageBarType.warning;
     default:
       return MessageBarType.error;

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -160,7 +160,8 @@
     "callMacOsScreenShareAccessDenied": "MacOS is blocking screen sharing. Update your privacy settings to allow this browser to record your screen.",
     "dismissButtonAriaLabel": "Close",
     "failedToJoinCallGeneric": "Failed to join call.",
-    "failedToJoinCallInvalidMeetingLink": "Unable to join Meeting. Invalid Link."
+    "failedToJoinCallInvalidMeetingLink": "Unable to join Meeting. Invalid Link.",
+    "startScreenSharingGeneric": "There was an issue starting screen share."
   },
   "videoGallery": {
     "screenIsBeingSharedMessage": "You are sharing your screen",


### PR DESCRIPTION
…ser is on mac (#2691)

* update Errorbar selector to be protective of mac

* Change files

* Duplicate change files for beta release

* Move CC into logic so we still see error in stable

* remove console log

* updating strings for generic cases

# What
<!--- Describe your changes. -->
Cherrypick Errorbar macOS fix into new beta
# Why
<!--- What problem does this change solve? -->
gets new strings into beta to fix known issue
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3124414
# How Tested
<!--- How did you test your change. What tests have you added. -->
Checked into main already