### PR TITLE
[Draft] OnRender DisplayName for fetching in component

### DIFF
--- a/packages/acs-ui-common/review/beta/acs-ui-common.api.md
+++ b/packages/acs-ui-common/review/beta/acs-ui-common.api.md
@@ -58,6 +58,9 @@ export const _logEvent: (logger: AzureLogger, event: TelemetryEvent) => void;
 export const _MAX_EVENT_LISTENERS = 50;
 
 // @public
+export const memoizeAllRet: <ArgsT extends unknown[], FnRetT>(fnToMemoize: (...args: ArgsT) => FnRetT) => (...args: ArgsT) => FnRetT;
+
+// @public
 export const memoizeFnAll: <KeyT, ArgsT extends unknown[], FnRetT, CallBackT extends CallbackType<KeyT, ArgsT, FnRetT>>(fnToMemoize: FunctionWithKey<KeyT, ArgsT, FnRetT>, shouldCacheUpdate?: (args1: unknown, args2: unknown) => boolean) => (callback: CallBackT) => FnRetT[];
 
 // @public

--- a/packages/acs-ui-common/src/index.ts
+++ b/packages/acs-ui-common/src/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 export { memoizeFnAll } from './memoizeFnAll';
+export { memoizeAllRet } from './memoizeAllRet';
 export {
   fromFlatCommunicationIdentifier,
   toFlatCommunicationIdentifier,

--- a/packages/acs-ui-common/src/memoizeAllRet.ts
+++ b/packages/acs-ui-common/src/memoizeAllRet.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { _safeJSONStringify } from './safeStringify';
+
+/**
+ * The function memoize is to cache all results return by the same function args
+ * It will compare function args to determine whether to return previous value or return a new one
+ * @param  fnToMemoize - the function needs to be memorized
+ * @public
+ */
+export const memoizeAllRet = <ArgsT extends unknown[], FnRetT>(
+  fnToMemoize: (...args: ArgsT) => FnRetT
+): ((...args: ArgsT) => FnRetT) => {
+  const cache = new Map<string, FnRetT>();
+
+  return (...args: ArgsT): FnRetT => {
+    const key = _safeJSONStringify(args);
+    if (!key) {
+      throw new Error('Get undefined key from args, please check args');
+    }
+    const value = cache.get(key);
+    if (value) {
+      return value;
+    }
+    const ret = fnToMemoize(...args);
+    cache.set(key, ret);
+    return ret;
+  };
+};

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1640,6 +1640,23 @@ export const _useContainerWidth: (containerRef: RefObject<HTMLElement>) => numbe
 // @internal
 export const _usePermissions: () => _Permissions;
 
+// Warning: (ae-internal-missing-underscore) The name "UserProfile" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export type UserProfile = {
+    userId: string;
+    displayName?: string;
+};
+
+// @internal (undocumented)
+export const _UserProfileProvider: (props: _UserProfileProviderProps) => JSX.Element;
+
+// @internal
+export type _UserProfileProviderProps = {
+    onFetchProfile?: (userId: string) => Promise<UserProfile | undefined>;
+    children: React_2.ReactNode;
+};
+
 // @public
 export const useTheme: () => Theme;
 

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1202,6 +1202,7 @@ export interface ParticipantItemProps {
     menuItems?: IContextualMenuItem[];
     onClick?: (props?: ParticipantItemProps) => void;
     onRenderAvatar?: OnRenderAvatarCallback;
+    onRenderDisplayName?: (userId: string, displayName: string) => JSX.Element;
     onRenderIcon?: (props?: ParticipantItemProps) => JSX.Element | null;
     participantState?: ParticipantState;
     presence?: PersonaPresence;
@@ -1252,6 +1253,7 @@ export type ParticipantListProps = {
     excludeMe?: boolean;
     onRenderParticipant?: (participant: ParticipantListParticipant) => JSX.Element | null;
     onRenderAvatar?: OnRenderAvatarCallback;
+    onRenderDisplayName?: (userId: string, displayName: string) => JSX.Element;
     onRemoveParticipant?: (userId: string) => void;
     onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
     onParticipantClick?: (participant?: ParticipantListParticipant) => void;
@@ -1393,6 +1395,7 @@ export const _RemoteVideoTile: React_2.MemoExoticComponent<(props: {
     renderElement?: HTMLElement | undefined;
     remoteVideoViewOptions?: VideoStreamOptions | undefined;
     onRenderAvatar?: OnRenderAvatarCallback | undefined;
+    onRenderDisplayName?: ((userId: string, displayName: string) => JSX.Element) | undefined;
     showMuteIndicator?: boolean | undefined;
     showLabel?: boolean | undefined;
     personaMinSize?: number | undefined;
@@ -1692,6 +1695,7 @@ export interface VideoGalleryProps {
     onDisposeRemoteStreamView?: (userId: string) => Promise<void>;
     onPinParticipant?: (userId: string) => void;
     onRenderAvatar?: OnRenderAvatarCallback;
+    onRenderDisplayName?: (userId: string, displayName: string) => JSX.Element;
     onRenderLocalVideoTile?: (localParticipant: VideoGalleryLocalParticipant) => JSX.Element;
     onRenderRemoteVideoTile?: (remoteParticipant: VideoGalleryRemoteParticipant) => JSX.Element;
     onUnpinParticipant?: (userId: string) => void;
@@ -1766,6 +1770,7 @@ export interface VideoTileProps {
     isSpeaking?: boolean;
     noVideoAvailableAriaLabel?: string;
     onLongTouch?: () => void;
+    onRenderDisplayName?: (userId: string, displayName: string) => JSX.Element;
     onRenderPlaceholder?: OnRenderAvatarCallback;
     participantState?: ParticipantState;
     personaMaxSize?: number;

--- a/packages/react-components/src/components/ParticipantItem.tsx
+++ b/packages/react-components/src/components/ParticipantItem.tsx
@@ -14,7 +14,7 @@ import {
   Stack,
   Text
 } from '@fluentui/react';
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useIdentifiers } from '../identifiers';
 import { useLocale } from '../localization';
 import { useTheme } from '../theming';
@@ -95,6 +95,8 @@ export interface ParticipantItemProps {
   me?: boolean;
   /** Optional callback returning a JSX element to override avatar. */
   onRenderAvatar?: OnRenderAvatarCallback;
+  /** Optional callback returning a JSX element to override display name. */
+  onRenderDisplayName?: (userId: string, displayName: string) => JSX.Element;
   /** Optional array of IContextualMenuItem for contextual menu. */
   menuItems?: IContextualMenuItem[];
   /** Optional callback returning a JSX element rendered on the right portion of the ParticipantItem. Intended for adding icons. */
@@ -143,6 +145,7 @@ export const ParticipantItem = (props: ParticipantItemProps): JSX.Element => {
     userId,
     displayName,
     onRenderAvatar,
+    onRenderDisplayName,
     menuItems,
     onRenderIcon,
     presence,
@@ -174,6 +177,10 @@ export const ParticipantItem = (props: ParticipantItemProps): JSX.Element => {
     showUnknownPersonaCoin: !me && (!displayName?.trim() || displayName === strings.displayNamePlaceholder)
   };
 
+  const onRenderAvatarText = useCallback(() => {
+    return onRenderDisplayName ? onRenderDisplayName(userId ?? '', displayName ?? '') : null;
+  }, [displayName, onRenderDisplayName, userId]);
+
   const avatar = onRenderAvatar ? (
     onRenderAvatar(userId ?? '', avatarOptions)
   ) : (
@@ -186,6 +193,7 @@ export const ParticipantItem = (props: ParticipantItemProps): JSX.Element => {
         styles?.avatar
       )}
       {...avatarOptions}
+      onRenderPrimaryText={onRenderDisplayName ? onRenderAvatarText : undefined}
     />
   );
 

--- a/packages/react-components/src/components/ParticipantList.tsx
+++ b/packages/react-components/src/components/ParticipantList.tsx
@@ -15,6 +15,7 @@ import { useIdentifiers } from '../identifiers';
 import { useLocale } from '../localization';
 /* @conditional-compile-remove(rooms) */
 import { _usePermissions } from '../permissions';
+import { _useUserProfile } from '../profile/ProfileProvider';
 import {
   BaseCustomStyles,
   CallParticipantListParticipant,
@@ -108,6 +109,8 @@ const onRenderParticipantDefault = (
     }
   }
 
+  const profileDisplayName = participant.userId ? _useUserProfile(participant.userId)?.displayName : undefined;
+
   const menuItems = createParticipantMenuItems && createParticipantMenuItems(participant);
 
   const onRenderIcon =
@@ -133,7 +136,7 @@ const onRenderParticipantDefault = (
       styles={styles}
       key={participant.userId}
       userId={participant.userId}
-      displayName={participant.displayName}
+      displayName={profileDisplayName ?? participant.displayName}
       me={myUserId ? participant.userId === myUserId : false}
       menuItems={menuItems}
       presence={presence}

--- a/packages/react-components/src/components/ParticipantList.tsx
+++ b/packages/react-components/src/components/ParticipantList.tsx
@@ -15,7 +15,6 @@ import { useIdentifiers } from '../identifiers';
 import { useLocale } from '../localization';
 /* @conditional-compile-remove(rooms) */
 import { _usePermissions } from '../permissions';
-import { _useUserProfile } from '../profile/ProfileProvider';
 import {
   BaseCustomStyles,
   CallParticipantListParticipant,
@@ -76,6 +75,8 @@ export type ParticipantListProps = {
   onRenderParticipant?: (participant: ParticipantListParticipant) => JSX.Element | null;
   /** Optional callback to render the avatar for each participant. This property will have no effect if `onRenderParticipant` is assigned.  */
   onRenderAvatar?: OnRenderAvatarCallback;
+  /** Optional callback to render the displayName for each participant. This property will have no effect if `onRenderParticipant` is assigned.  */
+  onRenderDisplayName?: (userId: string, displayName: string) => JSX.Element;
   /** Optional callback to render the context menu for each participant  */
   onRemoveParticipant?: (userId: string) => void;
   /** Optional callback to render custom menu items for each participant. */
@@ -96,7 +97,8 @@ const onRenderParticipantDefault = (
   createParticipantMenuItems?: (participant: ParticipantListParticipant) => IContextualMenuItem[],
   styles?: ParticipantListItemStyles,
   onParticipantClick?: (participant?: ParticipantListParticipant) => void,
-  showParticipantOverflowTooltip?: boolean
+  showParticipantOverflowTooltip?: boolean,
+  onRenderDisplayName?: (userId: string, displayName: string) => JSX.Element
 ): JSX.Element | null => {
   const callingParticipant = participant as CallParticipantListParticipant;
 
@@ -108,8 +110,6 @@ const onRenderParticipantDefault = (
       presence = PersonaPresence.away;
     }
   }
-
-  const profileDisplayName = participant.userId ? _useUserProfile(participant.userId)?.displayName : undefined;
 
   const menuItems = createParticipantMenuItems && createParticipantMenuItems(participant);
 
@@ -136,11 +136,12 @@ const onRenderParticipantDefault = (
       styles={styles}
       key={participant.userId}
       userId={participant.userId}
-      displayName={profileDisplayName ?? participant.displayName}
+      displayName={participant.displayName}
       me={myUserId ? participant.userId === myUserId : false}
       menuItems={menuItems}
       presence={presence}
       onRenderIcon={onRenderIcon}
+      onRenderDisplayName={onRenderDisplayName}
       onRenderAvatar={onRenderAvatar}
       onClick={() => onParticipantClick?.(participant)}
       showParticipantOverflowTooltip={showParticipantOverflowTooltip}
@@ -186,6 +187,7 @@ export const ParticipantList = (props: ParticipantListProps): JSX.Element => {
     participants,
     onRemoveParticipant,
     onRenderAvatar,
+    onRenderDisplayName,
     onRenderParticipant,
     onFetchParticipantMenuItems,
     showParticipantOverflowTooltip
@@ -249,7 +251,8 @@ export const ParticipantList = (props: ParticipantListProps): JSX.Element => {
               createParticipantMenuItems,
               participantItemStyles,
               props.onParticipantClick,
-              showParticipantOverflowTooltip
+              showParticipantOverflowTooltip,
+              onRenderDisplayName
             )
       )}
     </Stack>

--- a/packages/react-components/src/components/RemoteVideoTile.tsx
+++ b/packages/react-components/src/components/RemoteVideoTile.tsx
@@ -44,6 +44,7 @@ export const _RemoteVideoTile = React.memo(
     renderElement?: HTMLElement;
     remoteVideoViewOptions?: VideoStreamOptions;
     onRenderAvatar?: OnRenderAvatarCallback;
+    onRenderDisplayName?: (userId: string, displayName: string) => JSX.Element;
     showMuteIndicator?: boolean;
     showLabel?: boolean;
     personaMinSize?: number;
@@ -99,8 +100,6 @@ export const _RemoteVideoTile = React.memo(
       ]
     );
 
-    const profileDisplayName = _useUserProfile(userId)?.displayName;
-
     // Handle creating, destroying and updating the video stream as necessary
     const createVideoStreamResult = useRemoteVideoStreamLifecycleMaintainer(remoteVideoStreamProps);
 
@@ -144,7 +143,7 @@ export const _RemoteVideoTile = React.memo(
           key={userId}
           userId={userId}
           renderElement={renderVideoStreamElement}
-          displayName={profileDisplayName ?? remoteParticipant.displayName}
+          displayName={remoteParticipant.displayName}
           onRenderPlaceholder={onRenderAvatar}
           isMuted={remoteParticipant.isMuted}
           isSpeaking={remoteParticipant.isSpeaking}
@@ -163,6 +162,7 @@ export const _RemoteVideoTile = React.memo(
               convertContextualMenuItemsToDrawerMenuItemProps(contextualMenuProps, () => setDrawerMenuItemProps([]))
             )
           }
+          onRenderDisplayName={props.onRenderDisplayName}
         />
         {drawerMenuItemProps.length > 0 && (
           <Layer hostId={props.drawerMenuHostId}>

--- a/packages/react-components/src/components/RemoteVideoTile.tsx
+++ b/packages/react-components/src/components/RemoteVideoTile.tsx
@@ -3,6 +3,7 @@
 
 import { IContextualMenuProps, Layer, Stack } from '@fluentui/react';
 import React, { useMemo } from 'react';
+import { _useUserProfile } from '../profile/ProfileProvider';
 import {
   CreateVideoStreamViewResult,
   OnRenderAvatarCallback,
@@ -98,6 +99,8 @@ export const _RemoteVideoTile = React.memo(
       ]
     );
 
+    const profileDisplayName = _useUserProfile(userId)?.displayName;
+
     // Handle creating, destroying and updating the video stream as necessary
     const createVideoStreamResult = useRemoteVideoStreamLifecycleMaintainer(remoteVideoStreamProps);
 
@@ -141,7 +144,7 @@ export const _RemoteVideoTile = React.memo(
           key={userId}
           userId={userId}
           renderElement={renderVideoStreamElement}
-          displayName={remoteParticipant.displayName}
+          displayName={profileDisplayName ?? remoteParticipant.displayName}
           onRenderPlaceholder={onRenderAvatar}
           isMuted={remoteParticipant.isMuted}
           isSpeaking={remoteParticipant.isSpeaking}

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -33,6 +33,7 @@ import { floatingLocalVideoTileStyle } from './VideoGallery/styles/FloatingLocal
 import { useId } from '@fluentui/react-hooks';
 /* @conditional-compile-remove(pinned-participants) */
 import { PinnedParticipantsLayout } from './VideoGallery/PinnedParticipantsLayout';
+import { _useUserProfile } from '../profile/ProfileProvider';
 
 /**
  * @private
@@ -261,7 +262,11 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
       styles?.localVideo
     );
 
-    const initialsName = !localParticipant.displayName ? '' : localParticipant.displayName;
+    const profileDisplayName = localParticipant.userId
+      ? _useUserProfile(localParticipant.userId)?.displayName
+      : undefined;
+    const displayName = profileDisplayName ?? localParticipant.displayName;
+    const initialsName = !displayName ? '' : displayName;
 
     return (
       <Stack key="local-video-tile-key" tabIndex={0} aria-label={strings.localVideoMovementLabel} role={'dialog'}>

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -33,7 +33,6 @@ import { floatingLocalVideoTileStyle } from './VideoGallery/styles/FloatingLocal
 import { useId } from '@fluentui/react-hooks';
 /* @conditional-compile-remove(pinned-participants) */
 import { PinnedParticipantsLayout } from './VideoGallery/PinnedParticipantsLayout';
-import { _useUserProfile } from '../profile/ProfileProvider';
 
 /**
  * @private
@@ -140,8 +139,10 @@ export interface VideoGalleryProps {
   onRenderRemoteVideoTile?: (remoteParticipant: VideoGalleryRemoteParticipant) => JSX.Element;
   /** Callback to dispose a remote video stream view */
   onDisposeRemoteStreamView?: (userId: string) => Promise<void>;
-  /** Callback to render a particpant avatar */
+  /** Callback to render a participant avatar */
   onRenderAvatar?: OnRenderAvatarCallback;
+  /** Callback to render a participant display name */
+  onRenderDisplayName?: (userId: string, displayName: string) => JSX.Element;
   /**
    * Whether to display the local video camera switcher button
    */
@@ -207,6 +208,7 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
     styles,
     layout,
     onRenderAvatar,
+    onRenderDisplayName,
     showMuteIndicator,
     maxRemoteVideoStreams = DEFAULT_MAX_REMOTE_VIDEO_STREAMS,
     showCameraSwitcherInLocalPreview,
@@ -262,11 +264,7 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
       styles?.localVideo
     );
 
-    const profileDisplayName = localParticipant.userId
-      ? _useUserProfile(localParticipant.userId)?.displayName
-      : undefined;
-    const displayName = profileDisplayName ?? localParticipant.displayName;
-    const initialsName = !displayName ? '' : displayName;
+    const initialsName = !localParticipant.displayName ? '' : localParticipant.displayName;
 
     return (
       <Stack key="local-video-tile-key" tabIndex={0} aria-label={strings.localVideoMovementLabel} role={'dialog'}>
@@ -350,6 +348,7 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
           renderElement={isVideoParticipant ? remoteVideoStream?.renderElement : undefined}
           remoteVideoViewOptions={isVideoParticipant ? remoteVideoViewOptions : undefined}
           onRenderAvatar={onRenderAvatar}
+          onRenderDisplayName={onRenderDisplayName}
           showMuteIndicator={showMuteIndicator}
           strings={strings}
           /* @conditional-compile-remove(PSTN-calls) */

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -32,7 +32,6 @@ import { DirectionalHint, IContextualMenuProps } from '@fluentui/react';
 import useLongPress from './utils/useLongPress';
 /* @conditional-compile-remove(pinned-participants) */
 import { moreButtonStyles } from './styles/VideoTile.styles';
-import { _useUserProfile } from '../profile/ProfileProvider';
 
 /**
  * Strings of {@link VideoTile} that can be overridden.
@@ -82,6 +81,8 @@ export interface VideoTileProps {
   isMirrored?: boolean;
   /** Custom render Component function for no video is available. Render a Persona Icon if undefined. */
   onRenderPlaceholder?: OnRenderAvatarCallback;
+  /** Custom render Component function for displayName. Render default display name string when undefined. */
+  onRenderDisplayName?: (userId: string, displayName: string) => JSX.Element;
   /**
    * Show label on the VideoTile
    * @defaultValue true
@@ -223,6 +224,7 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
     /* @conditional-compile-remove(pinned-participants) */
     isPinned,
     onRenderPlaceholder,
+    onRenderDisplayName,
     renderElement,
     showLabel = true,
     showMuteIndicator = true,
@@ -304,10 +306,7 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
 
   const ids = useIdentifiers();
 
-  const profileDisplayName = userId ? _useUserProfile(userId)?.displayName : undefined;
-  const displayNameToRender = profileDisplayName ?? displayName;
-
-  const canShowLabel = (showLabel && displayNameToRender) || (showMuteIndicator && isMuted);
+  const canShowLabel = showLabel && (displayName || (showMuteIndicator && isMuted));
   const participantStateString = participantStateStringTrampoline(props, locale);
   return (
     <Stack
@@ -360,10 +359,10 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
               {canShowLabel && (
                 <Text
                   className={mergeStyles(displayNameStyle)}
-                  title={displayNameToRender}
+                  title={displayName}
                   style={{ color: participantStateString ? theme.palette.neutralSecondary : 'inherit' }}
                 >
-                  {displayNameToRender}
+                  {onRenderDisplayName ? onRenderDisplayName(userId ?? '', displayName ?? '') : displayName}
                 </Text>
               )}
               {participantStateString && (

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -32,6 +32,7 @@ import { DirectionalHint, IContextualMenuProps } from '@fluentui/react';
 import useLongPress from './utils/useLongPress';
 /* @conditional-compile-remove(pinned-participants) */
 import { moreButtonStyles } from './styles/VideoTile.styles';
+import { _useUserProfile } from '../profile/ProfileProvider';
 
 /**
  * Strings of {@link VideoTile} that can be overridden.
@@ -303,7 +304,10 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
 
   const ids = useIdentifiers();
 
-  const canShowLabel = showLabel && (displayName || (showMuteIndicator && isMuted));
+  const profileDisplayName = userId ? _useUserProfile(userId)?.displayName : undefined;
+  const displayNameToRender = profileDisplayName ?? displayName;
+
+  const canShowLabel = (showLabel && displayNameToRender) || (showMuteIndicator && isMuted);
   const participantStateString = participantStateStringTrampoline(props, locale);
   return (
     <Stack
@@ -356,10 +360,10 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
               {canShowLabel && (
                 <Text
                   className={mergeStyles(displayNameStyle)}
-                  title={displayName}
+                  title={displayNameToRender}
                   style={{ color: participantStateString ? theme.palette.neutralSecondary : 'inherit' }}
                 >
-                  {displayName}
+                  {displayNameToRender}
                 </Text>
               )}
               {participantStateString && (

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -49,3 +49,7 @@ export type {
   VideoStreamOptions,
   ViewScalingMode
 } from './types';
+
+export { _UserProfileProvider } from './profile/ProfileProvider';
+
+export type { _UserProfileProviderProps, UserProfile } from './profile/ProfileProvider';

--- a/packages/react-components/src/profile/ProfileProvider.tsx
+++ b/packages/react-components/src/profile/ProfileProvider.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+/**
+ * @internal
+ */
+export type _UserProfileFunction = {
+  onFetchProfile?: (userId: string) => Promise<UserProfile | undefined>;
+};
+
+/**
+ * @internal
+ */
+export type UserProfile = {
+  userId: string;
+  displayName?: string;
+};
+
+/**
+ * @internal
+ */
+export const UserProfileContext = createContext<_UserProfileFunction>({
+  onFetchProfile: undefined
+});
+
+/**
+ * Props for {@link _PermissionsProviderProps}.
+ *
+ * @internal
+ */
+export type _UserProfileProviderProps = {
+  /** Permission context to provide components */
+  onFetchProfile?: (userId: string) => Promise<UserProfile | undefined>;
+  /** Children to provide locale context. */
+  children: React.ReactNode;
+};
+
+/**
+ * @internal
+ */
+export const _UserProfileProvider = (props: _UserProfileProviderProps): JSX.Element => {
+  const { onFetchProfile, children } = props;
+  return <UserProfileContext.Provider value={{ onFetchProfile }}>{children}</UserProfileContext.Provider>;
+};
+
+/**
+ * @internal
+ * React hook to access permissions
+ */
+export const _useUserProfile = (userId: string): UserProfile | undefined => {
+  const onFetchUserProfile = useContext(UserProfileContext).onFetchProfile;
+  const [profile, setProfile] = useState<UserProfile | undefined>(undefined);
+
+  useEffect(() => {
+    if (!onFetchUserProfile) {
+      return;
+    }
+    onFetchUserProfile(userId).then((profile) => setProfile(profile));
+  }, [onFetchUserProfile, userId]);
+
+  return profile;
+};

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -139,6 +139,7 @@ export interface BaseCompositeProps<TIcons extends Record<string, JSX.Element>> 
     locale?: CompositeLocale;
     onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
     onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
+    onFetchProfile?: OnFetchProfileCallback;
     rtl?: boolean;
 }
 
@@ -1248,6 +1249,9 @@ export type NetworkDiagnosticChangedEvent = NetworkDiagnosticChangedEventArgs & 
 };
 
 // @public
+export type OnFetchProfileCallback = (userId: string) => Promise<Profile | undefined>;
+
+// @public
 export type ParticipantsAddedListener = (event: {
     participantsAdded: ChatParticipant[];
     addedBy: ChatParticipant;
@@ -1268,6 +1272,12 @@ export type ParticipantsRemovedListener = (event: {
     participantsRemoved: ChatParticipant[];
     removedBy: ChatParticipant;
 }) => void;
+
+// @public
+export type Profile = {
+    displayName?: string;
+    avatarPersonaData?: AvatarPersonaData;
+};
 
 // @beta
 export interface TeamsCallAdapter extends CommonCallAdapter {

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { _isInCall } from '@internal/calling-component-bindings';
-import { OnRenderAvatarCallback, ParticipantMenuItemsCallback, _UserProfileProvider } from '@internal/react-components';
+import { OnRenderAvatarCallback, ParticipantMenuItemsCallback } from '@internal/react-components';
 import React, { useEffect, useMemo } from 'react';
 import { AvatarPersonaDataCallback } from '../common/AvatarPersona';
 import { BaseProvider, BaseCompositeProps } from '../common/BaseComposite';
@@ -35,6 +35,7 @@ import { HoldPage } from './pages/HoldPage';
 import { UnsupportedBrowserPage } from './pages/UnsupportedBrowser';
 import { PermissionConstraints } from '@azure/communication-calling';
 import { memoizeAllRet } from '@internal/acs-ui-common';
+import { OnFetchProfileCallback } from '../common/Profile';
 
 /**
  * Props for {@link CallComposite}.
@@ -169,6 +170,7 @@ type MainScreenProps = {
   onRenderAvatar?: OnRenderAvatarCallback;
   callInvitationUrl?: string;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
+  onFetchProfile?: OnFetchProfileCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
   options?: CallCompositeOptions;
   /* @conditional-compile-remove(rooms) */
@@ -284,6 +286,7 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
           onRenderAvatar={onRenderAvatar}
           callInvitationURL={callInvitationUrl}
           onFetchAvatarPersonaData={onFetchAvatarPersonaData}
+          onFetchProfile={props.onFetchProfile}
           onFetchParticipantMenuItems={onFetchParticipantMenuItems}
           mobileView={props.mobileView}
           /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) */
@@ -399,33 +402,32 @@ export const CallComposite = (props: CallCompositeProps): JSX.Element => {
   return (
     <div className={mainScreenContainerClassName}>
       <BaseProvider {...props}>
-        <_UserProfileProvider onFetchProfile={memoizedOnFetchProfile}>
-          <CallAdapterProvider adapter={adapter}>
-            <MainScreen
-              callInvitationUrl={callInvitationUrl}
-              onFetchAvatarPersonaData={onFetchAvatarPersonaData}
-              onFetchParticipantMenuItems={onFetchParticipantMenuItems}
-              mobileView={mobileView}
-              /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) @conditional-compile-remove(call-readiness) */
-              modalLayerHostId={modalLayerHostId}
-              options={options}
-              /* @conditional-compile-remove(rooms) */
-              roleHint={roleHint}
-            />
-            {
-              // This layer host is for ModalLocalAndRemotePIP in CallPane. This LayerHost cannot be inside the CallPane
-              // because when the CallPane is hidden, ie. style property display is 'none', it takes up no space. This causes problems when dragging
-              // the Modal because the draggable bounds thinks it has no space and will always return to its initial position after dragging.
-              // Additionally, this layer host cannot be in the Call Arrangement as it needs to be rendered before useMinMaxDragPosition() in
-              // common/utils useRef is called.
-              // Warning: this is fragile and works because the call arrangement page is only rendered after the call has connected and thus this
-              // LayerHost will be guaranteed to have rendered (and subsequently mounted in the DOM). This ensures the DOM element will be available
-              // before the call to `document.getElementById(modalLayerHostId)` is made.
-              /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) @conditional-compile-remove(call-readiness) */
-              <LayerHost id={modalLayerHostId} className={mergeStyles(modalLayerHostStyle)} />
-            }
-          </CallAdapterProvider>
-        </_UserProfileProvider>
+        <CallAdapterProvider adapter={adapter}>
+          <MainScreen
+            callInvitationUrl={callInvitationUrl}
+            onFetchAvatarPersonaData={onFetchAvatarPersonaData}
+            onFetchProfile={memoizedOnFetchProfile}
+            onFetchParticipantMenuItems={onFetchParticipantMenuItems}
+            mobileView={mobileView}
+            /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) @conditional-compile-remove(call-readiness) */
+            modalLayerHostId={modalLayerHostId}
+            options={options}
+            /* @conditional-compile-remove(rooms) */
+            roleHint={roleHint}
+          />
+          {
+            // This layer host is for ModalLocalAndRemotePIP in CallPane. This LayerHost cannot be inside the CallPane
+            // because when the CallPane is hidden, ie. style property display is 'none', it takes up no space. This causes problems when dragging
+            // the Modal because the draggable bounds thinks it has no space and will always return to its initial position after dragging.
+            // Additionally, this layer host cannot be in the Call Arrangement as it needs to be rendered before useMinMaxDragPosition() in
+            // common/utils useRef is called.
+            // Warning: this is fragile and works because the call arrangement page is only rendered after the call has connected and thus this
+            // LayerHost will be guaranteed to have rendered (and subsequently mounted in the DOM). This ensures the DOM element will be available
+            // before the call to `document.getElementById(modalLayerHostId)` is made.
+            /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) @conditional-compile-remove(call-readiness) */
+            <LayerHost id={modalLayerHostId} className={mergeStyles(modalLayerHostStyle)} />
+          }
+        </CallAdapterProvider>
       </BaseProvider>
     </div>
   );

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -20,6 +20,7 @@ import { useCallback } from 'react';
 /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) */
 import { AvatarPersonaDataCallback } from '../../common/AvatarPersona';
 import { containerDivStyles } from '../../common/ContainerRectProps';
+import { OnFetchProfileCallback } from '../../common/Profile';
 /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) */
 import { useAdapter } from '../adapter/CallAdapterProvider';
 import { CallControls, CallControlsProps } from '../components/CallControls';
@@ -57,6 +58,7 @@ export interface CallArrangementProps {
   modalLayerHostId: string;
   /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) */
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
+  onFetchProfile?: OnFetchProfileCallback;
 }
 
 /**
@@ -106,6 +108,7 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
           callAdapter={adapter}
           onClose={closePane}
           onFetchAvatarPersonaData={props.onFetchAvatarPersonaData}
+          onFetchProfile={props.onFetchProfile}
           onFetchParticipantMenuItems={props.callControlProps?.onFetchParticipantMenuItems}
           onPeopleButtonClicked={
             showShowPeopleTabHeaderButton(props.callControlProps.options) ? openPeoplePane : undefined
@@ -122,15 +125,16 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
     }
     return <></>;
   }, [
-    activePane,
     adapter,
+    activePane,
     closePane,
-    props.callControlProps.callInvitationURL,
+    props.onFetchAvatarPersonaData,
+    props.onFetchProfile,
     props.callControlProps?.onFetchParticipantMenuItems,
     props.callControlProps.options,
-    props.mobileView,
+    props.callControlProps.callInvitationURL,
     props.modalLayerHostId,
-    props.onFetchAvatarPersonaData,
+    props.mobileView,
     openPeoplePane
   ]);
 

--- a/packages/react-composites/src/composites/CallComposite/components/CallPane.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallPane.tsx
@@ -37,6 +37,7 @@ import { AddPhoneNumberOptions } from '@azure/communication-calling';
 import { useAdapter } from '../adapter/CallAdapterProvider';
 import { isDisabled } from '../utils';
 import { CallSidePaneOption } from '../hooks/useSidePaneState';
+import { OnFetchProfileCallback } from '../../common/Profile';
 
 /**
  * Pane that is used to store participants for Call composite
@@ -47,6 +48,7 @@ export const CallPane = (props: {
   callAdapter: CommonCallAdapter;
   onClose: () => void;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
+  onFetchProfile?: OnFetchProfileCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
   onPeopleButtonClicked?: () => void;
   modalLayerHostId: string;

--- a/packages/react-composites/src/composites/CallComposite/components/MediaGallery.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/MediaGallery.tsx
@@ -19,6 +19,8 @@ import { localVideoCameraCycleButtonSelector } from '../selectors/LocalVideoTile
 import { LocalVideoCameraCycleButton } from '@internal/react-components';
 import { _formatString } from '@internal/acs-ui-common';
 import { useParticipantChangedAnnouncement } from '../utils/MediaGalleryUtils';
+import { OnFetchProfileCallback } from '../../common/Profile';
+import { DisplayName } from '../../common/DisplayName';
 
 const VideoGalleryStyles = {
   root: {
@@ -45,6 +47,7 @@ export interface MediaGalleryProps {
   isMicrophoneChecked?: boolean;
   onStartLocalVideo: () => Promise<void>;
   onRenderAvatar?: OnRenderAvatarCallback;
+  onFetchProfile?: OnFetchProfileCallback;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   isMobile?: boolean;
   drawerMenuHostId?: string;
@@ -79,6 +82,13 @@ export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
     [props.onFetchAvatarPersonaData]
   );
 
+  const onRenderDisplayName = useCallback(
+    (userId: string, displayName: string) => {
+      return <DisplayName userId={userId} displayName={displayName} onFetchProfile={props.onFetchProfile} />;
+    },
+    [props.onFetchProfile]
+  );
+
   useLocalVideoStartTrigger(!!props.isVideoStreamOn);
   const VideoGalleryMemoized = useMemo(() => {
     return (
@@ -91,12 +101,13 @@ export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
         showCameraSwitcherInLocalPreview={props.isMobile}
         localVideoCameraCycleButtonProps={cameraSwitcherProps}
         onRenderAvatar={onRenderAvatar}
+        onRenderDisplayName={onRenderDisplayName}
         /* @conditional-compile-remove(pinned-participants) */
         showRemoteVideoTileContextualMenu={!props.isMobile}
         // @TODO: Provide props.drawerMenuHostId to VideoGallery when VideoGallery props support it.
       />
     );
-  }, [videoGalleryProps, props.isMobile, cameraSwitcherProps, onRenderAvatar]);
+  }, [videoGalleryProps, props.isMobile, cameraSwitcherProps, onRenderAvatar, onRenderDisplayName]);
 
   return (
     <>

--- a/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
@@ -7,6 +7,7 @@ import { _isInCall } from '@internal/calling-component-bindings';
 import { ErrorBar, OnRenderAvatarCallback, ParticipantMenuItemsCallback } from '@internal/react-components';
 import React from 'react';
 import { AvatarPersonaDataCallback } from '../../common/AvatarPersona';
+import { OnFetchProfileCallback } from '../../common/Profile';
 import { useLocale } from '../../localization';
 import { CallCompositeOptions } from '../CallComposite';
 import { CallArrangement } from '../components/CallArrangement';
@@ -31,6 +32,7 @@ export interface CallPageProps {
   modalLayerHostId: string;
   callInvitationURL?: string;
   onRenderAvatar?: OnRenderAvatarCallback;
+  onFetchProfile?: OnFetchProfileCallback;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
   options?: CallCompositeOptions;
@@ -43,6 +45,7 @@ export const CallPage = (props: CallPageProps): JSX.Element => {
   const {
     callInvitationURL,
     onRenderAvatar,
+    onFetchProfile,
     onFetchAvatarPersonaData,
     onFetchParticipantMenuItems,
     options,
@@ -81,6 +84,7 @@ export const CallPage = (props: CallPageProps): JSX.Element => {
       }}
       /* @conditional-compile-remove(one-to-n-calling) */
       onFetchAvatarPersonaData={onFetchAvatarPersonaData}
+      onFetchProfile={onFetchProfile}
       mobileView={mobileView}
       /* @conditional-compile-remove(one-to-n-calling) */
       modalLayerHostId={props.modalLayerHostId}
@@ -92,6 +96,7 @@ export const CallPage = (props: CallPageProps): JSX.Element => {
               {...mediaGalleryProps}
               {...mediaGalleryHandlers}
               onRenderAvatar={onRenderAvatar}
+              onFetchProfile={onFetchProfile}
               onFetchAvatarPersonaData={onFetchAvatarPersonaData}
               drawerMenuHostId={drawerMenuHostId}
             />

--- a/packages/react-composites/src/composites/common/AvatarPersona.tsx
+++ b/packages/react-composites/src/composites/common/AvatarPersona.tsx
@@ -3,6 +3,7 @@
 
 import { IPersonaProps, Persona, PersonaInitialsColor } from '@fluentui/react';
 import React, { useEffect, useState } from 'react';
+import { OnFetchProfileCallback } from './Profile';
 
 /**
  * Custom data attributes for displaying avatar for a user.
@@ -57,9 +58,13 @@ export interface AvatarPersonaProps extends IPersonaProps {
    */
   userId?: string;
   /**
-   * A function that returns a Promise that resolves to the data to be displayed.
+   * A function that returns a Promise that resolves to the avatar data to be displayed.
    */
   dataProvider?: AvatarPersonaDataCallback;
+  /**
+   * A function that returns a Promise that resolves to the profile data to be displayed.
+   */
+  onFetchProfile?: OnFetchProfileCallback;
 }
 
 /**
@@ -70,10 +75,20 @@ export interface AvatarPersonaProps extends IPersonaProps {
  * @private
  */
 export const AvatarPersona = (props: AvatarPersonaProps): JSX.Element => {
-  const { userId, dataProvider, text, imageUrl, imageInitials, initialsColor, initialsTextColor, showOverflowTooltip } =
-    props;
+  const {
+    userId,
+    dataProvider,
+    text,
+    imageUrl,
+    imageInitials,
+    initialsColor,
+    initialsTextColor,
+    showOverflowTooltip,
+    onFetchProfile
+  } = props;
 
   const [data, setData] = useState<AvatarPersonaData | undefined>();
+  const [displayName, setDisplayName] = useState<string | undefined>();
 
   useEffect(() => {
     (async () => {
@@ -86,10 +101,17 @@ export const AvatarPersona = (props: AvatarPersonaProps): JSX.Element => {
     })();
   }, [data, dataProvider, userId]);
 
+  useEffect(() => {
+    (async () => {
+      const profile = await onFetchProfile?.(userId ?? '');
+      setDisplayName(profile ? profile.displayName : data?.text);
+    })();
+  }, [data, dataProvider, onFetchProfile, userId]);
+
   return (
     <Persona
       {...props}
-      text={data?.text ?? text}
+      text={displayName ?? text}
       imageUrl={data?.imageUrl ?? imageUrl}
       imageInitials={data?.imageInitials ?? imageInitials}
       initialsColor={data?.initialsColor ?? initialsColor}

--- a/packages/react-composites/src/composites/common/BaseComposite.tsx
+++ b/packages/react-composites/src/composites/common/BaseComposite.tsx
@@ -18,6 +18,7 @@ import { AvatarPersonaDataCallback } from './AvatarPersona';
 import { CallCompositeIcons, CallWithChatCompositeIcons, ChatCompositeIcons, DEFAULT_COMPOSITE_ICONS } from './icons';
 import { globalLayerHostStyle } from './styles/GlobalHostLayer.styles';
 import { useId } from '@fluentui/react-hooks';
+import { OnFetchProfileCallback } from './Profile';
 /**
  * Properties common to all composites exported from this library.
  *
@@ -56,6 +57,12 @@ export interface BaseCompositeProps<TIcons extends Record<string, JSX.Element>> 
    * will be what is provided to the adapter when the adapter is created.
    */
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
+
+  /**
+   * A callback function that can be used to provide custom data to a user profile including
+   * display name and avatar in Composite.
+   */
+  onFetchProfile?: OnFetchProfileCallback;
 
   /**
    * A callback function that can be used to provide custom menu items for a participant in

--- a/packages/react-composites/src/composites/common/DisplayName.tsx
+++ b/packages/react-composites/src/composites/common/DisplayName.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import React, { useEffect, useState } from 'react';
+import { OnFetchProfileCallback } from './Profile';
+
+type DisplayNameProps = {
+  userId: string;
+  displayName?: string;
+  onFetchProfile?: OnFetchProfileCallback;
+};
+
+/** private */
+export const DisplayName = (props: DisplayNameProps): JSX.Element => {
+  const { userId, displayName, onFetchProfile } = props;
+  const [name, setName] = useState(displayName);
+
+  useEffect(() => {
+    if (onFetchProfile) {
+      onFetchProfile(userId).then((profile) => {
+        setName(profile?.displayName);
+      });
+    }
+  }, [userId, onFetchProfile]);
+
+  return <>{name}</>;
+};

--- a/packages/react-composites/src/composites/common/ParticipantContainer.tsx
+++ b/packages/react-composites/src/composites/common/ParticipantContainer.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import {
   participantListContainerStyle,
   participantListMobileStyle,
@@ -17,6 +17,8 @@ import {
 } from '@internal/react-components';
 import { FocusZone, Stack, Text, useTheme } from '@fluentui/react';
 import { AvatarPersona, AvatarPersonaDataCallback } from './AvatarPersona';
+import { OnFetchProfileCallback } from './Profile';
+import { DisplayName } from './DisplayName';
 
 type ParticipantContainerProps = {
   onRenderAvatar?: OnRenderAvatarCallback;
@@ -48,6 +50,7 @@ export const ParticipantListWithHeading = (props: {
   title?: string;
   isMobile?: boolean;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
+  onFetchProfile?: OnFetchProfileCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
 }): JSX.Element => {
   const { onFetchAvatarPersonaData, onFetchParticipantMenuItems, title, participantListProps } = props;
@@ -63,6 +66,13 @@ export const ParticipantListWithHeading = (props: {
     [theme.palette.neutralSecondary, theme.fonts.smallPlus.fontSize, props.isMobile]
   );
 
+  const onRenderDisplayName = useCallback(
+    (userId: string, displayName: string) => {
+      return <DisplayName userId={userId} displayName={displayName} onFetchProfile={props.onFetchProfile} />;
+    },
+    [props.onFetchProfile]
+  );
+
   return (
     <Stack className={participantListStack}>
       <Stack.Item styles={subheadingStyleThemed}>{title}</Stack.Item>
@@ -73,6 +83,7 @@ export const ParticipantListWithHeading = (props: {
           onRenderAvatar={(userId, options) => (
             <>
               <AvatarPersona
+                onFetchProfile={props.onFetchProfile}
                 data-ui-id="chat-composite-participant-custom-avatar"
                 userId={userId}
                 {...options}
@@ -81,11 +92,12 @@ export const ParticipantListWithHeading = (props: {
               />
               {options?.text && (
                 <Text nowrap={true} styles={displayNameStyles}>
-                  {options?.text}
+                  {onRenderDisplayName ? onRenderDisplayName(userId ?? '', options?.text) : options?.text}
                 </Text>
               )}
             </>
           )}
+          onRenderDisplayName={onRenderDisplayName}
           onFetchParticipantMenuItems={onFetchParticipantMenuItems}
           showParticipantOverflowTooltip={!props.isMobile}
         />

--- a/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
+++ b/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
@@ -26,6 +26,7 @@ import { AddPeopleButton } from './AddPeopleButton';
 import { PhoneNumberIdentifier } from '@azure/communication-common';
 /* @conditional-compile-remove(PSTN-calls) */
 import { AddPhoneNumberOptions } from '@azure/communication-calling';
+import { OnFetchProfileCallback } from './Profile';
 
 /**
  * @private
@@ -36,6 +37,7 @@ export const PeoplePaneContent = (props: {
   onRemoveParticipant: (participantId: string) => void;
   /* @conditional-compile-remove(PSTN-calls) */
   onAddParticipant: (participant: PhoneNumberIdentifier, options?: AddPhoneNumberOptions) => void;
+  onFetchProfile?: OnFetchProfileCallback;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
   strings: CallWithChatCompositeStrings | /* @conditional-compile-remove(one-to-n-calling) */ CallCompositeStrings;
@@ -44,7 +46,8 @@ export const PeoplePaneContent = (props: {
   /* @conditional-compile-remove(PSTN-calls) */
   alternateCallerId?: string;
 }): JSX.Element => {
-  const { inviteLink, onFetchParticipantMenuItems, setDrawerMenuItems, strings, onRemoveParticipant } = props;
+  const { inviteLink, onFetchParticipantMenuItems, setDrawerMenuItems, strings, onRemoveParticipant, onFetchProfile } =
+    props;
   const participantListDefaultProps = usePropsFor(ParticipantList);
   const removeButtonAllowed = hasRemoveParticipantsPermissionTrampoline();
   const setDrawerMenuItemsForParticipant: (participant?: ParticipantListParticipant) => void = useMemo(() => {
@@ -94,6 +97,7 @@ export const PeoplePaneContent = (props: {
       isMobile={props.mobileView}
       participantListProps={participantListProps}
       onFetchAvatarPersonaData={props.onFetchAvatarPersonaData}
+      onFetchProfile={onFetchProfile}
       onFetchParticipantMenuItems={props.mobileView ? undefined : props.onFetchParticipantMenuItems}
       title={props.strings.peoplePaneSubTitle}
     />

--- a/packages/react-composites/src/composites/common/Profile.tsx
+++ b/packages/react-composites/src/composites/common/Profile.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AvatarPersonaData } from './AvatarPersona';
+
+/**
+ * Custom data attributes for displaying avatar for a user.
+ *
+ * @public
+ */
+export type Profile = {
+  /**
+   * Primary text to display, usually the name of the person.
+   */
+  displayName?: string;
+  avatarPersonaData?: AvatarPersonaData;
+};
+
+/**
+ * Callback function used to provide custom data to build profile for a user.
+ *
+ * @public
+ */
+export type OnFetchProfileCallback = (userId: string) => Promise<Profile | undefined>;

--- a/packages/react-composites/src/composites/index.ts
+++ b/packages/react-composites/src/composites/index.ts
@@ -8,6 +8,7 @@ export * from './CallComposite';
 export * from './CallWithChatComposite';
 
 export type { AvatarPersonaData, AvatarPersonaDataCallback } from './common/AvatarPersona';
+export type { OnFetchProfileCallback, Profile } from './common/Profile';
 export { COMPOSITE_ONLY_ICONS, DEFAULT_COMPOSITE_ICONS } from './common/icons';
 export type {
   CompositeIcons,

--- a/samples/Calling/src/app/views/CallCompositeContainer.tsx
+++ b/samples/Calling/src/app/views/CallCompositeContainer.tsx
@@ -5,7 +5,7 @@ import { CommonCallAdapter, CallCompositeOptions, CallComposite } from '@azure/c
 import { Spinner } from '@fluentui/react';
 import { useSwitchableFluentTheme } from '../theming/SwitchableFluentThemeProvider';
 import { useIsMobile } from '../utils/useIsMobile';
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect, useCallback } from 'react';
 import { CallScreenProps } from './CallScreen';
 
 export type CallCompositeContainerProps = CallScreenProps & { adapter?: CommonCallAdapter };
@@ -33,6 +33,10 @@ export const CallCompositeContainer = (props: CallCompositeContainerProps): JSX.
     return () => window.removeEventListener('beforeunload', disposeAdapter);
   }, [adapter]);
 
+  const onFetchProfile = useCallback(async () => {
+    return { displayName: 'Test User' };
+  }, []);
+
   if (!adapter) {
     return <Spinner label={'Creating adapter'} ariaLive="assertive" labelPosition="top" />;
   }
@@ -53,6 +57,7 @@ export const CallCompositeContainer = (props: CallCompositeContainerProps): JSX.
       formFactor={isMobileSession ? 'mobile' : 'desktop'}
       /* @conditional-compile-remove(call-readiness) */
       options={options}
+      onFetchProfile={onFetchProfile}
     />
   );
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
1. Add onRenderDisplayName for component to:
- leverage react reconciliation to update per displayName per component
- Allow user to render their own displayName in component level
- Allow user to match displayName customization to match custom avatar

2. Add an example of doing a fetch-and-forget displayName override

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->