### PR TITLE
Fix no sample backgrounds in production builds

### DIFF
--- a/change-beta/@azure-communication-react-07df2784-1e1f-44a6-b409-996ac1b3f58e.json
+++ b/change-beta/@azure-communication-react-07df2784-1e1f-44a6-b409-996ac1b3f58e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update webpack to copy backgrounds in prod builds",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-07df2784-1e1f-44a6-b409-996ac1b3f58e.json
+++ b/change/@azure-communication-react-07df2784-1e1f-44a6-b409-996ac1b3f58e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update webpack to copy backgrounds in prod builds",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/webpack/sampleapp.webpack.config.js
+++ b/common/config/webpack/sampleapp.webpack.config.js
@@ -5,6 +5,7 @@ const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+const CopyPlugin = require("copy-webpack-plugin");
 
 const webpackConfig = (sampleAppDir, env, babelConfig) => {
   const config = {
@@ -61,6 +62,12 @@ const webpackConfig = (sampleAppDir, env, babelConfig) => {
       }),
       new BundleAnalyzerPlugin({
         analyzerMode: 'json',
+      }),
+      new CopyPlugin({
+        patterns: [
+          { from: path.resolve(sampleAppDir, "public/manifest.json"), to: "manifest.json" },
+          { from: path.resolve(sampleAppDir, "public/backgrounds"), to: "backgrounds" },
+        ]
       })
     ],
     devServer: {

--- a/common/config/webpack/sampleapp.webpack.config.js
+++ b/common/config/webpack/sampleapp.webpack.config.js
@@ -66,7 +66,7 @@ const webpackConfig = (sampleAppDir, env, babelConfig) => {
       new CopyPlugin({
         patterns: [
           { from: path.resolve(sampleAppDir, "public/manifest.json"), to: "manifest.json" },
-          { from: path.resolve(sampleAppDir, "public/backgrounds"), to: "backgrounds" },
+          { from: path.resolve(sampleAppDir, "public/backgrounds"), to: "backgrounds",  noErrorOnMissing: true },
         ]
       })
     ],


### PR DESCRIPTION
## What

Update the webpack config to copy background files to build directory in production builds

## Why

Otherwise we do not bundle the images

## How Tested

(Currently deploying): https://github.com/Azure/communication-ui-library/actions/runs/4682106077