### PR TITLE
Prevent video gallery overflow when side pane is open in CallComposite

### DIFF
--- a/change-beta/@azure-communication-react-241d9d8a-edc9-473e-8bf4-dd5b13a034f1.json
+++ b/change-beta/@azure-communication-react-241d9d8a-edc9-473e-8bf4-dd5b13a034f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent overflow of VideoGallery when side pane is open",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-241d9d8a-edc9-473e-8bf4-dd5b13a034f1.json
+++ b/change/@azure-communication-react-241d9d8a-edc9-473e-8bf4-dd5b13a034f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent overflow of VideoGallery when side pane is open",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -87,7 +87,7 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
 
   /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) */
   const callCompositeContainerCSS = useMemo(() => {
-    return { display: isMobileWithActivePane ? 'none' : 'flex', width: '100%', height: '100%' };
+    return { display: isMobileWithActivePane ? 'none' : 'flex', minWidth: 0, width: '100%', height: '100%' };
   }, [isMobileWithActivePane]);
 
   // To be removed once feature is out of beta, replace with callCompositeContainerCSS


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Prevent video gallery overflow when side pane is open in CallComposite by setting min-width to 0 as suggested by the top answer here: https://stackoverflow.com/questions/36230944/prevent-flex-items-from-overflowing-a-container


<------------- Flex container ------------->
<----Video Gallery---><---Side Pane---->

Video Gallery is wrapped in a Stack with grow property set to true which allows overflow. When the width is narrow enough the VideoGallery uses the ScrollableHorizontalGallery causing overflow to the width of the VideoGallery.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Issue seen in Calling hero sample in this post:
https://teams.microsoft.com/l/message/19:5e150d250f724d1089c949305efdc8cc@thread.skype/1679940265587?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e9c1fc3-39df-4486-a26a-456d80e80f82&parentMessageId=1679940265587&teamName=Azure%20Communication%20Services&channelName=Web%20UI%20-%20Team&createdTime=1679940265587

# How Tested
<!--- How did you test your change. What tests have you added. -->
Reproduced in Calling sample and fixed as shown here:
https://user-images.githubusercontent.com/79475487/228150080-0365d149-02dd-410d-83a4-e2ec5b1266c3.mp4

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->