### PR TITLE
[Chat] Extend touchable/clickable area of button to full height of send box.

### DIFF
--- a/packages/react-components/src/components/InputBoxComponent.tsx
+++ b/packages/react-components/src/components/InputBoxComponent.tsx
@@ -109,7 +109,7 @@ export const InputBoxComponent = (props: InputBoxComponentProps): JSX.Element =>
     errorMessage: styles?.systemMessage,
     suffix: {
       backgroundColor: 'transparent',
-      padding: props.inlineChildren ? '0 0.25rem' : '0 0'
+      padding: '0 0'
     }
   });
 

--- a/packages/react-components/src/components/styles/SendBox.styles.ts
+++ b/packages/react-components/src/components/styles/SendBox.styles.ts
@@ -29,9 +29,8 @@ export const sendBoxWrapperStyles = mergeStyles({
  * @private
  */
 export const sendButtonStyle = mergeStyles({
-  height: '1.25rem',
-  width: '1.25rem',
-  marginRight: '0.313rem' // 5px
+  height: '2.25rem',
+  width: '2.25rem'
 });
 
 /**


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
As per requirement from Alex P design requirement: [Bug 3295649](https://skype.visualstudio.com/SPOOL/_workitems/edit/3295649): [P2]Send box send button too small

# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook or ChatComposite 
# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->