### PR TITLE
[VerticalGallery Bugfix] Video tile rendering controlled by index

### DIFF
--- a/packages/react-components/src/components/ResponsiveHorizontalGallery.tsx
+++ b/packages/react-components/src/components/ResponsiveHorizontalGallery.tsx
@@ -18,8 +18,9 @@ export const ResponsiveHorizontalGallery = (props: {
   childWidthRem: number;
   gapWidthRem: number;
   buttonWidthRem?: number;
+  setTilesToRender?: (indexes: number[]) => void;
 }): JSX.Element => {
-  const { childWidthRem, gapWidthRem, buttonWidthRem = 0 } = props;
+  const { childWidthRem, gapWidthRem, buttonWidthRem = 0, setTilesToRender } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   const containerWidth = _useContainerWidth(containerRef);
 
@@ -36,7 +37,11 @@ export const ResponsiveHorizontalGallery = (props: {
 
   return (
     <div ref={containerRef} className={mergeStyles(props.containerStyles)}>
-      <HorizontalGallery childrenPerPage={childrenPerPage} styles={props.horizontalGalleryStyles}>
+      <HorizontalGallery
+        childrenPerPage={childrenPerPage}
+        styles={props.horizontalGalleryStyles}
+        setTilesToRender={setTilesToRender}
+      >
         {props.children}
       </HorizontalGallery>
     </div>
@@ -87,5 +92,5 @@ const calculateChildrenPerPage = (args: {
   const childrenSpace = containerWidth - 2 * buttonWidth - 2 * gapWidth;
   // Now that we have childrenSpace width we can figure out how many children can fit in childrenSpace.
   // childrenSpace = n * childWidth + (n - 1) * gapWidth. Isolate n and take the floor.
-  return Math.floor((childrenSpace + gapWidth) / (childWidth + gapWidth));
+  return Math.max(Math.floor((childrenSpace + gapWidth) / (childWidth + gapWidth)), 1);
 };

--- a/packages/react-components/src/components/ResponsiveVerticalGallery.tsx
+++ b/packages/react-components/src/components/ResponsiveVerticalGallery.tsx
@@ -29,6 +29,8 @@ export interface ResponsiveVerticalGalleryProps {
   controlBarHeightRem?: number;
   /** container is shorter than 480 px. */
   isShort?: boolean;
+  /** Function to set which tiles to give video to in the children. */
+  setTilesToRender?: (indexes: number[]) => void;
 }
 
 /**
@@ -39,7 +41,15 @@ export interface ResponsiveVerticalGalleryProps {
  * @beta
  */
 export const ResponsiveVerticalGallery = (props: ResponsiveVerticalGalleryProps): JSX.Element => {
-  const { children, containerStyles, verticalGalleryStyles, gapHeightRem, controlBarHeightRem, isShort } = props;
+  const {
+    children,
+    containerStyles,
+    verticalGalleryStyles,
+    gapHeightRem,
+    controlBarHeightRem,
+    isShort,
+    setTilesToRender
+  } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   const containerHeight = _useContainerHeight(containerRef);
 
@@ -55,7 +65,11 @@ export const ResponsiveVerticalGallery = (props: ResponsiveVerticalGalleryProps)
   });
   return (
     <div ref={containerRef} className={mergeStyles(containerStyles)}>
-      <VerticalGallery childrenPerPage={childrenPerPage} styles={verticalGalleryStyles}>
+      <VerticalGallery
+        childrenPerPage={childrenPerPage}
+        styles={verticalGalleryStyles}
+        setTilesToRender={setTilesToRender}
+      >
         {children}
       </VerticalGallery>
     </div>

--- a/packages/react-components/src/components/VerticalGallery.tsx
+++ b/packages/react-components/src/components/VerticalGallery.tsx
@@ -106,10 +106,15 @@ export const VerticalGallery = (props: VerticalGalleryProps): JSX.Element => {
   const lastPage = Math.ceil(numberOfChildren / childrenPerPage);
   const childrenArray = React.Children.toArray(children);
 
-  const indexesArray: number[][] = bucketize([...Array(numberOfChildren).keys()], childrenPerPage);
-  if (setTilesToRender) {
-    setTilesToRender(indexesArray[page - 1]);
-  }
+  const indexesArray: number[][] = useMemo(() => {
+    return bucketize([...Array(numberOfChildren).keys()], childrenPerPage);
+  }, [numberOfChildren, childrenPerPage]);
+
+  useEffect(() => {
+    if (setTilesToRender && indexesArray) {
+      setTilesToRender(indexesArray[page - 1]);
+    }
+  }, [indexesArray, setTilesToRender, page]);
 
   const paginatedChildren: React.ReactNode[][] = useMemo(() => {
     return bucketize(childrenArray, childrenPerPage);

--- a/packages/react-components/src/components/VerticalGallery.tsx
+++ b/packages/react-components/src/components/VerticalGallery.tsx
@@ -74,6 +74,8 @@ export interface VerticalGalleryProps {
   childrenPerPage: number;
   /** Styles to customize the vertical gallery */
   styles?: VerticalGalleryStyles;
+  /** helper function to choose which tiles to give video to. */
+  setTilesToRender?: (indexes: number[]) => void;
 }
 
 interface VerticalGalleryControlBarProps {
@@ -92,7 +94,7 @@ interface VerticalGalleryControlBarProps {
  * @beta
  */
 export const VerticalGallery = (props: VerticalGalleryProps): JSX.Element => {
-  const { children, styles, childrenPerPage } = props;
+  const { children, styles, childrenPerPage, setTilesToRender } = props;
 
   const [page, setPage] = useState(1);
   const [buttonState, setButtonState] = useState<{ previous: boolean; next: boolean }>({ previous: true, next: true });
@@ -102,9 +104,15 @@ export const VerticalGallery = (props: VerticalGalleryProps): JSX.Element => {
 
   const numberOfChildren = React.Children.count(children);
   const lastPage = Math.ceil(numberOfChildren / childrenPerPage);
+  const childrenArray = React.Children.toArray(children);
+
+  const indexesArray: number[][] = bucketize([...Array(numberOfChildren).keys()], childrenPerPage);
+  if (setTilesToRender) {
+    setTilesToRender(indexesArray[page - 1]);
+  }
 
   const paginatedChildren: React.ReactNode[][] = useMemo(() => {
-    return bucketize(React.Children.toArray(children), childrenPerPage);
+    return bucketize(childrenArray, childrenPerPage);
   }, [children, childrenPerPage]);
 
   const firstIndexOfCurrentPage = (page - 1) * childrenPerPage;

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -3,7 +3,7 @@
 
 import { LayerHost, mergeStyles, Stack } from '@fluentui/react';
 import { useId } from '@fluentui/react-hooks';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTheme } from '../../theming';
 import { GridLayout } from '../GridLayout';
 import { isNarrowWidth } from '../utils/responsive';
@@ -98,11 +98,13 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     gridTiles.push(localVideoComponent);
   }
 
-  const horizontalGalleryTiles = horizontalGalleryParticipants.map((p) => {
+  const [indexesToRender, setIndexesToRender] = useState<number[]>([]);
+
+  const horizontalGalleryTiles = horizontalGalleryParticipants.map((p, i) => {
     return onRenderRemoteParticipant(
       p,
       maxRemoteVideoStreams && maxRemoteVideoStreams >= 0
-        ? p.videoStream?.isAvailable && activeVideoStreams++ < maxRemoteVideoStreams
+        ? p.videoStream?.isAvailable && indexesToRender.includes(i) && activeVideoStreams++ < maxRemoteVideoStreams
         : p.videoStream?.isAvailable
     );
   });
@@ -164,6 +166,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
       <OverflowGallery
         /* @conditional-compile-remove(vertical-gallery) */
         isShort={isShort}
+        setTilesToRender={setIndexesToRender}
         isNarrow={isNarrow}
         shouldFloatLocalVideo={true}
         overflowGalleryElements={horizontalGalleryTiles}

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -3,7 +3,7 @@
 
 import { LayerHost, mergeStyles, Stack } from '@fluentui/react';
 import { useId } from '@fluentui/react-hooks';
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTheme } from '../../theming';
 import { GridLayout } from '../GridLayout';
 import { isNarrowWidth } from '../utils/responsive';
@@ -98,7 +98,14 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     gridTiles.push(localVideoComponent);
   }
 
-  const [indexesToRender, setIndexesToRender] = useState<number[]>([]);
+  const [indexesToRender, setIndexesToRender] = useState<number[]>([0]);
+
+  const updateIndexes = useCallback(
+    (indexes: number[]): void => {
+      setIndexesToRender(indexes);
+    },
+    [setIndexesToRender]
+  );
 
   const horizontalGalleryTiles = horizontalGalleryParticipants.map((p, i) => {
     return onRenderRemoteParticipant(
@@ -166,7 +173,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
       <OverflowGallery
         /* @conditional-compile-remove(vertical-gallery) */
         isShort={isShort}
-        setTilesToRender={setIndexesToRender}
+        setTilesToRender={updateIndexes}
         isNarrow={isNarrow}
         shouldFloatLocalVideo={true}
         overflowGalleryElements={horizontalGalleryTiles}

--- a/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
@@ -109,6 +109,7 @@ export const OverflowGallery = (props: {
     <ResponsiveHorizontalGallery
       key="responsive-horizontal-gallery"
       containerStyles={containerStyles}
+      setTilesToRender={setTilesToRender}
       horizontalGalleryStyles={galleryStyles}
       childWidthRem={
         isNarrow ? SMALL_HORIZONTAL_GALLERY_TILE_SIZE_REM.width : LARGE_HORIZONTAL_GALLERY_TILE_SIZE_REM.width

--- a/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
@@ -102,7 +102,12 @@ export const OverflowGallery = (props: {
 
   /* @conditional-compile-remove(pinned-participants) */
   if (isNarrow) {
-    return <ScrollableHorizontalGallery horizontalGalleryElements={overflowGalleryElements} />;
+    return (
+      <ScrollableHorizontalGallery
+        horizontalGalleryElements={overflowGalleryElements}
+        setTilesToRender={setTilesToRender}
+      />
+    );
   }
 
   return (

--- a/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
@@ -33,6 +33,7 @@ import {
  */
 export const OverflowGallery = (props: {
   shouldFloatLocalVideo?: boolean;
+  setTilesToRender?: (indexes: number[]) => void;
   isNarrow?: boolean;
   /* @conditional-compile-remove(vertical-gallery) */
   isShort?: boolean;
@@ -45,6 +46,7 @@ export const OverflowGallery = (props: {
 }): JSX.Element => {
   const {
     shouldFloatLocalVideo = false,
+    setTilesToRender,
     isNarrow = false,
     /* @conditional-compile-remove(vertical-gallery) */
     isShort = false,
@@ -91,6 +93,7 @@ export const OverflowGallery = (props: {
         controlBarHeightRem={HORIZONTAL_GALLERY_BUTTON_WIDTH}
         gapHeightRem={HORIZONTAL_GALLERY_GAP}
         isShort={isShort}
+        setTilesToRender={setTilesToRender}
       >
         {overflowGalleryElements}
       </ResponsiveVerticalGallery>

--- a/packages/react-components/src/components/VideoGallery/ScrollableHorizontalGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/ScrollableHorizontalGallery.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Stack } from '@fluentui/react';
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useDraggable } from 'react-use-draggable-scroll';
 import {
   scrollableHorizontalGalleryContainerStyles,
@@ -13,8 +13,19 @@ import {
  * Component to display elements horizontally in a scrollable container
  * @private
  */
-export const ScrollableHorizontalGallery = (props: { horizontalGalleryElements?: JSX.Element[] }): JSX.Element => {
-  const { horizontalGalleryElements } = props;
+export const ScrollableHorizontalGallery = (props: {
+  horizontalGalleryElements?: JSX.Element[];
+  setTilesToRender?: (indexes: number[]) => void;
+}): JSX.Element => {
+  const { horizontalGalleryElements, setTilesToRender } = props;
+
+  const indexesArray = [...Array(horizontalGalleryElements?.length).keys()];
+
+  useEffect(() => {
+    if (setTilesToRender && indexesArray) {
+      setTilesToRender(indexesArray);
+    }
+  }, [indexesArray, setTilesToRender]);
 
   const ref = useRef<HTMLDivElement>() as React.MutableRefObject<HTMLInputElement>;
   const { events: dragabbleEvents } = useDraggable(ref);


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Create indexing array to determine which children are currently in view so the gallery layouts can determine when to render overflow video participants.
# Why
<!--- What problem does this change solve? -->
allows more users to see more video participants on each page of the vertical and horizontal gallery
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3115448
# How Tested
<!--- How did you test your change. What tests have you added. -->
Locally validated the functionality.