### PR TITLE
Alkwa/update tslib

### DIFF
--- a/change-beta/@azure-communication-react-633d0c02-87f2-4205-9035-812b10e89c00.json
+++ b/change-beta/@azure-communication-react-633d0c02-87f2-4205-9035-812b10e89c00.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "updating version of tslib for storybook warnings on exports",
+  "packageName": "@azure/communication-react",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-633d0c02-87f2-4205-9035-812b10e89c00.json
+++ b/change/@azure-communication-react-633d0c02-87f2-4205-9035-812b10e89c00.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "updating version of tslib for storybook warnings on exports",
+  "packageName": "@azure/communication-react",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2733,12 +2733,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-nwJ0UO5WZbbdU6mgiN1oZ/NLTbT/oeMVmZJtlbuQ+xCz57LODi/mPAndd4+BA3xU+4u7MhLl6GyQqX5hcyUsow==
-  /@microsoft/applicationinsights-common/2.8.11_tslib@2.3.1:
+  /@microsoft/applicationinsights-common/2.8.11_tslib@2.5.0:
     dependencies:
-      '@microsoft/applicationinsights-core-js': 2.8.11_tslib@2.3.1
+      '@microsoft/applicationinsights-core-js': 2.8.11_tslib@2.5.0
       '@microsoft/applicationinsights-shims': 2.0.2
       '@microsoft/dynamicproto-js': 1.1.8
-      tslib: 2.3.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       tslib: '*'
@@ -2751,11 +2751,11 @@ packages:
     dev: false
     resolution:
       integrity: sha512-+Vg8Cy06Z+Mwh4W7P5hqx03ThO+l5t7TfcP+ynuS1SGFIuYKaBOwxgt/uIIon8X12sk0dGkrPsTGZMiUtXJ5Zw==
-  /@microsoft/applicationinsights-core-js/2.8.11_tslib@2.3.1:
+  /@microsoft/applicationinsights-core-js/2.8.11_tslib@2.5.0:
     dependencies:
       '@microsoft/applicationinsights-shims': 2.0.2
       '@microsoft/dynamicproto-js': 1.1.8
-      tslib: 2.3.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       tslib: '*'
@@ -2779,10 +2779,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-0etD5TkBFi4cnleGivxc02uLJIaP/sGHpyzOXfYSuLzRchKGWwX+fVhirt/acIigh+Mi8tiDuXqZ92H7DE5mbA==
-  /@microsoft/applicationinsights-react-js/3.0.5_react@16.14.0+tslib@2.3.1:
+  /@microsoft/applicationinsights-react-js/3.0.5_react@16.14.0+tslib@2.5.0:
     dependencies:
-      '@microsoft/applicationinsights-common': 2.8.11_tslib@2.3.1
-      '@microsoft/applicationinsights-core-js': 2.8.11_tslib@2.3.1
+      '@microsoft/applicationinsights-common': 2.8.11_tslib@2.5.0
+      '@microsoft/applicationinsights-core-js': 2.8.11_tslib@2.5.0
       '@microsoft/applicationinsights-shims': 1.0.3
       history: 4.10.1
       react: 16.14.0
@@ -17892,10 +17892,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-  /tslib/2.3.1:
-    dev: false
-    resolution:
-      integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
   /tslib/2.5.0:
     dev: false
     resolution:
@@ -19460,11 +19456,12 @@ packages:
       rimraf: 2.7.1
       rollup: 2.42.4
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
+      tslib: 2.5.0
       typescript: 4.3.5
     dev: false
     name: '@rush-temp/acs-ui-common'
     resolution:
-      integrity: sha512-5HqNFsq5s36Sb00yZGJHjAv78xBb7ogl9DT+GpSunHts6GUqGzQX8zEVE+vN6RdE0+mw6DEcZm7CEi7QirAfdA==
+      integrity: sha512-Myj66M4mtFFeRqnvkPFucBISRQczv/CfblfaDdImzpifZI8sCicVwSuKHeMFFmXRAShn7JyCGszV8sXj99mcCA==
       tarball: file:projects/acs-ui-common.tgz
     version: 0.0.0
   file:projects/calling-component-bindings.tgz:
@@ -19500,11 +19497,12 @@ packages:
       rimraf: 2.7.1
       rollup: 2.42.4
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
+      tslib: 2.5.0
       typescript: 4.3.5
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-ixKHvnPbZVrXKdh1EbPIjBvOAnLnVhkm7wFsfCWOcksN0uHcTRuHjVuEdv1kSUwwp9f3JFOd26r2KrnbPH2ofg==
+      integrity: sha512-EeILZqTTz4m3lcnlieXngJkMOr36kn51zl0VJbfZQuOeEbUnLA7nLgF8KWbTZn3EUV9guLeTfiKfvya2PIz5xA==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
@@ -19540,11 +19538,12 @@ packages:
       rimraf: 2.7.1
       rollup: 2.42.4
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
+      tslib: 2.5.0
       typescript: 4.3.5
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-63AZgPE+5o8Bk+vwSREPRytao1Hx0dlGtJVFyERn25GKWt7O6DFFES0re/ZXo4UH/0d497sBYN10ZMxj1fe3Pg==
+      integrity: sha512-9mqZpbwTMY19CkFapfvjSfbzuA9G6HlabQyuvWAJcdRjyIKhSXIHLgHsw+njPPuM1nvMtGIi/1StLmkAt0H8gw==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
@@ -19609,6 +19608,7 @@ packages:
       source-map-explorer: 2.5.3
       style-loader: 2.0.0_webpack@5.76.0
       ts-loader: 8.4.0_typescript@4.3.5+webpack@5.76.0
+      tslib: 2.5.0
       typescript: 4.3.5
       url-loader: 4.1.1_webpack@5.76.0
       uuid: 8.3.2
@@ -19619,7 +19619,7 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-o6lUttajIZK9r0YjT54XeGDMJJGX9qbGBy1OkqBRvYe+zAlcKLW1PEVdxQ+MEnz8Xgu6mLGqSJfikPkZNAW4Nw==
+      integrity: sha512-QI+miPa6oyCl5enuqB7d4AEhmVEYJcGWHrNinaKUzWxyHrPB2XRIofMRaD4ocUOjEmJajYHB3hLkRbQN5eq/+g==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
@@ -19682,6 +19682,7 @@ packages:
       source-map-explorer: 2.5.3
       style-loader: 2.0.0_webpack@5.76.0
       ts-loader: 8.4.0_typescript@4.3.5+webpack@5.76.0
+      tslib: 2.5.0
       typescript: 4.3.5
       url-loader: 4.1.1_webpack@5.76.0
       uuid: 8.3.2
@@ -19692,7 +19693,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-y2RJAIxqagC7yyUclQaJCiGdsP7RfxBPKhgLqrfksRmHjMCbjhJtSI7M8S6eOEdrxGX+aEAlgJTOlQpI+jZrPg==
+      integrity: sha512-HTk1r2rZ3x1RKZptuaf+phz120B861tKj6KFKOejueplwd7SFjVKM7tw5YyAFysRjpbkbiRzpdokd+HlnM8yAw==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19725,11 +19726,12 @@ packages:
       reselect: 4.0.0
       rimraf: 2.7.1
       rollup: 2.42.4
+      tslib: 2.5.0
       typescript: 4.3.5
     dev: false
     name: '@rush-temp/chat-component-bindings'
     resolution:
-      integrity: sha512-aXyL95Wy5J3oDiCyWWelDy7p9HjsCQ4CM9IpmpvP0DpV03YrCSqi8Hlz+VkUqErxT02l5IA/Q9GUcV37lsfq9A==
+      integrity: sha512-ISqEOOuqGGY/sOGfAWFIyAYuAyUeHspFyFgbvXykI/1byw9d9EbabH/q428UHWX95nnBiCFp9SRuAnmXds2eBw==
       tarball: file:projects/chat-component-bindings.tgz
     version: 0.0.0
   file:projects/chat-stateful-client.tgz:
@@ -19767,11 +19769,12 @@ packages:
       rimraf: 2.7.1
       rollup: 2.42.4
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
+      tslib: 2.5.0
       typescript: 4.3.5
     dev: false
     name: '@rush-temp/chat-stateful-client'
     resolution:
-      integrity: sha512-zQb11kZtTnOt7ilKFlvvZXqk8S2IV8uhDzSQdVPhoQHVooLhNmztNUAn9pXi9Qv2GV/wC68gqgKt2ikkN/DVHg==
+      integrity: sha512-pfEGVbYBpuKGgL+hhqUls+AI2IDm0VKi8eNbc9KoL9zckXC6y2ywStqJorl9MGrmXkYrGsSXM+pauWife0h4wA==
       tarball: file:projects/chat-stateful-client.tgz
     version: 0.0.0
   file:projects/chat.tgz:
@@ -19831,6 +19834,7 @@ packages:
       rimraf: 2.7.1
       style-loader: 2.0.0_webpack@5.76.0
       ts-loader: 8.4.0_typescript@4.3.5+webpack@5.76.0
+      tslib: 2.5.0
       typescript: 4.3.5
       url-loader: 4.1.1_webpack@5.76.0
       webpack: 5.76.0_webpack-cli@4.10.0
@@ -19840,7 +19844,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-MhJxt3w/8UkrrG4zHRFYfofe+y1bqyTJ8lU3oj7fGp6oIAIM/irO+qBQ9ZuCZCFhYxfewgEUAq1w58eHucwo2g==
+      integrity: sha512-sFMgzUwaMPoTKek1fBUwIz0vSjL2qJBdWSoFWoARN2KUrt1ntIJ2SQ4WvGtD9O9v17einKeqd6iSIxionB9B2w==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19855,12 +19859,13 @@ packages:
       eslint-plugin-prettier: 3.4.1_8142a4287e8e8e0691574dfac8adcedb
       prettier: 2.3.1
       rimraf: 2.7.1
+      tslib: 2.5.0
       webpack: 5.76.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_webpack@5.76.0
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-+tmmgm74zTv/sX6BjHQY6qrX15CqJpNfPgVzDxonbtlZ0Fi4eQOi31xZ8Jv/uVY1tD8z5hNkuKi6pSJi89xDOw==
+      integrity: sha512-sl09hmJKHgF1xB5uvG8q1QLHYXLL8Ze84EQ1qyDiSg7VK5YocNh7PyM6jn4ccSJgy9EalsIhihMAZE3O/ZjXaA==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/check-typescript-regression.tgz:
@@ -19872,11 +19877,12 @@ packages:
       eslint-plugin-prettier: 3.4.1_8142a4287e8e8e0691574dfac8adcedb
       prettier: 2.3.1
       rimraf: 2.7.1
+      tslib: 2.5.0
       typescript: 3.8.3
     dev: false
     name: '@rush-temp/check-typescript-regression'
     resolution:
-      integrity: sha512-544CUhGX3OG/+YfC3ySM+jNxTTYD2oeJZba9vhDQCApmlEVFtMCsDGRfao2RTtwUSVrQg9ZaRNBqQDs/hDZYYA==
+      integrity: sha512-re1+TJ7TQ1RdrHlIP8EfV51Y7t368XMJl8rhuyBYQIgEEjKSv9uDlYOV7eOMm2EE9Aj015dofltwm34/wvmmBg==
       tarball: file:projects/check-typescript-regression.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
@@ -19959,6 +19965,7 @@ packages:
       styled-components: 5.2.3_2c10db6bed9aaf10b28f0c8606f7c0c7
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
       ts-node: 9.1.1_typescript@4.3.5
+      tslib: 2.5.0
       ttypescript: 1.5.15_ts-node@9.1.1+typescript@4.3.5
       type-fest: 2.5.4
       typescript: 4.3.5
@@ -19966,7 +19973,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-8sLTN2ZHqYz/xsOPvx+CvPwl1rZvsC4zZ6K/kOilLgcmYzUpRJqwhKsdI+WdPwyLwkkgLuqF50f/YIctVJVLbA==
+      integrity: sha512-D8Qv8C8UNO4SCQC+cr3mnNpZeNaFyNRG9vL9syhvohmX35lO5dJWUGvp1CarQyRaYyRE4nt6oeq+nHo8sKm5ww==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
@@ -20008,6 +20015,7 @@ packages:
       rimraf: 2.7.1
       style-loader: 2.0.0_webpack@5.76.0
       ts-loader: 8.4.0_typescript@4.3.5+webpack@5.76.0
+      tslib: 2.5.0
       typescript: 4.3.5
       uuid: 8.3.2
       webpack: 5.76.0_webpack-cli@4.10.0
@@ -20016,7 +20024,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-DFbTZIfP0Z9QNPjRkhbEcwXPK/tRSuSXuBcYvW41S/QdoiNl3IHPMx7s1VoGWMB/bWQAbJonmsmjdykhyVBLDA==
+      integrity: sha512-+j63dCX8IICLbE3Ud5CGqFBp90VAbelTOu4XV4kq8cwpsnLY9KLUoal0Jjd+WaxK1kyiG3mt9HFPQz+YQD73Qw==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -20029,11 +20037,12 @@ packages:
       rollup-plugin-sourcemaps: 0.6.3_cbd3c90e8cad9f4e60684ef470bc1615
       rollup-plugin-svg: 2.0.0
       ts-node: 9.1.1_typescript@4.3.5
+      tslib: 2.5.0
       typescript: 4.3.5
     dev: false
     name: '@rush-temp/config'
     resolution:
-      integrity: sha512-GrTa+wUIHZZLqQnBjcAZm5iE8sTn3q5womE43SWmb68X526faR9POeqAuEEijeSgSrLb+f5hhh/ElnvXwtHuJg==
+      integrity: sha512-DUAqc3JC9qj7mtpS84Ydm85v65dTHYD0KPF1tI6C1iODHNrnKovRCQ9oN+7Nm4Vkzp5FwXCKUdpZ1IYl+O4ZPQ==
       tarball: file:projects/config.tgz
     version: 0.0.0
   file:projects/fake-backends.tgz:
@@ -20070,12 +20079,13 @@ packages:
       rimraf: 2.7.1
       rollup: 2.42.4
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
+      tslib: 2.5.0
       typescript: 4.3.5
       webpack: 5.76.0
     dev: false
     name: '@rush-temp/fake-backends'
     resolution:
-      integrity: sha512-PjwTlqnh0/p70t2fZJUdKcpWm1Oqc8PH2l9DMIbReazD7MmqlXmBhdp3RIUCwUfrJtndT9VL80Jpv7Hze4QYXg==
+      integrity: sha512-6xvBSpYoNPixeT1MQ5fxVnqwXWEW4MW/PRCL+7ouWUMqwrVNySFA0POcmeSO3OOOWRaSmPyyL3R7sAEodWVM5Q==
       tarball: file:projects/fake-backends.tgz
     version: 0.0.0
   file:projects/northstar-wrapper.tgz:
@@ -20094,11 +20104,12 @@ packages:
       react-dom: 16.13.1_react@16.14.0
       rimraf: 2.7.1
       scheduler: 0.20.2
+      tslib: 2.5.0
       typescript: 3.8.3
     dev: false
     name: '@rush-temp/northstar-wrapper'
     resolution:
-      integrity: sha512-Rmm3J2R2zmWHsOamvLy8PYxvEGcKJ657Wu+5mVnJbFU3gd0TD0QWdyGGhAoT31uFiFRd3nadMDAuKNukNgy1PA==
+      integrity: sha512-uG6HIoWaLTmh4KoRvi5K7GDN6u6QXrPE0Ll4t5RM5xX/dhkQ3Qa5WTI75u2xuc1agoga1NqLx1QV2pdxL6t2nA==
       tarball: file:projects/northstar-wrapper.tgz
     version: 0.0.0
   file:projects/react-components.tgz:
@@ -20177,6 +20188,7 @@ packages:
       styled-components: 5.2.3_2c10db6bed9aaf10b28f0c8606f7c0c7
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
       ts-node: 9.1.1_typescript@4.3.5
+      tslib: 2.5.0
       type-fest: 2.5.4
       typescript: 4.3.5
       uuid: 8.3.2
@@ -20184,7 +20196,7 @@ packages:
     dev: false
     name: '@rush-temp/react-components'
     resolution:
-      integrity: sha512-jK1S5ilWo1ZsNT/W1krw15v9UtQuh3gn+OSqwjeQt9f1gCp8phqd2c6F/ang4G1SXNMJjxpJUWX1Bnjb4GTbyQ==
+      integrity: sha512-qujIMpktkOpBg+PTK2OObSmXk7MaMB7ntQWh6IfiDhjFTnSqoE9dJdJWVrV3e2LX2teG5CEzElWwYHWbaevutQ==
       tarball: file:projects/react-components.tgz
     version: 0.0.0
   file:projects/react-composites.tgz:
@@ -20286,6 +20298,7 @@ packages:
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
       ts-loader: 8.4.0_typescript@4.3.5+webpack@5.76.0
       ts-node: 9.1.1_typescript@4.3.5
+      tslib: 2.5.0
       type-fest: 2.5.4
       typescript: 4.3.5
       uuid: 8.3.2
@@ -20296,7 +20309,7 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-t4WbkKiq/lhC/gbOHWbnRdFB+cWTbXPcO+kew53f8iRMkL9/Lrwwjahlfj9cRX7HkklVb9GgfDVuU4yDdJJWzw==
+      integrity: sha512-uQiCXo9n4Eg61wWw4XJPwjzNCeZyCfXQjnGJbpKwvhR/cQBiDmfYCwnMxzxxKbK/zF1m/YE0Ns49W1IWWf1eOg==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
@@ -20315,12 +20328,13 @@ packages:
       node-static: 0.7.11
       playwright: 1.22.2
       rimraf: 2.7.1
+      tslib: 2.5.0
       typescript: 4.3.5
       uuid: 8.3.2
     dev: false
     name: '@rush-temp/sample-automation-tests'
     resolution:
-      integrity: sha512-Sjvu9hYDkOkjr+Mhr1UNo4ziX1UU705xauTC6gfoGcgycHJn+zA3A7nfZI68jD5PdsfUHZVD/9H5TjakyrOGIQ==
+      integrity: sha512-y6GuXMIghZ8/udTVmBiMn8C9XOJAKJeCbYRjSzynB35QeDeL8/xLnjgCBp+dEWZJPpCiGegEoR87FgzqssQTEA==
       tarball: file:projects/sample-automation-tests.tgz
     version: 0.0.0
   file:projects/sample-static-html-composites.tgz:
@@ -20351,6 +20365,7 @@ packages:
       react: 16.14.0
       react-dom: 16.13.1_react@16.14.0
       rimraf: 2.7.1
+      tslib: 2.5.0
       typescript: 4.3.5
       uuid: 8.3.2
       webpack: 5.76.0_webpack-cli@4.10.0
@@ -20359,7 +20374,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-ko1yt/0XbzGYUir7V6Qm+fzPitpOvBk3CttbYaX8GSQkiwSF28PRdvrFVpNL7N2vOuru0EupaQrgmo0ey5jTAA==
+      integrity: sha512-VXliTXXMwy1+p7YG59c6nqP+w/mKZLi2OTSCaevd6Y4AIGjxSbCuI7lRkCyfEmEipWBVGUjltdObx4QGS+wSUg==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -20405,6 +20420,7 @@ packages:
       ts-loader: 8.4.0_typescript@4.3.5+webpack@5.76.0
       ts-node: 9.1.1_typescript@4.3.5
       ts-node-dev: 1.1.8_typescript@4.3.5
+      tslib: 2.5.0
       typescript: 4.3.5
       webpack: 5.76.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_webpack@5.76.0
@@ -20412,7 +20428,7 @@ packages:
     dev: false
     name: '@rush-temp/server'
     resolution:
-      integrity: sha512-E5DK1IeEBpG0UDst9I6O7quAwvueQhYUPZAhTKHGzqWYKpZx0MIiC11g4vaxGNm7NvusN2xBEZ1j7ZqhrDjSFg==
+      integrity: sha512-xAMkmIKZUxfekqQ44Dl5utmfd6XxiLltvwqkVQREPit0N7fIvSxku7hCBymBkbEesR7YZnQFnChff9jNomhrLw==
       tarball: file:projects/server.tgz
     version: 0.0.0
   file:projects/storybook.tgz:
@@ -20432,7 +20448,7 @@ packages:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@microsoft/api-documenter': 7.12.22
       '@microsoft/api-extractor': 7.18.21
-      '@microsoft/applicationinsights-react-js': 3.0.5_react@16.14.0+tslib@2.3.1
+      '@microsoft/applicationinsights-react-js': 3.0.5_react@16.14.0+tslib@2.5.0
       '@microsoft/applicationinsights-web': 2.6.5
       '@storybook/addon-actions': 6.5.16_react-dom@16.13.1+react@16.14.0
       '@storybook/addon-controls': 6.5.16_21967b81d2c78d5d5bef666521618933
@@ -20505,7 +20521,7 @@ packages:
       styled-components: 5.2.3_2c10db6bed9aaf10b28f0c8606f7c0c7
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
       ts-node: 9.1.1_typescript@4.3.5
-      tslib: 2.3.1
+      tslib: 2.5.0
       typescript: 4.3.5
       uuid: 8.3.2
       webpack: 5.76.0
@@ -20513,7 +20529,7 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-HKv1S5ZgfrvXWVgMSbAPkjJM5doICsnIbCfdvnE8fNeoHvDvJAmg4MSDjharSqkW2RnkeZ+sz2TJ+GWfaoVhSQ==
+      integrity: sha512-tBd0106bPAj4te88mTtoSyO5XTsGiK/KCPqaOW5jF2rWEkz929CehE7NRGWcqoLMZcrs2/6xGK1JvnNlTQBSQg==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -110,7 +110,7 @@ packages:
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.3
       events: 3.3.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     engines:
       node: '>=12.0.0'
@@ -164,7 +164,7 @@ packages:
   /@azure/core-auth/1.3.2:
     dependencies:
       '@azure/abort-controller': 1.1.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     engines:
       node: '>=12.0.0'
@@ -186,7 +186,7 @@ packages:
       '@azure/core-auth': 1.4.0
       '@azure/core-rest-pipeline': 1.10.1
       '@azure/core-tracing': 1.0.0-preview.13
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     engines:
       node: '>=12.0.0'
@@ -219,7 +219,7 @@ packages:
       node-fetch: 2.6.7
       process: 0.11.10
       tough-cookie: 4.1.2
-      tslib: 2.4.1
+      tslib: 2.5.0
       tunnel: 0.0.6
       uuid: 8.3.2
       xml2js: 0.4.23
@@ -232,7 +232,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/logger': 1.0.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     engines:
       node: '>=12.0.0'
@@ -281,7 +281,7 @@ packages:
       form-data: 4.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       uuid: 8.3.2
     dev: false
     engines:
@@ -1884,7 +1884,7 @@ packages:
   /@fluentui/date-time-utilities/8.5.4:
     dependencies:
       '@fluentui/set-version': 8.2.6
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-PHLrbKs/s80xVkvFLQkaYb78a9nRUlohj8FCDBFQ8F1qPJj3iVH1RuSLyTiCIRJy/v1hW6KMEIXqLu/EoMefXw==
@@ -1898,7 +1898,7 @@ packages:
   /@fluentui/dom-utilities/2.2.6:
     dependencies:
       '@fluentui/set-version': 8.2.6
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-yJOEiFj/TfR307hzZn15kNocC0P3j2BltrAJznhgXywMKJhIczATFTfj2len7YMHxLttnR5yDz/oYpyBLSk4rw==
@@ -1907,7 +1907,7 @@ packages:
       '@fluentui/set-version': 8.2.6
       '@fluentui/style-utilities': 8.9.6_20d09e348401b0c6dd91fc14ba93384f
       '@fluentui/utilities': 8.13.9_20d09e348401b0c6dd91fc14ba93384f
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '*'
@@ -1922,7 +1922,7 @@ packages:
       '@fluentui/utilities': 8.13.9_20d09e348401b0c6dd91fc14ba93384f
       '@types/react': 16.14.34
       react: 16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '>=16.8.0 <19.0.0'
@@ -1931,14 +1931,14 @@ packages:
       integrity: sha512-7XKz23HB7IeIIXORS1os2fIakYTLTTGFcs+mnK5f/b4xFJAOxxdte6i10f2WsPPFiTjW1kLOzICsRsfwuHAVRw==
   /@fluentui/keyboard-key/0.4.4:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-nx0bQ9B5QtUym9a21ig5eHPt2T6EWaqrleFb37d6ImikP6xVXUHrWQJFuVS1CSg0n63KOPsmh1QvAUfxfmyLhw==
   /@fluentui/merge-styles/8.5.7:
     dependencies:
       '@fluentui/set-version': 8.2.6
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-t/mOQTigj51n7z6VPZ1nlb9getkzoLVhN0aUbOJUSD5qvu0gZqSBh7Y9xIP6QeYWF4q6wcZhEggo8HOgYqaWQw==
@@ -2010,7 +2010,7 @@ packages:
       '@fluentui/style-utilities': 8.9.6_20d09e348401b0c6dd91fc14ba93384f
       '@types/react': 16.14.34
       react: 16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '>=16.8.0 <19.0.0'
@@ -2026,7 +2026,7 @@ packages:
       '@fluentui/utilities': 8.13.9_20d09e348401b0c6dd91fc14ba93384f
       '@types/react': 16.14.34
       react: 16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '>=16.8.0 <19.0.0'
@@ -2040,7 +2040,7 @@ packages:
       '@fluentui/utilities': 8.13.9_20d09e348401b0c6dd91fc14ba93384f
       '@types/react': 16.14.34
       react: 16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '>=16.8.0 <19.0.0'
@@ -2069,7 +2069,7 @@ packages:
     dependencies:
       '@griffel/react': 1.5.4_react@16.14.0
       react: 16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       react: '>=16.8.0 <19.0.0'
@@ -2148,7 +2148,7 @@ packages:
     dependencies:
       '@types/react': 16.14.34
       react: 16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '>=16.8.0 <19.0.0'
@@ -2168,7 +2168,7 @@ packages:
       '@fluentui/set-version': 8.2.6
       '@types/react': 16.14.34
       react: 16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '>=16.8.0 <19.0.0'
@@ -2194,7 +2194,7 @@ packages:
       '@types/react-dom': 16.9.17
       react: 16.14.0
       react-dom: 16.13.1_react@16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '>=16.8.0 <19.0.0'
@@ -2207,7 +2207,7 @@ packages:
     dependencies:
       '@fluentui/set-version': 8.2.6
       '@fluentui/theme': 2.6.25_20d09e348401b0c6dd91fc14ba93384f
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '*'
@@ -2216,7 +2216,7 @@ packages:
       integrity: sha512-7ua5xD9N6gEq47FZWREeeVzKaYbsthVHC2PiKwsae65GMmyBS35AA7Fxx2AGJmI2j9z7JkMd+qMEjQ2I+poe7w==
   /@fluentui/set-version/8.2.6:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-zXIfscQ1ZAiEpHc5taMrDEtTP2NtPBGlz2HbOpZiQ3aj/xcnUT7nT73ctb+Q2bHIqlDCHEaFRQxy/HG6koGYAA==
@@ -2233,7 +2233,7 @@ packages:
       '@fluentui/theme': 2.6.25_20d09e348401b0c6dd91fc14ba93384f
       '@fluentui/utilities': 8.13.9_20d09e348401b0c6dd91fc14ba93384f
       '@microsoft/load-themed-styles': 1.10.295
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '*'
@@ -2253,7 +2253,7 @@ packages:
       '@fluentui/react': 8.98.8_be457b8870bd20e1d840272f6132c06f
       '@fluentui/scheme-utilities': 8.3.22_20d09e348401b0c6dd91fc14ba93384f
       '@fluentui/set-version': 8.2.6
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '*'
@@ -2269,7 +2269,7 @@ packages:
       '@fluentui/utilities': 8.13.9_20d09e348401b0c6dd91fc14ba93384f
       '@types/react': 16.14.34
       react: 16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '>=16.8.0 <19.0.0'
@@ -2283,7 +2283,7 @@ packages:
       '@fluentui/set-version': 8.2.6
       '@types/react': 16.14.34
       react: 16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       '@types/react': '>=16.8.0 <19.0.0'
@@ -2300,7 +2300,7 @@ packages:
       csstype: 3.1.1
       rtl-css-js: 1.16.1
       stylis: 4.1.3
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-bGYgCIjyAh/TtTPowiGcS8E7u8Kt0pjL55ZwMOcqmvkKIv1CHyAgK+DUgGiCuM4YGuN0QLV0X/mLddStcVyPsg==
@@ -2308,7 +2308,7 @@ packages:
     dependencies:
       '@griffel/core': 1.9.2
       react: 16.14.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       react: '>=16.8.0 <19.0.0'
@@ -2731,12 +2731,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-nwJ0UO5WZbbdU6mgiN1oZ/NLTbT/oeMVmZJtlbuQ+xCz57LODi/mPAndd4+BA3xU+4u7MhLl6GyQqX5hcyUsow==
-  /@microsoft/applicationinsights-common/2.8.9_tslib@2.3.1:
+  /@microsoft/applicationinsights-common/2.8.9_tslib@2.5.0:
     dependencies:
-      '@microsoft/applicationinsights-core-js': 2.8.9_tslib@2.3.1
+      '@microsoft/applicationinsights-core-js': 2.8.9_tslib@2.5.0
       '@microsoft/applicationinsights-shims': 2.0.2
       '@microsoft/dynamicproto-js': 1.1.7
-      tslib: 2.3.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       tslib: '*'
@@ -2749,11 +2749,11 @@ packages:
     dev: false
     resolution:
       integrity: sha512-+Vg8Cy06Z+Mwh4W7P5hqx03ThO+l5t7TfcP+ynuS1SGFIuYKaBOwxgt/uIIon8X12sk0dGkrPsTGZMiUtXJ5Zw==
-  /@microsoft/applicationinsights-core-js/2.8.9_tslib@2.3.1:
+  /@microsoft/applicationinsights-core-js/2.8.9_tslib@2.5.0:
     dependencies:
       '@microsoft/applicationinsights-shims': 2.0.2
       '@microsoft/dynamicproto-js': 1.1.7
-      tslib: 2.3.1
+      tslib: 2.5.0
     dev: false
     peerDependencies:
       tslib: '*'
@@ -2777,10 +2777,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-0etD5TkBFi4cnleGivxc02uLJIaP/sGHpyzOXfYSuLzRchKGWwX+fVhirt/acIigh+Mi8tiDuXqZ92H7DE5mbA==
-  /@microsoft/applicationinsights-react-js/3.0.5_react@16.14.0+tslib@2.3.1:
+  /@microsoft/applicationinsights-react-js/3.0.5_react@16.14.0+tslib@2.5.0:
     dependencies:
-      '@microsoft/applicationinsights-common': 2.8.9_tslib@2.3.1
-      '@microsoft/applicationinsights-core-js': 2.8.9_tslib@2.3.1
+      '@microsoft/applicationinsights-common': 2.8.9_tslib@2.5.0
+      '@microsoft/applicationinsights-core-js': 2.8.9_tslib@2.5.0
       '@microsoft/applicationinsights-shims': 1.0.3
       history: 4.10.1
       react: 16.14.0
@@ -4602,7 +4602,7 @@ packages:
       flat-cache: 3.0.4
       micromatch: 4.0.5
       react-docgen-typescript: 2.2.2_typescript@4.3.5
-      tslib: 2.4.1
+      tslib: 2.5.0
       typescript: 4.3.5
       webpack: 5.76.0
     dev: false
@@ -6499,7 +6499,7 @@ packages:
       integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
   /ast-types/0.14.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     engines:
       node: '>=4'
@@ -7295,7 +7295,7 @@ packages:
   /camel-case/4.1.2:
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
@@ -8758,7 +8758,7 @@ packages:
   /dot-case/3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
@@ -9246,7 +9246,7 @@ packages:
       remark-mdx: 1.6.22
       remark-parse: 8.0.3
       remark-stringify: 8.1.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       unified: 9.2.2
     dev: false
     engines:
@@ -9374,7 +9374,7 @@ packages:
       eslint-mdx: 1.17.1_eslint@7.32.0
       eslint-plugin-markdown: 2.2.1_eslint@7.32.0
       synckit: 0.4.1
-      tslib: 2.4.1
+      tslib: 2.5.0
       vfile: 4.2.1
     dev: false
     engines:
@@ -13221,7 +13221,7 @@ packages:
       integrity: sha512-RPNliZOFkqFumDhvYqOaNY4Uz9oJM2K9tC6JWsJJsNdhuONW4LQHRBpb0qf4pJApVffI5N39SwzWZJuEhfd7eQ==
   /lower-case/2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
@@ -13869,7 +13869,7 @@ packages:
   /no-case/3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
@@ -14457,7 +14457,7 @@ packages:
   /param-case/3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
@@ -14592,7 +14592,7 @@ packages:
   /pascal-case/3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: false
     resolution:
       integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
@@ -17361,7 +17361,7 @@ packages:
       integrity: sha512-qImOD23aDfnIDNqlG1NOehdB9IYsn1V9oByPjKY1nakv2MQYCEMyX033/q+aEtYCpmYK1cv2+NTmlH+ra6GA5A==
   /synckit/0.4.1:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
       uuid: 8.3.2
     dev: false
     engines:
@@ -17857,14 +17857,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-  /tslib/2.3.1:
-    dev: false
-    resolution:
-      integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
   /tslib/2.4.1:
     dev: false
     resolution:
       integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+  /tslib/2.5.0:
+    dev: false
+    resolution:
+      integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
   /tsutils/3.21.0_typescript@4.3.5:
     dependencies:
       tslib: 1.14.1
@@ -19469,7 +19469,7 @@ packages:
     dev: false
     name: '@rush-temp/calling-component-bindings'
     resolution:
-      integrity: sha512-ixKHvnPbZVrXKdh1EbPIjBvOAnLnVhkm7wFsfCWOcksN0uHcTRuHjVuEdv1kSUwwp9f3JFOd26r2KrnbPH2ofg==
+      integrity: sha512-eEYDANCE3j4J5TnP8gU7cHlK4HhUpq6bKUYoytzgQx0ufqr4W/TG1ZoYDtl/sMDPz+ATUpxdiNor4kWvUFPDMg==
       tarball: file:projects/calling-component-bindings.tgz
     version: 0.0.0
   file:projects/calling-stateful-client.tgz:
@@ -19509,7 +19509,7 @@ packages:
     dev: false
     name: '@rush-temp/calling-stateful-client'
     resolution:
-      integrity: sha512-63AZgPE+5o8Bk+vwSREPRytao1Hx0dlGtJVFyERn25GKWt7O6DFFES0re/ZXo4UH/0d497sBYN10ZMxj1fe3Pg==
+      integrity: sha512-LTZrQnMEDdUeas8XusGB3AcfQBGOcTdPRKuQO3gIeMbJ7mVwGdcH2PT0f/XjqRCOj3zWkzTMHlvVn+kdfUJXUA==
       tarball: file:projects/calling-stateful-client.tgz
     version: 0.0.0
   file:projects/calling.tgz:
@@ -19584,7 +19584,7 @@ packages:
     dev: false
     name: '@rush-temp/calling'
     resolution:
-      integrity: sha512-o6lUttajIZK9r0YjT54XeGDMJJGX9qbGBy1OkqBRvYe+zAlcKLW1PEVdxQ+MEnz8Xgu6mLGqSJfikPkZNAW4Nw==
+      integrity: sha512-m/ZBaEj8IhxagFWizM6ibP5w1Zjck83AcxRzuyM7kuPXKfp9EtdePRlJyUjMn2cKgmSgwO5V9LqnJB8Tguo8UA==
       tarball: file:projects/calling.tgz
     version: 0.0.0
   file:projects/callwithchat.tgz:
@@ -19657,7 +19657,7 @@ packages:
     dev: false
     name: '@rush-temp/callwithchat'
     resolution:
-      integrity: sha512-y2RJAIxqagC7yyUclQaJCiGdsP7RfxBPKhgLqrfksRmHjMCbjhJtSI7M8S6eOEdrxGX+aEAlgJTOlQpI+jZrPg==
+      integrity: sha512-DEbd7FLfo57PD2NiMq4FnxU6L2ktr3wqwYp4rB+PSgfWmQyb8uDKkpXvBV15Xy5GGeV42K90Hk67ImR+ZzP8Wg==
       tarball: file:projects/callwithchat.tgz
     version: 0.0.0
   file:projects/chat-component-bindings.tgz:
@@ -19694,7 +19694,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-component-bindings'
     resolution:
-      integrity: sha512-aXyL95Wy5J3oDiCyWWelDy7p9HjsCQ4CM9IpmpvP0DpV03YrCSqi8Hlz+VkUqErxT02l5IA/Q9GUcV37lsfq9A==
+      integrity: sha512-GL+GPRolYx9skDbl9H/VgB3Krdo+uZauB4MddRrWi8hri7TaoqpJPIBcYxXlnotwb2JOGQkDkt4XghncQbVsTA==
       tarball: file:projects/chat-component-bindings.tgz
     version: 0.0.0
   file:projects/chat-stateful-client.tgz:
@@ -19736,7 +19736,7 @@ packages:
     dev: false
     name: '@rush-temp/chat-stateful-client'
     resolution:
-      integrity: sha512-zQb11kZtTnOt7ilKFlvvZXqk8S2IV8uhDzSQdVPhoQHVooLhNmztNUAn9pXi9Qv2GV/wC68gqgKt2ikkN/DVHg==
+      integrity: sha512-zZJbBDQxr46y3YvXaPd+jmr7fVU8BoiDxzmLlFOOsD2oMKNrysUDmiZdazV16LgTSbkfz8y/CwKqia52q67pGw==
       tarball: file:projects/chat-stateful-client.tgz
     version: 0.0.0
   file:projects/chat.tgz:
@@ -19805,7 +19805,7 @@ packages:
     dev: false
     name: '@rush-temp/chat'
     resolution:
-      integrity: sha512-MhJxt3w/8UkrrG4zHRFYfofe+y1bqyTJ8lU3oj7fGp6oIAIM/irO+qBQ9ZuCZCFhYxfewgEUAq1w58eHucwo2g==
+      integrity: sha512-prEGi+GNpfxrJuJlOXyKvTaFML7MUSFVm8qHDQ71c2cdzQARs7rSYFeuRNz/9f8o2izY41dDNg6Gykc6WbYHrg==
       tarball: file:projects/chat.tgz
     version: 0.0.0
   file:projects/check-treeshaking.tgz:
@@ -19825,7 +19825,7 @@ packages:
     dev: false
     name: '@rush-temp/check-treeshaking'
     resolution:
-      integrity: sha512-+tmmgm74zTv/sX6BjHQY6qrX15CqJpNfPgVzDxonbtlZ0Fi4eQOi31xZ8Jv/uVY1tD8z5hNkuKi6pSJi89xDOw==
+      integrity: sha512-/z2XExqUdJMUuwFfEJaJ07biHIEOmVt1PBi1O04YVo1TxmgiTGK9qvlKBKhXFQiPxp2+weqox6QnkZfWFYb8Yg==
       tarball: file:projects/check-treeshaking.tgz
     version: 0.0.0
   file:projects/check-typescript-regression.tgz:
@@ -19847,7 +19847,7 @@ packages:
     dev: false
     name: '@rush-temp/check-typescript-regression'
     resolution:
-      integrity: sha512-544CUhGX3OG/+YfC3ySM+jNxTTYD2oeJZba9vhDQCApmlEVFtMCsDGRfao2RTtwUSVrQg9ZaRNBqQDs/hDZYYA==
+      integrity: sha512-4IpTfhLEORaphzhrcP8GJZt1mNKsBP4/6IQlQmai+1XN0nb54PJWLHBs9nMoad04/dJeGu7N60RSmx8Qw/GFHA==
       tarball: file:projects/check-typescript-regression.tgz
     version: 0.0.0
   file:projects/communication-react.tgz:
@@ -19937,7 +19937,7 @@ packages:
     dev: false
     name: '@rush-temp/communication-react'
     resolution:
-      integrity: sha512-8sLTN2ZHqYz/xsOPvx+CvPwl1rZvsC4zZ6K/kOilLgcmYzUpRJqwhKsdI+WdPwyLwkkgLuqF50f/YIctVJVLbA==
+      integrity: sha512-a8ZL6SEPObdI7oAtU4dcmXvDZjnUpnPBBZda1sxqQ5Iflc0kr0AjhV5T+3qy+HJDQ71x8f6zvY7Meiog8HQmpg==
       tarball: file:projects/communication-react.tgz
     version: 0.0.0
   file:projects/component-examples.tgz:
@@ -19987,7 +19987,7 @@ packages:
     dev: false
     name: '@rush-temp/component-examples'
     resolution:
-      integrity: sha512-DFbTZIfP0Z9QNPjRkhbEcwXPK/tRSuSXuBcYvW41S/QdoiNl3IHPMx7s1VoGWMB/bWQAbJonmsmjdykhyVBLDA==
+      integrity: sha512-29cLt2Z9MIEJpYc9+PSGeaXSybRLQSEoQoP7ZUHAhH44rrpRaIXx7otiU294BIeTjTLOIQp+mxL8lAnEFJWCPg==
       tarball: file:projects/component-examples.tgz
     version: 0.0.0
   file:projects/config.tgz:
@@ -20046,7 +20046,7 @@ packages:
     dev: false
     name: '@rush-temp/fake-backends'
     resolution:
-      integrity: sha512-PjwTlqnh0/p70t2fZJUdKcpWm1Oqc8PH2l9DMIbReazD7MmqlXmBhdp3RIUCwUfrJtndT9VL80Jpv7Hze4QYXg==
+      integrity: sha512-qlU23QabLoivT5HYrYfQOtsFUl3TYv0oH1bbri8qubcEnbWNZEOGjOrl7r8tlX1mRYzn/FTN/tG/T832yPMMCw==
       tarball: file:projects/fake-backends.tgz
     version: 0.0.0
   file:projects/northstar-wrapper.tgz:
@@ -20155,7 +20155,7 @@ packages:
     dev: false
     name: '@rush-temp/react-components'
     resolution:
-      integrity: sha512-8D7ZbOgOrP0qHz+sJPQYggj8C2+pD6iRha1T95uE16kH4hQ8k6W3Oicljdv6/Pgay4FjFtfA1aUsTq8IFQ1mWw==
+      integrity: sha512-RDwwYZAl5U4N99Rr2AipfxK/9gD1qJ+nMTX5b3Gh5uCw9A5LjLwW8vTwnrGax6DdCAsfS2xWNPCvnndEWTpwPA==
       tarball: file:projects/react-components.tgz
     version: 0.0.0
   file:projects/react-composites.tgz:
@@ -20267,7 +20267,7 @@ packages:
     dev: false
     name: '@rush-temp/react-composites'
     resolution:
-      integrity: sha512-t4WbkKiq/lhC/gbOHWbnRdFB+cWTbXPcO+kew53f8iRMkL9/Lrwwjahlfj9cRX7HkklVb9GgfDVuU4yDdJJWzw==
+      integrity: sha512-xy0zMDZeOWs+XDHixhGyM0PR2dV0Xt++G12UtJzPWKjDcQX74PJqVLalNlFEEw1Chn57eGyoabdGJ25CWvtnaA==
       tarball: file:projects/react-composites.tgz
     version: 0.0.0
   file:projects/sample-automation-tests.tgz:
@@ -20330,7 +20330,7 @@ packages:
     dev: false
     name: '@rush-temp/sample-static-html-composites'
     resolution:
-      integrity: sha512-ko1yt/0XbzGYUir7V6Qm+fzPitpOvBk3CttbYaX8GSQkiwSF28PRdvrFVpNL7N2vOuru0EupaQrgmo0ey5jTAA==
+      integrity: sha512-1PCK89tstK6+HHS+yG4k9dD8eeap9o6eNCV5l5B5NP+BjGbnI8pvvjk0c4RQ6NF5IDCqyDFXjOHW3ttRA6285w==
       tarball: file:projects/sample-static-html-composites.tgz
     version: 0.0.0
   file:projects/server.tgz:
@@ -20403,7 +20403,7 @@ packages:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@microsoft/api-documenter': 7.12.22
       '@microsoft/api-extractor': 7.18.21
-      '@microsoft/applicationinsights-react-js': 3.0.5_react@16.14.0+tslib@2.3.1
+      '@microsoft/applicationinsights-react-js': 3.0.5_react@16.14.0+tslib@2.5.0
       '@microsoft/applicationinsights-web': 2.6.5
       '@storybook/addon-actions': 6.5.15_react-dom@16.13.1+react@16.14.0
       '@storybook/addon-controls': 6.5.15_21967b81d2c78d5d5bef666521618933
@@ -20476,7 +20476,7 @@ packages:
       styled-components: 5.2.3_2c10db6bed9aaf10b28f0c8606f7c0c7
       ts-jest: 26.5.6_jest@26.6.0+typescript@4.3.5
       ts-node: 9.1.1_typescript@4.3.5
-      tslib: 2.3.1
+      tslib: 2.5.0
       typescript: 4.3.5
       uuid: 8.3.2
       webpack: 5.76.0
@@ -20484,7 +20484,7 @@ packages:
     dev: false
     name: '@rush-temp/storybook'
     resolution:
-      integrity: sha512-HKv1S5ZgfrvXWVgMSbAPkjJM5doICsnIbCfdvnE8fNeoHvDvJAmg4MSDjharSqkW2RnkeZ+sz2TJ+GWfaoVhSQ==
+      integrity: sha512-tBd0106bPAj4te88mTtoSyO5XTsGiK/KCPqaOW5jF2rWEkz929CehE7NRGWcqoLMZcrs2/6xGK1JvnNlTQBSQg==
       tarball: file:projects/storybook.tgz
     version: 0.0.0
 specifiers:

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -34,7 +34,7 @@
     "@microsoft/applicationinsights-web": "~2.6.2",
     "copy-to-clipboard": "~3.3.1",
     "resize-observer-polyfill": "~1.5.1",
-    "tslib": "~2.3.1",
+    "tslib": "~2.5.0",
     "uuid": "^8.1.0",
     "browserslist": "~4.20.4"
   },


### PR DESCRIPTION
# What
(node:7695) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at /workspaces/communication-ui-library/packages/storybook/node_modules/tslib/package.json.
Update this package.json to use a subpath pattern like "./*".

I found that as of tslib@2.4.0 they had fixed the issue to add ./* in addition to ./. Seeing as we had an opportunity to update I chose to update to tslib@2.5.0