### PR TITLE
Cherry-pick `safari sidepane chat scroll, new message, and input box position bugfix` to 1.5.1-beta.5 release branch

### DIFF
--- a/change-beta/@azure-communication-react-0ce62415-d370-4337-9592-750d9a1fd06e.json
+++ b/change-beta/@azure-communication-react-0ce62415-d370-4337-9592-750d9a1fd06e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix scroll and new message prompt in sidepane chat for safari",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-0ce62415-d370-4337-9592-750d9a1fd06e.json
+++ b/change/@azure-communication-react-0ce62415-d370-4337-9592-750d9a1fd06e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix scroll and new message prompt in sidepane chat for safari",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/SidePane/SidePane.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/SidePane/SidePane.tsx
@@ -4,6 +4,7 @@
 import React, { useCallback } from 'react';
 import { Stack } from '@fluentui/react';
 import {
+  containerContextStyles,
   paneBodyContainer,
   scrollableContainer,
   scrollableContainerContents
@@ -85,7 +86,9 @@ export const SidePane = (props: SidePaneProps): JSX.Element => {
         <Stack verticalFill styles={scrollableContainer}>
           {ContentRender && (
             <Stack.Item verticalFill styles={scrollableContainerContents}>
-              <ContentRender />
+              <Stack styles={containerContextStyles}>
+                <ContentRender />
+              </Stack>
             </Stack.Item>
           )}
           {OverrideContentRender && (
@@ -97,7 +100,9 @@ export const SidePane = (props: SidePaneProps): JSX.Element => {
                   : scrollableContainerContents
               }
             >
-              <OverrideContentRender />
+              <Stack styles={containerContextStyles}>
+                <OverrideContentRender />
+              </Stack>
             </Stack.Item>
           )}
         </Stack>

--- a/packages/react-composites/src/composites/common/styles/ParticipantContainer.styles.ts
+++ b/packages/react-composites/src/composites/common/styles/ParticipantContainer.styles.ts
@@ -79,6 +79,10 @@ export const scrollableContainerContents: IStackItemStyles = {
 /**
  * @private
  */
+export const containerContextStyles: IStackStyles = { root: { position: 'absolute', height: '100%', width: '100%' } };
+/**
+ * @private
+ */
 export const peopleSubheadingStyle: IStackItemStyles = {
   root: {
     fontSize: '0.75rem'


### PR DESCRIPTION
Cherrypick https://github.com/Azure/communication-ui-library/pull/3116 to 1.5.1-beta.5 release branch
