### PR TITLE
[Chat] Remove extra arguments on CancelEditCallback

### DIFF
--- a/change-beta/@azure-communication-react-46cbf89c-7094-4b7d-b374-951e2d5f9121.json
+++ b/change-beta/@azure-communication-react-46cbf89c-7094-4b7d-b374-951e2d5f9121.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[MessageThread] Remove extra arguments on CancelEditCallback",
+  "packageName": "@azure/communication-react",
+  "email": "joshlai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-46cbf89c-7094-4b7d-b374-951e2d5f9121.json
+++ b/change/@azure-communication-react-46cbf89c-7094-4b7d-b374-951e2d5f9121.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[MessageThread] Remove extra arguments on CancelEditCallback",
+  "packageName": "@azure/communication-react",
+  "email": "joshlai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1162,9 +1162,7 @@ export interface CameraSitePermissionsProps extends CommonSitePermissionsProps {
 export type CameraSitePermissionsStrings = SitePermissionsStrings;
 
 // @public
-export type CancelEditCallback = (messageId: string, metadata?: Record<string, string>, options?: {
-    attachedFilesMetadata?: FileMetadata[];
-}) => void;
+export type CancelEditCallback = (messageId: string) => void;
 
 // @beta
 export interface CaptionsAvailableLanguageStrings {

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -240,9 +240,7 @@ export interface CameraSitePermissionsProps extends CommonSitePermissionsProps {
 export type CameraSitePermissionsStrings = SitePermissionsStrings;
 
 // @public
-export type CancelEditCallback = (messageId: string, metadata?: Record<string, string>, options?: {
-    attachedFilesMetadata?: FileMetadata[];
-}) => void;
+export type CancelEditCallback = (messageId: string) => void;
 
 // @internal
 export const _Caption: (props: _CaptionProps) => JSX.Element;

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponent.tsx
@@ -26,13 +26,7 @@ type ChatMessageComponentProps = {
       attachedFilesMetadata?: FileMetadata[];
     }
   ) => Promise<void>;
-  onCancelMessageEdit?: (
-    messageId: string,
-    metadata?: Record<string, string>,
-    options?: {
-      attachedFilesMetadata?: FileMetadata[];
-    }
-  ) => void;
+  onCancelMessageEdit?: (messageId: string) => void;
   /**
    * Callback to delete a message. Also called before resending a message that failed to send.
    * @param messageId ID of the message to delete
@@ -133,8 +127,8 @@ export const ChatMessageComponent = (props: ChatMessageComponentProps): JSX.Elem
             (await props.onUpdateMessage(message.messageId, text, metadata, options));
           setIsEditing(false);
         }}
-        onCancel={(messageId, metadata, options) => {
-          props.onCancelMessageEdit && props.onCancelMessageEdit(messageId, metadata, options);
+        onCancel={(messageId) => {
+          props.onCancelMessageEdit && props.onCancelMessageEdit(messageId);
           setIsEditing(false);
         }}
       />

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsEditBox.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsEditBox.tsx
@@ -29,13 +29,7 @@ const onRenderSubmitIcon = (color: string): JSX.Element => {
 
 /** @private */
 export type ChatMessageComponentAsEditBoxProps = {
-  onCancel?: (
-    messageId: string,
-    metadata?: Record<string, string>,
-    options?: {
-      attachedFilesMetadata?: FileMetadata[];
-    }
-  ) => void;
+  onCancel?: (messageId: string) => void;
   onSubmit: (
     text: string,
     metadata?: Record<string, string>,
@@ -151,7 +145,7 @@ export const ChatMessageComponentAsEditBox = (props: ChatMessageComponentAsEditB
           tooltipContent={strings.editBoxCancelButton}
           onRenderIcon={onRenderThemedCancelIcon}
           onClick={() => {
-            onCancel && onCancel(message.messageId, message.metadata, { attachedFilesMetadata });
+            onCancel && onCancel(message.messageId);
           }}
           id={'dismissIconWrapper'}
         />

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -522,15 +522,7 @@ export type UpdateMessageCallback = (
  * @public
  * Callback function run when a message edit is cancelled.
  */
-export type CancelEditCallback = (
-  messageId: string,
-  /* @conditional-compile-remove(file-sharing) */
-  metadata?: Record<string, string>,
-  /* @conditional-compile-remove(file-sharing) */
-  options?: {
-    attachedFilesMetadata?: FileMetadata[];
-  }
-) => void;
+export type CancelEditCallback = (messageId: string) => void;
 
 /**
  * Props for {@link MessageThread}.

--- a/packages/storybook/stories/MessageThread/snippets/Default.snippet.tsx
+++ b/packages/storybook/stories/MessageThread/snippets/Default.snippet.tsx
@@ -19,9 +19,9 @@ export const DefaultMessageThreadExample: () => JSX.Element = () => {
           setMessages(updated);
           return Promise.reject('Failed to update');
         }}
-        onCancelMessageEdit={(id, metadata) => {
+        onCancelMessageEdit={(id) => {
           const updated = messages.map((m) =>
-            m.messageId === id ? { ...m, metadata, failureReason: undefined, status: undefined } : m
+            m.messageId === id ? { ...m, failureReason: undefined, status: undefined } : m
           );
           setMessages(updated);
         }}


### PR DESCRIPTION
# What
As per feedback from Azure Review, removing extra arguments in CancelEditCallback

# Why
New method should not expose so many arguments, we will expose them if we find a need for them 

# How Tested

# Process & policy checklist

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->