### PR TITLE
[VerticalGallery bugfix] Overflow participants showing video streams on different pages

### DIFF
--- a/change-beta/@azure-communication-react-2145cbc1-9060-4898-b40d-321f83de5a68.json
+++ b/change-beta/@azure-communication-react-2145cbc1-9060-4898-b40d-321f83de5a68.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update overflow gallery to render video tiles on multiple pages if video participants present.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-2145cbc1-9060-4898-b40d-321f83de5a68.json
+++ b/change/@azure-communication-react-2145cbc1-9060-4898-b40d-321f83de5a68.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update overflow gallery to render video tiles on multiple pages if video participants present.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/HorizontalGallery.tsx
+++ b/packages/react-components/src/components/HorizontalGallery.tsx
@@ -88,7 +88,7 @@ export const HorizontalGallery = (props: HorizontalGalleryProps): JSX.Element =>
         p,
         maxRemoteVideoStreams && maxRemoteVideoStreams >= 0
           ? p.videoStream?.isAvailable && activeVideoStreams++ < maxRemoteVideoStreams
-          : p.videoStream?.isAvailable
+          : false
       );
     });
 

--- a/packages/react-components/src/components/ResponsiveHorizontalGallery.tsx
+++ b/packages/react-components/src/components/ResponsiveHorizontalGallery.tsx
@@ -6,20 +6,30 @@ import React, { useRef } from 'react';
 import { HorizontalGallery, HorizontalGalleryStyles } from './HorizontalGallery';
 import { _convertRemToPx as convertRemToPx } from '@internal/acs-ui-common';
 import { _useContainerWidth } from './utils/responsive';
+import { VideoGalleryRemoteParticipant } from '../types';
 
 /**
  * Wrapped HorizontalGallery that adjusts the number of items per page based on the
  * available width obtained from a ResizeObserver, width per child, gap width, and button width
  */
 export const ResponsiveHorizontalGallery = (props: {
-  children: React.ReactNode;
+  galleryParticipants: VideoGalleryRemoteParticipant[];
   containerStyles: IStyle;
   horizontalGalleryStyles: HorizontalGalleryStyles;
   childWidthRem: number;
   gapWidthRem: number;
   buttonWidthRem?: number;
+  onRenderRemoteParticipant: (participant: VideoGalleryRemoteParticipant, isVideoParticipant?: boolean) => JSX.Element;
+  maxRemoteVideoStreams?: number;
 }): JSX.Element => {
-  const { childWidthRem, gapWidthRem, buttonWidthRem = 0 } = props;
+  const {
+    childWidthRem,
+    gapWidthRem,
+    buttonWidthRem = 0,
+    galleryParticipants,
+    maxRemoteVideoStreams,
+    onRenderRemoteParticipant
+  } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   const containerWidth = _useContainerWidth(containerRef);
 
@@ -27,7 +37,7 @@ export const ResponsiveHorizontalGallery = (props: {
   const rightPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingRight) : 0;
 
   const childrenPerPage = calculateChildrenPerPage({
-    numberOfChildren: React.Children.count(props.children),
+    numberOfChildren: galleryParticipants.length,
     containerWidth: (containerWidth ?? 0) - leftPadding - rightPadding,
     childWidthRem,
     gapWidthRem,
@@ -36,9 +46,13 @@ export const ResponsiveHorizontalGallery = (props: {
 
   return (
     <div ref={containerRef} className={mergeStyles(props.containerStyles)}>
-      <HorizontalGallery childrenPerPage={childrenPerPage} styles={props.horizontalGalleryStyles}>
-        {props.children}
-      </HorizontalGallery>
+      <HorizontalGallery
+        childrenPerPage={childrenPerPage}
+        galleryParticipants={galleryParticipants}
+        onRenderRemoteParticipant={onRenderRemoteParticipant}
+        maxRemoteVideoStreams={maxRemoteVideoStreams}
+        styles={props.horizontalGalleryStyles}
+      />
     </div>
   );
 };

--- a/packages/react-components/src/components/ResponsiveVerticalGallery.test.tsx
+++ b/packages/react-components/src/components/ResponsiveVerticalGallery.test.tsx
@@ -103,16 +103,15 @@ const mountResponsiveVerticalGallery = (attrs: {
   isShort?: boolean;
 }): ReactWrapper<ResponsiveVerticalGalleryProps> => {
   const { remoteParticipants, isShort } = attrs;
-  const tiles = remoteParticipants.map((p) => <VideoTile key={p.userId}></VideoTile>);
   return mount(
     <ResponsiveVerticalGallery
+      onRenderRemoteParticipant={(p) => <VideoTile key={p.userId}></VideoTile>}
+      galleryParticipants={remoteParticipants}
       containerStyles={verticalGalleryContainerStyle(true, false, !!isShort)}
       verticalGalleryStyles={{ children: LARGE_HORIZONTAL_GALLERY_TILE_STYLE }}
       gapHeightRem={HORIZONTAL_GALLERY_GAP}
       isShort
-    >
-      {tiles}
-    </ResponsiveVerticalGallery>
+    />
   );
 };
 

--- a/packages/react-components/src/components/ResponsiveVerticalGallery.tsx
+++ b/packages/react-components/src/components/ResponsiveVerticalGallery.tsx
@@ -67,7 +67,7 @@ export const ResponsiveVerticalGallery = (props: ResponsiveVerticalGalleryProps)
     controlBarHeight: controlBarHeightRem ?? 2,
     isShort: isShort ?? false
   });
-  console.log(childrenPerPage);
+
   return (
     <div ref={containerRef} className={mergeStyles(containerStyles)}>
       <VerticalGallery

--- a/packages/react-components/src/components/ResponsiveVerticalGallery.tsx
+++ b/packages/react-components/src/components/ResponsiveVerticalGallery.tsx
@@ -4,6 +4,7 @@
 import { IStyle, mergeStyles } from '@fluentui/react';
 import { _convertRemToPx } from '@internal/acs-ui-common';
 import React, { useRef } from 'react';
+import { VideoGalleryRemoteParticipant } from '../types';
 import { _useContainerHeight } from './utils/responsive';
 import { VerticalGallery, VerticalGalleryStyles } from './VerticalGallery';
 import {
@@ -18,7 +19,7 @@ import {
  */
 export interface ResponsiveVerticalGalleryProps {
   /** Video tiles to be rendered in the Vertical Gallery */
-  children: React.ReactNode;
+  galleryParticipants: VideoGalleryRemoteParticipant[];
   /** Styles for the Children space container */
   containerStyles: IStyle;
   /** Styles for the VerticalGallery component */
@@ -29,6 +30,10 @@ export interface ResponsiveVerticalGalleryProps {
   controlBarHeightRem?: number;
   /** container is shorter than 480 px. */
   isShort?: boolean;
+  /** Maximum number of video streams allowed based on amount left from grid view */
+  maxRemoteVideoStreams?: number;
+  /** Render function for the video tiles */
+  onRenderRemoteParticipant: (participant: VideoGalleryRemoteParticipant, isVideoParticipant?: boolean) => JSX.Element;
 }
 
 /**
@@ -39,7 +44,16 @@ export interface ResponsiveVerticalGalleryProps {
  * @beta
  */
 export const ResponsiveVerticalGallery = (props: ResponsiveVerticalGalleryProps): JSX.Element => {
-  const { children, containerStyles, verticalGalleryStyles, gapHeightRem, controlBarHeightRem, isShort } = props;
+  const {
+    containerStyles,
+    verticalGalleryStyles,
+    gapHeightRem,
+    controlBarHeightRem,
+    isShort,
+    galleryParticipants,
+    onRenderRemoteParticipant,
+    maxRemoteVideoStreams
+  } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   const containerHeight = _useContainerHeight(containerRef);
 
@@ -47,17 +61,22 @@ export const ResponsiveVerticalGallery = (props: ResponsiveVerticalGalleryProps)
   const bottomPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingBottom) : 0;
 
   const childrenPerPage = calculateChildrenPerPage({
-    numberOfChildren: React.Children.count(children),
+    numberOfChildren: galleryParticipants.length,
     containerHeight: (containerHeight ?? 0) - topPadding - bottomPadding,
     gapHeightRem,
     controlBarHeight: controlBarHeightRem ?? 2,
     isShort: isShort ?? false
   });
+  console.log(childrenPerPage);
   return (
     <div ref={containerRef} className={mergeStyles(containerStyles)}>
-      <VerticalGallery childrenPerPage={childrenPerPage} styles={verticalGalleryStyles}>
-        {children}
-      </VerticalGallery>
+      <VerticalGallery
+        galleryParticipants={galleryParticipants}
+        onRenderRemoteParticipant={onRenderRemoteParticipant}
+        childrenPerPage={childrenPerPage}
+        styles={verticalGalleryStyles}
+        maxRemoteVideoStreams={maxRemoteVideoStreams}
+      />
     </div>
   );
 };

--- a/packages/react-components/src/components/VerticalGallery.tsx
+++ b/packages/react-components/src/components/VerticalGallery.tsx
@@ -113,8 +113,6 @@ export const VerticalGallery = (props: VerticalGalleryProps): JSX.Element => {
     return bucketize(galleryParticipants, childrenPerPage);
   }, [galleryParticipants, childrenPerPage]);
 
-  console.log(paginatedChildren);
-
   const firstIndexOfCurrentPage = (page - 1) * childrenPerPage;
   const clippedPage = firstIndexOfCurrentPage < numberOfChildren - 1 ? page : lastPage;
   const childrenOnCurrentPage = paginatedChildren[clippedPage - 1];

--- a/packages/react-components/src/components/VerticalGallery.tsx
+++ b/packages/react-components/src/components/VerticalGallery.tsx
@@ -124,7 +124,7 @@ export const VerticalGallery = (props: VerticalGalleryProps): JSX.Element => {
         p,
         maxRemoteVideoStreams && maxRemoteVideoStreams >= 0
           ? p.videoStream?.isAvailable && activeVideoStreams++ < maxRemoteVideoStreams
-          : p.videoStream?.isAvailable
+          : false
       );
     });
 

--- a/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
@@ -66,21 +66,12 @@ export const DefaultLayout = (props: DefaultLayoutProps): JSX.Element => {
     );
   });
 
-  const horizontalGalleryTiles = horizontalGalleryParticipants.map((p) => {
-    return onRenderRemoteParticipant(
-      p,
-      maxRemoteVideoStreams && maxRemoteVideoStreams >= 0
-        ? p.videoStream?.isAvailable && activeVideoStreams++ < maxRemoteVideoStreams
-        : p.videoStream?.isAvailable
-    );
-  });
-
   if (localVideoComponent) {
     gridTiles.push(localVideoComponent);
   }
 
   const overflowGallery = useMemo(() => {
-    if (horizontalGalleryTiles.length === 0) {
+    if (horizontalGalleryParticipants.length === 0) {
       return null;
     }
     return (
@@ -89,7 +80,9 @@ export const DefaultLayout = (props: DefaultLayoutProps): JSX.Element => {
         /* @conditional-compile-remove(vertical-gallery) */
         isShort={isShort}
         shouldFloatLocalVideo={false}
-        overflowGalleryElements={horizontalGalleryTiles}
+        remoteParticipants={horizontalGalleryParticipants}
+        onRenderRemoteParticipant={onRenderRemoteParticipant}
+        maxRemoteVideoStreams={maxRemoteVideoStreams - activeVideoStreams}
         horizontalGalleryStyles={styles?.horizontalGallery}
         /* @conditional-compile-remove(vertical-gallery) */
         veritcalGalleryStyles={styles?.verticalGallery}
@@ -100,8 +93,10 @@ export const DefaultLayout = (props: DefaultLayoutProps): JSX.Element => {
   }, [
     isNarrow,
     /* @conditional-compile-remove(vertical-gallery) */ isShort,
-    horizontalGalleryTiles,
     styles?.horizontalGallery,
+    horizontalGalleryParticipants,
+    onRenderRemoteParticipant,
+    activeVideoStreams,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout,
     /* @conditional-compile-remove(vertical-gallery) */ styles?.verticalGallery
   ]);

--- a/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
@@ -98,7 +98,8 @@ export const DefaultLayout = (props: DefaultLayoutProps): JSX.Element => {
     onRenderRemoteParticipant,
     activeVideoStreams,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout,
-    /* @conditional-compile-remove(vertical-gallery) */ styles?.verticalGallery
+    /* @conditional-compile-remove(vertical-gallery) */ styles?.verticalGallery,
+    maxRemoteVideoStreams
   ]);
 
   return (

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -98,15 +98,6 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     gridTiles.push(localVideoComponent);
   }
 
-  const horizontalGalleryTiles = horizontalGalleryParticipants.map((p) => {
-    return onRenderRemoteParticipant(
-      p,
-      maxRemoteVideoStreams && maxRemoteVideoStreams >= 0
-        ? p.videoStream?.isAvailable && activeVideoStreams++ < maxRemoteVideoStreams
-        : p.videoStream?.isAvailable
-    );
-  });
-
   const layerHostId = useId('layerhost');
 
   const localVideoSize = useMemo(() => {
@@ -114,7 +105,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
       return SMALL_FLOATING_MODAL_SIZE_PX;
     }
     /* @conditional-compile-remove(vertical-gallery) */
-    if (horizontalGalleryTiles.length > 0 && overflowGalleryLayout === 'VerticalRight') {
+    if (horizontalGalleryParticipants.length > 0 && overflowGalleryLayout === 'VerticalRight') {
       return isNarrow
         ? SMALL_FLOATING_MODAL_SIZE_PX
         : isShort
@@ -123,7 +114,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     }
     return LARGE_FLOATING_MODAL_SIZE_PX;
   }, [
-    horizontalGalleryTiles.length,
+    horizontalGalleryParticipants.length,
     isNarrow,
     /* @conditional-compile-remove(vertical-gallery) */ isShort,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout
@@ -141,7 +132,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
         >
           {localVideoComponent}
         </Stack>
-      ) : horizontalGalleryTiles.length > 0 ? (
+      ) : horizontalGalleryParticipants.length > 0 ? (
         <Stack className={mergeStyles(localVideoTileContainerStyle(theme, localVideoSize))}>
           {localVideoComponent}
         </Stack>
@@ -157,16 +148,19 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     ) : undefined;
 
   const overflowGallery = useMemo(() => {
-    if (horizontalGalleryTiles.length === 0) {
+    if (horizontalGalleryParticipants.length === 0) {
       return null;
     }
     return (
       <OverflowGallery
+        onRenderRemoteParticipant={onRenderRemoteParticipant}
         /* @conditional-compile-remove(vertical-gallery) */
         isShort={isShort}
         isNarrow={isNarrow}
         shouldFloatLocalVideo={true}
-        overflowGalleryElements={horizontalGalleryTiles}
+        maxRemoteVideoStreams={maxRemoteVideoStreams && maxRemoteVideoStreams - activeVideoStreams}
+        remoteParticipants={horizontalGalleryParticipants}
+        // overflowGalleryElements={horizontalGalleryTiles}
         horizontalGalleryStyles={styles?.horizontalGallery}
         /* @conditional-compile-remove(vertical-gallery) */
         veritcalGalleryStyles={styles?.verticalGallery}
@@ -175,9 +169,11 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
       />
     );
   }, [
+    onRenderRemoteParticipant,
     isNarrow,
+    maxRemoteVideoStreams,
     /* @conditional-compile-remove(vertical-gallery) */ isShort,
-    horizontalGalleryTiles,
+    horizontalGalleryParticipants,
     styles?.horizontalGallery,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout,
     /* @conditional-compile-remove(vertical-gallery) */ styles?.verticalGallery

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -58,7 +58,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     screenShareComponent,
     onRenderRemoteParticipant,
     styles,
-    maxRemoteVideoStreams = 4,
+    maxRemoteVideoStreams,
     showCameraSwitcherInLocalPreview,
     parentWidth,
     parentHeight,
@@ -171,7 +171,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
   }, [
     onRenderRemoteParticipant,
     isNarrow,
-    maxRemoteVideoStreams,
+    activeVideoStreams,
     /* @conditional-compile-remove(vertical-gallery) */ isShort,
     horizontalGalleryParticipants,
     styles?.horizontalGallery,

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -58,7 +58,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     screenShareComponent,
     onRenderRemoteParticipant,
     styles,
-    maxRemoteVideoStreams,
+    maxRemoteVideoStreams = 4,
     showCameraSwitcherInLocalPreview,
     parentWidth,
     parentHeight,
@@ -158,7 +158,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
         isShort={isShort}
         isNarrow={isNarrow}
         shouldFloatLocalVideo={true}
-        maxRemoteVideoStreams={maxRemoteVideoStreams && maxRemoteVideoStreams - activeVideoStreams}
+        maxRemoteVideoStreams={maxRemoteVideoStreams - activeVideoStreams}
         remoteParticipants={horizontalGalleryParticipants}
         // overflowGalleryElements={horizontalGalleryTiles}
         horizontalGalleryStyles={styles?.horizontalGallery}

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -176,7 +176,8 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     horizontalGalleryParticipants,
     styles?.horizontalGallery,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout,
-    /* @conditional-compile-remove(vertical-gallery) */ styles?.verticalGallery
+    /* @conditional-compile-remove(vertical-gallery) */ styles?.verticalGallery,
+    maxRemoteVideoStreams
   ]);
 
   return (

--- a/packages/react-components/src/components/VideoGallery/Layout.ts
+++ b/packages/react-components/src/components/VideoGallery/Layout.ts
@@ -30,7 +30,7 @@ export interface LayoutProps {
    * Maximum number of participant remote video streams that is rendered.
    * @defaultValue 4
    */
-  maxRemoteVideoStreams?: number;
+  maxRemoteVideoStreams: number;
   /**
    * Width of parent element
    */

--- a/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
@@ -133,8 +133,9 @@ export const OverflowGallery = (props: {
       }
       buttonWidthRem={HORIZONTAL_GALLERY_BUTTON_WIDTH}
       gapWidthRem={HORIZONTAL_GALLERY_GAP}
-    >
-      {overflowGalleryTiles}
-    </ResponsiveHorizontalGallery>
+      galleryParticipants={remoteParticipants}
+      onRenderRemoteParticipant={onRenderRemoteParticipant}
+      maxRemoteVideoStreams={maxRemoteVideoStreams}
+    />
   );
 };

--- a/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
@@ -3,6 +3,7 @@
 
 import { concatStyleSets } from '@fluentui/react';
 import React, { useMemo } from 'react';
+import { VideoGalleryRemoteParticipant } from '../../types';
 import { HorizontalGalleryStyles } from '../HorizontalGallery';
 import { ResponsiveHorizontalGallery } from '../ResponsiveHorizontalGallery';
 /* @conditional-compile-remove(vertical-gallery) */
@@ -32,11 +33,14 @@ import {
  * @private
  */
 export const OverflowGallery = (props: {
+  onRenderRemoteParticipant: (participant: VideoGalleryRemoteParticipant, isVideoParticipant?: boolean) => JSX.Element;
   shouldFloatLocalVideo?: boolean;
   isNarrow?: boolean;
   /* @conditional-compile-remove(vertical-gallery) */
   isShort?: boolean;
-  overflowGalleryElements?: JSX.Element[];
+  remoteParticipants: VideoGalleryRemoteParticipant[];
+  maxRemoteVideoStreams?: number;
+  // overflowGalleryElements?: JSX.Element[];
   horizontalGalleryStyles?: HorizontalGalleryStyles;
   /* @conditional-compile-remove(vertical-gallery) */
   veritcalGalleryStyles?: VerticalGalleryStyles;
@@ -44,15 +48,20 @@ export const OverflowGallery = (props: {
   overflowGalleryLayout?: OverflowGalleryLayout;
 }): JSX.Element => {
   const {
+    onRenderRemoteParticipant,
     shouldFloatLocalVideo = false,
     isNarrow = false,
     /* @conditional-compile-remove(vertical-gallery) */
     isShort = false,
-    overflowGalleryElements,
+    // overflowGalleryElements,
+    remoteParticipants,
+    maxRemoteVideoStreams,
     horizontalGalleryStyles,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout = 'HorizontalBottom',
     /* @conditional-compile-remove(vertical-gallery) */ veritcalGalleryStyles
   } = props;
+
+  let activeVideoStreams = 0;
 
   const containerStyles = useMemo(() => {
     /* @conditional-compile-remove(vertical-gallery) */
@@ -66,6 +75,17 @@ export const OverflowGallery = (props: {
     isNarrow,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout
   ]);
+
+  const overflowGalleryTiles =
+    remoteParticipants &&
+    remoteParticipants.map((p) => {
+      return onRenderRemoteParticipant(
+        p,
+        maxRemoteVideoStreams && maxRemoteVideoStreams >= 0
+          ? p.videoStream?.isAvailable && activeVideoStreams++ < maxRemoteVideoStreams
+          : p.videoStream?.isAvailable
+      );
+    });
 
   const galleryStyles = useMemo(() => {
     /* @conditional-compile-remove(vertical-gallery) */
@@ -82,7 +102,7 @@ export const OverflowGallery = (props: {
   ]);
 
   /* @conditional-compile-remove(vertical-gallery) */
-  if (overflowGalleryLayout === 'VerticalRight') {
+  if (overflowGalleryLayout === 'VerticalRight' && remoteParticipants) {
     return (
       <ResponsiveVerticalGallery
         key="responsive-vertical-gallery"
@@ -91,15 +111,16 @@ export const OverflowGallery = (props: {
         controlBarHeightRem={HORIZONTAL_GALLERY_BUTTON_WIDTH}
         gapHeightRem={HORIZONTAL_GALLERY_GAP}
         isShort={isShort}
-      >
-        {overflowGalleryElements}
-      </ResponsiveVerticalGallery>
+        galleryParticipants={remoteParticipants}
+        onRenderRemoteParticipant={onRenderRemoteParticipant}
+        maxRemoteVideoStreams={maxRemoteVideoStreams}
+      />
     );
   }
 
   /* @conditional-compile-remove(pinned-participants) */
   if (isNarrow) {
-    return <ScrollableHorizontalGallery horizontalGalleryElements={overflowGalleryElements} />;
+    return <ScrollableHorizontalGallery horizontalGalleryElements={overflowGalleryTiles} />;
   }
 
   return (
@@ -113,7 +134,7 @@ export const OverflowGallery = (props: {
       buttonWidthRem={HORIZONTAL_GALLERY_BUTTON_WIDTH}
       gapWidthRem={HORIZONTAL_GALLERY_GAP}
     >
-      {overflowGalleryElements}
+      {overflowGalleryTiles}
     </ResponsiveHorizontalGallery>
   );
 };

--- a/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
@@ -39,7 +39,7 @@ export const OverflowGallery = (props: {
   /* @conditional-compile-remove(vertical-gallery) */
   isShort?: boolean;
   remoteParticipants: VideoGalleryRemoteParticipant[];
-  maxRemoteVideoStreams?: number;
+  maxRemoteVideoStreams: number;
   // overflowGalleryElements?: JSX.Element[];
   horizontalGalleryStyles?: HorizontalGalleryStyles;
   /* @conditional-compile-remove(vertical-gallery) */

--- a/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
@@ -61,8 +61,6 @@ export const OverflowGallery = (props: {
     /* @conditional-compile-remove(vertical-gallery) */ veritcalGalleryStyles
   } = props;
 
-  let activeVideoStreams = 0;
-
   const containerStyles = useMemo(() => {
     /* @conditional-compile-remove(vertical-gallery) */
     if (overflowGalleryLayout === 'VerticalRight') {
@@ -75,17 +73,6 @@ export const OverflowGallery = (props: {
     isNarrow,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout
   ]);
-
-  const overflowGalleryTiles =
-    remoteParticipants &&
-    remoteParticipants.map((p) => {
-      return onRenderRemoteParticipant(
-        p,
-        maxRemoteVideoStreams && maxRemoteVideoStreams >= 0
-          ? p.videoStream?.isAvailable && activeVideoStreams++ < maxRemoteVideoStreams
-          : p.videoStream?.isAvailable
-      );
-    });
 
   const galleryStyles = useMemo(() => {
     /* @conditional-compile-remove(vertical-gallery) */
@@ -120,7 +107,13 @@ export const OverflowGallery = (props: {
 
   /* @conditional-compile-remove(pinned-participants) */
   if (isNarrow) {
-    return <ScrollableHorizontalGallery horizontalGalleryElements={overflowGalleryTiles} />;
+    return (
+      <ScrollableHorizontalGallery
+        galleryparticipants={remoteParticipants}
+        onRenderRemoteParticipant={onRenderRemoteParticipant}
+        maxRemoteVideoStreams={maxRemoteVideoStreams}
+      />
+    );
   }
 
   return (

--- a/packages/react-components/src/components/VideoGallery/ScrollableHorizontalGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/ScrollableHorizontalGallery.tsx
@@ -32,7 +32,7 @@ export const ScrollableHorizontalGallery = (props: {
         p,
         maxRemoteVideoStreams && maxRemoteVideoStreams >= 0
           ? p.videoStream?.isAvailable && activeVideoStreams++ < maxRemoteVideoStreams
-          : p.videoStream?.isAvailable
+          : false
       );
     });
 

--- a/packages/react-components/src/components/VideoGallery/ScrollableHorizontalGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/ScrollableHorizontalGallery.tsx
@@ -4,6 +4,7 @@
 import { Stack } from '@fluentui/react';
 import React, { useRef } from 'react';
 import { useDraggable } from 'react-use-draggable-scroll';
+import { VideoGalleryRemoteParticipant } from '../../types';
 import {
   scrollableHorizontalGalleryContainerStyles,
   scrollableHorizontalGalleryStyles
@@ -13,11 +14,27 @@ import {
  * Component to display elements horizontally in a scrollable container
  * @private
  */
-export const ScrollableHorizontalGallery = (props: { horizontalGalleryElements?: JSX.Element[] }): JSX.Element => {
-  const { horizontalGalleryElements } = props;
+export const ScrollableHorizontalGallery = (props: {
+  galleryparticipants: VideoGalleryRemoteParticipant[];
+  onRenderRemoteParticipant: (participant: VideoGalleryRemoteParticipant, isVideoParticipant?: boolean) => JSX.Element;
+  maxRemoteVideoStreams?: number;
+}): JSX.Element => {
+  const { galleryparticipants, onRenderRemoteParticipant, maxRemoteVideoStreams } = props;
 
   const ref = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLInputElement>;
   const { events: dragabbleEvents } = useDraggable(ref);
+  let activeVideoStreams = 0;
+
+  const overflowGalleryTiles =
+    galleryparticipants &&
+    galleryparticipants.map((p) => {
+      return onRenderRemoteParticipant(
+        p,
+        maxRemoteVideoStreams && maxRemoteVideoStreams >= 0
+          ? p.videoStream?.isAvailable && activeVideoStreams++ < maxRemoteVideoStreams
+          : p.videoStream?.isAvailable
+      );
+    });
 
   return (
     <div ref={ref} {...dragabbleEvents} className={scrollableHorizontalGalleryContainerStyles}>
@@ -27,7 +44,7 @@ export const ScrollableHorizontalGallery = (props: { horizontalGalleryElements?:
         styles={scrollableHorizontalGalleryStyles}
         tokens={{ childrenGap: '0.5rem' }}
       >
-        {horizontalGalleryElements}
+        {overflowGalleryTiles}
       </Stack>
     </div>
   );


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
![image](https://user-images.githubusercontent.com/94866715/224447593-799612b7-de03-4516-8445-b77679eaeacb.png)
![image](https://user-images.githubusercontent.com/94866715/224447602-febae409-9c5d-418c-ba36-e8504fd8d7e6.png)

# Why
<!--- What problem does this change solve? -->
Allows video participants on other pages to have their streams rendered
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3115448
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran locally in samples and on mobile device.