### PR TITLE
Fix leaving with screenshare error and off center tiles in vertical gallery

### DIFF
--- a/change-beta/@azure-communication-react-a44490ad-73fc-48b8-9ca5-47be397384fd.json
+++ b/change-beta/@azure-communication-react-a44490ad-73fc-48b8-9ca5-47be397384fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert bug fix \"Video gallery show local tile and horizontal/vertical gallery when screensharing with no participant (#2822)\"",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-a44490ad-73fc-48b8-9ca5-47be397384fd.json
+++ b/change/@azure-communication-react-a44490ad-73fc-48b8-9ca5-47be397384fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Revert bug fix \"Video gallery show local tile and horizontal/vertical gallery when screensharing with no participant (#2822)\"",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -325,10 +325,7 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
   /* @conditional-compile-remove(pinned-participants) */
   const drawerMenuHostId = useId('drawerMenuHost', drawerMenuHostIdFromProp);
 
-  const shouldFloatLocalVideo = !!(
-    (layout === 'floatingLocalVideo' && remoteParticipants.length > 0) ||
-    localParticipant.isScreenSharingOn
-  );
+  const shouldFloatLocalVideo = !!(layout === 'floatingLocalVideo' && remoteParticipants.length > 0);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const containerWidth = _useContainerWidth(containerRef);

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -98,7 +98,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     );
   });
 
-  const shouldFloatLocalVideo = remoteParticipants.length > 0 || !!screenShareComponent;
+  const shouldFloatLocalVideo = remoteParticipants.length > 0;
 
   if (!shouldFloatLocalVideo && localVideoComponent) {
     gridTiles.push(localVideoComponent);
@@ -131,7 +131,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
       return SMALL_FLOATING_MODAL_SIZE_REM;
     }
     /* @conditional-compile-remove(vertical-gallery) */
-    if ((overflowGalleryTiles.length > 0 || !!screenShareComponent) && overflowGalleryPosition === 'VerticalRight') {
+    if (overflowGalleryTiles.length > 0 && overflowGalleryPosition === 'VerticalRight') {
       return isNarrow
         ? SMALL_FLOATING_MODAL_SIZE_REM
         : isShort
@@ -143,8 +143,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     overflowGalleryTiles.length,
     isNarrow,
     /* @conditional-compile-remove(vertical-gallery) */ isShort,
-    /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryPosition,
-    /* @conditional-compile-remove(vertical-gallery) */ screenShareComponent
+    /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryPosition
   ]);
 
   const wrappedLocalVideoComponent =
@@ -159,7 +158,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
         >
           {localVideoComponent}
         </Stack>
-      ) : overflowGalleryTiles.length > 0 || !!screenShareComponent ? (
+      ) : overflowGalleryTiles.length > 0 ? (
         <Stack className={mergeStyles(localVideoTileContainerStyle(theme, localVideoSizeRem))}>
           {localVideoComponent}
         </Stack>
@@ -175,7 +174,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     ) : undefined;
 
   const overflowGallery = useMemo(() => {
-    if (overflowGalleryTiles.length === 0 && !screenShareComponent) {
+    if (overflowGalleryTiles.length === 0) {
       return null;
     }
     return (
@@ -203,7 +202,6 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     styles?.horizontalGallery,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryPosition,
     setIndexesToRender,
-    screenShareComponent,
     /* @conditional-compile-remove(vertical-gallery) */ styles?.verticalGallery
   ]);
 

--- a/packages/react-components/src/components/VideoGallery/styles/VideoGalleryResponsiveVerticalGallery.styles.ts
+++ b/packages/react-components/src/components/VideoGallery/styles/VideoGalleryResponsiveVerticalGallery.styles.ts
@@ -35,8 +35,6 @@ export const VERTICAL_GALLERY_TILE_SIZE_REM = { minHeight: 6.75, maxHeight: 11, 
  *
  * width is being increased by 1rem to account for the gap width desired for the VerticalGallery.
  *
- * Add 1.5 rem on width to account for horizontal padding
- *
  * @param shouldFloatLocalVideo whether rendered in floating layout or not
  * @returns Style set for VerticalGallery container.
  */
@@ -47,20 +45,20 @@ export const verticalGalleryContainerStyle = (
 ): IStyle => {
   return isNarrow && isShort
     ? {
-        width: `${SHORT_VERTICAL_GALLERY_TILE_SIZE_REM.width + 1.5}rem`,
+        width: `${SHORT_VERTICAL_GALLERY_TILE_SIZE_REM.width}rem`,
         height: shouldFloatLocalVideo ? `calc(100% - ${SMALL_FLOATING_MODAL_SIZE_REM.height}rem)` : '100%',
         paddingBottom: '0.5rem'
       }
     : !isNarrow && isShort
     ? {
-        width: `${SHORT_VERTICAL_GALLERY_TILE_SIZE_REM.width + 1.5}rem`,
+        width: `${SHORT_VERTICAL_GALLERY_TILE_SIZE_REM.width}rem`,
         height: shouldFloatLocalVideo
           ? `calc(100% - ${SHORT_VERTICAL_GALLERY_FLOATING_MODAL_SIZE_REM.height}rem)`
           : '100%',
         paddingBottom: '0.5rem'
       }
     : {
-        width: `${VERTICAL_GALLERY_TILE_SIZE_REM.width + 1.5}rem`,
+        width: `${VERTICAL_GALLERY_TILE_SIZE_REM.width}rem`,
         height: shouldFloatLocalVideo ? `calc(100% - ${VERTICAL_GALLERY_FLOATING_MODAL_SIZE_REM.height}rem)` : '100%',
         paddingBottom: '0.5rem'
       };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Revert PR #2822 
Reopen bug https://skype.visualstudio.com/SPOOL/_workitems/edit/3135146 after merging this

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Leaving when screensharing results in blank screen and console error: https://skype.visualstudio.com/SPOOL/_workitems/edit/3207595
Tiles off center when there is no page counter: https://skype.visualstudio.com/SPOOL/_workitems/edit/3207597

# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested on local CallWithChat sample
https://user-images.githubusercontent.com/79475487/229065066-b01f9b95-b0cf-40d7-a02a-0aa24d0664c1.mp4

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->