### PR TITLE
Fix captions console error cannot set spoken language because captions has not started 

### DIFF
--- a/change-beta/@azure-communication-react-08da0c76-6d95-4e32-af66-7eca78a77fc6.json
+++ b/change-beta/@azure-communication-react-08da0c76-6d95-4e32-af66-7eca78a77fc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed captions console error cannot set spoken language as captions has not started ",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-08da0c76-6d95-4e32-af66-7eca78a77fc6.json
+++ b/change/@azure-communication-react-08da0c76-6d95-4e32-af66-7eca78a77fc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed captions console error cannot set spoken language as captions has not started ",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/CaptionsSettingsModal.tsx
+++ b/packages/react-components/src/components/CaptionsSettingsModal.tsx
@@ -95,10 +95,9 @@ export const _CaptionsSettingsModal = (props: _CaptionsSettingsModalProps): JSX.
     if (isCaptionsFeatureActive) {
       onSetSpokenLanguage(languageCode);
     } else {
-      await onStartCaptions({ spokenLanguage: languageCode });
       // set spoken language when start captions with a spoken language specified.
       // this is to fix the bug when a second user starts captions with a new spoken language, captions bot ignore that spoken language
-      onSetSpokenLanguage(languageCode);
+      Promise.resolve(onStartCaptions({ spokenLanguage: languageCode })).then(() => onSetSpokenLanguage(languageCode));
     }
     onDismiss();
   }, [onDismiss, isCaptionsFeatureActive, onSetSpokenLanguage, onStartCaptions, selectedItem.key]);

--- a/packages/react-components/src/components/StartCaptionsButton.tsx
+++ b/packages/react-components/src/components/StartCaptionsButton.tsx
@@ -97,10 +97,9 @@ export const _StartCaptionsButton = (props: _StartCaptionsButtonProps): JSX.Elem
     if (props.checked) {
       onStopCaptions();
     } else {
-      await onStartCaptions(options);
       // set spoken language when start captions with a spoken language specified.
       // this is to fix the bug when a second user starts captions with a new spoken language, captions bot ignore that spoken language
-      onSetSpokenLanguage(options.spokenLanguage);
+      Promise.resolve(onStartCaptions(options)).then(() => onSetSpokenLanguage(options.spokenLanguage));
     }
   }, [props.checked, onStartCaptions, onStopCaptions, onSetSpokenLanguage, options]);
 

--- a/packages/react-composites/src/composites/common/CaptionsBannerMoreButton.tsx
+++ b/packages/react-composites/src/composites/common/CaptionsBannerMoreButton.tsx
@@ -54,12 +54,13 @@ export const CaptionsBannerMoreButton = (props: CaptionsBannerMoreButtonProps): 
 
   /* @conditional-compile-remove(close-captions) */
   const startCaptions = useCallback(async () => {
-    await startCaptionsButtonHandlers.onStartCaptions({
-      spokenLanguage: startCaptionsButtonProps.currentSpokenLanguage
-    });
     // set spoken language when start captions with a spoken language specified.
     // this is to fix the bug when a second user starts captions with a new spoken language, captions bot ignore that spoken language
-    startCaptionsButtonHandlers.onSetSpokenLanguage(startCaptionsButtonProps.currentSpokenLanguage);
+    Promise.resolve(
+      startCaptionsButtonHandlers.onStartCaptions({
+        spokenLanguage: startCaptionsButtonProps.currentSpokenLanguage
+      })
+    ).then(() => startCaptionsButtonHandlers.onSetSpokenLanguage(startCaptionsButtonProps.currentSpokenLanguage));
   }, [startCaptionsButtonHandlers, startCaptionsButtonProps.currentSpokenLanguage]);
 
   /* @conditional-compile-remove(close-captions) */

--- a/packages/react-composites/src/composites/common/ControlBar/DesktopMoreButton.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/DesktopMoreButton.tsx
@@ -59,12 +59,13 @@ export const DesktopMoreButton = (props: DesktopMoreButtonProps): JSX.Element =>
   const startCaptionsButtonHandlers = useHandlers(_StartCaptionsButton);
   /* @conditional-compile-remove(close-captions) */
   const startCaptions = useCallback(async () => {
-    await startCaptionsButtonHandlers.onStartCaptions({
-      spokenLanguage: startCaptionsButtonProps.currentSpokenLanguage
-    });
     // set spoken language when start captions with a spoken language specified.
     // this is to fix the bug when a second user starts captions with a new spoken language, captions bot ignore that spoken language
-    startCaptionsButtonHandlers.onSetSpokenLanguage(startCaptionsButtonProps.currentSpokenLanguage);
+    Promise.resolve(
+      startCaptionsButtonHandlers.onStartCaptions({
+        spokenLanguage: startCaptionsButtonProps.currentSpokenLanguage
+      })
+    ).then(() => startCaptionsButtonHandlers.onSetSpokenLanguage(startCaptionsButtonProps.currentSpokenLanguage));
   }, [startCaptionsButtonHandlers, startCaptionsButtonProps.currentSpokenLanguage]);
 
   /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */ /* @conditional-compile-remove(close-captions) */

--- a/packages/react-composites/src/composites/common/Drawer/MoreDrawer.tsx
+++ b/packages/react-composites/src/composites/common/Drawer/MoreDrawer.tsx
@@ -288,12 +288,13 @@ export const MoreDrawer = (props: MoreDrawerProps): JSX.Element => {
   /* @conditional-compile-remove(close-captions) */
   const onToggleChange = useCallback(async () => {
     if (!startCaptionsButtonProps.checked) {
-      await startCaptionsButtonHandlers.onStartCaptions({
-        spokenLanguage: currentSpokenLanguage
-      });
       // set spoken language when start captions with a spoken language specified.
       // this is to fix the bug when a second user starts captions with a new spoken language, captions bot ignore that spoken language
-      startCaptionsButtonHandlers.onSetSpokenLanguage(currentSpokenLanguage);
+      Promise.resolve(
+        startCaptionsButtonHandlers.onStartCaptions({
+          spokenLanguage: currentSpokenLanguage
+        })
+      ).then(() => startCaptionsButtonHandlers.onSetSpokenLanguage(currentSpokenLanguage));
     } else {
       startCaptionsButtonHandlers.onStopCaptions();
     }


### PR DESCRIPTION
# What
Fix captions console error cannot set spoken language because captions has not started 

# Why
<img width="804" alt="Screenshot 2023-04-18 at 11 48 23 AM" src="https://user-images.githubusercontent.com/96077406/233154595-53b0b85f-8c36-4e4c-b99b-56f2199fa888.png">

# How Tested
Tested with samples 

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->