### PR TITLE
Fix Bug when captions scroll bar moves down automatically when scroll back everytime new captions is received 

### DIFF
--- a/packages/react-components/src/components/styles/Captions.style.ts
+++ b/packages/react-components/src/components/styles/Captions.style.ts
@@ -34,7 +34,8 @@ export const captionClassName = mergeStyles({
  */
 export const captionContainerClassName = mergeStyles({
   marginTop: _pxToRem(6),
-  marginBottom: _pxToRem(6)
+  marginBottom: _pxToRem(6),
+  overflowAnchor: 'none'
 });
 
 /**


### PR DESCRIPTION
# What
When user scroll up to read captions, sometimes the scroll bar will auto move down a little bit when new captions come in, and this is due to scroll bar auto anchoring when container size change
Added a css line to prevent auto anchoring 

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->