### PR TITLE
[Release] Remove call-transfer feature from in-progress features and add pre-release changelog

### DIFF
--- a/change-beta/@azure-communication-react-a215f5dd-d4db-42f8-ab2d-00c83dff20ba.json
+++ b/change-beta/@azure-communication-react-a215f5dd-d4db-42f8-ab2d-00c83dff20ba.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Add abiltiy to accept or reject transfer requests through CallAdapter event subscription. Call composite shows transfer page when a transfer request is accepted followed by seamless transition to new call.",
+  "comment": "Add ability to accept or reject transfer requests through CallAdapter event subscription. Call composite shows transfer page when a transfer request is accepted followed by seamless transition to new call.",
   "packageName": "@azure/communication-react",
   "email": "miguelgamis@microsoft.com",
   "dependentChangeType": "patch"

--- a/change-beta/@azure-communication-react-a215f5dd-d4db-42f8-ab2d-00c83dff20ba.json
+++ b/change-beta/@azure-communication-react-a215f5dd-d4db-42f8-ab2d-00c83dff20ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add abiltiy to accept or reject transfer requests through CallAdapter event subscription. Call composite shows transfer page when a transfer request is accepted followed by seamless transition to new call.",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-a215f5dd-d4db-42f8-ab2d-00c83dff20ba.json
+++ b/change/@azure-communication-react-a215f5dd-d4db-42f8-ab2d-00c83dff20ba.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Add abiltiy to accept or reject transfer requests through CallAdapter event subscription. Call composite shows transfer page when a transfer request is accepted followed by seamless transition to new call.",
+  "comment": "Add ability to accept or reject transfer requests through CallAdapter event subscription. Call composite shows transfer page when a transfer request is accepted followed by seamless transition to new call.",
   "packageName": "@azure/communication-react",
   "email": "miguelgamis@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@azure-communication-react-a215f5dd-d4db-42f8-ab2d-00c83dff20ba.json
+++ b/change/@azure-communication-react-a215f5dd-d4db-42f8-ab2d-00c83dff20ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add abiltiy to accept or reject transfer requests through CallAdapter event subscription. Call composite shows transfer page when a transfer request is accepted followed by seamless transition to new call.",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/babel/.babelrc.js
+++ b/common/config/babel/.babelrc.js
@@ -79,8 +79,6 @@ process.env['COMMUNICATION_REACT_FLAVOR'] !== 'beta' &&
         'click-to-call',
         // Mention feature
         'mention',
-        // Feature for call transfer
-        'call-transfer',
         // Optimal Video count feature,
         'optimal-video-count'
       ],


### PR DESCRIPTION
# What
- Remove call-transfer feature from in-progress features 
- Add pre-release changelog

# Why
Call transfer feature is ready for Public Preview. We will release it in our June release

# Process & policy checklist
- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.