### PR TITLE
[BugFix BetaBlocking] Fix PSTN start Call

### DIFF
--- a/change-beta/@azure-communication-react-77512195-cb86-4a65-8c90-1fd39cfac690.json
+++ b/change-beta/@azure-communication-react-77512195-cb86-4a65-8c90-1fd39cfac690.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix PSTN id parsing and add unit test to validate E.164 format numbers.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-77512195-cb86-4a65-8c90-1fd39cfac690.json
+++ b/change/@azure-communication-react-77512195-cb86-4a65-8c90-1fd39cfac690.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix PSTN id parsing and add unit test to validate E.164 format numbers.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/acs-ui-common/src/identifier.test.ts
+++ b/packages/acs-ui-common/src/identifier.test.ts
@@ -19,6 +19,15 @@ test('Communication user conversions', () => {
   expect(toFlatCommunicationIdentifier(parsed)).toEqual('8:acs:OPAQUE');
 });
 
+test('phone number conversion from E.164 format', () => {
+  const parsed = fromFlatCommunicationIdentifier('+15555555555');
+  expect(isPhoneNumberIdentifier(parsed)).toBeTruthy;
+  expect(parsed).toEqual({
+    kind: 'phoneNumber',
+    phoneNumber: '15555555555'
+  });
+});
+
 test('Phone number conversions', () => {
   const parsed = fromFlatCommunicationIdentifier('4:OPAQUE');
   expect(isPhoneNumberIdentifier(parsed)).toBeTruthy();

--- a/packages/acs-ui-common/src/identifier.ts
+++ b/packages/acs-ui-common/src/identifier.ts
@@ -23,7 +23,9 @@ export const toFlatCommunicationIdentifier = (identifier: CommunicationIdentifie
  * @public
  */
 export const fromFlatCommunicationIdentifier = (id: string): CommunicationIdentifier => {
-  return createIdentifierFromRawId(id);
+  // if the id passed is a phone number we need to build the rawId to pass in
+  const rawId = id.indexOf('+') === 0 ? '4:' + id.slice(1) : id;
+  return createIdentifierFromRawId(rawId);
 };
 
 /**


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Update `fromFlatCommunicationIdentifier` function to handle E.164 format phone numbers as Id's
# Why
<!--- What problem does this change solve? -->
Allows for startCall handler in Adapter to parse out correct id type.
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3141060
# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated calls can be connected again locally. added unit test for util function that parses id