### PR TITLE
[Chat] Show message content in an alert after sending mention messages in Storybook

### DIFF
--- a/change-beta/@azure-communication-react-72bcd241-0e7c-489d-bda4-ecec6f5d31d6.json
+++ b/change-beta/@azure-communication-react-72bcd241-0e7c-489d-bda4-ecec6f5d31d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Show message content in an alert after sending mention messages in Storybook",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-72bcd241-0e7c-489d-bda4-ecec6f5d31d6.json
+++ b/change/@azure-communication-react-72bcd241-0e7c-489d-bda4-ecec6f5d31d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Show message content in an alert after sending mention messages in Storybook",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/SendBox/snippets/Mentions.snippet.tsx
+++ b/packages/storybook/stories/SendBox/snippets/Mentions.snippet.tsx
@@ -30,9 +30,7 @@ export const MentionsExample: () => JSX.Element = () => (
     <div style={{ width: '31.25rem', height: '20rem' }}>
       <div style={{ width: '31.25rem', height: '17rem' }} /> {/*Spacer for layout*/}
       <SendBox
-        onSendMessage={async () => {
-          return;
-        }}
+        onSendMessage={async (message) => alert(`sent message: ${message} `)}
         onTyping={async () => {
           return;
         }}


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
In the Sendbox page of the Storybook, `Docs` tab and `Mentioning Users` section,
Users should be able to see the message content via alert after tap on the send button

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->