### PR TITLE
Point readme instructions to install non-fixed versions of peer deps

### DIFF
--- a/change-beta/@azure-communication-react-9119d37c-a257-4f03-8516-1b51b3e4eb1d.json
+++ b/change-beta/@azure-communication-react-9119d37c-a257-4f03-8516-1b51b3e4eb1d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Point readme instructions to install non-fixed versions of peer deps",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-9119d37c-a257-4f03-8516-1b51b3e4eb1d.json
+++ b/change/@azure-communication-react-9119d37c-a257-4f03-8516-1b51b3e4eb1d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Point readme instructions to install non-fixed versions of peer deps",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/communication-react/README.md
+++ b/packages/communication-react/README.md
@@ -22,10 +22,9 @@ npm i @azure/communication-react
 `@azure/communication-react` specifies core Azure Communication Services as `peerDependencies` so that
 you can most consistently use the API from the core libraries in your application. You need to install those libraries as well:
 
-
 ```bash
-npm i @azure/communication-calling@1.4.4
-npm i @azure/communication-chat@1.3.2-beta.1
+npm i @azure/communication-calling
+npm i @azure/communication-chat
 ```
 
 ## Storybook


### PR DESCRIPTION
# What
Point readme instructions to install non-fixed versions of peer deps

# Why
Currently they point to specific versions they shouldn't:
![image](https://github.com/Azure/communication-ui-library/assets/2684369/4750e5be-56b5-41ce-9f50-2f64551e093e)

# How Tested
n/a