### PR TITLE
Remove video effects button from CallWithChat in release 1.5.1 beta.2

### DIFF
--- a/change-beta/@azure-communication-react-d7d147bb-8b7d-422e-a1a7-f39a76b2682f.json
+++ b/change-beta/@azure-communication-react-d7d147bb-8b7d-422e-a1a7-f39a76b2682f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove video effects button from CallWithChat control bar",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-d7d147bb-8b7d-422e-a1a7-f39a76b2682f.json
+++ b/change/@azure-communication-react-d7d147bb-8b7d-422e-a1a7-f39a76b2682f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Remove video effects button from CallWithChat control bar",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -480,8 +480,6 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
                 containerWidth={containerWidth}
                 /* @conditional-compile-remove(PSTN-calls) */
                 onClickShowDialpad={alternateCallerId ? onClickShowDialpad : undefined}
-                /* @conditional-compile-remove(video-background-effects) */
-                onShowVideoEffectsPicker={setShowVideoEffectsPane}
               />
             </Stack.Item>
           </ChatAdapterProvider>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Remove video effects button from CallWithChat control bar in release 1.5.1 beta.2

![image](https://user-images.githubusercontent.com/79475487/229599181-5afe68e9-e66c-432a-bc9c-907a9f7fba72.png)
