### PR TITLE
[BugFix] hidden button fix next to display name

### DIFF
--- a/change-beta/@azure-communication-react-1c6faaa8-8c95-4225-94ff-e1e218d94b33.json
+++ b/change-beta/@azure-communication-react-1c6faaa8-8c95-4225-94ff-e1e218d94b33.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove empty space to the right of participant displayName when tile is not being interacted with.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-1c6faaa8-8c95-4225-94ff-e1e218d94b33.json
+++ b/change/@azure-communication-react-1c6faaa8-8c95-4225-94ff-e1e218d94b33.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove empty space to the right of participant displayName when tile is not being interacted with.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/VideoTile.styles.ts
+++ b/packages/react-components/src/components/styles/VideoTile.styles.ts
@@ -129,7 +129,8 @@ export const moreButtonStyles: IButtonStyles = {
     zIndex: 1,
     color: 'inherit',
     top: '-0.125rem',
-    height: '100%'
+    height: '100%',
+    padding: '0rem'
   },
   rootHovered: {
     background: 'none'


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Remove the padding from the button when it is hidden
# Why
<!--- What problem does this change solve? -->
![image](https://github.com/Azure/communication-ui-library/assets/94866715/03a511e8-7613-4286-858d-e7315beef2c0)

<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3210879
# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran locally in storybook and sample app to make sure it is appearing correctly and that it is still keyboard accessible.