### PR TITLE
Fix CTE storybook sample code

### DIFF
--- a/change-beta/@azure-communication-react-5f766f7d-6096-4af1-8577-4685bbaac4e9.json
+++ b/change-beta/@azure-communication-react-5f766f7d-6096-4af1-8577-4685bbaac4e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Memoize Teams call adapter args for CTE storybook sample code.",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-5f766f7d-6096-4af1-8577-4685bbaac4e9.json
+++ b/change/@azure-communication-react-5f766f7d-6096-4af1-8577-4685bbaac4e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Memoize Teams call adapter args for CTE storybook sample code.",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/snippets/CommunicationAsTeamsUser.snippet.tsx
+++ b/packages/storybook/stories/snippets/CommunicationAsTeamsUser.snippet.tsx
@@ -60,7 +60,7 @@ export const ContosoCallContainer = (props: ContainerProps): JSX.Element => {
         : undefined,
       options
     }),
-    [props.userId, credential, props.meetingUrl]
+    [props.userId, credential, props.meetingUrl, options]
   );
 
   const adapter = useTeamsCallAdapter(teamsCallAdapterArgs, undefined, leaveCall);

--- a/packages/storybook/stories/snippets/CommunicationAsTeamsUser.snippet.tsx
+++ b/packages/storybook/stories/snippets/CommunicationAsTeamsUser.snippet.tsx
@@ -60,7 +60,7 @@ export const ContosoCallContainer = (props: ContainerProps): JSX.Element => {
         : undefined,
       options
     }),
-    [props.userId, credential]
+    [props.userId, credential, props.meetingUrl]
   );
 
   const adapter = useTeamsCallAdapter(teamsCallAdapterArgs, undefined, leaveCall);

--- a/packages/storybook/stories/snippets/CommunicationAsTeamsUser.snippet.tsx
+++ b/packages/storybook/stories/snippets/CommunicationAsTeamsUser.snippet.tsx
@@ -13,8 +13,6 @@ import React, { useCallback, useMemo } from 'react';
 export type ContainerProps = {
   userId: MicrosoftTeamsUserIdentifier;
   token: string;
-  locator: string;
-  displayName: string;
   formFactor?: 'desktop' | 'mobile';
   fluentTheme?: PartialTheme | Theme;
   callInvitationURL?: string;
@@ -51,8 +49,8 @@ export const ContosoCallContainer = (props: ContainerProps): JSX.Element => {
     [onFetchProfile]
   );
 
-  const adapter = useTeamsCallAdapter(
-    {
+  const teamsCallAdapterArgs = useMemo(
+    () => ({
       userId: props.userId,
       credential,
       locator: props.meetingUrl
@@ -61,10 +59,11 @@ export const ContosoCallContainer = (props: ContainerProps): JSX.Element => {
           }
         : undefined,
       options
-    },
-    undefined,
-    leaveCall
+    }),
+    [props.userId, credential]
   );
+
+  const adapter = useTeamsCallAdapter(teamsCallAdapterArgs, undefined, leaveCall);
 
   if (!props.meetingUrl) {
     return <>Teams meeting link is not provided.</>;


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Memoize Teams call adapter args for CTE storybook sample code to avoid re-render of CallComposite.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
To fix #2801 

# How Tested
<!--- How did you test your change. What tests have you added. -->
In my own CRA sample

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->