### PR TITLE
[bugfix][storybook] Update Calling Custom Data Model Example's userId identifier

### DIFF
--- a/change-beta/@azure-communication-react-b53e8f77-e59f-44cc-a569-fb73e3f4c750.json
+++ b/change-beta/@azure-communication-react-b53e8f77-e59f-44cc-a569-fb73e3f4c750.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update storybook custom data model calling example to wrap userId as an identifier",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-b53e8f77-e59f-44cc-a569-fb73e3f4c750.json
+++ b/change/@azure-communication-react-b53e8f77-e59f-44cc-a569-fb73e3f4c750.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update storybook custom data model calling example to wrap userId as an identifier",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/CallComposite/CustomDataModelExample.stories.tsx
+++ b/packages/storybook/stories/CallComposite/CustomDataModelExample.stories.tsx
@@ -30,7 +30,7 @@ const CustomDataModelStory = (args: ArgsFrom<typeof storyControls>, context): JS
   const containerProps = useMemo(() => {
     if (args.userId && args.token) {
       const containerProps = {
-        userId: args.userId,
+        userId: { communicationUserId: args.userId },
         token: args.token,
         locator: createGUID()
       };


### PR DESCRIPTION
# What
Wrap userId as a communicationIdentifier

# Why
Calling Custom Data Model Example failed to initialize cause userId was being passed in a string and not a proper identifier.
https://skype.visualstudio.com/SPOOL/_workitems/edit/3166070

# How Tested
Locally ran storybook on macOS

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->