### PR TITLE
[Chat] Margin fix for mention send box example in Storybook

### DIFF
--- a/change-beta/@azure-communication-react-ef4473ae-6b96-450d-b4ef-9df5d467dc38.json
+++ b/change-beta/@azure-communication-react-ef4473ae-6b96-450d-b4ef-9df5d467dc38.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fixed margins for mention send box example in Storybook",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-ef4473ae-6b96-450d-b4ef-9df5d467dc38.json
+++ b/change/@azure-communication-react-ef4473ae-6b96-450d-b4ef-9df5d467dc38.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fixed margins for mention send box example in Storybook",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/SendBox/snippets/Mentions.snippet.tsx
+++ b/packages/storybook/stories/SendBox/snippets/Mentions.snippet.tsx
@@ -27,8 +27,7 @@ const trigger = '@';
 
 export const MentionsExample: () => JSX.Element = () => (
   <FluentThemeProvider>
-    <div style={{ width: '31.25rem', height: '20rem' }}>
-      <div style={{ width: '31.25rem', height: '17rem' }} /> {/*Spacer for layout*/}
+    <div style={{ width: '31.25rem', marginTop: '12rem' }}>
       <SendBox
         onSendMessage={async (message) => alert(`sent message: ${message} `)}
         onTyping={async () => {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Margin fix for mention send box example in Storybook

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
- when long text was pasted and a mention trigger was added, the suggestions popover wasn't fully visible

# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->