### PR TITLE
[Vertical Gallery] Calculate children utils

### DIFF
--- a/change-beta/@azure-communication-react-53fc64d1-9d91-4879-b51f-df54f9caf649.json
+++ b/change-beta/@azure-communication-react-53fc64d1-9d91-4879-b51f-df54f9caf649.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Refactor helper functions for calculating children per page in responsive gallery to be util functions that can be mocked in testing.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-53fc64d1-9d91-4879-b51f-df54f9caf649.json
+++ b/change/@azure-communication-react-53fc64d1-9d91-4879-b51f-df54f9caf649.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Refactor helper functions for calculating children per page in responsive gallery to be util functions that can be mocked in testing.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/ResponsiveHorizontalGallery.tsx
+++ b/packages/react-components/src/components/ResponsiveHorizontalGallery.tsx
@@ -4,8 +4,8 @@
 import { IStyle, mergeStyles } from '@fluentui/react';
 import React, { useRef } from 'react';
 import { HorizontalGallery, HorizontalGalleryStyles } from './HorizontalGallery';
-import { _convertRemToPx as convertRemToPx } from '@internal/acs-ui-common';
 import { _useContainerWidth } from './utils/responsive';
+import { calculateHorizontalChildrenPerPage } from './VideoGallery/utils/OverflowGalleryUtils';
 
 /**
  * Wrapped HorizontalGallery that adjusts the number of items per page based on the
@@ -24,18 +24,10 @@ export const ResponsiveHorizontalGallery = (props: {
   const containerRef = useRef<HTMLDivElement>(null);
   const containerWidth = _useContainerWidth(containerRef);
 
-  const leftPadding = containerRef.current
-    ? !isNaN(parseFloat(getComputedStyle(containerRef.current).paddingLeft))
-      ? parseFloat(getComputedStyle(containerRef.current).paddingLeft)
-      : 0
-    : 0;
-  const rightPadding = containerRef.current
-    ? !isNaN(parseFloat(getComputedStyle(containerRef.current).paddingRight))
-      ? parseFloat(getComputedStyle(containerRef.current).paddingRight)
-      : 0
-    : 0;
+  const leftPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingLeft) : 0;
+  const rightPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingRight) : 0;
 
-  const childrenPerPage = calculateChildrenPerPage({
+  const childrenPerPage = calculateHorizontalChildrenPerPage({
     numberOfChildren: React.Children.count(props.children),
     containerWidth: (containerWidth ?? 0) - leftPadding - rightPadding,
     childWidthRem,
@@ -54,51 +46,4 @@ export const ResponsiveHorizontalGallery = (props: {
       </HorizontalGallery>
     </div>
   );
-};
-
-/**
- * Helper function to calculate children per page for HorizontalGallery based on width of container, child, buttons, and
- * gaps in between
- */
-const calculateChildrenPerPage = (args: {
-  numberOfChildren: number;
-  containerWidth: number;
-  childWidthRem: number;
-  gapWidthRem: number;
-  buttonWidthRem: number;
-}): number => {
-  const { numberOfChildren, containerWidth, buttonWidthRem, childWidthRem, gapWidthRem } = args;
-
-  const childWidth = convertRemToPx(childWidthRem);
-  const gapWidth = convertRemToPx(gapWidthRem);
-
-  /** First check how many children can fit in containerWidth.
-   *    __________________________________
-   *   |                ||                |
-   *   |                ||                |
-   *   |________________||________________|
-   *   <-----------containerWidth--------->
-   *  containerWidth = n * childWidth + (n - 1) * gapWidth. Isolate n and take the floor.
-   */
-  const numberOfChildrenInContainer = Math.floor((containerWidth + gapWidth) / (childWidth + gapWidth));
-  // If all children fit then return numberOfChildrenInContainer
-  if (numberOfChildren <= numberOfChildrenInContainer) {
-    return numberOfChildrenInContainer;
-  }
-
-  const buttonWidth = convertRemToPx(buttonWidthRem);
-
-  /** We know we need to paginate. So we need to subtract the buttonWidth twice and gapWidth twice from
-   * containerWidth to compute childrenSpace
-   *   <-----------containerWidth--------->
-   *    __________________________________
-   *   | ||             ||             || |
-   *   |<||             ||             ||>|
-   *   |_||_____________||_____________||_|
-   *       <-------childrenSpace------>
-   */
-  const childrenSpace = containerWidth - 2 * buttonWidth - 2 * gapWidth;
-  // Now that we have childrenSpace width we can figure out how many children can fit in childrenSpace.
-  // childrenSpace = n * childWidth + (n - 1) * gapWidth. Isolate n and take the floor.
-  return Math.max(Math.floor((childrenSpace + gapWidth) / (childWidth + gapWidth)), 1);
 };

--- a/packages/react-components/src/components/ResponsiveVerticalGallery.tsx
+++ b/packages/react-components/src/components/ResponsiveVerticalGallery.tsx
@@ -6,10 +6,7 @@ import { _convertRemToPx } from '@internal/acs-ui-common';
 import React, { useRef } from 'react';
 import { _useContainerHeight } from './utils/responsive';
 import { VerticalGallery, VerticalGalleryStyles } from './VerticalGallery';
-import {
-  SHORT_VERTICAL_GALLERY_TILE_SIZE_REM,
-  VERTICAL_GALLERY_TILE_SIZE_REM
-} from './VideoGallery/styles/VideoGalleryResponsiveVerticalGallery.styles';
+import { calculateVerticalChildrenPerPage } from './VideoGallery/utils/OverflowGalleryUtils';
 
 /**
  * Props for the Responsive wrapper of the VerticalGallery component
@@ -53,18 +50,10 @@ export const ResponsiveVerticalGallery = (props: ResponsiveVerticalGalleryProps)
   const containerRef = useRef<HTMLDivElement>(null);
   const containerHeight = _useContainerHeight(containerRef);
 
-  const topPadding = containerRef.current
-    ? !isNaN(parseFloat(getComputedStyle(containerRef.current).paddingTop))
-      ? parseFloat(getComputedStyle(containerRef.current).paddingTop)
-      : 0
-    : 0;
-  const bottomPadding = containerRef.current
-    ? !isNaN(parseFloat(getComputedStyle(containerRef.current).paddingBottom))
-      ? parseFloat(getComputedStyle(containerRef.current).paddingBottom)
-      : 0
-    : 0;
+  const topPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingTop) : 0;
+  const bottomPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingBottom) : 0;
 
-  const childrenPerPage = calculateChildrenPerPage({
+  const childrenPerPage = calculateVerticalChildrenPerPage({
     numberOfChildren: React.Children.count(children),
     containerHeight: (containerHeight ?? 0) - topPadding - bottomPadding,
     gapHeightRem,
@@ -82,66 +71,4 @@ export const ResponsiveVerticalGallery = (props: ResponsiveVerticalGalleryProps)
       </VerticalGallery>
     </div>
   );
-};
-
-/**
- * Helper function to find the number of children for the VerticalGallery on each page.
- */
-const calculateChildrenPerPage = (args: {
-  numberOfChildren: number;
-  containerHeight: number;
-  gapHeightRem: number;
-  controlBarHeight: number;
-  isShort: boolean;
-}): number => {
-  const { numberOfChildren, containerHeight, gapHeightRem, controlBarHeight, isShort } = args;
-
-  const childMinHeightPx = _convertRemToPx(
-    isShort ? SHORT_VERTICAL_GALLERY_TILE_SIZE_REM.minHeight : VERTICAL_GALLERY_TILE_SIZE_REM.minHeight
-  );
-  const gapHeightPx = _convertRemToPx(gapHeightRem);
-  const controlBarHeightPx = _convertRemToPx(controlBarHeight);
-
-  /** First check how many children can fit in containerHeight.
-   *
-   *   _________________
-   *   |                |
-   *   |                |
-   *   |________________|
-   *    _________________
-   *   |                |
-   *   |                |
-   *   |________________|
-   *
-   *      <   n/m   >
-   *
-   * number of children = container height - (2* gap height + button height) / childMinHeight
-   *
-   * we want to find the maximum number of children at the smallest size we can fit in the gallery and then resize them
-   * to fill in the space as much as possible
-   *
-   * First we will find the max number of children without any controls we can fit.
-   */
-
-  const maxNumberOfChildrenInContainer = Math.floor((containerHeight + gapHeightPx) / (childMinHeightPx + gapHeightPx));
-  // if all of the children fit in the container just return the number of children
-  if (numberOfChildren <= maxNumberOfChildrenInContainer) {
-    return maxNumberOfChildrenInContainer;
-  }
-
-  /**
-   * For the pagination we know the container height, the height of the button bar and the 2 times the gap
-   * height, top tile and bottom tile above control bar. So the child space is calculated as:
-   *
-   *      space = height - controlbar - (2 * gap)
-   */
-  const childSpace = containerHeight - controlBarHeightPx - 2 * gapHeightPx;
-
-  /**
-   * Now that we have the childrenSpace height we can figure out how many Children can fir in the childrenSpace.
-   * childrenSpace = n * childHeightMin + (n - 1) * gapHeight. isolate n and take the floor.
-   *
-   * We want to always return at least one video tile if there are children present.So we take the max.
-   */
-  return Math.max(Math.floor((childSpace + gapHeightPx) / (childMinHeightPx + gapHeightPx)), 1);
 };

--- a/packages/react-components/src/components/VideoGallery.test.tsx
+++ b/packages/react-components/src/components/VideoGallery.test.tsx
@@ -13,6 +13,7 @@ import { VideoTile } from './VideoTile';
 import { v1 as createGUID } from 'uuid';
 import * as responsive from './utils/responsive';
 import * as acs_ui_common from '@internal/acs-ui-common';
+import * as childrenCalculations from './VideoGallery/utils/OverflowGalleryUtils';
 import { RemoteScreenShare } from './VideoGallery/RemoteScreenShare';
 import { act } from 'react-dom/test-utils';
 /* @conditional-compile-remove(vertical-gallery) */
@@ -611,6 +612,32 @@ const mockVideoGalleryInternalHelpers = (): void => {
   jest.spyOn(acs_ui_common, '_convertRemToPx').mockImplementation((rem: number) => {
     return rem * 16;
   });
+  jest
+    .spyOn(childrenCalculations, 'calculateHorizontalChildrenPerPage')
+    .mockImplementation(
+      (args: {
+        numberOfChildren: number;
+        containerWidth: number;
+        childWidthRem: number;
+        gapWidthRem: number;
+        buttonWidthRem: number;
+      }) => {
+        return 2;
+      }
+    );
+  jest
+    .spyOn(childrenCalculations, 'calculateVerticalChildrenPerPage')
+    .mockImplementation(
+      (args: {
+        numberOfChildren: number;
+        containerHeight: number;
+        gapHeightRem: number;
+        controlBarHeight: number;
+        isShort: boolean;
+      }) => {
+        return 4;
+      }
+    );
   // Need to mock hook _useContainerWidth because the returned width is used by HorizontalGallery to decide
   // how many tiles to show per page
   jest.spyOn(responsive, '_useContainerWidth').mockImplementation(() => 500);

--- a/packages/react-components/src/components/VideoGallery.test.tsx
+++ b/packages/react-components/src/components/VideoGallery.test.tsx
@@ -612,32 +612,30 @@ const mockVideoGalleryInternalHelpers = (): void => {
   jest.spyOn(acs_ui_common, '_convertRemToPx').mockImplementation((rem: number) => {
     return rem * 16;
   });
-  jest
-    .spyOn(childrenCalculations, 'calculateHorizontalChildrenPerPage')
-    .mockImplementation(
-      (args: {
-        numberOfChildren: number;
-        containerWidth: number;
-        childWidthRem: number;
-        gapWidthRem: number;
-        buttonWidthRem: number;
-      }) => {
-        return 2;
-      }
-    );
-  jest
-    .spyOn(childrenCalculations, 'calculateVerticalChildrenPerPage')
-    .mockImplementation(
-      (args: {
-        numberOfChildren: number;
-        containerHeight: number;
-        gapHeightRem: number;
-        controlBarHeight: number;
-        isShort: boolean;
-      }) => {
-        return 4;
-      }
-    );
+  jest.spyOn(childrenCalculations, 'calculateHorizontalChildrenPerPage').mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (args: {
+      numberOfChildren: number;
+      containerWidth: number;
+      childWidthRem: number;
+      gapWidthRem: number;
+      buttonWidthRem: number;
+    }) => {
+      return 2;
+    }
+  );
+  jest.spyOn(childrenCalculations, 'calculateVerticalChildrenPerPage').mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (args: {
+      numberOfChildren: number;
+      containerHeight: number;
+      gapHeightRem: number;
+      controlBarHeight: number;
+      isShort: boolean;
+    }) => {
+      return 4;
+    }
+  );
   // Need to mock hook _useContainerWidth because the returned width is used by HorizontalGallery to decide
   // how many tiles to show per page
   jest.spyOn(responsive, '_useContainerWidth').mockImplementation(() => 500);

--- a/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
@@ -12,6 +12,7 @@ import { rootLayoutStyle } from './styles/DefaultLayout.styles';
 import { videoGalleryLayoutGap } from './styles/Layout.styles';
 import { useOrganizedParticipants } from './utils/videoGalleryLayoutUtils';
 import { OverflowGallery } from './OverflowGallery';
+import { DEFAULT_MAX_REMOTE_VIDEO_STREAMS } from '../VideoGallery';
 
 /**
  * Props for {@link DefaultLayout}.
@@ -34,7 +35,7 @@ export const DefaultLayout = (props: DefaultLayoutProps): JSX.Element => {
     screenShareComponent,
     onRenderRemoteParticipant,
     styles,
-    maxRemoteVideoStreams,
+    maxRemoteVideoStreams = DEFAULT_MAX_REMOTE_VIDEO_STREAMS,
     parentWidth,
     /* @conditional-compile-remove(vertical-gallery) */
     parentHeight,
@@ -66,7 +67,10 @@ export const DefaultLayout = (props: DefaultLayoutProps): JSX.Element => {
     );
   });
 
-  const [indexesToRender, setIndexesToRender] = useState<number[]>([0]);
+  /** instantiate indexes available to render with indexes available that would be on first page */
+  const [indexesToRender, setIndexesToRender] = useState<number[]>([
+    ...Array(maxRemoteVideoStreams - activeVideoStreams).keys()
+  ]);
 
   const horizontalGalleryTiles = horizontalGalleryParticipants.map((p, i) => {
     return onRenderRemoteParticipant(

--- a/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
@@ -12,7 +12,6 @@ import { rootLayoutStyle } from './styles/DefaultLayout.styles';
 import { videoGalleryLayoutGap } from './styles/Layout.styles';
 import { useOrganizedParticipants } from './utils/videoGalleryLayoutUtils';
 import { OverflowGallery } from './OverflowGallery';
-import { DEFAULT_MAX_REMOTE_VIDEO_STREAMS } from '../VideoGallery';
 
 /**
  * Props for {@link DefaultLayout}.
@@ -35,7 +34,7 @@ export const DefaultLayout = (props: DefaultLayoutProps): JSX.Element => {
     screenShareComponent,
     onRenderRemoteParticipant,
     styles,
-    maxRemoteVideoStreams = DEFAULT_MAX_REMOTE_VIDEO_STREAMS,
+    maxRemoteVideoStreams,
     parentWidth,
     /* @conditional-compile-remove(vertical-gallery) */
     parentHeight,

--- a/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
@@ -66,7 +66,13 @@ export const DefaultLayout = (props: DefaultLayoutProps): JSX.Element => {
     );
   });
 
-  /** instantiate indexes available to render with indexes available that would be on first page */
+  /**
+   * instantiate indexes available to render with indexes available that would be on first page
+   *
+   * For some interesting components which doesn't strictly follow the order of the array, we might
+   * re-render the initial tiles -> dispose them -> create new tiles, we need to take care of
+   * this case when those components are here
+   */
   const [indexesToRender, setIndexesToRender] = useState<number[]>([
     ...Array(maxRemoteVideoStreams - activeVideoStreams).keys()
   ]);

--- a/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/DefaultLayout.tsx
@@ -69,7 +69,7 @@ export const DefaultLayout = (props: DefaultLayoutProps): JSX.Element => {
   /**
    * instantiate indexes available to render with indexes available that would be on first page
    *
-   * For some interesting components which doesn't strictly follow the order of the array, we might
+   * For some components which do not strictly follow the order of the array, we might
    * re-render the initial tiles -> dispose them -> create new tiles, we need to take care of
    * this case when those components are here
    */

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -98,7 +98,13 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     gridTiles.push(localVideoComponent);
   }
 
-  /** instantiate indexes available to render with indexes available that would be on first page */
+  /**
+   * instantiate indexes available to render with indexes available that would be on first page
+   *
+   * For some interesting components which doesn't strictly follow the order of the array, we might
+   * re-render the initial tiles -> dispose them -> create new tiles, we need to take care of
+   * this case when those components are here
+   */
   const [indexesToRender, setIndexesToRender] = useState<number[]>([
     ...Array(maxRemoteVideoStreams - activeVideoStreams).keys()
   ]);

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -101,7 +101,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
   /**
    * instantiate indexes available to render with indexes available that would be on first page
    *
-   * For some interesting components which doesn't strictly follow the order of the array, we might
+   * For some components which do not strictly follow the order of the array, we might
    * re-render the initial tiles -> dispose them -> create new tiles, we need to take care of
    * this case when those components are here
    */

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -27,7 +27,6 @@ import { innerLayoutStyle, layerHostStyle, rootLayoutStyle } from './styles/Floa
 import { videoGalleryLayoutGap } from './styles/Layout.styles';
 import { useOrganizedParticipants } from './utils/videoGalleryLayoutUtils';
 import { OverflowGallery } from './OverflowGallery';
-import { DEFAULT_MAX_REMOTE_VIDEO_STREAMS } from '../VideoGallery';
 
 /**
  * Props for {@link FloatingLocalVideoLayout}.
@@ -59,7 +58,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     screenShareComponent,
     onRenderRemoteParticipant,
     styles,
-    maxRemoteVideoStreams = DEFAULT_MAX_REMOTE_VIDEO_STREAMS,
+    maxRemoteVideoStreams,
     showCameraSwitcherInLocalPreview,
     parentWidth,
     parentHeight,

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -27,6 +27,7 @@ import { innerLayoutStyle, layerHostStyle, rootLayoutStyle } from './styles/Floa
 import { videoGalleryLayoutGap } from './styles/Layout.styles';
 import { useOrganizedParticipants } from './utils/videoGalleryLayoutUtils';
 import { OverflowGallery } from './OverflowGallery';
+import { DEFAULT_MAX_REMOTE_VIDEO_STREAMS } from '../VideoGallery';
 
 /**
  * Props for {@link FloatingLocalVideoLayout}.
@@ -58,7 +59,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     screenShareComponent,
     onRenderRemoteParticipant,
     styles,
-    maxRemoteVideoStreams,
+    maxRemoteVideoStreams = DEFAULT_MAX_REMOTE_VIDEO_STREAMS,
     showCameraSwitcherInLocalPreview,
     parentWidth,
     parentHeight,
@@ -98,7 +99,10 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     gridTiles.push(localVideoComponent);
   }
 
-  const [indexesToRender, setIndexesToRender] = useState<number[]>([0]);
+  /** instantiate indexes available to render with indexes available that would be on first page */
+  const [indexesToRender, setIndexesToRender] = useState<number[]>([
+    ...Array(maxRemoteVideoStreams - activeVideoStreams).keys()
+  ]);
 
   const horizontalGalleryTiles = horizontalGalleryParticipants.map((p, i) => {
     return onRenderRemoteParticipant(

--- a/packages/react-components/src/components/VideoGallery/Layout.ts
+++ b/packages/react-components/src/components/VideoGallery/Layout.ts
@@ -30,7 +30,7 @@ export interface LayoutProps {
    * Maximum number of participant remote video streams that is rendered.
    * @defaultValue 4
    */
-  maxRemoteVideoStreams?: number;
+  maxRemoteVideoStreams: number;
   /**
    * Width of parent element
    */

--- a/packages/react-components/src/components/VideoGallery/utils/OverflowGalleryUtils.ts
+++ b/packages/react-components/src/components/VideoGallery/utils/OverflowGalleryUtils.ts
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { _convertRemToPx as convertRemToPx } from '@internal/acs-ui-common';
+import {
+  SHORT_VERTICAL_GALLERY_TILE_SIZE_REM,
+  VERTICAL_GALLERY_TILE_SIZE_REM
+} from '../styles/VideoGalleryResponsiveVerticalGallery.styles';
+
+/**
+ * Helper function to calculate children per page for HorizontalGallery based on width of container, child, buttons, and
+ * gaps in between
+ *
+ * @private
+ */
+export const calculateHorizontalChildrenPerPage = (args: {
+  numberOfChildren: number;
+  containerWidth: number;
+  childWidthRem: number;
+  gapWidthRem: number;
+  buttonWidthRem: number;
+}): number => {
+  const { numberOfChildren, containerWidth, buttonWidthRem, childWidthRem, gapWidthRem } = args;
+
+  const childWidth = convertRemToPx(childWidthRem);
+  const gapWidth = convertRemToPx(gapWidthRem);
+
+  /** First check how many children can fit in containerWidth.
+   *    __________________________________
+   *   |                ||                |
+   *   |                ||                |
+   *   |________________||________________|
+   *   <-----------containerWidth--------->
+   *  containerWidth = n * childWidth + (n - 1) * gapWidth. Isolate n and take the floor.
+   */
+  const numberOfChildrenInContainer = Math.floor((containerWidth + gapWidth) / (childWidth + gapWidth));
+  // If all children fit then return numberOfChildrenInContainer
+  if (numberOfChildren <= numberOfChildrenInContainer) {
+    return numberOfChildrenInContainer;
+  }
+
+  const buttonWidth = convertRemToPx(buttonWidthRem);
+
+  /** We know we need to paginate. So we need to subtract the buttonWidth twice and gapWidth twice from
+   * containerWidth to compute childrenSpace
+   *   <-----------containerWidth--------->
+   *    __________________________________
+   *   | ||             ||             || |
+   *   |<||             ||             ||>|
+   *   |_||_____________||_____________||_|
+   *       <-------childrenSpace------>
+   */
+  const childrenSpace = containerWidth - 2 * buttonWidth - 2 * gapWidth;
+  // Now that we have childrenSpace width we can figure out how many children can fit in childrenSpace.
+  // childrenSpace = n * childWidth + (n - 1) * gapWidth. Isolate n and take the floor.
+  return Math.max(Math.floor((childrenSpace + gapWidth) / (childWidth + gapWidth)), 1);
+};
+
+/**
+ * Helper function to find the number of children for the VerticalGallery on each page.
+ *
+ * @private
+ */
+export const calculateVerticalChildrenPerPage = (args: {
+  numberOfChildren: number;
+  containerHeight: number;
+  gapHeightRem: number;
+  controlBarHeight: number;
+  isShort: boolean;
+}): number => {
+  const { numberOfChildren, containerHeight, gapHeightRem, controlBarHeight, isShort } = args;
+
+  const childMinHeightPx = convertRemToPx(
+    isShort ? SHORT_VERTICAL_GALLERY_TILE_SIZE_REM.minHeight : VERTICAL_GALLERY_TILE_SIZE_REM.minHeight
+  );
+  const gapHeightPx = convertRemToPx(gapHeightRem);
+  const controlBarHeightPx = convertRemToPx(controlBarHeight);
+
+  /** First check how many children can fit in containerHeight.
+   *
+   *   _________________
+   *   |                |
+   *   |                |
+   *   |________________|
+   *    _________________
+   *   |                |
+   *   |                |
+   *   |________________|
+   *
+   *      <   n/m   >
+   *
+   * number of children = container height - (2* gap height + button height) / childMinHeight
+   *
+   * we want to find the maximum number of children at the smallest size we can fit in the gallery and then resize them
+   * to fill in the space as much as possible
+   *
+   * First we will find the max number of children without any controls we can fit.
+   */
+
+  const maxNumberOfChildrenInContainer = Math.floor((containerHeight + gapHeightPx) / (childMinHeightPx + gapHeightPx));
+  // if all of the children fit in the container just return the number of children
+  if (numberOfChildren <= maxNumberOfChildrenInContainer) {
+    return maxNumberOfChildrenInContainer;
+  }
+
+  /**
+   * For the pagination we know the container height, the height of the button bar and the 2 times the gap
+   * height, top tile and bottom tile above control bar. So the child space is calculated as:
+   *
+   *      space = height - controlbar - (2 * gap)
+   */
+  const childSpace = containerHeight - controlBarHeightPx - 2 * gapHeightPx;
+
+  /**
+   * Now that we have the childrenSpace height we can figure out how many Children can fir in the childrenSpace.
+   * childrenSpace = n * childHeightMin + (n - 1) * gapHeight. isolate n and take the floor.
+   *
+   * We want to always return at least one video tile if there are children present.So we take the max.
+   */
+  return Math.max(Math.floor((childSpace + gapHeightPx) / (childMinHeightPx + gapHeightPx)), 1);
+};


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Move children per page functions to utils to enable mocking of them in tests due to DOM constraints.
# Why
<!--- What problem does this change solve? -->
Fixes performance issues and testing issues around using a indexes array to determine which tiles in overflow gallery can be rendered.
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3115448
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran tests and apps locally to see passing tests and performance results