### PR TITLE
[bugfix] Set MaxHeight to drawerSurface and drawerMenu

### DIFF
--- a/change-beta/@azure-communication-react-02670397-a3f7-4513-88b1-b0d40e409963.json
+++ b/change-beta/@azure-communication-react-02670397-a3f7-4513-88b1-b0d40e409963.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set MaxHeight to drawerSurface and drawerMenu",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-02670397-a3f7-4513-88b1-b0d40e409963.json
+++ b/change/@azure-communication-react-02670397-a3f7-4513-88b1-b0d40e409963.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Set MaxHeight to drawerSurface and drawerMenu",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -885,6 +885,7 @@ export interface _DrawerMenuItemProps {
 
 // @internal
 export interface _DrawerMenuProps {
+    disableMaxHeight?: boolean;
     heading?: string;
     // (undocumented)
     items: _DrawerMenuItemProps[];
@@ -904,6 +905,7 @@ export const _DrawerSurface: (props: _DrawerSurfaceProps) => JSX.Element;
 // @internal
 export interface _DrawerSurfaceProps {
     children: React_2.ReactNode;
+    disableMaxHeight?: boolean;
     heading?: string;
     onLightDismiss: () => void;
     styles?: _DrawerSurfaceStyles;

--- a/packages/react-components/src/components/Drawer/DrawerMenu.tsx
+++ b/packages/react-components/src/components/Drawer/DrawerMenu.tsx
@@ -37,6 +37,12 @@ export interface _DrawerMenuProps {
    */
   heading?: string;
 
+  /**
+   * By default, maxHeight value is set to 75%.
+   * Set value to true for no default maxHeight to be applied on drawerSurface
+   */
+  disableMaxHeight?: boolean;
+
   styles?: _DrawerMenuStyles;
 }
 
@@ -93,6 +99,7 @@ export const _DrawerMenu = (props: _DrawerMenuProps): JSX.Element => {
 
   return (
     <_DrawerSurface
+      disableMaxHeight={props.disableMaxHeight}
       styles={props.styles?.drawerSurfaceStyles}
       onLightDismiss={props.onLightDismiss}
       heading={props.heading}

--- a/packages/react-components/src/components/Drawer/DrawerSurface.tsx
+++ b/packages/react-components/src/components/Drawer/DrawerSurface.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { FocusTrapZone, IStyle, mergeStyles, Stack } from '@fluentui/react';
+import { FocusTrapZone, IStyle, mergeStyles, mergeStyleSets, Stack } from '@fluentui/react';
 import React from 'react';
 import { BaseCustomStyles } from '../../types';
 import { DrawerContentContainer } from './DrawerContentContainer';
@@ -40,6 +40,12 @@ export interface _DrawerSurfaceProps {
    */
   heading?: string;
 
+  /**
+   * By default, maxHeight value is set to 75%.
+   * Set value to true for no default maxHeight to be applied on drawerSurface
+   */
+  disableMaxHeight?: boolean;
+
   /** Styles for the {@link DrawerSurface} */
   styles?: _DrawerSurfaceStyles;
 }
@@ -51,7 +57,10 @@ export interface _DrawerSurfaceProps {
  * @internal
  */
 export const _DrawerSurface = (props: _DrawerSurfaceProps): JSX.Element => {
-  const rootStyles = mergeStyles(drawerSurfaceStyles, props.styles?.root);
+  const rootStyles = props.disableMaxHeight
+    ? mergeStyles(drawerSurfaceStyles, props.styles?.root)
+    : mergeStyles(drawerSurfaceStyles, focusTrapZoneStyles, props.styles?.root);
+  const containerStyles = mergeStyleSets(drawerContentContainerStyles, props.styles?.drawerContentContainer);
 
   return (
     <Stack className={rootStyles}>
@@ -66,7 +75,7 @@ export const _DrawerSurface = (props: _DrawerSurfaceProps): JSX.Element => {
         // Note: this still correctly captures keyboard focus, this just allows mouse click outside of the focus trap.
         isClickableOutsideFocusTrap={true}
       >
-        <DrawerContentContainer styles={props.styles?.drawerContentContainer} heading={props.heading}>
+        <DrawerContentContainer styles={containerStyles} heading={props.heading}>
           {props.children}
         </DrawerContentContainer>
       </FocusTrapZone>
@@ -78,4 +87,21 @@ const drawerSurfaceStyles: IStyle = {
   width: '100%',
   height: '100%',
   background: 'rgba(0,0,0,0.4)'
+};
+
+const focusTrapZoneStyles: IStyle = {
+  // Targets FocusTrapZone in drawer.
+  // Setting percentage to Height to transform a container does not work unless the
+  // direct parent container also has a Height set other than 'auto'.
+  '> div:nth-child(2)': {
+    maxHeight: '75%',
+    overflow: 'auto'
+  }
+};
+
+const drawerContentContainerStyles: BaseCustomStyles = {
+  root: {
+    // Needed to fill max height from parent, drawerSurfaceStyles
+    height: '100%'
+  }
 };

--- a/packages/react-composites/src/composites/CallComposite/components/CallReadinessModal.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallReadinessModal.tsx
@@ -186,7 +186,11 @@ export const CallReadinessModal = (props: {
     return (
       <>
         {isPermissionsModalDismissed && (
-          <_DrawerSurface onLightDismiss={onLightDismissTriggered} styles={drawerContainerStyles(DRAWER_HIGH_Z_BAND)}>
+          <_DrawerSurface
+            disableMaxHeight={true}
+            onLightDismiss={onLightDismissTriggered}
+            styles={drawerContainerStyles(DRAWER_HIGH_Z_BAND)}
+          >
             {modal()}
           </_DrawerSurface>
         )}
@@ -323,7 +327,11 @@ export const CallReadinessModalFallBack = (props: {
     return (
       <>
         {(checkPermissionModalShowing || audioState === 'prompt' || videoState === 'prompt') && (
-          <_DrawerSurface onLightDismiss={onLightDismissTriggered} styles={drawerContainerStyles(DRAWER_HIGH_Z_BAND)}>
+          <_DrawerSurface
+            disableMaxHeight={true}
+            onLightDismiss={onLightDismissTriggered}
+            styles={drawerContainerStyles(DRAWER_HIGH_Z_BAND)}
+          >
             <CameraAndMicrophoneSitePermissions
               appName={'app'}
               /* @conditional-compile-remove(unsupported-browser) */
@@ -340,7 +348,11 @@ export const CallReadinessModalFallBack = (props: {
           </_DrawerSurface>
         )}
         {isPermissionsModalDismissed && !checkPermissionModalShowing && modal !== undefined && (
-          <_DrawerSurface onLightDismiss={onLightDismissTriggered} styles={drawerContainerStyles(DRAWER_HIGH_Z_BAND)}>
+          <_DrawerSurface
+            disableMaxHeight={true}
+            onLightDismiss={onLightDismissTriggered}
+            styles={drawerContainerStyles(DRAWER_HIGH_Z_BAND)}
+          >
             {modal()}
           </_DrawerSurface>
         )}

--- a/packages/react-composites/src/composites/common/AddPeopleDropdown.tsx
+++ b/packages/react-composites/src/composites/common/AddPeopleDropdown.tsx
@@ -139,7 +139,11 @@ export const AddPeopleDropdown = (props: AddPeopleDropdownProps): JSX.Element =>
 
         {addPeopleDrawerMenuItems.length > 0 && (
           <Stack styles={drawerContainerStyles()} data-ui-id="call-add-people-dropdown">
-            <_DrawerMenu onLightDismiss={() => setAddPeopleDrawerMenuItems([])} items={addPeopleDrawerMenuItems} />
+            <_DrawerMenu
+              disableMaxHeight={true}
+              onLightDismiss={() => setAddPeopleDrawerMenuItems([])}
+              items={addPeopleDrawerMenuItems}
+            />
           </Stack>
         )}
         {alternateCallerId && (

--- a/packages/react-composites/src/composites/common/CallingDialpad.tsx
+++ b/packages/react-composites/src/composites/common/CallingDialpad.tsx
@@ -89,7 +89,7 @@ export const CallingDialpad = (props: CallingDialpadProps): JSX.Element => {
       <Stack data-ui-id="call-with-chat-composite-dialpad">
         {showDialpad && (
           <Stack styles={drawerContainerStyles()}>
-            <_DrawerSurface onLightDismiss={onDismissTriggered}>
+            <_DrawerSurface disableMaxHeight={true} onLightDismiss={onDismissTriggered}>
               <Stack style={{ padding: '1rem' }}>{dialpadComponent()}</Stack>
             </_DrawerSurface>
           </Stack>

--- a/packages/react-composites/src/composites/common/Drawer/SpokenLanguageDrawer.styles.ts
+++ b/packages/react-composites/src/composites/common/Drawer/SpokenLanguageDrawer.styles.ts
@@ -10,7 +10,6 @@ import { _DrawerMenuStyles } from '@internal/react-components';
  */
 export const spokenLanguageDrawerStyles = (theme: Theme): _DrawerMenuStyles => ({
   root: {
-    height: _pxToRem(300),
     overflow: 'auto'
   },
   drawerSurfaceStyles: {

--- a/packages/react-composites/src/composites/common/SendDtmfDialpad.tsx
+++ b/packages/react-composites/src/composites/common/SendDtmfDialpad.tsx
@@ -56,7 +56,7 @@ export const SendDtmfDialpad = (props: SendDtmfDialpadProps): JSX.Element => {
       <Stack>
         {showDialpad && (
           <Stack styles={drawerContainerStyles()}>
-            <_DrawerSurface onLightDismiss={onDismissTriggered}>
+            <_DrawerSurface disableMaxHeight={true} onLightDismiss={onDismissTriggered}>
               <Stack style={{ padding: '1rem' }}>
                 <Dialpad
                   styles={dialpadStyle}

--- a/packages/storybook/stories/INTERNAL/CallReadiness/BrowserPermissionDenied/snippets/BrowserPermissionDeniedAndroidDrawer.snippet.tsx
+++ b/packages/storybook/stories/INTERNAL/CallReadiness/BrowserPermissionDenied/snippets/BrowserPermissionDeniedAndroidDrawer.snippet.tsx
@@ -26,7 +26,7 @@ export const BrowserPemissionDeniedAndroidDrawer: () => JSX.Element = () => {
           </Stack>
         )}
         {isDrawerShowing && (
-          <_DrawerSurface onLightDismiss={onLightDismissTriggered}>
+          <_DrawerSurface disableMaxHeight={true} onLightDismiss={onLightDismissTriggered}>
             <CameraAndMicrophoneSitePermissions
               appName={'Contoso app'}
               onTroubleshootingClick={() => alert('clicked troubleshooting link')}

--- a/packages/storybook/stories/INTERNAL/CallReadiness/BrowserPermissionDenied/snippets/BrowserPermissionDeniedDrawer.snippet.tsx
+++ b/packages/storybook/stories/INTERNAL/CallReadiness/BrowserPermissionDenied/snippets/BrowserPermissionDeniedDrawer.snippet.tsx
@@ -26,7 +26,7 @@ export const BrowserPermissionDeniedDrawer: () => JSX.Element = () => {
           </Stack>
         )}
         {isDrawerShowing && (
-          <_DrawerSurface onLightDismiss={onLightDismissTriggered}>
+          <_DrawerSurface disableMaxHeight={true} onLightDismiss={onLightDismissTriggered}>
             <BrowserPermissionDenied
               onTroubleshootingClick={() => alert('clicked trouble shooting link')}
               onTryAgainClick={() => alert('clicked on try again button')}

--- a/packages/storybook/stories/INTERNAL/CallReadiness/BrowserPermissionDenied/snippets/BrowserPermissionDeniedIOSDrawer.snippet.tsx
+++ b/packages/storybook/stories/INTERNAL/CallReadiness/BrowserPermissionDenied/snippets/BrowserPermissionDeniedIOSDrawer.snippet.tsx
@@ -26,7 +26,7 @@ export const BrowserPermissionDeniedIOSDrawer: () => JSX.Element = () => {
           </Stack>
         )}
         {isDrawerShowing && (
-          <_DrawerSurface onLightDismiss={onLightDismissTriggered}>
+          <_DrawerSurface disableMaxHeight={true} onLightDismiss={onLightDismissTriggered}>
             <BrowserPermissionDeniedIOS
               onTroubleshootingClick={() => alert('clicked trouble shooting link')}
               onTryAgainClick={() => alert('clicked on try again button')}

--- a/packages/storybook/stories/INTERNAL/Drawer/DrawerSurface.stories.tsx
+++ b/packages/storybook/stories/INTERNAL/Drawer/DrawerSurface.stories.tsx
@@ -29,7 +29,7 @@ const DrawerSurfaceStory = (/*args*/): JSX.Element => {
         </Stack>
       )}
       {isDrawerShowing && (
-        <DrawerSurfaceComponent onLightDismiss={onLightDismissTriggered}>
+        <DrawerSurfaceComponent disableMaxHeight={true} onLightDismiss={onLightDismissTriggered}>
           <PowerpointContent />
         </DrawerSurfaceComponent>
       )}


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
SpokenLanguage List Drawer Menu mobileview set to 75% height.
<img width="40%" alt="Screenshot 2023-05-19 at 15 44 33" src="https://github.com/Azure/communication-ui-library/assets/97130533/0b7af0a3-6438-4db4-af2a-17a1804a91b7">
<img width="25%" alt="Screenshot 2023-05-19 at 15 44 16" src="https://github.com/Azure/communication-ui-library/assets/97130533/61c918a1-eaa0-4826-a440-df2b9a0c5d71">

Edit:
Applied the fix to drawerSurface component instead of only the spokenLanguageDrawer as per comments suggested.
Tested, and current ui is not impacted. However, now, any contextual menu that spans the whole view vertically will not be restricted to 75%.
<img width="25%" alt="image" src="https://github.com/Azure/communication-ui-library/assets/97130533/de6b28cd-2792-4f0c-9b1f-d8ce7a852631">
<img width="25%" alt="image" src="https://github.com/Azure/communication-ui-library/assets/97130533/e715f690-f79e-4455-8ee0-a542cc6042fb">

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
SpokenLanguage Drawer Menu encompassed the full screen on mobile, causing issues with dismissing the menu.
https://skype.visualstudio.com/SPOOL/_workitems/edit/3233595
<img width="30%" alt="image" src="https://github.com/Azure/communication-ui-library/assets/97130533/12492496-3cca-468c-abee-c345a0130ffb">

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->