### PR TITLE
[Chat] Fixed selection indexes for mouse click events on mention

### DIFF
--- a/change-beta/@azure-communication-react-dedbc6a1-ca23-4689-b1e4-19f00c12c238.json
+++ b/change-beta/@azure-communication-react-dedbc6a1-ca23-4689-b1e4-19f00c12c238.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fixed selection indexes for mouse click events on mention",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-dedbc6a1-ca23-4689-b1e4-19f00c12c238.json
+++ b/change/@azure-communication-react-dedbc6a1-ca23-4689-b1e4-19f00c12c238.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fixed selection indexes for mouse click events on mention",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/TextFieldWithMention/TextFieldWithMention.tsx
+++ b/packages/react-components/src/components/TextFieldWithMention/TextFieldWithMention.tsx
@@ -436,10 +436,15 @@ export const TextFieldWithMention = (props: TextFieldWithMentionProps): JSX.Elem
                   event.currentTarget.selectionDirection
                 );
               }
+              setSelectionStartValue(mentionTag.plainTextBeginIndex);
+              setSelectionEndValue(mentionEndIndex);
+            } else {
+              // bounds of the mention were selected
+              setSelectionStartValue(event.currentTarget.selectionStart);
+              setSelectionEndValue(event.currentTarget.selectionEnd);
             }
-            setSelectionStartValue(mentionTag.plainTextBeginIndex);
-            setSelectionEndValue(mentionEndIndex);
           } else {
+            // not a mention tag
             setSelectionStartValue(event.currentTarget.selectionStart);
             setSelectionEndValue(nullToUndefined(event.currentTarget.selectionEnd));
           }


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fix an issue with mouse selection and editing.
Steps to test: 

1. paste long text in the input box
2. add mention
3. click on the middle of the pasted text
4. click at the end of the text
5. start typing

Expected result: the typed text is added without any issues

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Editing for text with mentions didn't work as expected

# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->