### PR TITLE
[Chat] Fix for a cursor position during message editing

### DIFF
--- a/change-beta/@azure-communication-react-29e3b3f9-3d78-4851-a761-6c65b0a42c8a.json
+++ b/change-beta/@azure-communication-react-29e3b3f9-3d78-4851-a761-6c65b0a42c8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed an issue with a cursor position when multiline parameter is set to true",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-29e3b3f9-3d78-4851-a761-6c65b0a42c8a.json
+++ b/change/@azure-communication-react-29e3b3f9-3d78-4851-a761-6c65b0a42c8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed an issue with a cursor position when multiline parameter is set to true",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/InputBoxComponent.tsx
+++ b/packages/react-components/src/components/InputBoxComponent.tsx
@@ -178,6 +178,12 @@ export const InputBoxComponent = (props: InputBoxComponentProps): JSX.Element =>
         value={textValue}
         onChange={onChange}
         onKeyDown={onTextFieldKeyDown}
+        onFocus={(e) => {
+          // Fix for setting the cursor to the correct position when multiline is true
+          // This approach should be reviewed during migration to FluentUI v9
+          e.currentTarget.value = '';
+          e.currentTarget.value = textValue;
+        }}
       />
     );
   };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Fixed an issue with a cursor position when multiline parameter is set to true

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
The cursor position should be set to the end of the string instead of the beggining of it when edit is started

# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->