### PR TITLE
[Vertical Galleries] Update styles to allow tile vertical resizing

### DIFF
--- a/packages/react-components/src/components/VerticalGallery.tsx
+++ b/packages/react-components/src/components/VerticalGallery.tsx
@@ -111,7 +111,7 @@ export const VerticalGallery = (props: VerticalGalleryProps): JSX.Element => {
   }, [page, numberOfChildren, lastPage, showButtons]);
 
   const childContainerStyle = useMemo(() => {
-    return { root: childrenContainerStyle };
+    return { root: childrenContainerStyle(2) };
   }, []);
 
   const childrenStyles = useMemo(() => {

--- a/packages/react-components/src/components/VideoGallery/styles/VideoGalleryResponsiveVerticalGallery.styles.ts
+++ b/packages/react-components/src/components/VideoGallery/styles/VideoGalleryResponsiveVerticalGallery.styles.ts
@@ -39,7 +39,9 @@ export const VERTICAL_GALLERY_TILE_STYLE = {
   minHeight: `${VERTICAL_GALLERY_TILE_SIZE_REM.minHeight}rem`,
   minWidth: `${VERTICAL_GALLERY_TILE_SIZE_REM.width}rem`,
   maxHeight: `${VERTICAL_GALLERY_TILE_SIZE_REM.maxHeight}rem`,
-  maxWidth: `${VERTICAL_GALLERY_TILE_SIZE_REM.width}rem`
+  maxWidth: `${VERTICAL_GALLERY_TILE_SIZE_REM.width}rem`,
+  width: '100%',
+  height: '100%'
 };
 /**
  * @private

--- a/packages/react-components/src/components/styles/VerticalGallery.styles.ts
+++ b/packages/react-components/src/components/styles/VerticalGallery.styles.ts
@@ -13,9 +13,12 @@ export const VERTICAL_GALLERY_GAP = 0.5;
 /**
  * @private
  */
-export const childrenContainerStyle: IStyle = {
-  width: '100%',
-  gap: `${VERTICAL_GALLERY_GAP}rem`
+export const childrenContainerStyle = (pageControlBarHeight: number): IStyle => {
+  return {
+    width: '100%',
+    height: `calc(100% - ${pageControlBarHeight + VERTICAL_GALLERY_GAP}rem)`,
+    gap: `${VERTICAL_GALLERY_GAP}rem`
+  };
 };
 
 /**


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Allows the remote video tiles to resize on their own up to the max of 144px creating a 1:1 aspect ratio
![image](https://user-images.githubusercontent.com/94866715/221714505-b059d782-2d53-4ac6-b77a-e244f774a48c.png)
![image](https://user-images.githubusercontent.com/94866715/221714512-293d23fb-f26a-4af7-a4a8-a9427771c98f.png)

# Why
<!--- What problem does this change solve? -->
Allows for tiles to resize to show more room for the remote participant.
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3151611
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran locally in storybook, will add hermetic tests to check the client heights of the tiles to make sure they are the right size.