### PR TITLE
[Alternative stopgap fix] Limit accepting a transfer request to 5 seconds to mitigate timeout failure

### DIFF
--- a/change-beta/@azure-communication-react-1ed624f5-9cea-4638-af34-22c860b557fd.json
+++ b/change-beta/@azure-communication-react-1ed624f5-9cea-4638-af34-22c860b557fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Prevent timeout of transfer request by enforcing 5 second limit to accept and rejecting otherwise",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-1ed624f5-9cea-4638-af34-22c860b557fd.json
+++ b/change/@azure-communication-react-1ed624f5-9cea-4638-af34-22c860b557fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Prevent timeout of transfer request by enforcing 5 second limit to accept and rejecting otherwise",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
# What
Limit accepting a transfer request to 5 seconds to mitigate timeout
Alternative stopgap fix to #3228 

Downsides: 
- we will have reject telemetry data that comes from user accepting after 5 seconds
- not sophisticated at all

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3305535

# How Tested
https://github.com/Azure/communication-ui-library/assets/79475487/2f0bf3d5-4adb-4f78-b397-0d4e77a65f44

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->