### PR TITLE
Ensure injected buttons are secondary to existing buttons

### DIFF
--- a/change-beta/@azure-communication-react-da0d4255-af67-4d9b-ada4-ec12db4d46fb.json
+++ b/change-beta/@azure-communication-react-da0d4255-af67-4d9b-ada4-ec12db4d46fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure injected buttons are secondary to existing buttons",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-da0d4255-af67-4d9b-ada4-ec12db4d46fb.json
+++ b/change/@azure-communication-react-da0d4255-af67-4d9b-ada4-ec12db4d46fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure injected buttons are secondary to existing buttons",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
@@ -381,6 +381,19 @@ export const CommonCallControlBar = (props: CommonCallControlBarProps & Containe
           <Stack.Item>
             <div ref={sidepaneControlsRef}>
               <Stack horizontal className={!props.mobileView ? mergeStyles(desktopButtonContainerStyle) : undefined}>
+                {isEnabled(options?.peopleButton) && (
+                  <PeopleButton
+                    checked={props.peopleButtonChecked}
+                    ariaLabel={peopleButtonStrings?.label}
+                    showLabel={options.displayType !== 'compact'}
+                    onClick={props.onPeopleButtonClicked}
+                    data-ui-id="common-call-composite-people-button"
+                    disabled={props.disableButtonsForLobbyPage || isDisabled(options.peopleButton)}
+                    strings={peopleButtonStrings}
+                    styles={commonButtonStyles}
+                  />
+                )}
+                {isEnabled(options?.chatButton) && chatButton}
                 {
                   /* @conditional-compile-remove(control-bar-button-injection) */
                   customButtons['secondary']
@@ -395,19 +408,6 @@ export const CommonCallControlBar = (props: CommonCallControlBarProps & Containe
                       );
                     })
                 }
-                {isEnabled(options?.peopleButton) && (
-                  <PeopleButton
-                    checked={props.peopleButtonChecked}
-                    ariaLabel={peopleButtonStrings?.label}
-                    showLabel={options.displayType !== 'compact'}
-                    onClick={props.onPeopleButtonClicked}
-                    data-ui-id="common-call-composite-people-button"
-                    disabled={props.disableButtonsForLobbyPage || isDisabled(options.peopleButton)}
-                    strings={peopleButtonStrings}
-                    styles={commonButtonStyles}
-                  />
-                )}
-                {isEnabled(options?.chatButton) && chatButton}
               </Stack>
             </div>
           </Stack.Item>


### PR DESCRIPTION
# What
When secondary buttons are injected, they should be placed after existing buttons instead of before.

# Why
To be consistent with with primary button injection, we give existing buttons the position precedence

# How Tested
E2E snapshots will highlight these changes.