### PR TITLE
[Chat][Mention] Resolve accessibility issues with mention popover

### DIFF
--- a/packages/react-components/src/components/MentionPopover.tsx
+++ b/packages/react-components/src/components/MentionPopover.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { Persona, PersonaSize, Stack, mergeStyles, useTheme } from '@fluentui/react';
+import { Persona, PersonaSize, Stack, mergeStyles, useTheme, FocusZone } from '@fluentui/react';
 import {
   mentionPopoverContainerStyle,
   headerStyleThemed,
@@ -251,6 +251,7 @@ export const _MentionPopover = (props: _MentionPopoverProps): JSX.Element => {
     (suggestion: Mention, onSuggestionSelected: (suggestion: Mention) => void, active: boolean): JSX.Element => {
       return (
         <div
+          role={'menuitem'}
           data-is-focusable={true}
           /* @conditional-compile-remove(mention) */
           data-ui-id={ids.mentionSuggestionItem}
@@ -314,18 +315,20 @@ export const _MentionPopover = (props: _MentionPopoverProps): JSX.Element => {
         <Stack.Item styles={headerStyleThemed(theme)} aria-label={title}>
           {getHeaderTitle()}
         </Stack.Item>
-        <Stack
-          /* @conditional-compile-remove(mention) */
-          data-ui-id={ids.mentionSuggestionList}
-          className={suggestionListStyle}
-        >
-          {suggestions.map((suggestion, index) => {
-            const active = index === activeSuggestionIndex;
-            return onRenderSuggestionItem
-              ? onRenderSuggestionItem(suggestion, onSuggestionSelected, active)
-              : defaultOnRenderSuggestionItem(suggestion, onSuggestionSelected, active);
-          })}
-        </Stack>
+        <FocusZone shouldFocusOnMount={true}>
+          <Stack
+            /* @conditional-compile-remove(mention) */
+            data-ui-id={ids.mentionSuggestionList}
+            className={suggestionListStyle}
+          >
+            {suggestions.map((suggestion, index) => {
+              const active = index === activeSuggestionIndex;
+              return onRenderSuggestionItem
+                ? onRenderSuggestionItem(suggestion, onSuggestionSelected, active)
+                : defaultOnRenderSuggestionItem(suggestion, onSuggestionSelected, active);
+            })}
+          </Stack>
+        </FocusZone>
       </Stack>
     </div>
   );


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

- When using narrator/voice over, the focus should be put on the first item in the popover when it appears.
- Each item in the list should have a role of menu item

# Why

These accessibility issues needed to be addressed.

# How Tested

- Locally run storybook and test with 'SendBox - AtMention' example
- Use narrator/voice-over with Chrome on Mac OS by pressing CMD + F5
- Open popover


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->