### PR TITLE
[BugFix] Resize local video tile based on local feed size

### DIFF
--- a/packages/react-components/src/components/LocalVideoTile.tsx
+++ b/packages/react-components/src/components/LocalVideoTile.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Stack } from '@fluentui/react';
-import { _formatString } from '@internal/acs-ui-common';
+import { _formatString, _pxToRem } from '@internal/acs-ui-common';
 import React, { useMemo } from 'react';
 import { OnRenderAvatarCallback, VideoStreamOptions, CreateVideoStreamViewResult } from '../types';
 import { LocalVideoCameraCycleButton, LocalVideoCameraCycleButtonProps } from './LocalVideoCameraButton';
@@ -66,7 +66,7 @@ export const _LocalVideoTile = React.memo(
         onCreateLocalStreamView,
         onDisposeLocalStreamView,
         renderElementExists: !!renderElement,
-        scalingMode: localVideoViewOptions?.scalingMode
+        scalingMode: 'Fit'
       }),
       [
         isAvailable,
@@ -88,7 +88,7 @@ export const _LocalVideoTile = React.memo(
         // Returning `undefined` results in the placeholder with avatar being shown
         return undefined;
       }
-
+      renderElement.setAttribute('style', 'height: 100%');
       return (
         <>
           <FloatingLocalCameraCycleButton
@@ -105,6 +105,7 @@ export const _LocalVideoTile = React.memo(
       localVideoCameraSwitcherLabel,
       localVideoSelectedDescription,
       renderElement,
+      renderElement?.clientWidth,
       showCameraSwitcherInLocalPreview
     ]);
 

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -507,7 +507,8 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
       localVideoComponent: localVideoTile,
       parentWidth: containerWidth,
       parentHeight: containerHeight,
-      /* @conditional-compile-remove(pinned-participants) */ pinnedParticipantUserIds: pinnedParticipants
+      /* @conditional-compile-remove(pinned-participants) */ pinnedParticipantUserIds: pinnedParticipants,
+      localTileWidth: localParticipant.videoStream?.renderElement?.clientWidth
     }),
     [
       remoteParticipants,
@@ -521,7 +522,8 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
       containerHeight,
       onRenderRemoteVideoTile,
       defaultOnRenderVideoTile,
-      /* @conditional-compile-remove(pinned-participants) */ pinnedParticipants
+      /* @conditional-compile-remove(pinned-participants) */ pinnedParticipants,
+      localParticipant.videoStream?.renderElement?.clientWidth
     ]
   );
 

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideo.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideo.tsx
@@ -34,8 +34,9 @@ export const FloatingLocalVideo = (props: {
   isNarrow?: boolean;
   parentWidth?: number;
   parentHeight?: number;
+  localTileWidth?: number;
 }): JSX.Element => {
-  const { localVideoComponent, layerHostId, isNarrow, parentWidth, parentHeight } = props;
+  const { localVideoComponent, layerHostId, isNarrow, parentWidth, parentHeight, localTileWidth } = props;
 
   const theme = useTheme();
 
@@ -56,7 +57,10 @@ export const FloatingLocalVideo = (props: {
     [parentHeight, parentWidth, modalHeight, modalWidth]
   );
 
-  const modalStyles = useMemo(() => floatingLocalVideoModalStyle(theme, isNarrow), [theme, isNarrow]);
+  const modalStyles = useMemo(
+    () => floatingLocalVideoModalStyle(theme, isNarrow, localTileWidth),
+    [theme, isNarrow, localTileWidth]
+  );
   const layerProps = useMemo(() => ({ hostId: layerHostId }), [layerHostId]);
 
   return (

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -59,7 +59,6 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     localTileWidth
   } = props;
 
-  console.log(localTileWidth);
   const theme = useTheme();
 
   const isNarrow = parentWidth ? isNarrowWidth(parentWidth) : false;
@@ -105,7 +104,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
       // When we use showCameraSwitcherInLocalPreview it disables dragging to allow keyboard navigation.
       showCameraSwitcherInLocalPreview ? (
         <Stack
-          className={mergeStyles(localVideoTileWithControlsContainerStyle(theme, isNarrow), {
+          className={mergeStyles(localVideoTileWithControlsContainerStyle(theme, isNarrow, localTileWidth), {
             boxShadow: theme.effects.elevation8,
             zIndex: LOCAL_VIDEO_TILE_ZINDEX
           })}
@@ -113,7 +112,9 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
           {localVideoComponent}
         </Stack>
       ) : horizontalGalleryTiles.length > 0 ? (
-        <Stack className={mergeStyles(localVideoTileContainerStyle(theme, isNarrow))}>{localVideoComponent}</Stack>
+        <Stack className={mergeStyles(localVideoTileContainerStyle(theme, isNarrow, localTileWidth))}>
+          {localVideoComponent}
+        </Stack>
       ) : (
         <FloatingLocalVideo
           localVideoComponent={localVideoComponent}
@@ -121,6 +122,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
           isNarrow={isNarrow}
           parentWidth={parentWidth}
           parentHeight={parentHeight}
+          localTileWidth={localTileWidth}
         />
       )
     ) : undefined;

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -55,9 +55,11 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     showCameraSwitcherInLocalPreview,
     parentWidth,
     parentHeight,
-    /* @conditional-compile-remove(pinned-participants) */ pinnedParticipantUserIds
+    /* @conditional-compile-remove(pinned-participants) */ pinnedParticipantUserIds,
+    localTileWidth
   } = props;
 
+  console.log(localTileWidth);
   const theme = useTheme();
 
   const isNarrow = parentWidth ? isNarrowWidth(parentWidth) : false;

--- a/packages/react-components/src/components/VideoGallery/Layout.ts
+++ b/packages/react-components/src/components/VideoGallery/Layout.ts
@@ -38,4 +38,8 @@ export interface LayoutProps {
    * List of pinned participant userIds
    */
   pinnedParticipantUserIds?: string[];
+  /**
+   * Width of the renderElement once it renders a stream.
+   */
+  localTileWidth?: number;
 }

--- a/packages/react-components/src/components/VideoGallery/styles/FloatingLocalVideo.styles.ts
+++ b/packages/react-components/src/components/VideoGallery/styles/FloatingLocalVideo.styles.ts
@@ -51,6 +51,7 @@ export const localVideoTileContainerStyle = (theme: Theme, isNarrow?: boolean): 
   return {
     minWidth: isNarrow ? _pxToRem(SMALL_FLOATING_MODAL_SIZE_PX.width) : _pxToRem(LARGE_FLOATING_MODAL_SIZE_PX.width),
     minHeight: isNarrow ? _pxToRem(SMALL_FLOATING_MODAL_SIZE_PX.height) : _pxToRem(LARGE_FLOATING_MODAL_SIZE_PX.height),
+    width: 'auto',
     position: 'absolute',
     bottom: _pxToRem(localVideoTileOuterPaddingPX),
     borderRadius: theme.effects.roundedCorner4,
@@ -108,8 +109,8 @@ export const floatingLocalVideoTileStyle: VideoTileStylesProps = {
   root: {
     position: 'absolute',
     zIndex: LOCAL_VIDEO_TILE_ZINDEX,
-    height: '100%',
-    width: '100%'
+    height: '100%'
+    // width: '100%'
   }
 };
 

--- a/packages/react-components/src/components/VideoGallery/styles/FloatingLocalVideo.styles.ts
+++ b/packages/react-components/src/components/VideoGallery/styles/FloatingLocalVideo.styles.ts
@@ -47,11 +47,16 @@ export const LOCAL_VIDEO_TILE_ZINDEX = 2;
 /**
  * @private
  */
-export const localVideoTileContainerStyle = (theme: Theme, isNarrow?: boolean): IStyle => {
+export const localVideoTileContainerStyle = (theme: Theme, isNarrow?: boolean, localStreamWidth?: number): IStyle => {
   return {
-    minWidth: isNarrow ? _pxToRem(SMALL_FLOATING_MODAL_SIZE_PX.width) : _pxToRem(LARGE_FLOATING_MODAL_SIZE_PX.width),
+    minWidth:
+      localStreamWidth && localStreamWidth > 0
+        ? _pxToRem(localStreamWidth)
+        : isNarrow
+        ? _pxToRem(SMALL_FLOATING_MODAL_SIZE_PX.width)
+        : _pxToRem(LARGE_FLOATING_MODAL_SIZE_PX.width),
     minHeight: isNarrow ? _pxToRem(SMALL_FLOATING_MODAL_SIZE_PX.height) : _pxToRem(LARGE_FLOATING_MODAL_SIZE_PX.height),
-    width: 'auto',
+    width: localStreamWidth ? _pxToRem(localStreamWidth) : 'auto',
     position: 'absolute',
     bottom: _pxToRem(localVideoTileOuterPaddingPX),
     borderRadius: theme.effects.roundedCorner4,
@@ -65,8 +70,12 @@ export const localVideoTileContainerStyle = (theme: Theme, isNarrow?: boolean): 
 /**
  * @private
  */
-export const localVideoTileWithControlsContainerStyle = (theme: Theme, isNarrow?: boolean): IStackStyles => {
-  return concatStyleSets(localVideoTileContainerStyle(theme, isNarrow), {
+export const localVideoTileWithControlsContainerStyle = (
+  theme: Theme,
+  isNarrow?: boolean,
+  localStreamWidth?: number
+): IStackStyles => {
+  return concatStyleSets(localVideoTileContainerStyle(theme, isNarrow, localStreamWidth), {
     root: { boxShadow: theme.effects.elevation8 }
   });
 };
@@ -76,11 +85,12 @@ export const localVideoTileWithControlsContainerStyle = (theme: Theme, isNarrow?
  */
 export const floatingLocalVideoModalStyle = (
   theme: Theme,
-  isNarrow?: boolean
+  isNarrow?: boolean,
+  localStreamWidth?: number
 ): IStyleFunctionOrObject<IModalStyleProps, IModalStyles> => {
   return concatStyleSets(
     {
-      main: localVideoTileContainerStyle(theme, isNarrow)
+      main: localVideoTileContainerStyle(theme, isNarrow, localStreamWidth)
     },
     {
       main: {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Styles for local video tile are based on local stream width
# Why
<!--- What problem does this change solve? -->
Allows the local stream to always be fit scaling mode so local user can see the whole of their stream
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3042907
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran locally to see resizing happen