### PR TITLE
Unblock PR failures by updating user agent used in e2e tests

### DIFF
--- a/change-beta/@azure-communication-react-7b99dd72-2469-48b3-bb48-59ccd5f14cb1.json
+++ b/change-beta/@azure-communication-react-7b99dd72-2469-48b3-bb48-59ccd5f14cb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Unblock PR failures by updating user agent used in e2e tests",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-7b99dd72-2469-48b3-bb48-59ccd5f14cb1.json
+++ b/change/@azure-communication-react-7b99dd72-2469-48b3-bb48-59ccd5f14cb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Unblock PR failures by updating user agent used in e2e tests",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/playwright.config.common.ts
+++ b/packages/react-composites/playwright.config.common.ts
@@ -74,7 +74,7 @@ const config: PlaywrightTestConfig = {
         viewport: DESKTOP_4_TO_3_VIEWPORT,
         launchOptions: { ...chromeLaunchOptions },
         contextOptions: {
-          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0'
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0'
         }
       }
     },
@@ -84,7 +84,7 @@ const config: PlaywrightTestConfig = {
         viewport: DESKTOP_16_TO_9_VIEWPORT,
         launchOptions: { ...chromeLaunchOptions },
         contextOptions: {
-          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0'
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0'
         }
       },
       testMatch: ['OverflowGallery.test.ts']
@@ -95,7 +95,7 @@ const config: PlaywrightTestConfig = {
         ...devices['Nexus 5'],
         launchOptions: { ...chromeLaunchOptions },
         userAgent:
-          'Mozilla/5.0 (Linux; Android 12; SM-S901B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.125 Mobile Safari/537.36'
+          'Mozilla/5.0 (Linux; Android 12; SM-S901B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile Safari/537.36'
       }
     },
     {
@@ -103,7 +103,7 @@ const config: PlaywrightTestConfig = {
       use: {
         // Nexus 5 user agent string, taken from node_modules/.../playwright-core/.../deviceDescriptorsSource.json
         userAgent:
-          'Mozilla/5.0 (Linux; Android 12; SM-S901B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.5359.125 Mobile Safari/537.36',
+          'Mozilla/5.0 (Linux; Android 12; SM-S901B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Mobile Safari/537.36',
         // Support smallest supported mobile viewport (iPhone 5/SE) ({ width: 568, height: 320 })
         viewport: { width: 568, height: 320 },
         deviceScaleFactor: 2,

--- a/packages/storybook/stories/QuickStarts/snippets/CallAppStateful.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/CallAppStateful.snippet.tsx
@@ -30,10 +30,10 @@ function App(): JSX.Element {
 
   useEffect(() => {
     if (callAgent === undefined && statefulCallClient) {
-      const createUserAgent = async (): Promise<void> => {
+      const createCallAgent = async (): Promise<void> => {
         setCallAgent(await statefulCallClient.createCallAgent(tokenCredential, { displayName: displayName }));
       };
-      createUserAgent();
+      createCallAgent();
     }
   }, [callAgent, statefulCallClient, tokenCredential, displayName]);
 

--- a/packages/storybook/stories/QuickStarts/snippets/CallAppStatefulComplete.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/CallAppStatefulComplete.snippet.tsx
@@ -39,10 +39,10 @@ function App(): JSX.Element {
 
   useEffect(() => {
     if (callAgent === undefined && statefulCallClient) {
-      const createUserAgent = async (): Promise<void> => {
+      const createCallAgent = async (): Promise<void> => {
         setCallAgent(await statefulCallClient.createCallAgent(tokenCredential, { displayName: displayName }));
       };
-      createUserAgent();
+      createCallAgent();
     }
   }, [callAgent, statefulCallClient, tokenCredential, displayName]);
 

--- a/packages/storybook/stories/QuickStarts/snippets/CallAppStatefulProviders.snippet.tsx
+++ b/packages/storybook/stories/QuickStarts/snippets/CallAppStatefulProviders.snippet.tsx
@@ -38,10 +38,10 @@ function App(): JSX.Element {
 
   useEffect(() => {
     if (callAgent === undefined && statefulCallClient) {
-      const createUserAgent = async (): Promise<void> => {
+      const createCallAgent = async (): Promise<void> => {
         setCallAgent(await statefulCallClient.createCallAgent(tokenCredential, { displayName: displayName }));
       };
-      createUserAgent();
+      createCallAgent();
     }
   }, [callAgent, statefulCallClient, tokenCredential, displayName]);
 

--- a/samples/tests/playwright.config.ts
+++ b/samples/tests/playwright.config.ts
@@ -38,8 +38,7 @@ const config: PlaywrightTestConfig = {
         },
         // using chromium useragent from windows to avoid breaking the unsupportedBrowser page
         contextOptions: {
-          userAgent:
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36 Edg/107.0.1418.42'
+          userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0'
         }
       }
     }


### PR DESCRIPTION
# What
Update user agent used in e2e tests to chrome 112.0.0.0

# Why
e2e tests are failing because they are showing 'browser out of date' warning.

This is a quick fix, a longer term solution will be worked on as well

# How Tested

CI Should pass once more