### PR TITLE
[Chat] Fix mention popover position being incorrect in long text

### DIFF
--- a/change-beta/@azure-communication-react-93b4d593-4a04-460d-94b0-ffc7624c89ab.json
+++ b/change-beta/@azure-communication-react-93b4d593-4a04-460d-94b0-ffc7624c89ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix mention popover position is far up in long text",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-93b4d593-4a04-460d-94b0-ffc7624c89ab.json
+++ b/change/@azure-communication-react-93b4d593-4a04-460d-94b0-ffc7624c89ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix mention popover position is far up in long text",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/TextFieldWithMention/TextFieldWithMention.tsx
+++ b/packages/react-components/src/components/TextFieldWithMention/TextFieldWithMention.tsx
@@ -529,7 +529,9 @@ export const TextFieldWithMention = (props: TextFieldWithMentionProps): JSX.Elem
         const textField = event.currentTarget;
         const relativePosition = Caret.getRelativePosition(textField);
         const adjustOffset = Math.max(0, textField.scrollHeight - textField.clientHeight);
-        relativePosition.top -= adjustOffset;
+        if (relativePosition.top > adjustOffset) {
+          relativePosition.top -= adjustOffset;
+        }
         setCaretPosition(relativePosition);
 
         if (triggerPriorIndex !== undefined) {

--- a/packages/react-components/src/components/styles/MentionPopover.style.ts
+++ b/packages/react-components/src/components/styles/MentionPopover.style.ts
@@ -71,7 +71,7 @@ export const suggestionItemStackStyle = (theme: Theme, isSuggestionHovered: bool
     alignItems: 'center',
     height: '36px',
     padding: '0 0.75rem',
-    background: isSuggestionHovered ? theme.palette.neutralLight : theme.palette.white,
+    background: isSuggestionHovered ? theme.palette.neutralLighter : theme.palette.white,
     border: activeBorder ? `0.0625rem solid ${theme.palette.neutralSecondary}` : 'none'
   });
 };

--- a/packages/react-components/src/components/styles/MentionPopover.style.ts
+++ b/packages/react-components/src/components/styles/MentionPopover.style.ts
@@ -72,6 +72,6 @@ export const suggestionItemStackStyle = (theme: Theme, isSuggestionHovered: bool
     height: '36px',
     padding: '0 0.75rem',
     background: isSuggestionHovered ? theme.palette.neutralLighter : theme.palette.white,
-    border: activeBorder ? `0.0625rem solid ${theme.palette.neutralSecondary}` : 'none'
+    outline: activeBorder ? `0.0625rem solid ${theme.palette.neutralSecondary}` : 'none'
   });
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
When the text content is long enough to make the text input field scrollable, then try to mention someone on the first line of the text causing the mention popover's position being too high up.

Also fixed:
1. changed the hover background color of mention popover item from neutralLight to neutralLighter
2. when a mention suggestion is active, the item UI shrunk a bit due to the border

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
1. Paste in some long text message to make the text input field scrollable
2. Scroll to the first line of the message
3. Mention someone in the first line

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->