### PR TITLE
[A11y bugfix] Allow voice controls to action people button in Call and CallWithChat

### DIFF
--- a/change-beta/@azure-communication-react-ea81f159-4460-4f1a-96b4-5ce8dde4044b.json
+++ b/change-beta/@azure-communication-react-ea81f159-4460-4f1a-96b4-5ce8dde4044b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Aria labels for people button to allow for voice access controls on windows.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-696ca73a-856e-4a9a-97e4-b6b66b3099b4.json
+++ b/change/@azure-communication-react-696ca73a-856e-4a9a-97e4-b6b66b3099b4.json
@@ -1,5 +1,5 @@
 {
-  "type": "pre-release",
+  "type": "prerelease",
   "comment": "Video Effects Button and Pane",
   "packageName": "@azure/communication-react",
   "email": "97124699+prabhjot-msft@users.noreply.github.com",

--- a/change/@azure-communication-react-ea81f159-4460-4f1a-96b4-5ce8dde4044b.json
+++ b/change/@azure-communication-react-ea81f159-4460-4f1a-96b4-5ce8dde4044b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update Aria labels for people button to allow for voice access controls on windows.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -252,15 +252,6 @@ export const CallControls = (props: CallControlsProps & ContainerRectProps): JSX
                 onClick={props.onPeopleButtonClicked}
                 data-ui-id="call-composite-people-button"
                 strings={peopleButtonStrings}
-                score
-                controls
-                in
-                that
-                particular
-                call
-                check
-                control
-                bar
                 disabled={isDisabled(options?.participantsButton)}
               />
             )}

--- a/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallControls.tsx
@@ -247,10 +247,20 @@ export const CallControls = (props: CallControlsProps & ContainerRectProps): JSX
               /* @conditional-compile-remove(one-to-n-calling) */ /* @conditional-compile-remove(PSTN-calls) */
               <People
                 checked={props.peopleButtonChecked}
+                ariaLabel={peopleButtonStrings?.label}
                 showLabel={options?.displayType !== 'compact'}
                 onClick={props.onPeopleButtonClicked}
                 data-ui-id="call-composite-people-button"
                 strings={peopleButtonStrings}
+                score
+                controls
+                in
+                that
+                particular
+                call
+                check
+                control
+                bar
                 disabled={isDisabled(options?.participantsButton)}
               />
             )}

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatControlBar.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatControlBar.tsx
@@ -273,6 +273,7 @@ export const CallWithChatControlBar = (props: CallWithChatControlBarProps & Cont
           {isEnabled(options?.peopleButton) && (
             <PeopleButton
               checked={props.peopleButtonChecked}
+              ariaLabel={peopleButtonStrings?.label}
               showLabel={options.displayType !== 'compact'}
               onClick={props.onPeopleButtonClicked}
               data-ui-id="call-with-chat-composite-people-button"


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Update Aria strings on people buttons in both composites to be their label
# Why
<!--- What problem does this change solve? -->
Allows windows users using voice access to open the people pane.
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3118291
# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested windows feature locally (Very cool!)