### PR TITLE
Fix usePropsFor hook storybook snippet

### DIFF
--- a/change-beta/@azure-communication-react-0eac1278-418b-4cd6-a54d-00324f005570.json
+++ b/change-beta/@azure-communication-react-0eac1278-418b-4cd6-a54d-00324f005570.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix usePropsFor hook storybook snippet",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-0eac1278-418b-4cd6-a54d-00324f005570.json
+++ b/change/@azure-communication-react-0eac1278-418b-4cd6-a54d-00324f005570.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix usePropsFor hook storybook snippet",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/Stateful Client/UsePropsForHook.stories.mdx
+++ b/packages/storybook/stories/Stateful Client/UsePropsForHook.stories.mdx
@@ -20,7 +20,7 @@ To see a full end-to-end example using usePropsFor, see [Getting Started with St
 import React from 'react';
 import { VideoGallery, usePropsFor } from '@azure/communication-react';
 
-export const ChatScreen = () => {
+export const CallScreen = () => {
   const props = usePropsFor(VideoGallery);
   return <VideoGallery {...props} />;
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
`usePropsFor` snippet for Calling example in storybook should not say "ChatScreen"

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
![image](https://user-images.githubusercontent.com/79475487/233150612-8b06de35-e3d4-4c9a-96bb-13bcdc7106ea.png)

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->