### PR TITLE
Alkwa/fix captions error

### DIFF
--- a/change-beta/@azure-communication-react-edfa78b4-dff7-4e04-be78-b42247c62e65.json
+++ b/change-beta/@azure-communication-react-edfa78b4-dff7-4e04-be78-b42247c62e65.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update unsubscribe logic for captions",
+  "packageName": "@azure/communication-react",
+  "email": "alkwa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-edfa78b4-dff7-4e04-be78-b42247c62e65.json
+++ b/change/@azure-communication-react-edfa78b4-dff7-4e04-be78-b42247c62e65.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update unsubscribe logic for captions",
+  "packageName": "@azure/communication-react",
+  "email": "alkwa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -891,6 +891,17 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | BetaTea
     }
   }
 
+  /* @conditional-compile-remove(close-captions) */
+  private unsubscribeFromCaptionEvents(): void {
+    if (this.call && this.call.state === 'Connected' && _isTeamsMeetingCall(this.call)) {
+      this._call?.feature(Features.TeamsCaptions).off('captionsReceived', this.captionsReceived.bind(this));
+      this._call
+        ?.feature(Features.TeamsCaptions)
+        .off('isCaptionsActiveChanged', this.isCaptionsActiveChanged.bind(this));
+      this.call?.off('stateChanged', this.subscribeToCaptionEvents.bind(this));
+    }
+  }
+
   private subscribeCallEvents(): void {
     this.call?.on('remoteParticipantsUpdated', this.onRemoteParticipantsUpdated.bind(this));
     this.call?.on('isMutedChanged', this.isMyMutedChanged.bind(this));
@@ -913,16 +924,7 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | BetaTea
     this.call?.off('idChanged', this.callIdChanged.bind(this));
 
     /* @conditional-compile-remove(close-captions) */
-    if (this.getState().call?.captionsFeature.isCaptionsFeatureActive) {
-      /* @conditional-compile-remove(close-captions) */
-      this._call?.feature(Features.TeamsCaptions).off('captionsReceived', this.captionsReceived.bind(this));
-      /* @conditional-compile-remove(close-captions) */
-      this._call
-        ?.feature(Features.TeamsCaptions)
-        .off('isCaptionsActiveChanged', this.isCaptionsActiveChanged.bind(this));
-      /* @conditional-compile-remove(close-captions) */
-      this.call?.off('stateChanged', this.subscribeToCaptionEvents.bind(this));
-    }
+    this.unsubscribeFromCaptionEvents();
   }
 
   private isMyMutedChanged = (): void => {

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -911,12 +911,18 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | BetaTea
     this.call?.off('isMutedChanged', this.isMyMutedChanged.bind(this));
     this.call?.off('isScreenSharingOnChanged', this.isScreenSharingOnChanged.bind(this));
     this.call?.off('idChanged', this.callIdChanged.bind(this));
+
     /* @conditional-compile-remove(close-captions) */
-    this._call?.feature(Features.TeamsCaptions).off('captionsReceived', this.captionsReceived.bind(this));
-    /* @conditional-compile-remove(close-captions) */
-    this._call?.feature(Features.TeamsCaptions).off('isCaptionsActiveChanged', this.isCaptionsActiveChanged.bind(this));
-    /* @conditional-compile-remove(close-captions) */
-    this.call?.off('stateChanged', this.subscribeToCaptionEvents.bind(this));
+    if (this.getState().call?.captionsFeature.isCaptionsFeatureActive) {
+      /* @conditional-compile-remove(close-captions) */
+      this._call?.feature(Features.TeamsCaptions).off('captionsReceived', this.captionsReceived.bind(this));
+      /* @conditional-compile-remove(close-captions) */
+      this._call
+        ?.feature(Features.TeamsCaptions)
+        .off('isCaptionsActiveChanged', this.isCaptionsActiveChanged.bind(this));
+      /* @conditional-compile-remove(close-captions) */
+      this.call?.off('stateChanged', this.subscribeToCaptionEvents.bind(this));
+    }
   }
 
   private isMyMutedChanged = (): void => {


### PR DESCRIPTION
# What
We are seeing a captions error in the console when we are trying to end a call. This is odd as captions hasn't even been started and I am not in an interop call. I thought about using a better check from a condition in the stateful client but I ended up just mirroring the same condition we use when the captions are "subscribed"

# Why
We are trying to unregister from captions when we haven't even registered for captions in an interop call

# How Tested
Tested locally in an acs group call. Validated that with the unsubscribe condition we are not seeing the error anymore.
Validated with teams meeting interop. No error
Validate with teams meeting as a Teams user. No Error.
