### PR TITLE
[Storybook bug] Fix import snippets for screenshare and camera buttons.

### DIFF
--- a/change-beta/@azure-communication-react-7909e747-88b6-4ea5-a557-48c27fc54d84.json
+++ b/change-beta/@azure-communication-react-7909e747-88b6-4ea5-a557-48c27fc54d84.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix import statements on camera button and screenshare button pages.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-7909e747-88b6-4ea5-a557-48c27fc54d84.json
+++ b/change/@azure-communication-react-7909e747-88b6-4ea5-a557-48c27fc54d84.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix import statements on camera button and screenshare button pages.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/ControlBar/Buttons/Camera/Camera.stories.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/Camera/Camera.stories.tsx
@@ -20,7 +20,7 @@ const ButtonWithDevicesMenuExampleText = require('!!raw-loader!./snippets/WithDe
 const ButtonWithLabelExampleText = require('!!raw-loader!./snippets/WithLabel.snippet.tsx').default;
 
 const importStatement = `
-import { CameraButton } from '@azure/communication-ui';
+import { CameraButton } from '@azure/communication-react';
 `;
 
 const getDocs: () => JSX.Element = () => {

--- a/packages/storybook/stories/ControlBar/Buttons/ScreenShare/ScreenShare.stories.tsx
+++ b/packages/storybook/stories/ControlBar/Buttons/ScreenShare/ScreenShare.stories.tsx
@@ -17,7 +17,7 @@ const DefaultButtonExampleText = require('!!raw-loader!./snippets/Default.snippe
 const ButtonWithLabelExampleText = require('!!raw-loader!./snippets/WithLabel.snippet.tsx').default;
 
 const importStatement = `
-import { ScreenShareButton } from '@azure/communication-ui';
+import { ScreenShareButton } from '@azure/communication-react';
 `;
 
 const getDocs: () => JSX.Element = () => {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fix import statements to be `@azure/communication-react` instead of `@azure/communication-react` 
# Why
<!--- What problem does this change solve? -->
Fixes wrong imports that might confuse contoso.
<!--- Provide a link if you are addressing an open issue. -->
N/A found while OCE
# How Tested
<!--- How did you test your change. What tests have you added. -->
Inspected locally