### PR TITLE
Fix call with chat flickering

### DIFF
--- a/change-beta/@azure-communication-react-d0d9fb45-5c61-4302-bae6-b5f8c43c4f97.json
+++ b/change-beta/@azure-communication-react-d0d9fb45-5c61-4302-bae6-b5f8c43c4f97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent overflow of call composite in call with chat composite when side pane is open",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-d0d9fb45-5c61-4302-bae6-b5f8c43c4f97.json
+++ b/change/@azure-communication-react-d0d9fb45-5c61-4302-bae6-b5f8c43c4f97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent overflow of call composite in call with chat composite when side pane is open",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/styles/CallWithChatCompositeStyles.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/styles/CallWithChatCompositeStyles.ts
@@ -21,7 +21,8 @@ export const callCompositeContainerStyles: IStackStyles = {
     // Start a new stacking context so that any `position:absolute` elements
     // inside the call composite do not compete with its siblings.
     position: 'relative',
-    width: '100%'
+    width: '100%',
+    minWidth: 0
   }
 };
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fix call with chat flickering cause by CallComposite overflow when side pane is open in CallWithChatComposite by setting min-width to 0 as suggested by the top answer here: https://stackoverflow.com/questions/36230944/prevent-flex-items-from-overflowing-a-container

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Similar observation seen on CallWithChat composite seen in Calling hero sample in this post:
https://teams.microsoft.com/l/message/19:5e150d250f724d1089c949305efdc8cc@thread.skype/1679940265587?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e9c1fc3-39df-4486-a26a-456d80e80f82&parentMessageId=1679940265587&teamName=Azure%20Communication%20Services&channelName=Web%20UI%20-%20Team&createdTime=1679940265587

# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested on local sample

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->