### PR TITLE
Get treeshaked build in production mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,6 +455,8 @@ jobs:
       - name: Run dependency update for stable
         if: ${{ matrix.flavor == 'stable' }}
         run: rush update:stable
+      - name: Build dependencies
+        run: rush build -t @azure/communication-react
       - name: Build
         run: rush build -o calling
       - name: Tests
@@ -499,6 +501,8 @@ jobs:
       - name: Run dependency update for stable
         if: ${{ matrix.flavor == 'stable' }}
         run: rush update:stable
+      - name: Build dependencies
+        run: rush build -t @azure/communication-react
       - name: Build
         run: rush build -o chat
       - name: Tests
@@ -543,6 +547,8 @@ jobs:
       - name: Run dependency update for stable
         if: ${{ matrix.flavor == 'stable' }}
         run: rush update:stable
+      - name: Build dependencies
+        run: rush build -t @azure/communication-react
       - name: Build
         run: rush build -o callwithchat
       - name: Tests

--- a/change-beta/@azure-communication-react-bb34f268-20c3-4cda-bc86-d5e07b44cfe6.json
+++ b/change-beta/@azure-communication-react-bb34f268-20c3-4cda-bc86-d5e07b44cfe6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Get treeshaked build in production mode",
+  "packageName": "@azure/communication-react",
+  "email": "jiangnanhello@live.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-bb34f268-20c3-4cda-bc86-d5e07b44cfe6.json
+++ b/change/@azure-communication-react-bb34f268-20c3-4cda-bc86-d5e07b44cfe6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Get treeshaked build in production mode",
+  "packageName": "@azure/communication-react",
+  "email": "jiangnanhello@live.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/webpack/sampleapp.webpack.config.js
+++ b/common/config/webpack/sampleapp.webpack.config.js
@@ -10,10 +10,14 @@ const CopyPlugin = require("copy-webpack-plugin");
 const webpackConfig = (sampleAppDir, env, babelConfig) => {
   const config = {
     entry: './src/index.tsx',
+    mode: env.production ? 'production' : 'development',
     ...(env.production || !env.development ? {} : { devtool: 'eval-source-map' }),
-    resolve: {
+    resolve:  {
       extensions: ['.ts', '.tsx', '.js'],
-      alias: {
+      alias: env.production ? {
+        // read dist folder from package to simulate production environment
+        '@azure/communication-react': path.resolve(sampleAppDir, '../../packages/communication-react'),
+      } : {
         // reference internal packlets src directly for hot reloading when developing
         '@azure/communication-react': path.resolve(sampleAppDir, '../../packages/communication-react/src'),
         '@internal/react-components': path.resolve(sampleAppDir, '../../packages/react-components/src'),


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Get treeshaked build in production mode

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

The current webpack mapping supports hot reload really well for daily development, but it blocks webpack treeshaking. So we conditionally choose the mapping when it is in development mode for getting more production-like bundles

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->