### PR TITLE
[CallWithChat] Updating the factory method for creating callwithchatadapter from stateful clients. 

### DIFF
--- a/change-beta/@azure-communication-react-f6b4b8a1-c762-4136-8285-d8cd9166436f.json
+++ b/change-beta/@azure-communication-react-f6b4b8a1-c762-4136-8285-d8cd9166436f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[AzureCommunicationCallWithChatAdapter] Creating call with chat adapter from state now take an options bag",
+  "packageName": "@azure/communication-react",
+  "email": "joshlai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-f6b4b8a1-c762-4136-8285-d8cd9166436f.json
+++ b/change/@azure-communication-react-f6b4b8a1-c762-4136-8285-d8cd9166436f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[AzureCommunicationCallWithChatAdapter] Creating call with chat adapter from state now take an options bag",
+  "packageName": "@azure/communication-react",
+  "email": "joshlai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -182,7 +182,7 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
     callClient: StatefulCallClient;
     chatClient: StatefulChatClient;
     chatThreadClient: ChatThreadClient;
-    options?: CallWithChatOptions;
+    options?: AzureCommunicationChatAdapterOptions;
 };
 
 // @public
@@ -192,6 +192,11 @@ export type AzureCommunicationChatAdapterArgs = {
     displayName: string;
     credential: CommunicationTokenCredential;
     threadId: string;
+};
+
+// @beta
+export type AzureCommunicationChatAdapterOptions = {
+    credential?: CommunicationTokenCredential;
 };
 
 // @public
@@ -1084,7 +1089,7 @@ export interface CallWithChatControlOptions extends CommonCallControlOptions {
 export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | 'messageReceived' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
 
 // @beta
-export type CallWithChatOptions = ChatAdapterOptions;
+export type CallWithChatOptions = AzureCommunicationChatAdapterOptions;
 
 // @beta
 export const CameraAndMicrophoneSitePermissions: (props: CameraAndMicrophoneSitePermissionsProps) => JSX.Element;
@@ -1289,11 +1294,6 @@ export type CaptionsReceivedListener = (event: {
 
 // @public
 export type ChatAdapter = ChatAdapterThreadManagement & AdapterState<ChatAdapterState> & Disposable & ChatAdapterSubscribers & FileUploadAdapter;
-
-// @beta
-export type ChatAdapterOptions = {
-    credential?: CommunicationTokenCredential;
-};
 
 // @public
 export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
@@ -1861,7 +1861,7 @@ export const createAzureCommunicationCallAdapterFromClient: (callClient: Statefu
 export const createAzureCommunicationCallWithChatAdapter: ({ userId, displayName, credential, endpoint, locator, alternateCallerId, callAdapterOptions }: AzureCommunicationCallWithChatAdapterArgs) => Promise<CallWithChatAdapter>;
 
 // @public
-export function createAzureCommunicationCallWithChatAdapterFromClients(callClient: StatefulCallClient, callAgent: CallAgent, callLocator: CallAdapterLocator | TeamsMeetingLinkLocator, chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: CallWithChatOptions): Promise<CallWithChatAdapter>;
+export function createAzureCommunicationCallWithChatAdapterFromClients(callClient: StatefulCallClient, callAgent: CallAgent, callLocator: CallAdapterLocator | TeamsMeetingLinkLocator, chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: AzureCommunicationChatAdapterOptions): Promise<CallWithChatAdapter>;
 
 // @public
 export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -182,9 +182,7 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
     callClient: StatefulCallClient;
     chatClient: StatefulChatClient;
     chatThreadClient: ChatThreadClient;
-    options?: {
-        credential?: CommunicationTokenCredential;
-    };
+    options?: CallWithChatOptions;
 };
 
 // @public
@@ -1086,6 +1084,9 @@ export interface CallWithChatControlOptions extends CommonCallControlOptions {
 export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | 'messageReceived' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
 
 // @beta
+export type CallWithChatOptions = ChatAdapterOptions;
+
+// @beta
 export const CameraAndMicrophoneSitePermissions: (props: CameraAndMicrophoneSitePermissionsProps) => JSX.Element;
 
 // @beta
@@ -1860,9 +1861,7 @@ export const createAzureCommunicationCallAdapterFromClient: (callClient: Statefu
 export const createAzureCommunicationCallWithChatAdapter: ({ userId, displayName, credential, endpoint, locator, alternateCallerId, callAdapterOptions }: AzureCommunicationCallWithChatAdapterArgs) => Promise<CallWithChatAdapter>;
 
 // @public
-export function createAzureCommunicationCallWithChatAdapterFromClients(callClient: StatefulCallClient, callAgent: CallAgent, callLocator: CallAdapterLocator | TeamsMeetingLinkLocator, chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: {
-    credential?: CommunicationTokenCredential;
-}): Promise<CallWithChatAdapter>;
+export function createAzureCommunicationCallWithChatAdapterFromClients(callClient: StatefulCallClient, callAgent: CallAgent, callLocator: CallAdapterLocator | TeamsMeetingLinkLocator, chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: CallWithChatOptions): Promise<CallWithChatAdapter>;
 
 // @public
 export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -182,6 +182,9 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
     callClient: StatefulCallClient;
     chatClient: StatefulChatClient;
     chatThreadClient: ChatThreadClient;
+    options?: {
+        credential?: CommunicationTokenCredential;
+    };
 };
 
 // @public
@@ -1857,7 +1860,9 @@ export const createAzureCommunicationCallAdapterFromClient: (callClient: Statefu
 export const createAzureCommunicationCallWithChatAdapter: ({ userId, displayName, credential, endpoint, locator, alternateCallerId, callAdapterOptions }: AzureCommunicationCallWithChatAdapterArgs) => Promise<CallWithChatAdapter>;
 
 // @public
-export const createAzureCommunicationCallWithChatAdapterFromClients: ({ callClient, callAgent, callLocator, chatClient, chatThreadClient }: AzureCommunicationCallWithChatAdapterFromClientArgs) => Promise<CallWithChatAdapter>;
+export function createAzureCommunicationCallWithChatAdapterFromClients(callClient: StatefulCallClient, callAgent: CallAgent, callLocator: CallAdapterLocator | TeamsMeetingLinkLocator, chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: {
+    credential?: CommunicationTokenCredential;
+}): Promise<CallWithChatAdapter>;
 
 // @public
 export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1089,9 +1089,6 @@ export interface CallWithChatControlOptions extends CommonCallControlOptions {
 export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | 'messageReceived' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
 
 // @beta
-export type CallWithChatOptions = AzureCommunicationChatAdapterOptions;
-
-// @beta
 export const CameraAndMicrophoneSitePermissions: (props: CameraAndMicrophoneSitePermissionsProps) => JSX.Element;
 
 // @beta

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -126,6 +126,9 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
     callClient: StatefulCallClient;
     chatClient: StatefulChatClient;
     chatThreadClient: ChatThreadClient;
+    options?: {
+        credential?: CommunicationTokenCredential;
+    };
 };
 
 // @public
@@ -1039,7 +1042,9 @@ export const createAzureCommunicationCallWithChatAdapter: ({ userId, displayName
 export const _createAzureCommunicationCallWithChatAdapterFromAdapters: (callAdapter: CallAdapter, chatAdapter: ChatAdapter) => CallWithChatAdapter;
 
 // @public
-export const createAzureCommunicationCallWithChatAdapterFromClients: ({ callClient, callAgent, callLocator, chatClient, chatThreadClient }: AzureCommunicationCallWithChatAdapterFromClientArgs) => Promise<CallWithChatAdapter>;
+export function createAzureCommunicationCallWithChatAdapterFromClients(callClient: StatefulCallClient, callAgent: CallAgent, callLocator: CallAdapterLocator | TeamsMeetingLinkLocator, chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: {
+    credential?: CommunicationTokenCredential;
+}): Promise<CallWithChatAdapter>;
 
 // @public
 export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -817,9 +817,6 @@ export interface CallWithChatControlOptions extends CommonCallControlOptions {
 export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | 'messageReceived' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
 
 // @beta
-export type CallWithChatOptions = AzureCommunicationChatAdapterOptions;
-
-// @beta
 export type CaptionsReceivedListener = (event: {
     captionsInfo: CaptionsInfo;
 }) => void;

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -126,9 +126,7 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
     callClient: StatefulCallClient;
     chatClient: StatefulChatClient;
     chatThreadClient: ChatThreadClient;
-    options?: {
-        credential?: CommunicationTokenCredential;
-    };
+    options?: CallWithChatOptions;
 };
 
 // @public
@@ -814,6 +812,9 @@ export interface CallWithChatControlOptions extends CommonCallControlOptions {
 export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | 'messageReceived' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
 
 // @beta
+export type CallWithChatOptions = ChatAdapterOptions;
+
+// @beta
 export type CaptionsReceivedListener = (event: {
     captionsInfo: CaptionsInfo;
 }) => void;
@@ -1042,9 +1043,7 @@ export const createAzureCommunicationCallWithChatAdapter: ({ userId, displayName
 export const _createAzureCommunicationCallWithChatAdapterFromAdapters: (callAdapter: CallAdapter, chatAdapter: ChatAdapter) => CallWithChatAdapter;
 
 // @public
-export function createAzureCommunicationCallWithChatAdapterFromClients(callClient: StatefulCallClient, callAgent: CallAgent, callLocator: CallAdapterLocator | TeamsMeetingLinkLocator, chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: {
-    credential?: CommunicationTokenCredential;
-}): Promise<CallWithChatAdapter>;
+export function createAzureCommunicationCallWithChatAdapterFromClients(callClient: StatefulCallClient, callAgent: CallAgent, callLocator: CallAdapterLocator | TeamsMeetingLinkLocator, chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: CallWithChatOptions): Promise<CallWithChatAdapter>;
 
 // @public
 export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -126,7 +126,7 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
     callClient: StatefulCallClient;
     chatClient: StatefulChatClient;
     chatThreadClient: ChatThreadClient;
-    options?: CallWithChatOptions;
+    options?: AzureCommunicationChatAdapterOptions;
 };
 
 // @public
@@ -136,6 +136,11 @@ export type AzureCommunicationChatAdapterArgs = {
     displayName: string;
     credential: CommunicationTokenCredential;
     threadId: string;
+};
+
+// @beta
+export type AzureCommunicationChatAdapterOptions = {
+    credential?: CommunicationTokenCredential;
 };
 
 // @public
@@ -812,7 +817,7 @@ export interface CallWithChatControlOptions extends CommonCallControlOptions {
 export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | 'messageReceived' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
 
 // @beta
-export type CallWithChatOptions = ChatAdapterOptions;
+export type CallWithChatOptions = AzureCommunicationChatAdapterOptions;
 
 // @beta
 export type CaptionsReceivedListener = (event: {
@@ -821,11 +826,6 @@ export type CaptionsReceivedListener = (event: {
 
 // @public
 export type ChatAdapter = ChatAdapterThreadManagement & AdapterState<ChatAdapterState> & Disposable & ChatAdapterSubscribers & FileUploadAdapter;
-
-// @beta
-export type ChatAdapterOptions = {
-    credential?: CommunicationTokenCredential;
-};
 
 // @public
 export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
@@ -1043,7 +1043,7 @@ export const createAzureCommunicationCallWithChatAdapter: ({ userId, displayName
 export const _createAzureCommunicationCallWithChatAdapterFromAdapters: (callAdapter: CallAdapter, chatAdapter: ChatAdapter) => CallWithChatAdapter;
 
 // @public
-export function createAzureCommunicationCallWithChatAdapterFromClients(callClient: StatefulCallClient, callAgent: CallAgent, callLocator: CallAdapterLocator | TeamsMeetingLinkLocator, chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: CallWithChatOptions): Promise<CallWithChatAdapter>;
+export function createAzureCommunicationCallWithChatAdapterFromClients(callClient: StatefulCallClient, callAgent: CallAgent, callLocator: CallAdapterLocator | TeamsMeetingLinkLocator, chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: AzureCommunicationChatAdapterOptions): Promise<CallWithChatAdapter>;
 
 // @public
 export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -843,6 +843,10 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
   callClient: StatefulCallClient;
   chatClient: StatefulChatClient;
   chatThreadClient: ChatThreadClient;
+  /* @conditional-compile-remove(teams-inline-images) */
+  options?: {
+    credential?: CommunicationTokenCredential;
+  };
 };
 
 /**
@@ -853,19 +857,33 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
  *
  * @public
  */
-export const createAzureCommunicationCallWithChatAdapterFromClients = async ({
-  callClient,
-  callAgent,
-  callLocator,
-  chatClient,
-  chatThreadClient
-}: AzureCommunicationCallWithChatAdapterFromClientArgs): Promise<CallWithChatAdapter> => {
+export async function createAzureCommunicationCallWithChatAdapterFromClients(
+  callClient: StatefulCallClient,
+  callAgent: CallAgent,
+  callLocator: CallAdapterLocator | TeamsMeetingLinkLocator,
+  chatClient: StatefulChatClient,
+  chatThreadClient: ChatThreadClient,
+  /* @conditional-compile-remove(teams-inline-images) */
+  options?: {
+    credential?: CommunicationTokenCredential;
+  }
+): Promise<CallWithChatAdapter> {
   const createCallAdapterPromise = createAzureCommunicationCallAdapterFromClient(callClient, callAgent, callLocator);
-
-  const createChatAdapterPromise = createAzureCommunicationChatAdapterFromClient(chatClient, chatThreadClient);
+  /* @conditional-compile-remove(teams-inline-images) */
+  let chatOptions;
+  /* @conditional-compile-remove(teams-inline-images) */
+  if (options && options.credential) {
+    chatOptions = { credential: options.credential };
+  }
+  const createChatAdapterPromise = createAzureCommunicationChatAdapterFromClient(
+    chatClient,
+    chatThreadClient,
+    /* @conditional-compile-remove(teams-inline-images) */
+    chatOptions
+  );
   const [callAdapter, chatAdapter] = await Promise.all([createCallAdapterPromise, createChatAdapterPromise]);
   return new AzureCommunicationCallWithChatAdapter(callAdapter, chatAdapter);
-};
+}
 
 /**
  * Create a {@link CallWithChatAdapter} from the underlying adapters.

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -833,13 +833,6 @@ export const useAzureCommunicationCallWithChatAdapter = (
   return adapter;
 };
 
-/* @conditional-compile-remove(teams-inline-images) */
-/**
- * Configuration options to include when creating CallWithChatAdapter.
- * @beta
- */
-export type CallWithChatOptions = AzureCommunicationChatAdapterOptions;
-
 /**
  * Arguments for {@link createAzureCommunicationCallWithChatAdapterFromClient}
  *

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -55,6 +55,7 @@ import {
   mergeChatAdapterStateIntoCallWithChatAdapterState
 } from '../state/CallWithChatAdapterState';
 import {
+  ChatAdapterOptions,
   createAzureCommunicationChatAdapter,
   createAzureCommunicationChatAdapterFromClient
 } from '../../ChatComposite/adapter/AzureCommunicationChatAdapter';
@@ -832,6 +833,13 @@ export const useAzureCommunicationCallWithChatAdapter = (
   return adapter;
 };
 
+/* @conditional-compile-remove(teams-inline-images) */
+/**
+ * Configuration options to include when creating CallWithChatAdapter.
+ * @beta
+ */
+export type CallWithChatOptions = ChatAdapterOptions;
+
 /**
  * Arguments for {@link createAzureCommunicationCallWithChatAdapterFromClient}
  *
@@ -844,9 +852,7 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
   chatClient: StatefulChatClient;
   chatThreadClient: ChatThreadClient;
   /* @conditional-compile-remove(teams-inline-images) */
-  options?: {
-    credential?: CommunicationTokenCredential;
-  };
+  options?: CallWithChatOptions;
 };
 
 /**
@@ -864,22 +870,14 @@ export async function createAzureCommunicationCallWithChatAdapterFromClients(
   chatClient: StatefulChatClient,
   chatThreadClient: ChatThreadClient,
   /* @conditional-compile-remove(teams-inline-images) */
-  options?: {
-    credential?: CommunicationTokenCredential;
-  }
+  options?: CallWithChatOptions
 ): Promise<CallWithChatAdapter> {
   const createCallAdapterPromise = createAzureCommunicationCallAdapterFromClient(callClient, callAgent, callLocator);
-  /* @conditional-compile-remove(teams-inline-images) */
-  let chatOptions;
-  /* @conditional-compile-remove(teams-inline-images) */
-  if (options && options.credential) {
-    chatOptions = { credential: options.credential };
-  }
   const createChatAdapterPromise = createAzureCommunicationChatAdapterFromClient(
     chatClient,
     chatThreadClient,
     /* @conditional-compile-remove(teams-inline-images) */
-    chatOptions
+    options
   );
   const [callAdapter, chatAdapter] = await Promise.all([createCallAdapterPromise, createChatAdapterPromise]);
   return new AzureCommunicationCallWithChatAdapter(callAdapter, chatAdapter);

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -55,7 +55,7 @@ import {
   mergeChatAdapterStateIntoCallWithChatAdapterState
 } from '../state/CallWithChatAdapterState';
 import {
-  ChatAdapterOptions,
+  AzureCommunicationChatAdapterOptions,
   createAzureCommunicationChatAdapter,
   createAzureCommunicationChatAdapterFromClient
 } from '../../ChatComposite/adapter/AzureCommunicationChatAdapter';
@@ -838,7 +838,7 @@ export const useAzureCommunicationCallWithChatAdapter = (
  * Configuration options to include when creating CallWithChatAdapter.
  * @beta
  */
-export type CallWithChatOptions = ChatAdapterOptions;
+export type CallWithChatOptions = AzureCommunicationChatAdapterOptions;
 
 /**
  * Arguments for {@link createAzureCommunicationCallWithChatAdapterFromClient}
@@ -852,7 +852,7 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
   chatClient: StatefulChatClient;
   chatThreadClient: ChatThreadClient;
   /* @conditional-compile-remove(teams-inline-images) */
-  options?: CallWithChatOptions;
+  options?: AzureCommunicationChatAdapterOptions;
 };
 
 /**
@@ -870,7 +870,7 @@ export async function createAzureCommunicationCallWithChatAdapterFromClients(
   chatClient: StatefulChatClient,
   chatThreadClient: ChatThreadClient,
   /* @conditional-compile-remove(teams-inline-images) */
-  options?: CallWithChatOptions
+  options?: AzureCommunicationChatAdapterOptions
 ): Promise<CallWithChatAdapter> {
   const createCallAdapterPromise = createAzureCommunicationCallAdapterFromClient(callClient, callAgent, callLocator);
   const createChatAdapterPromise = createAzureCommunicationChatAdapterFromClient(

--- a/packages/react-composites/src/composites/CallWithChatComposite/index.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/index.ts
@@ -15,8 +15,6 @@ export type {
   AzureCommunicationCallWithChatAdapterFromClientArgs,
   CallAndChatLocator
 } from './adapter/AzureCommunicationCallWithChatAdapter';
-/* @conditional-compile-remove(teams-inline-images) */
-export type { CallWithChatOptions } from './adapter/AzureCommunicationCallWithChatAdapter';
 export {
   createAzureCommunicationCallWithChatAdapter,
   createAzureCommunicationCallWithChatAdapterFromClients,

--- a/packages/react-composites/src/composites/CallWithChatComposite/index.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/index.ts
@@ -15,6 +15,8 @@ export type {
   AzureCommunicationCallWithChatAdapterFromClientArgs,
   CallAndChatLocator
 } from './adapter/AzureCommunicationCallWithChatAdapter';
+/* @conditional-compile-remove(teams-inline-images) */
+export type { CallWithChatOptions } from './adapter/AzureCommunicationCallWithChatAdapter';
 export {
   createAzureCommunicationCallWithChatAdapter,
   createAzureCommunicationCallWithChatAdapterFromClients,

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -481,7 +481,7 @@ const convertEventType = (type: string): ChatMessageType => {
  * Configuration options to include when creating AzureCommunicationChatAdapter.
  * @beta
  */
-export type ChatAdapterOptions = {
+export type AzureCommunicationChatAdapterOptions = {
   credential?: CommunicationTokenCredential;
 };
 

--- a/packages/react-composites/src/composites/ChatComposite/index.ts
+++ b/packages/react-composites/src/composites/ChatComposite/index.ts
@@ -8,7 +8,7 @@ export {
 } from './adapter/AzureCommunicationChatAdapter';
 export type { AzureCommunicationChatAdapterArgs } from './adapter/AzureCommunicationChatAdapter';
 /* @conditional-compile-remove(teams-inline-images) */
-export type { ChatAdapterOptions } from './adapter/AzureCommunicationChatAdapter';
+export type { AzureCommunicationChatAdapterOptions } from './adapter/AzureCommunicationChatAdapter';
 export { ChatComposite } from './ChatComposite';
 export type { ChatCompositeProps, ChatCompositeOptions } from './ChatComposite';
 

--- a/packages/storybook/stories/Adapters/Adapters.stories.mdx
+++ b/packages/storybook/stories/Adapters/Adapters.stories.mdx
@@ -197,7 +197,7 @@ async function createAzureCommunicationCallAdapter(args: AzureCommunicationChatA
 async function createAzureCommunicationChatAdapterFromClient(
   chatClient: StatefulChatClient,
   chatThreadClient: ChatThreadClient,
-  options?: ChatAdapterOptions
+  options?: AzureCommunicationChatAdapterOptions
 );
 ```
 
@@ -205,10 +205,10 @@ async function createAzureCommunicationChatAdapterFromClient(
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | **`chatClient`**         | [`StatefulChatClient`](https://docs.microsoft.com/en-us/javascript/api/@azure/communication-react/statefulchatclient) |
 | **`chatThreadClient`**   | [`ChatThreadClient`](https://docs.microsoft.com/en-us/javascript/api/@azure/communication-chat/chatthreadclient)      |
-| **`options`** **(Beta)** | `ChatAdapterOptions`                                                                                                  |
+| **`options`** **(Beta)** | `AzureCommunicationChatAdapterOptions`                                                                                |
 
 ```ts
-export type ChatAdapterOptions = {
+export type AzureCommunicationChatAdapterOptions = {
   credential?: CommunicationTokenCredential;
 };
 ```


### PR DESCRIPTION
# What
Included new options bags in the factory method when creating from stateful client

# Why
Chat adapter needs the credential in the options bag to perform inline image download. 
So we need a new argument to be able to pass that downstream. 

# How Tested


# Process & policy checklist

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->