### PR TITLE
Update github actions to no longer create PRs

### DIFF
--- a/.github/workflows/create-prerelease-branch.yml
+++ b/.github/workflows/create-prerelease-branch.yml
@@ -136,12 +136,9 @@ jobs:
           git commit -m 'Create groom me file for groom changelog branch'
           git push -u origin ${{ steps.groombranch.outputs.groombranch }}
 
-      # Create a PR from the changes
-      - name: Create PR
+      - name: REMOVED - DO THIS MANUALLY! Create PR of changelog branch to pre-release branch
         run: |
-          curl \
-            -X POST \
-            -H 'Accept: application/vnd.github.v3+json' \
-            -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://api.github.com/repos/Azure/communication-ui-library/pulls \
-            -d '{ "title":"${{ steps.version.outputs.version }} groom branch -> pre-release branch", "head":"${{ steps.groombranch.outputs.groombranch }}", "base":"${{ steps.prereleasebranch.outputs.prereleasebranch }}", "body":"Groom pre-release branch for ${{ steps.version.outputs.version }} Please groom CHANGELOG.md in this branch. Created by the `${{ github.event.inputs.bump_type }} pre-release branch - create` GitHub action. Please review." }'
+          echo "Creating pull requests by GitHub Action is no longer supported per Microsoft Open Source Security Policy."
+          echo "Please create a pull request manually from ${{ steps.groombranch.outputs.groombranch }} to ${{ steps.prereleasebranch.outputs.prereleasebranch }}."
+          echo "In the PR description please include the following text: `Please groom CHANGELOG.md in this branch`."
+          echo "See example: https://github.com/Azure/communication-ui-library/pull/2694"

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -107,14 +107,11 @@ jobs:
       - name: Hop back to pre-release branch
         run: git checkout ${{ github.event.inputs.branch }}
 
-      - name: Create pull request for pre-release back to main
+      - name: REMOVED - DO THIS MANUALLY! Create pull request for pre-release back to main
         run: |
-          curl \
-            -X POST \
-            -H 'Accept: application/vnd.github.v3+json' \
-            -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            https://api.github.com/repos/Azure/communication-ui-library/pulls \
-            -d '{ "title":"${{ steps.version.outputs.version }} pre-release branch", "head":"${{ github.event.inputs.branch }}", "base":"main", "body":"Merge prerelease branch back into main. Version: ${{ steps.version.outputs.version }}. Created by the `Create release branch - create` GitHub action. Please review." }'
+          echo "Creating pull requests by GitHub Action is no longer supported per Microsoft Open Source Security Policy."
+          echo "Please create a pull request manually from ${{ github.event.inputs.branch }} to main."
+          echo "See example: https://github.com/Azure/communication-ui-library/pull/2631"
 
       # if a stable release bump the package versions to beta.0 numbers for next beta release
       - name: Bump versions for pre-release branch if stable release

--- a/change-beta/@azure-communication-react-6693b657-05ee-4c41-9330-8e4e6d0a04bd.json
+++ b/change-beta/@azure-communication-react-6693b657-05ee-4c41-9330-8e4e6d0a04bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update github actions to no longer create PRs",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-6693b657-05ee-4c41-9330-8e4e6d0a04bd.json
+++ b/change/@azure-communication-react-6693b657-05ee-4c41-9330-8e4e6d0a04bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update github actions to no longer create PRs",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/docs/releases/creating-a-release.md
+++ b/docs/releases/creating-a-release.md
@@ -37,7 +37,7 @@ Use the [create-prerelease-branch](https://github.com/Azure/communication-ui-lib
 This section describes what the workflow above does. Understanding the workflow actions is useful in case the workflow fails.
 
 1. Create a `prerelease/<release-tag>` branch, bump the package version for `@azure/communication-react` as appropriate and collect all change files into a changelog.
-1. Creates another branch for manually summarizing the changes collected in the changelog and opens a Pull Request into the `prerelease/<release-tag>`. **Merge this PR before going to step 1.2**.
+1. Creates another branch for manually summarizing the changes collected in the changelog and ~~opens a Pull Request into the `prerelease/<release-tag>`~~ you must open a PR manually of this new branch (`groom-changelog/<release-tag>`) into the prerelease branch (`prerelease/<release-tag>`). **Merge this PR before going to step 1.2**.
     1. This step will also create a file called `GROOMME.md` which should be deleted when completing the PR back into the pre-release branch to signify that the changelog has been manually groomed.
     1. See [tips for how to prune the generated changelog](./pruning-a-changelog.md) into a readable summary of the release.
 
@@ -74,7 +74,7 @@ This section describes what the workflow above does. Understanding the workflow 
   2. The action will synchronize the package telemetry verions on the release branch.
   3. After making these changes it will make a PR from the pre-release branch back into `main`.
 
-Continuing the example above, this action should be triggered once `groom_changelog_3.0.0` is merged. It will create the following new branches and Pull Requests:
+Continuing the example above, this action should be triggered once `groom_changelog_3.0.0` is merged. It will create the following new branches ~~and Pull Requests~~:
 
 ```mermaid
 graph LR
@@ -87,7 +87,10 @@ graph LR
   prerelease -.-o|Create Pull Request| main
 ```
 
-- Manual step for now: Disable the beta checks on the CI if this is a stable release, or the stable checks if this is a beta relase. This is to ensure that any cherry pick PR's going into release dont run against the wrong build flavor in CI causing failures. Editing the [CI workflow](../../.github/workflows/ci.yml): Modify the output `JSON` string to remove the `beta` flavor for `stable` releases / `stable` flavor for `beta` releases.
+After running the action there are two manual steps you must do:
+
+- Create a PR of `release/<release-tag>` into `main` to merge the release branch back into `main`. This PR should be merged after the release is complete.
+- Disable the beta checks on the CI if this is a stable release, or the stable checks if this is a beta relase. This is to ensure that any cherry pick PR's going into release dont run against the wrong build flavor in CI causing failures. Editing the [CI workflow](../../.github/workflows/ci.yml): Modify the output `JSON` string to remove the `beta` flavor for `stable` releases / `stable` flavor for `beta` releases.
 
 ## Step 2: Prepare for release
 

--- a/docs/releases/creating-a-release.md
+++ b/docs/releases/creating-a-release.md
@@ -37,7 +37,7 @@ Use the [create-prerelease-branch](https://github.com/Azure/communication-ui-lib
 This section describes what the workflow above does. Understanding the workflow actions is useful in case the workflow fails.
 
 1. Create a `prerelease/<release-tag>` branch, bump the package version for `@azure/communication-react` as appropriate and collect all change files into a changelog.
-1. Creates another branch for manually summarizing the changes collected in the changelog and ~~opens a Pull Request into the `prerelease/<release-tag>`~~ per [security policy](https://aka.ms/opensource/actions-changes-230217) you must open a PR manually of this new branch (`groom-changelog/<release-tag>`) into the prerelease branch (`prerelease/<release-tag>`). **Merge this PR before going to step 1.2**.
+1. Creates another branch for manually summarizing the changes collected in the changelog and ~~opens a Pull Request into the `prerelease/<release-tag>`~~ per [security policy](https://aka.ms/opensource/actions-changes-230217) you must open a PR manually of this new branch (`groom-changelog/<release-tag>`) into the prerelease branch (`prerelease/<release-tag>`). **Merge this PR before going to `Step 1.2: Create release branch`**.
     1. This step will also create a file called `GROOMME.md` which should be deleted when completing the PR back into the pre-release branch to signify that the changelog has been manually groomed.
     1. See [tips for how to prune the generated changelog](./pruning-a-changelog.md) into a readable summary of the release.
 

--- a/docs/releases/creating-a-release.md
+++ b/docs/releases/creating-a-release.md
@@ -37,7 +37,7 @@ Use the [create-prerelease-branch](https://github.com/Azure/communication-ui-lib
 This section describes what the workflow above does. Understanding the workflow actions is useful in case the workflow fails.
 
 1. Create a `prerelease/<release-tag>` branch, bump the package version for `@azure/communication-react` as appropriate and collect all change files into a changelog.
-1. Creates another branch for manually summarizing the changes collected in the changelog and ~~opens a Pull Request into the `prerelease/<release-tag>`~~ you must open a PR manually of this new branch (`groom-changelog/<release-tag>`) into the prerelease branch (`prerelease/<release-tag>`). **Merge this PR before going to step 1.2**.
+1. Creates another branch for manually summarizing the changes collected in the changelog and ~~opens a Pull Request into the `prerelease/<release-tag>`~~ per [security policy](https://aka.ms/opensource/actions-changes-230217) you must open a PR manually of this new branch (`groom-changelog/<release-tag>`) into the prerelease branch (`prerelease/<release-tag>`). **Merge this PR before going to step 1.2**.
     1. This step will also create a file called `GROOMME.md` which should be deleted when completing the PR back into the pre-release branch to signify that the changelog has been manually groomed.
     1. See [tips for how to prune the generated changelog](./pruning-a-changelog.md) into a readable summary of the release.
 
@@ -74,7 +74,7 @@ This section describes what the workflow above does. Understanding the workflow 
   2. The action will synchronize the package telemetry verions on the release branch.
   3. After making these changes it will make a PR from the pre-release branch back into `main`.
 
-Continuing the example above, this action should be triggered once `groom_changelog_3.0.0` is merged. It will create the following new branches ~~and Pull Requests~~:
+Continuing the example above, this action should be triggered once `groom_changelog_3.0.0` is merged. It will create the following new branches ~~and Pull Requests~~ (Pull requests must now be created manually per [security policy](https://aka.ms/opensource/actions-changes-230217)):
 
 ```mermaid
 graph LR


### PR DESCRIPTION
# What
* No longer create PRs during release actions.
* Update workflow to instead have some text where the PR creation was
* Update release instructions to do this manually

# Why
Due to a security issue we can no longer have github actions put up PRs:
![image](https://user-images.githubusercontent.com/2684369/220460983-aeaabd6a-4b31-472d-918c-cdce2e0bcf78.png)
https://aka.ms/opensource/actions-changes-230217

# How Tested
n/a