### PR TITLE
Fix browser permissions storybook snippets

### DIFF
--- a/change-beta/@azure-communication-react-4832ab9d-9a4a-4fb9-8da2-940e895a6aca.json
+++ b/change-beta/@azure-communication-react-4832ab9d-9a4a-4fb9-8da2-940e895a6aca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "FIx browser permission snippets",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-4832ab9d-9a4a-4fb9-8da2-940e895a6aca.json
+++ b/change/@azure-communication-react-4832ab9d-9a4a-4fb9-8da2-940e895a6aca.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "FIx browser permission snippets",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/SitePermissions/snippets/SitePermissionsCheckModal.snippet.tsx
+++ b/packages/storybook/stories/SitePermissions/snippets/SitePermissionsCheckModal.snippet.tsx
@@ -1,19 +1,20 @@
 import {
   CameraAndMicrophoneSitePermissions,
   CameraSitePermissions,
+  DEFAULT_COMPONENT_ICONS,
   MicrophoneSitePermissions
 } from '@azure/communication-react';
-import { Modal, PrimaryButton, Stack } from '@fluentui/react';
+import { Modal, PrimaryButton, Stack, registerIcons } from '@fluentui/react';
 import React, { useState } from 'react';
-import { useLocale } from '../../../../react-components/src/localization';
+
+registerIcons({
+  icons: DEFAULT_COMPONENT_ICONS
+});
 
 export const SitePermissionsCheckModal: () => JSX.Element = () => {
   const [microphoneCameraModalOpen, setMicrophoneCameraModalOpen] = useState<boolean>(false);
   const [microphoneModalOpen, setMicrophoneModalOpen] = useState<boolean>(false);
   const [cameraModalOpen, setCameraModalOpen] = useState<boolean>(false);
-  const micCameralocale = useLocale().strings.CameraAndMicrophoneSitePermissionsCheck;
-  const cameraLocale = useLocale().strings.CameraSitePermissionsCheck;
-  const microphoneLocale = useLocale().strings.MicrophoneSitePermissionsCheck;
   return (
     <Stack horizontal>
       <PrimaryButton
@@ -46,7 +47,6 @@ export const SitePermissionsCheckModal: () => JSX.Element = () => {
           onTroubleshootingClick={() => {
             alert('clicked trouble shooting');
           }}
-          strings={micCameralocale}
           kind={'check'}
         />
       </Modal>
@@ -56,7 +56,6 @@ export const SitePermissionsCheckModal: () => JSX.Element = () => {
           onTroubleshootingClick={() => {
             alert('clicked trouble shooting');
           }}
-          strings={microphoneLocale}
           kind={'check'}
         />
       </Modal>
@@ -69,7 +68,6 @@ export const SitePermissionsCheckModal: () => JSX.Element = () => {
           onContinueAnywayClick={() => {
             setCameraModalOpen(false);
           }}
-          strings={cameraLocale}
           kind={'check'}
         />
       </Modal>

--- a/packages/storybook/stories/SitePermissions/snippets/SitePermissionsDeniedModal.snippet.tsx
+++ b/packages/storybook/stories/SitePermissions/snippets/SitePermissionsDeniedModal.snippet.tsx
@@ -1,19 +1,21 @@
 import {
   CameraAndMicrophoneSitePermissions,
   CameraSitePermissions,
+  DEFAULT_COMPONENT_ICONS,
   MicrophoneSitePermissions
 } from '@azure/communication-react';
-import { Modal, PrimaryButton, Stack } from '@fluentui/react';
+import { Modal, PrimaryButton, Stack, registerIcons } from '@fluentui/react';
 import React, { useState } from 'react';
-import { useLocale } from '../../../../react-components/src/localization';
+
+registerIcons({
+  icons: DEFAULT_COMPONENT_ICONS
+});
 
 export const SitePermissionsDeniedModal: () => JSX.Element = () => {
   const [microphoneCameraModalOpen, setMicrophoneCameraModalOpen] = useState<boolean>(false);
   const [microphoneModalOpen, setMicrophoneModalOpen] = useState<boolean>(false);
   const [cameraModalOpen, setCameraModalOpen] = useState<boolean>(false);
-  const micCameralocale = useLocale().strings.CameraAndMicrophoneSitePermissionsDenied;
-  const cameraLocale = useLocale().strings.CameraSitePermissionsDenied;
-  const microphoneLocale = useLocale().strings.MicrophoneSitePermissionsDenied;
+
   return (
     <Stack horizontal>
       <PrimaryButton
@@ -46,7 +48,6 @@ export const SitePermissionsDeniedModal: () => JSX.Element = () => {
           onTroubleshootingClick={() => {
             alert('clicked trouble shooting');
           }}
-          strings={micCameralocale}
           kind={'denied'}
         />
       </Modal>
@@ -56,7 +57,6 @@ export const SitePermissionsDeniedModal: () => JSX.Element = () => {
           onTroubleshootingClick={() => {
             alert('clicked trouble shooting');
           }}
-          strings={microphoneLocale}
           kind={'denied'}
         />
       </Modal>
@@ -69,7 +69,6 @@ export const SitePermissionsDeniedModal: () => JSX.Element = () => {
           onContinueAnywayClick={() => {
             setCameraModalOpen(false);
           }}
-          strings={cameraLocale}
           kind={'denied'}
         />
       </Modal>

--- a/packages/storybook/stories/SitePermissions/snippets/SitePermissionsExample.snippet.tsx
+++ b/packages/storybook/stories/SitePermissions/snippets/SitePermissionsExample.snippet.tsx
@@ -4,25 +4,17 @@
 import {
   CameraAndMicrophoneSitePermissions,
   CameraSitePermissions,
+  DEFAULT_COMPONENT_ICONS,
   MicrophoneSitePermissions
 } from '@azure/communication-react';
-import { Stack } from '@fluentui/react';
+import { Stack, registerIcons } from '@fluentui/react';
 import React from 'react';
-import { useLocale } from '../../../../react-components/src/localization';
+
+registerIcons({
+  icons: DEFAULT_COMPONENT_ICONS
+});
 
 export const SitePermissionsExample: () => JSX.Element = () => {
-  const micCameralocaleRequest = useLocale().strings.CameraAndMicrophoneSitePermissionsRequest;
-  const cameraLocaleRequest = useLocale().strings.CameraSitePermissionsRequest;
-  const microphoneLocaleRequest = useLocale().strings.MicrophoneSitePermissionsRequest;
-
-  const micCameralocaleCheck = useLocale().strings.CameraAndMicrophoneSitePermissionsCheck;
-  const cameraLocaleCheck = useLocale().strings.CameraSitePermissionsCheck;
-  const microphoneLocaleCheck = useLocale().strings.MicrophoneSitePermissionsCheck;
-
-  const micCameralocaleDenied = useLocale().strings.CameraAndMicrophoneSitePermissionsDenied;
-  const cameraLocaleDenied = useLocale().strings.CameraSitePermissionsDenied;
-  const microphoneLocaleDenied = useLocale().strings.MicrophoneSitePermissionsDenied;
-
   return (
     <Stack>
       <Stack horizontal>
@@ -32,7 +24,6 @@ export const SitePermissionsExample: () => JSX.Element = () => {
             onTroubleshootingClick={() => {
               alert('clicked trouble shooting');
             }}
-            strings={micCameralocaleRequest}
             kind={'request'}
           />
         </Stack>
@@ -42,7 +33,6 @@ export const SitePermissionsExample: () => JSX.Element = () => {
             onTroubleshootingClick={() => {
               alert('clicked trouble shooting');
             }}
-            strings={microphoneLocaleRequest}
             kind={'request'}
           />
         </Stack>
@@ -53,9 +43,8 @@ export const SitePermissionsExample: () => JSX.Element = () => {
               alert('clicked trouble shooting');
             }}
             onContinueAnywayClick={() => {
-              alert('clicked continuec anyway');
+              alert('clicked continue anyway');
             }}
-            strings={cameraLocaleRequest}
             kind={'request'}
           />
         </Stack>
@@ -67,7 +56,6 @@ export const SitePermissionsExample: () => JSX.Element = () => {
             onTroubleshootingClick={() => {
               alert('clicked trouble shooting');
             }}
-            strings={micCameralocaleDenied}
             kind={'denied'}
           />
         </Stack>
@@ -77,7 +65,6 @@ export const SitePermissionsExample: () => JSX.Element = () => {
             onTroubleshootingClick={() => {
               alert('clicked trouble shooting');
             }}
-            strings={microphoneLocaleDenied}
             kind={'denied'}
           />
         </Stack>
@@ -88,9 +75,8 @@ export const SitePermissionsExample: () => JSX.Element = () => {
               alert('clicked trouble shooting');
             }}
             onContinueAnywayClick={() => {
-              alert('clicked continuec anyway');
+              alert('clicked continue anyway');
             }}
-            strings={cameraLocaleDenied}
             kind={'denied'}
           />
         </Stack>
@@ -102,7 +88,6 @@ export const SitePermissionsExample: () => JSX.Element = () => {
             onTroubleshootingClick={() => {
               alert('clicked trouble shooting');
             }}
-            strings={micCameralocaleCheck}
             kind={'check'}
           />
         </Stack>
@@ -112,7 +97,6 @@ export const SitePermissionsExample: () => JSX.Element = () => {
             onTroubleshootingClick={() => {
               alert('clicked trouble shooting');
             }}
-            strings={microphoneLocaleCheck}
             kind={'check'}
           />
         </Stack>
@@ -123,9 +107,8 @@ export const SitePermissionsExample: () => JSX.Element = () => {
               alert('clicked trouble shooting');
             }}
             onContinueAnywayClick={() => {
-              alert('clicked continuec anyway');
+              alert('clicked continue anyway');
             }}
-            strings={cameraLocaleCheck}
             kind={'check'}
           />
         </Stack>

--- a/packages/storybook/stories/SitePermissions/snippets/SitePermissionsRequestModal.snippet.tsx
+++ b/packages/storybook/stories/SitePermissions/snippets/SitePermissionsRequestModal.snippet.tsx
@@ -4,10 +4,15 @@
 import {
   CameraAndMicrophoneSitePermissions,
   CameraSitePermissions,
+  DEFAULT_COMPONENT_ICONS,
   MicrophoneSitePermissions
 } from '@azure/communication-react';
-import { Modal, PrimaryButton, Stack } from '@fluentui/react';
+import { Modal, PrimaryButton, Stack, registerIcons } from '@fluentui/react';
 import React, { useState } from 'react';
+
+registerIcons({
+  icons: DEFAULT_COMPONENT_ICONS
+});
 
 export const SitePermissionsRequestModal: () => JSX.Element = () => {
   const [microphoneCameraModalOpen, setMicrophoneCameraModalOpen] = useState<boolean>(false);

--- a/packages/storybook/stories/SitePermissions/snippets/SitePermissionsRequestModal.snippet.tsx
+++ b/packages/storybook/stories/SitePermissions/snippets/SitePermissionsRequestModal.snippet.tsx
@@ -8,15 +8,12 @@ import {
 } from '@azure/communication-react';
 import { Modal, PrimaryButton, Stack } from '@fluentui/react';
 import React, { useState } from 'react';
-import { useLocale } from '../../../../react-components/src/localization';
 
 export const SitePermissionsRequestModal: () => JSX.Element = () => {
   const [microphoneCameraModalOpen, setMicrophoneCameraModalOpen] = useState<boolean>(false);
   const [microphoneModalOpen, setMicrophoneModalOpen] = useState<boolean>(false);
   const [cameraModalOpen, setCameraModalOpen] = useState<boolean>(false);
-  const micCameralocale = useLocale().strings.CameraAndMicrophoneSitePermissionsRequest;
-  const cameraLocale = useLocale().strings.CameraSitePermissionsRequest;
-  const microphoneLocale = useLocale().strings.MicrophoneSitePermissionsRequest;
+
   return (
     <Stack horizontal>
       <PrimaryButton
@@ -49,7 +46,6 @@ export const SitePermissionsRequestModal: () => JSX.Element = () => {
           onTroubleshootingClick={() => {
             alert('clicked trouble shooting');
           }}
-          strings={micCameralocale}
           kind={'request'}
         />
       </Modal>
@@ -59,7 +55,6 @@ export const SitePermissionsRequestModal: () => JSX.Element = () => {
           onTroubleshootingClick={() => {
             alert('clicked trouble shooting');
           }}
-          strings={microphoneLocale}
           kind={'request'}
         />
       </Modal>
@@ -72,7 +67,6 @@ export const SitePermissionsRequestModal: () => JSX.Element = () => {
           onContinueAnywayClick={() => {
             setCameraModalOpen(false);
           }}
-          strings={cameraLocale}
           kind={'request'}
         />
       </Modal>

--- a/packages/storybook/stories/UnsupportedBrowser/snippets/UnsupportedBrowserExamples.snippet.tsx
+++ b/packages/storybook/stories/UnsupportedBrowser/snippets/UnsupportedBrowserExamples.snippet.tsx
@@ -1,9 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { UnsupportedBrowser, UnsupportedBrowserVersion, UnsupportedOperatingSystem } from '@azure/communication-react';
-import { Stack } from '@fluentui/react';
+import {
+  DEFAULT_COMPONENT_ICONS,
+  UnsupportedBrowser,
+  UnsupportedBrowserVersion,
+  UnsupportedOperatingSystem
+} from '@azure/communication-react';
+import { Stack, registerIcons } from '@fluentui/react';
 import React from 'react';
+
+registerIcons({
+  icons: DEFAULT_COMPONENT_ICONS
+});
 
 export const UnsupportedBrowserExamples: () => JSX.Element = () => {
   return (

--- a/packages/storybook/stories/UnsupportedBrowser/snippets/UnsupportedEnvironmentModal.snippet.tsx
+++ b/packages/storybook/stories/UnsupportedBrowser/snippets/UnsupportedEnvironmentModal.snippet.tsx
@@ -1,9 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { UnsupportedBrowser, UnsupportedBrowserVersion, UnsupportedOperatingSystem } from '@azure/communication-react';
-import { Modal, PrimaryButton, Stack } from '@fluentui/react';
+import {
+  DEFAULT_COMPONENT_ICONS,
+  UnsupportedBrowser,
+  UnsupportedBrowserVersion,
+  UnsupportedOperatingSystem
+} from '@azure/communication-react';
+import { Modal, PrimaryButton, Stack, registerIcons } from '@fluentui/react';
 import React, { useState } from 'react';
+
+registerIcons({
+  icons: DEFAULT_COMPONENT_ICONS
+});
 
 export const UnsupportedEnvironmentModals: () => JSX.Element = () => {
   const [unsupportedBrowserModalOpen, setUnsupportedBrowserModalOpen] = useState<boolean>(false);


### PR DESCRIPTION
# What

- These components have built in local usage with localization provider same as all components so remove bad reference to `useLocale`.
- Ensure registerIcons is called

# Why

Stories were broken to external users

# How Tested
Locally:

![image](https://github.com/Azure/communication-ui-library/assets/2684369/59b5e5d0-0d0e-4796-b799-5e03dca906fb)

