### PR TITLE
Fix publish stroybook action - update checkout fetch depth

### DIFF
--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3

--- a/change-beta/@azure-communication-react-8336f938-69cf-4b1c-a707-0f9ae06a0d08.json
+++ b/change-beta/@azure-communication-react-8336f938-69cf-4b1c-a707-0f9ae06a0d08.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix publish stroybook action - update checkout fetch depth",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-8336f938-69cf-4b1c-a707-0f9ae06a0d08.json
+++ b/change/@azure-communication-react-8336f938-69cf-4b1c-a707-0f9ae06a0d08.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix publish stroybook action - update checkout fetch depth",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
# What
Update fetch-depth of publish storybook github action

# Why
Regression after #2981

Applying suggested fix:
![image](https://user-images.githubusercontent.com/2684369/235242802-cd4f3c4f-203d-4bc7-a00c-84de62326b55.png)

# How Tested
CI should pass