### PR TITLE
Define message status for storybook message thread to make sure 'try send again' does not show up in fly out menu

### DIFF
--- a/change-beta/@azure-communication-react-529cbe65-72af-44b2-9808-55e373e9fb18.json
+++ b/change-beta/@azure-communication-react-529cbe65-72af-44b2-9808-55e373e9fb18.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make sure message status in storybook is defined to avoid 'try send again' showing up",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-529cbe65-72af-44b2-9808-55e373e9fb18.json
+++ b/change/@azure-communication-react-529cbe65-72af-44b2-9808-55e373e9fb18.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make sure message status in storybook is defined to avoid 'try send again' showing up",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
+++ b/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
@@ -195,7 +195,7 @@ const MessageThreadStory = (args): JSX.Element => {
     // We dont want to render the status for previous messages
     existingChatMessages.forEach((message) => {
       if (message.messageType === 'chat') {
-        message.status = undefined;
+        message.status = 'seen';
       }
     });
     setChatMessages([...existingChatMessages, GenerateMockNewChatMessage()]);

--- a/packages/storybook/stories/MessageThread/placeholdermessages.ts
+++ b/packages/storybook/stories/MessageThread/placeholdermessages.ts
@@ -52,8 +52,8 @@ export const GenerateMockNewChatMessage = (): ChatMessage => {
     createdOn: new Date('2020-04-13T00:00:00.000+07:01'),
     mine: true,
     attached: false,
-    status: 'seen' as MessageStatus,
-    contentType: 'text'
+    contentType: 'text',
+    status: 'seen' as MessageStatus
   };
 };
 
@@ -102,7 +102,8 @@ export const GenerateMockHistoryChatMessages = (): ChatMessage[] => {
       createdOn: new Date('2019-04-13T00:00:00.000+08:10'),
       mine: true,
       attached: false,
-      contentType: 'text'
+      contentType: 'text',
+      status: 'seen' as MessageStatus
     },
     {
       messageType: 'chat',
@@ -139,7 +140,8 @@ export const GenerateMockChatMessages = (): ChatMessage[] => {
       createdOn: new Date('2020-04-13T00:00:00.000+08:10'),
       mine: true,
       attached: false,
-      contentType: 'text'
+      contentType: 'text',
+      status: 'seen' as MessageStatus
     },
     {
       messageType: 'chat',
@@ -169,7 +171,8 @@ export const GenerateMockChatMessages = (): ChatMessage[] => {
       createdOn: new Date('2020-04-13T00:00:00.000+08:07'),
       mine: true,
       attached: false,
-      contentType: 'text'
+      contentType: 'text',
+      status: 'seen' as MessageStatus
     },
     {
       messageType: 'chat',
@@ -229,8 +232,8 @@ export const GenerateMockChatMessages = (): ChatMessage[] => {
       createdOn: new Date('2020-04-13T00:00:00.000+08:02'),
       mine: true,
       attached: false,
-      status: 'seen' as MessageStatus,
-      contentType: 'text'
+      contentType: 'text',
+      status: 'seen' as MessageStatus
     },
     {
       messageType: 'chat',


### PR DESCRIPTION
# What

Define message status for storybook message thread 

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3132408

# How Tested
<img width="480" alt="Screenshot 2023-02-08 at 10 50 46 PM" src="https://user-images.githubusercontent.com/96077406/217739455-9fb09ada-41c8-4651-b44e-149ed15a53bb.png">
