### PR TITLE
[Chat] Updated initial index value in findStringsDiffIndexes

### DIFF
--- a/change-beta/@azure-communication-react-2d9563fb-07b5-48e2-bb80-232218358820.json
+++ b/change-beta/@azure-communication-react-2d9563fb-07b5-48e2-bb80-232218358820.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated initial index value in findStringsDiffIndexes to include the last symbol in the strings",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-2d9563fb-07b5-48e2-bb80-232218358820.json
+++ b/change/@azure-communication-react-2d9563fb-07b5-48e2-bb80-232218358820.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated initial index value in findStringsDiffIndexes to include the last symbol in the strings",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/TextFieldWithMention/mentionTagUtils.ts
+++ b/packages/react-components/src/components/TextFieldWithMention/mentionTagUtils.ts
@@ -652,7 +652,7 @@ export const findStringsDiffIndexes = (props: DiffIndexesProps): DiffIndexesResu
       newChangeEnd = newTextLength;
       oldChangeEnd = oldTextLength;
     } else {
-      for (let i = 1; i < newTextLength && oldTextLength - i >= changeStart; i++) {
+      for (let i = 0; i < newTextLength && oldTextLength - i >= changeStart; i++) {
         newChangeEnd = newTextLength - i - 1;
         oldChangeEnd = oldTextLength - i - 1;
 
@@ -673,7 +673,7 @@ export const findStringsDiffIndexes = (props: DiffIndexesProps): DiffIndexesResu
       newChangeEnd = newTextLength;
       oldChangeEnd = oldTextLength;
     } else {
-      for (let i = 1; i < oldTextLength && newTextLength - i >= changeStart; i++) {
+      for (let i = 0; i < oldTextLength && newTextLength - i >= changeStart; i++) {
         newChangeEnd = newTextLength - i - 1;
         oldChangeEnd = oldTextLength - i - 1;
         if (newText[newChangeEnd] !== oldText[oldChangeEnd]) {
@@ -687,7 +687,7 @@ export const findStringsDiffIndexes = (props: DiffIndexesProps): DiffIndexesResu
     }
   } else {
     // replacement
-    for (let i = 1; i < oldTextLength && oldTextLength - i >= changeStart; i++) {
+    for (let i = 0; i < oldTextLength && oldTextLength - i >= changeStart; i++) {
       newChangeEnd = newTextLength - i - 1;
       oldChangeEnd = oldTextLength - i - 1;
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Updated initial index value in findStringsDiffIndexes to include the last symbol in the strings

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Previously when changed a selected value at the end of the string, the last symbol wasn't included but it should be.
Steps to reproduce:
1. Type '@1 bla' with selectinon @1 as a mention
2. Select 'bla'
3. Paste 'Paste' or 'bbb' or 'bb' (different cases will be handled for different difference between old text and new text length)
Previous result: The text is not changed as expected

# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->