### PR TITLE
Correct MessageThread API definition and underlying logic

### DIFF
--- a/change-beta/@azure-communication-react-3e9cd036-f8fa-4914-9d4d-9677bd166a14.json
+++ b/change-beta/@azure-communication-react-3e9cd036-f8fa-4914-9d4d-9677bd166a14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Correct MessageThread API definition",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-3e9cd036-f8fa-4914-9d4d-9677bd166a14.json
+++ b/change/@azure-communication-react-3e9cd036-f8fa-4914-9d4d-9677bd166a14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Correct MessageThread API definition",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2496,7 +2496,7 @@ export type MessageThreadProps = {
     onRenderFileDownloads?: (userId: string, message: ChatMessage) => JSX.Element;
     onUpdateMessage?: UpdateMessageCallback;
     onDeleteMessage?: (messageId: string) => Promise<void>;
-    onSendMessage?: (messageId: string) => Promise<void>;
+    onSendMessage?: (content: string) => Promise<void>;
     disableEditing?: boolean;
     strings?: Partial<MessageThreadStrings>;
     fileDownloadHandler?: FileDownloadHandler;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -1907,7 +1907,7 @@ export type MessageThreadProps = {
     onRenderMessage?: (messageProps: MessageProps, messageRenderer?: MessageRenderer) => JSX.Element;
     onUpdateMessage?: UpdateMessageCallback;
     onDeleteMessage?: (messageId: string) => Promise<void>;
-    onSendMessage?: (messageId: string) => Promise<void>;
+    onSendMessage?: (content: string) => Promise<void>;
     disableEditing?: boolean;
     strings?: Partial<MessageThreadStrings>;
 };

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1084,7 +1084,7 @@ export type MessageThreadProps = {
     onRenderFileDownloads?: (userId: string, message: ChatMessage) => JSX.Element;
     onUpdateMessage?: UpdateMessageCallback;
     onDeleteMessage?: (messageId: string) => Promise<void>;
-    onSendMessage?: (messageId: string) => Promise<void>;
+    onSendMessage?: (content: string) => Promise<void>;
     disableEditing?: boolean;
     strings?: Partial<MessageThreadStrings>;
     fileDownloadHandler?: FileDownloadHandler;

--- a/packages/react-components/review/stable/react-components.api.md
+++ b/packages/react-components/review/stable/react-components.api.md
@@ -910,7 +910,7 @@ export type MessageThreadProps = {
     onRenderMessage?: (messageProps: MessageProps, messageRenderer?: MessageRenderer) => JSX.Element;
     onUpdateMessage?: UpdateMessageCallback;
     onDeleteMessage?: (messageId: string) => Promise<void>;
-    onSendMessage?: (messageId: string) => Promise<void>;
+    onSendMessage?: (content: string) => Promise<void>;
     disableEditing?: boolean;
     strings?: Partial<MessageThreadStrings>;
 };

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponent.tsx
@@ -75,7 +75,7 @@ export const ChatMessageComponent = (props: ChatMessageComponentProps): JSX.Elem
 
   const onEditClick = useCallback(() => setIsEditing(true), [setIsEditing]);
 
-  const { onDeleteMessage, onSendMessage, message } = props;
+  const { onDeleteMessage, onUpdateMessage, onSendMessage, message } = props;
   const onRemoveClick = useCallback(() => {
     if (onDeleteMessage && message.messageId) {
       onDeleteMessage(message.messageId);
@@ -86,9 +86,15 @@ export const ChatMessageComponent = (props: ChatMessageComponentProps): JSX.Elem
     }
   }, [message.messageId, message.clientMessageId, onDeleteMessage]);
   const onResendClick = useCallback(() => {
-    onDeleteMessage && message.clientMessageId && onDeleteMessage(message.clientMessageId);
-    onSendMessage && onSendMessage(message.content ?? '');
-  }, [message.clientMessageId, message.content, onSendMessage, onDeleteMessage]);
+    if (onUpdateMessage && message.messageId) {
+      // if the message has an ID, then it has been sent and so we need to update the existing,
+      // rather than the delete / send again flow
+      onUpdateMessage(message.messageId, message.content ?? '', message.metadata);
+    } else if (onDeleteMessage && onSendMessage && message.clientMessageId) {
+      onDeleteMessage(message.clientMessageId);
+      onSendMessage(message.content ?? message.clientMessageId ?? '');
+    }
+  }, [message.clientMessageId, message.content, onSendMessage, onDeleteMessage, onUpdateMessage]);
 
   if (props.message.messageType !== 'chat') {
     return <></>;

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponent.tsx
@@ -25,7 +25,7 @@ type ChatMessageComponentProps = {
     }
   ) => Promise<void>;
   /**
-   * Callback to delete a message. Also called when resending a message that failed to send.
+   * Callback to delete a message. Also called before resending a message that failed to send.
    * @param messageId ID of the message to delete
    */
   onDeleteMessage?: (messageId: string) => Promise<void>;

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponent.tsx
@@ -24,9 +24,14 @@ type ChatMessageComponentProps = {
       attachedFilesMetadata?: FileMetadata[];
     }
   ) => Promise<void>;
+  /**
+   * Callback to delete a message. Also called when resending a message that failed to send.
+   * @param messageId ID of the message to delete
+   */
   onDeleteMessage?: (messageId: string) => Promise<void>;
   /**
-   * Optional callback called when message is sent
+   * Callback to send a message
+   * @param content The message content to send
    */
   onSendMessage?: (content: string) => Promise<void>;
   strings: MessageThreadStrings;
@@ -75,7 +80,7 @@ export const ChatMessageComponent = (props: ChatMessageComponentProps): JSX.Elem
 
   const onEditClick = useCallback(() => setIsEditing(true), [setIsEditing]);
 
-  const { onDeleteMessage, onUpdateMessage, onSendMessage, message } = props;
+  const { onDeleteMessage, onSendMessage, message } = props;
   const onRemoveClick = useCallback(() => {
     if (onDeleteMessage && message.messageId) {
       onDeleteMessage(message.messageId);
@@ -86,15 +91,9 @@ export const ChatMessageComponent = (props: ChatMessageComponentProps): JSX.Elem
     }
   }, [message.messageId, message.clientMessageId, onDeleteMessage]);
   const onResendClick = useCallback(() => {
-    if (onUpdateMessage && message.messageId) {
-      // if the message has an ID, then it has been sent and so we need to update the existing,
-      // rather than the delete / send again flow
-      onUpdateMessage(message.messageId, message.content ?? '', message.metadata);
-    } else if (onDeleteMessage && onSendMessage && message.clientMessageId) {
-      onDeleteMessage(message.clientMessageId);
-      onSendMessage(message.content ?? message.clientMessageId ?? '');
-    }
-  }, [message.clientMessageId, message.content, onSendMessage, onDeleteMessage, onUpdateMessage]);
+    onDeleteMessage && message.clientMessageId && onDeleteMessage(message.clientMessageId);
+    onSendMessage && onSendMessage(message.content ?? '');
+  }, [message.clientMessageId, message.content, onSendMessage, onDeleteMessage]);
 
   if (props.message.messageType !== 'chat') {
     return <></>;

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -601,10 +601,10 @@ export type MessageThreadProps = {
   /**
    * Optional callback to send a message.
    *
-   * @param messageId - message id from chatClient
+   * @param content - message body to send
    *
    */
-  onSendMessage?: (messageId: string) => Promise<void>;
+  onSendMessage?: (content: string) => Promise<void>;
 
   /**
   /**


### PR DESCRIPTION
# What
The `MessageThread` component has an `onMessageSend` property, which is documented as passing the message ID.
This is not the case, it is passed through to the underlying component and the parameter is the message body to send

# Why
Sending the message needs the body to send, the API should behave in the same way as all the other onSendMessage implementations and should behave as documented.


# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->
