### PR TITLE
Update release validation for new security requirements

### DIFF
--- a/.github/workflows/deploy-feature-azure-webapps.yml
+++ b/.github/workflows/deploy-feature-azure-webapps.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  # Needed for Azure login
   id-token: write
 
 jobs:

--- a/.github/workflows/deploy-release-azure-webapps.yml
+++ b/.github/workflows/deploy-release-azure-webapps.yml
@@ -21,7 +21,7 @@ jobs:
   calling:
     name: Build and Deploy Calling App
     runs-on: ubuntu-latest
-    environment: staging
+    environment: production
     steps:
       - uses: actions/checkout@v3
         with:
@@ -64,7 +64,7 @@ jobs:
   chat:
     name: Build and Deploy Chat App
     runs-on: ubuntu-latest
-    environment: staging
+    environment: production
     steps:
       - uses: actions/checkout@v3
         with:
@@ -107,7 +107,7 @@ jobs:
   callwithchat:
     name: Build and Deploy CallWithChat App
     runs-on: ubuntu-latest
-    environment: staging
+    environment: production
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/deploy-release-azure-webapps.yml
+++ b/.github/workflows/deploy-release-azure-webapps.yml
@@ -13,73 +13,136 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  # Needed for Azure login
+  id-token: write
+
 jobs:
-  build-and-deploy-samples:
-    name: Build and Deploy samples
+  calling:
+    name: Build and Deploy Calling App
     runs-on: ubuntu-latest
-    environment: production
+    environment: staging
     steps:
       - uses: actions/checkout@v3
-
-      - name: Use Node.js 16.x
+        with:
+          fetch-depth: 0
+      - name: Use Node.js v16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
-
-      - name: Restore node_modules from cache
-        uses: actions/cache@v3
-        with:
-          path: common/temp/pnpm-store
-          key: ${{ runner.os }}-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}
-
-      - name: Install Rush
+          node-version: '16.x'
+      - name: Install rush
         run: npm install -g @microsoft/rush@5.47.0
-
-      - name: Install Dependencies
-        run: rush install --max-install-attempts 3
-
+      - name: Install dependencies
+        run: rush install
       # Switch flavor to stable when it is release branch
       - name: Switch flavor for stable build
         if: ${{ !contains(github.ref, 'beta') }}
         run: rush switch-flavor:stable
-
       # Switch flavor to beta release when it is beta release branch
       - name: Switch flavor for beta release build
         if: ${{ contains(github.ref, 'beta') }}
         run: rush switch-flavor:beta-release
-
-      - name: Build Projects
-        run: rush build
-
-      - name: Package Calling Sample Artifact
+      - name: Build Server
+        run: rush build -o server
+      - name: Build Calling
+        run: rush build -o calling
+      - name: Package Calling App
         run: rushx package
         working-directory: ./samples/Calling
-
-      - name: 'Deploy Calling Sample WebApp'
+      - name: Log in with Azure
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Deploy Calling
         uses: azure/webapps-deploy@v2
         with:
           app-name: acs-ui-dev-web-call-hero-beta-validation2
-          publish-profile: ${{ secrets.AZURE_BETA_GROUPCALLING_WEBAPP_PUBLISH_PROFILE }}
           package: ./samples/Calling/dist
 
-      - name: Package Chat Sample Artifact
+  chat:
+    name: Build and Deploy Chat App
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Use Node.js v16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install rush
+        run: npm install -g @microsoft/rush@5.47.0
+      - name: Install dependencies
+        run: rush install
+      # Switch flavor to stable when it is release branch
+      - name: Switch flavor for stable build
+        if: ${{ !contains(github.ref, 'beta') }}
+        run: rush switch-flavor:stable
+      # Switch flavor to beta release when it is beta release branch
+      - name: Switch flavor for beta release build
+        if: ${{ contains(github.ref, 'beta') }}
+        run: rush switch-flavor:beta-release
+      - name: Build Server
+        run: rush build -o server
+      - name: Build Chat
+        run: rush build -o chat
+      - name: Package Chat App
         run: rushx package
         working-directory: ./samples/Chat
-
-      - name: 'Deploy Chat Sample WebApp'
+      - name: Log in with Azure
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Deploy Chat
         uses: azure/webapps-deploy@v2
         with:
           app-name: acs-ui-dev-web-chat-hero-beta-validation2
-          publish-profile: ${{ secrets.AZURE_BETA_GROUPCHAT_WEBAPP_PUBLISH_PROFILE }}
           package: ./samples/Chat/dist
 
+  callwithchat:
+    name: Build and Deploy CallWithChat App
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Use Node.js v16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+      - name: Install rush
+        run: npm install -g @microsoft/rush@5.47.0
+      - name: Install dependencies
+        run: rush install
+      # Switch flavor to stable when it is release branch
+      - name: Switch flavor for stable build
+        if: ${{ !contains(github.ref, 'beta') }}
+        run: rush switch-flavor:stable
+      # Switch flavor to beta release when it is beta release branch
+      - name: Switch flavor for beta release build
+        if: ${{ contains(github.ref, 'beta') }}
+        run: rush switch-flavor:beta-release
+      - name: Build Server
+        run: rush build -o server
+      - name: Build CallWithChat
+        run: rush build -o callwithchat
       - name: Package CallWithChat Sample Artifact
         run: rushx package
         working-directory: ./samples/CallWithChat
-
-      - name: 'Deploy CallWithChat Sample WebApp'
+      - name: Log in with Azure
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Deploy CallWithChat
         uses: azure/webapps-deploy@v2
         with:
           app-name: acs-ui-dev-web-meeting-hero-beta-validation2
-          publish-profile: ${{ secrets.AZURE_BETA_MEETING_WEBAPP_PUBLISH_PROFILE }}
           package: ./samples/CallWithChat/dist

--- a/change-beta/@azure-communication-react-b1501d76-e2dc-4c64-b72b-a86f6b328e00.json
+++ b/change-beta/@azure-communication-react-b1501d76-e2dc-4c64-b72b-a86f6b328e00.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update release validation for new security requirements",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-b1501d76-e2dc-4c64-b72b-a86f6b328e00.json
+++ b/change/@azure-communication-react-b1501d76-e2dc-4c64-b72b-a86f6b328e00.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update release validation for new security requirements",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
# What

- Update release to do an azure login instead of publish profile
- Split apps across multiple jobs, **drops time from 27minutes --> 8minutes**

# Why

New security requirement ([more info](https://eng.ms/docs/cloud-ai-platform/devdiv/serverless-paas-balam/serverless-paas-benbyrd/app-service-web-apps/antares-trouble-shooting-guides-tsg/partnertsgs/basicauth#how-to-enable-oidc-authentication-for-github-actions-instead-of-basic-authentication))

# How Tested
https://github.com/Azure/communication-ui-library/actions/runs/5257696739