### PR TITLE
[Chat][Mention] Remove displayText from <msft-mention> tag

### DIFF
--- a/change-beta/@azure-communication-react-26897390-5615-4ae3-8818-289d5617a094.json
+++ b/change-beta/@azure-communication-react-26897390-5615-4ae3-8818-289d5617a094.json
@@ -1,5 +1,5 @@
 {
-  "type": "pre-release",
+  "type": "prerelease",
   "comment": "A menu item role for mention popover items and create FocusZone to ensure the first item is focused when using talk back.",
   "packageName": "@azure/communication-react",
   "email": "palatter@microsoft.com",

--- a/change-beta/@azure-communication-react-6469303f-f7dd-44ab-8b8c-f0ad6cc58d53.json
+++ b/change-beta/@azure-communication-react-6469303f-f7dd-44ab-8b8c-f0ad6cc58d53.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove displayText from msft-mention",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-26897390-5615-4ae3-8818-289d5617a094.json
+++ b/change/@azure-communication-react-26897390-5615-4ae3-8818-289d5617a094.json
@@ -1,5 +1,5 @@
 {
-  "type": "pre-release",
+  "type": "prerelease",
   "comment": "A menu item role for mention popover items and create FocusZone to ensure the first item is focused when using talk back.",
   "packageName": "@azure/communication-react",
   "email": "palatter@microsoft.com",

--- a/change/@azure-communication-react-6469303f-f7dd-44ab-8b8c-f0ad6cc58d53.json
+++ b/change/@azure-communication-react-6469303f-f7dd-44ab-8b8c-f0ad6cc58d53.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove displayText from msft-mention",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ChatMessage/MentionRenderer.tsx
+++ b/packages/react-components/src/components/ChatMessage/MentionRenderer.tsx
@@ -12,9 +12,5 @@ import { Mention } from '../MentionPopover';
 export const defaultOnMentionRender = (mention: Mention): JSX.Element => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const MsftMention = 'msft-mention' as any;
-  return (
-    <MsftMention id={mention.id} displayText={mention.displayText}>
-      {mention.displayText}
-    </MsftMention>
-  );
+  return <MsftMention id={mention.id}>{mention.displayText}</MsftMention>;
 };

--- a/packages/react-components/src/components/InputBoxComponent.tsx
+++ b/packages/react-components/src/components/InputBoxComponent.tsx
@@ -207,7 +207,6 @@ export const InputBoxComponent = (props: InputBoxComponentProps): JSX.Element =>
   /* @conditional-compile-remove(mention) */
   const onSuggestionSelected = useCallback(
     (suggestion: Mention) => {
-      console.log('onSuggestionSelected', suggestion);
       let selectionEnd = textFieldRef?.current?.selectionEnd || -1;
       if (selectionEnd < 0) {
         selectionEnd = 0;

--- a/packages/react-components/src/components/InputBoxComponent.tsx
+++ b/packages/react-components/src/components/InputBoxComponent.tsx
@@ -1643,9 +1643,8 @@ const findStringsDiffIndexes = (props: DiffIndexesProps): DiffIndexesResult => {
  */
 const htmlStringForMentionSuggestion = (suggestion: Mention, localeStrings: ComponentStrings): string => {
   const idHTML = ' id ="' + suggestion.id + '"';
-  const displayTextHTML = ' displayText ="' + suggestion.displayText + '"';
   const displayText = getDisplayNameForMentionSuggestion(suggestion, localeStrings);
-  return '<' + MSFT_MENTION_TAG + idHTML + displayTextHTML + '>' + displayText + '</' + MSFT_MENTION_TAG + '>';
+  return '<' + MSFT_MENTION_TAG + idHTML + '>' + displayText + '</' + MSFT_MENTION_TAG + '>';
 };
 
 /* @conditional-compile-remove(mention) */

--- a/packages/react-components/src/components/InputBoxComponent.tsx
+++ b/packages/react-components/src/components/InputBoxComponent.tsx
@@ -207,6 +207,7 @@ export const InputBoxComponent = (props: InputBoxComponentProps): JSX.Element =>
   /* @conditional-compile-remove(mention) */
   const onSuggestionSelected = useCallback(
     (suggestion: Mention) => {
+      console.log('onSuggestionSelected', suggestion);
       let selectionEnd = textFieldRef?.current?.selectionEnd || -1;
       if (selectionEnd < 0) {
         selectionEnd = 0;
@@ -814,8 +815,10 @@ export const InputBoxComponent = (props: InputBoxComponentProps): JSX.Element =>
             setCaretIndex(undefined);
             setSelectionStartValue(null);
             setSelectionEndValue(null);
-            // Dismiss the suggestions on blur
-            setMentionSuggestions([]);
+            // Dismiss the suggestions on blur, after enough time to select by mouse if needed
+            setTimeout(() => {
+              setMentionSuggestions([]);
+            }, 200);
           }}
           autoComplete="off"
           onKeyDown={onTextFieldKeyDown}

--- a/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
+++ b/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
@@ -91,7 +91,7 @@ import { FluentThemeProvider, MessageThread } from '@azure/communication-react';
 `;
 
 const mentionTag = `
-<msft-mention id="<id>" displayText="<display text>">
+<msft-mention id='<id>'>
   Displayable Text
 </msft-mention>
 `;

--- a/packages/storybook/stories/MessageThread/snippets/MessageWithCustomMentionRenderer.snippet.tsx
+++ b/packages/storybook/stories/MessageThread/snippets/MessageWithCustomMentionRenderer.snippet.tsx
@@ -11,7 +11,7 @@ export const MessageWithCustomMentionRenderer: () => JSX.Element = () => {
       senderId: user1Id,
       senderDisplayName: 'Kat Larsson',
       messageId: Math.random().toString(),
-      content: `Hey <msft-mention id="${user2Id}" displayText="Robert Tolbert">Robert Tolbert</msft-mention>, can you help me with my internet connection?`,
+      content: `Hey <msft-mention id="${user2Id}">Robert Tolbert</msft-mention>, can you help me with my internet connection?`,
       createdOn: new Date('2019-04-13T00:00:00.000+08:10'),
       mine: false,
       attached: false,


### PR DESCRIPTION
# What
The displayText parameter from the msft-mention tag is not used and is duplicated by the tag-enclosed text, which is what is rendered.

# Why
Redundant and confusing API removed

# How Tested
Storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->