### PR TITLE
[Chat][Storybook] Fixed the story ordering

### DIFF
--- a/change-beta/@azure-communication-react-0ed41d98-eeea-4e2a-9fd9-3f513b6cfc3f.json
+++ b/change-beta/@azure-communication-react-0ed41d98-eeea-4e2a-9fd9-3f513b6cfc3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed storybook order and typo",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-0ed41d98-eeea-4e2a-9fd9-3f513b6cfc3f.json
+++ b/change/@azure-communication-react-0ed41d98-eeea-4e2a-9fd9-3f513b6cfc3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed storybook order and typo",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -79,7 +79,7 @@ export const parameters = {
           "Themes",
           "Teams Interop",
           [
-            "Composite Banner",
+            "Compliance Banner",
             "Lobby",
             "Inline Image",
           ],

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -73,6 +73,18 @@ export const parameters = {
           'Communication as Teams user'
         ],
         EXAMPLES_FOLDER_PREFIX,
+        [
+          "Device Settings",
+          "Local Preview",
+          "Themes",
+          "Teams Interop",
+          [
+            "Composite Banner",
+            "Lobby",
+            "Inline Image",
+          ],
+          "Incoming Call Alerts"
+        ],  
         STATEFUL_CLIENT_PREFIX,
         [
           'Overview',

--- a/packages/storybook/stories/Examples/TeamsInterop/TeamsInteropDocs.tsx
+++ b/packages/storybook/stories/Examples/TeamsInterop/TeamsInteropDocs.tsx
@@ -43,7 +43,7 @@ export const getDocs: () => JSX.Element = () => {
       </Description>
       <Subheading>Use MessageThread component with Inline Image Support</Subheading>
       <Description>
-        `MessageThread` is deisgned to be responsive and supports inline images natively. To achieve this, you need to
+        `MessageThread` is designed to be responsive and supports inline images natively. To achieve this, you need to
         simply pass in chat messages in HTML format with `img` tag embedded to `MessageThread` component without any
         additional setup.
       </Description>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
fixed storybook ordering: 
<img width="264" alt="image" src="https://user-images.githubusercontent.com/109105353/232159429-5ac9af95-c752-4e51-bdec-4ae9de5ac6c5.png">

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
to be aligned with file content

# How Tested
<!--- How did you test your change. What tests have you added. -->
storybook link
# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->