### PR TITLE
Video gallery show local tile and horizontal/vertical gallery when screensharing with no participant

### DIFF
--- a/packages/react-components/src/components/VerticalGallery.tsx
+++ b/packages/react-components/src/components/VerticalGallery.tsx
@@ -152,7 +152,7 @@ export const VerticalGallery = (props: VerticalGalleryProps): JSX.Element => {
   return (
     <Stack className={mergeStyles(rootStyle, styles?.root)}>
       <Stack styles={childContainerStyle}>
-        {childrenOnCurrentPage.map((child, i) => {
+        {childrenOnCurrentPage?.map((child, i) => {
           return (
             <Stack.Item
               key={i}

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -325,7 +325,10 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
   /* @conditional-compile-remove(pinned-participants) */
   const drawerMenuHostId = useId('drawerMenuHost', drawerMenuHostIdFromProp);
 
-  const shouldFloatLocalVideo = !!(layout === 'floatingLocalVideo' && remoteParticipants.length > 0);
+  const shouldFloatLocalVideo = !!(
+    (layout === 'floatingLocalVideo' && remoteParticipants.length > 0) ||
+    localParticipant.isScreenSharingOn
+  );
 
   const containerRef = useRef<HTMLDivElement>(null);
   const containerWidth = _useContainerWidth(containerRef);

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -92,7 +92,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     );
   });
 
-  const shouldFloatLocalVideo = remoteParticipants.length > 0;
+  const shouldFloatLocalVideo = remoteParticipants.length > 0 || !!screenShareComponent;
 
   if (!shouldFloatLocalVideo && localVideoComponent) {
     gridTiles.push(localVideoComponent);
@@ -114,7 +114,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
       return SMALL_FLOATING_MODAL_SIZE_PX;
     }
     /* @conditional-compile-remove(vertical-gallery) */
-    if (horizontalGalleryTiles.length > 0 && overflowGalleryLayout === 'VerticalRight') {
+    if ((horizontalGalleryTiles.length > 0 || !!screenShareComponent) && overflowGalleryLayout === 'VerticalRight') {
       return isNarrow
         ? SMALL_FLOATING_MODAL_SIZE_PX
         : isShort
@@ -126,7 +126,8 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     horizontalGalleryTiles.length,
     isNarrow,
     /* @conditional-compile-remove(vertical-gallery) */ isShort,
-    /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout
+    /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout,
+    /* @conditional-compile-remove(vertical-gallery) */ screenShareComponent
   ]);
 
   const wrappedLocalVideoComponent =
@@ -141,7 +142,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
         >
           {localVideoComponent}
         </Stack>
-      ) : horizontalGalleryTiles.length > 0 ? (
+      ) : horizontalGalleryTiles.length > 0 || !!screenShareComponent ? (
         <Stack className={mergeStyles(localVideoTileContainerStyle(theme, localVideoSize))}>
           {localVideoComponent}
         </Stack>
@@ -157,7 +158,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     ) : undefined;
 
   const overflowGallery = useMemo(() => {
-    if (horizontalGalleryTiles.length === 0) {
+    if (horizontalGalleryTiles.length === 0 && !screenShareComponent) {
       return null;
     }
     return (
@@ -179,6 +180,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     /* @conditional-compile-remove(vertical-gallery) */ isShort,
     horizontalGalleryTiles,
     styles?.horizontalGallery,
+    screenShareComponent,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryLayout,
     /* @conditional-compile-remove(vertical-gallery) */ styles?.verticalGallery
   ]);

--- a/packages/react-components/src/components/VideoGallery/styles/VideoGalleryResponsiveVerticalGallery.styles.ts
+++ b/packages/react-components/src/components/VideoGallery/styles/VideoGalleryResponsiveVerticalGallery.styles.ts
@@ -35,6 +35,8 @@ export const VERTICAL_GALLERY_TILE_SIZE_REM = { minHeight: 6.75, maxHeight: 11, 
  *
  * width is being increased by 1rem to account for the gap width desired for the VerticalGallery.
  *
+ * Add 1.5 rem on width to account for horizontal padding
+ *
  * @param shouldFloatLocalVideo whether rendered in floating layout or not
  * @returns Style set for VerticalGallery container.
  */
@@ -45,20 +47,20 @@ export const verticalGalleryContainerStyle = (
 ): IStyle => {
   return isNarrow && isShort
     ? {
-        width: `${SHORT_VERTICAL_GALLERY_TILE_SIZE_REM.width}rem`,
+        width: `${SHORT_VERTICAL_GALLERY_TILE_SIZE_REM.width + 1.5}rem`,
         height: shouldFloatLocalVideo ? `calc(100% - ${_pxToRem(SMALL_FLOATING_MODAL_SIZE_PX.height)})` : '100%',
         paddingBottom: '0.5rem'
       }
     : !isNarrow && isShort
     ? {
-        width: `${SHORT_VERTICAL_GALLERY_TILE_SIZE_REM.width}rem`,
+        width: `${SHORT_VERTICAL_GALLERY_TILE_SIZE_REM.width + 1.5}rem`,
         height: shouldFloatLocalVideo
           ? `calc(100% - ${_pxToRem(SHORT_VERTICAL_GALLERY_FLOATING_MODAL_SIZE_PX.height)})`
           : '100%',
         paddingBottom: '0.5rem'
       }
     : {
-        width: `${VERTICAL_GALLERY_TILE_SIZE_REM.width}rem`,
+        width: `${VERTICAL_GALLERY_TILE_SIZE_REM.width + 1.5}rem`,
         height: shouldFloatLocalVideo
           ? `calc(100% - ${_pxToRem(VERTICAL_GALLERY_FLOATING_MODAL_SIZE_PX.height)})`
           : '100%',


### PR DESCRIPTION
# What
Video gallery show local tile and horizontal/vertical gallery when screensharing with no participant

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3135146

# How Tested
Tested with samples

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->