### PR TITLE
[bugfix][a11y] Heading role added to 'Start a call' heading in config page

### DIFF
--- a/change-beta/@azure-communication-react-950465c0-b477-49dc-b8be-bd8ce7ab27a6.json
+++ b/change-beta/@azure-communication-react-950465c0-b477-49dc-b8be-bd8ce7ab27a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add heading role and aria level for start a call config heading",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-950465c0-b477-49dc-b8be-bd8ce7ab27a6.json
+++ b/change/@azure-communication-react-950465c0-b477-49dc-b8be-bd8ce7ab27a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add heading role and aria level for start a call config heading",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -128,7 +128,11 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
 
   const locale = useLocale();
   const title = (
-    <Stack.Item className={mobileView ? titleContainerStyleMobile : titleContainerStyleDesktop}>
+    <Stack.Item
+      className={mobileView ? titleContainerStyleMobile : titleContainerStyleDesktop}
+      role="heading"
+      aria-level={1}
+    >
       {locale.strings.call.configurationPageTitle}
     </Stack.Item>
   );


### PR DESCRIPTION
# What
Add heading role to 'Start a call' heading in config page
<img src="https://user-images.githubusercontent.com/97130533/228054665-088a58fd-f0ea-40ce-83a5-c7b4b0f0efd9.png" width="50%"/>


# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/2763501

# How Tested
Tested on Calling Sample on MacOS chrome browser