### PR TITLE
[BugFix] Update streamUtils to work better with disposing local video

### DIFF
--- a/change-beta/@azure-communication-react-6a375515-cc06-4886-b1c8-b13fd2933b74.json
+++ b/change-beta/@azure-communication-react-6a375515-cc06-4886-b1c8-b13fd2933b74.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updates streamUtils to handle multiple Calls from components.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-6a375515-cc06-4886-b1c8-b13fd2933b74.json
+++ b/change/@azure-communication-react-6a375515-cc06-4886-b1c8-b13fd2933b74.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updates streamUtils to handle multiple Calls from components.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/src/handlers/createCommonHandlers.ts
+++ b/packages/calling-component-bindings/src/handlers/createCommonHandlers.ts
@@ -115,10 +115,6 @@ export const createDefaultCommonCallingHandlers = memoizeOne(
       }
       if (call && call.localVideoStreams.find((s) => areStreamsEqual(s, stream))) {
         await call.stopVideo(stream);
-        await callClient.disposeView(callId, undefined, {
-          source: stream.source,
-          mediaStreamType: stream.mediaStreamType
-        });
       }
     };
 

--- a/packages/calling-stateful-client/src/StreamUtils.ts
+++ b/packages/calling-stateful-client/src/StreamUtils.ts
@@ -507,8 +507,6 @@ function disposeViewLocalVideo(context: CallContext, internalContext: InternalCa
     data: streamLogInfo
   });
 
-  context.setLocalVideoStreamRendererView(callId, undefined);
-
   const renderInfo = internalContext.getLocalRenderInfo(callId);
   if (!renderInfo) {
     _logEvent(callingStatefulLogger, {
@@ -557,9 +555,6 @@ function disposeViewLocalVideo(context: CallContext, internalContext: InternalCa
     return;
   }
 
-  // Else the state must be in the "Rendered" state, so we can dispose the renderer and clean up the state.
-  internalContext.setLocalRenderInfo(callId, renderInfo.stream, 'NotRendered', undefined);
-
   if (renderInfo.renderer) {
     _logEvent(callingStatefulLogger, {
       name: EventNames.DISPOSING_LOCAL_RENDERER,
@@ -568,6 +563,11 @@ function disposeViewLocalVideo(context: CallContext, internalContext: InternalCa
       data: streamLogInfo
     });
     renderInfo.renderer.dispose();
+
+    // Else the state must be in the "Rendered" state, so we can dispose the renderer and clean up the state.
+    internalContext.setLocalRenderInfo(callId, renderInfo.stream, 'NotRendered', undefined);
+
+    context.setLocalVideoStreamRendererView(callId, undefined);
   } else {
     _logEvent(callingStatefulLogger, {
       name: EventNames.LOCAL_RENDERER_NOT_FOUND,


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
There was a race condition between CallSubscriber, LocalVideoTile, and Camera button. updated to better handle this. Camera button no longer directly calls dispose view.
# Why
<!--- What problem does this change solve? --> 
Camera button kept losing the race throwing 
![image](https://user-images.githubusercontent.com/94866715/217123254-0104e8d1-4e9c-4333-9d78-b6fe1b8a8d25.png)
Video tile result now properly returns saying the view was already disposed of. 
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3135605
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran locally error no longer happens and camera properly turns off. will bug bash with new beta