### PR TITLE
Add cancelEdit callback to the adapter layer

### DIFF
--- a/change-beta/@azure-communication-react-4350dfda-8677-4c7f-bfd0-8fe302f1e423.json
+++ b/change-beta/@azure-communication-react-4350dfda-8677-4c7f-bfd0-8fe302f1e423.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add stub of cancel functionality to adapter layer",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-4350dfda-8677-4c7f-bfd0-8fe302f1e423.json
+++ b/change/@azure-communication-react-4350dfda-8677-4c7f-bfd0-8fe302f1e423.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add stub of cancel functionality to adapter layer",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-component-bindings/src/handlers/createHandlers.ts
+++ b/packages/chat-component-bindings/src/handlers/createHandlers.ts
@@ -118,7 +118,7 @@ export const createDefaultChatHandlers = memoizeOne(
             break;
           }
         }
-        // keep fetching read receipts until read receipt time < earlist message time
+        // keep fetching read receipts until read receipt time < earliest message time
         let readReceipt = await readReceiptIterator.next();
         while (!readReceipt.done && parseInt(readReceipt?.value?.chatMessageId) >= earliestTime) {
           readReceipt = await readReceiptIterator.next();

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -193,7 +193,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   }
 
   async fetchInitialData(): Promise<void> {
-    // If get properties fails we dont want to try to get the participants after.
+    // If get properties fails we don't want to try to get the participants after.
     await this.asyncTeeErrorToEventEmitter(async () => {
       await this.chatThreadClient.getProperties();
       // Fetch all participants who joined before the local user.
@@ -282,6 +282,10 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
       return await this.handlers.onUpdateMessage(messageId, content, metadata, options);
       return await this.handlers.onUpdateMessage(messageId, content);
     });
+  }
+
+  async cancelMessageEdit(messageId: string): Promise<void> {
+    // Reset message to original content, which is a no-op here.
   }
 
   async deleteMessage(messageId: string): Promise<void> {

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -284,7 +284,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
     });
   }
 
-  async cancelMessageEdit(messageId: string): Promise<void> {
+  async cancelMessageEdit(/*messageId: string*/): Promise<void> {
     // Reset message to original content, which is a no-op here.
   }
 


### PR DESCRIPTION
# What
Some time ago, a proper edit cancel callback was added to the MessageThread component. It is not necessary to implement this within our chat composite from a logic point of view, it was more for implementors _not_ using an ACS backend to be able to get proper state updates.

This PR passes the handler through to the composite

# Why
Developer experience completeness

# How Tested
Chat sample

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->