### PR TITLE
[Release] Update script to bump beta version

### DIFF
--- a/change-beta/@azure-communication-react-0548d4a9-d7d1-4987-9858-8a3a6520c8e8.json
+++ b/change-beta/@azure-communication-react-0548d4a9-d7d1-4987-9858-8a3a6520c8e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update beta version bump script",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-0548d4a9-d7d1-4987-9858-8a3a6520c8e8.json
+++ b/change/@azure-communication-react-0548d4a9-d7d1-4987-9858-8a3a6520c8e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update beta version bump script",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/common/scripts/bump-beta-version.js
+++ b/common/scripts/bump-beta-version.js
@@ -28,6 +28,7 @@ const bumpBetaVersion = (currentVersion) => {
     return `${major}.${newMinor}.0-beta.${newBeta}`
   }
 
+  const newBeta = Number.parseInt(betaVersion) + 1;
   return `${major}.${minor}.${patch}-beta.${newBeta}`
 }
 

--- a/common/scripts/bump-beta-version.js
+++ b/common/scripts/bump-beta-version.js
@@ -13,19 +13,19 @@ const main = () => {
 
 const bumpBetaVersion = (currentVersion) => {
   const versionStrs = currentVersion.split('-beta.');
-  const [major, minor] = versionStrs[0].split('.');
+  const [major, minor, patch] = versionStrs[0].split('.');
   const betaVersion = versionStrs[1];
   
-  // If there is no beta version then we simply append '-beta.0'
   if (betaVersion === undefined) {
-    return [versionStrs, 0].join('-beta.');
+    // We will bump the minor version when we create a beta on top of a stable one
+    const newMinor = Number.parseInt(minor) + 1;
+    // If there is no beta version then we simply append '-beta.0'
+    return `${major}.${newMinor}.0-beta.0`
   }
 
   const newBeta = Number.parseInt(betaVersion) + 1;
-  // We will bump the minor version when we create a beta on top of a stable one
-  const newMinor = Number.parseInt(betaVersion) === 0 ? Number.parseInt(minor) + 1 : minor;
 
-  return [[major, newMinor, 0].join('.'), `${newBeta}`].join('-beta.');
+  return `${major}.${minor}.${patch}-beta.${newBeta}`
 }
 
 main();

--- a/common/scripts/bump-beta-version.js
+++ b/common/scripts/bump-beta-version.js
@@ -17,13 +17,16 @@ const bumpBetaVersion = (currentVersion) => {
   const betaVersion = versionStrs[1];
   
   if (betaVersion === undefined) {
-    // We will bump the minor version when we create a beta on top of a stable one
     const newMinor = Number.parseInt(minor) + 1;
-    // If there is no beta version then we simply append '-beta.0'
     return `${major}.${newMinor}.0-beta.0`
   }
 
-  const newBeta = Number.parseInt(betaVersion) + 1;
+  if (Number.parseInt(betaVersion) === 0) {
+    // We will bump the minor version when we create a beta on top of a stable one
+    const newMinor = Number.parseInt(minor) + 1;
+    const newBeta = Number.parseInt(betaVersion) + 1;
+    return `${major}.${newMinor}.0-beta.${newBeta}`
+  }
 
   return `${major}.${minor}.${patch}-beta.${newBeta}`
 }

--- a/common/scripts/bump-beta-version.js
+++ b/common/scripts/bump-beta-version.js
@@ -13,12 +13,19 @@ const main = () => {
 
 const bumpBetaVersion = (currentVersion) => {
   const versionStrs = currentVersion.split('-beta.');
-  const newBeta = versionStrs[1] === undefined ? 0 : Number.parseInt(versionStrs[1]) + 1;
-  const [major, minor, patch] = versionStrs[0].split('.');
-  const newPatch = Number.parseInt(patch) + 1;
+  const [major, minor] = versionStrs[0].split('.');
+  const betaVersion = versionStrs[1];
+  
+  // If there is no beta version then we simply append '-beta.0'
+  if (betaVersion === undefined) {
+    return [versionStrs, 0].join('-beta.');
+  }
 
-  // We will bump the patch version when create a beta on top of a stable one
-  return [[major, minor, newBeta === 0 ? newPatch : patch].join('.'), `${newBeta}`].join('-beta.');
+  const newBeta = Number.parseInt(betaVersion) + 1;
+  // We will bump the minor version when we create a beta on top of a stable one
+  const newMinor = Number.parseInt(betaVersion) === 0 ? Number.parseInt(minor) + 1 : minor;
+
+  return [[major, newMinor, 0].join('.'), `${newBeta}`].join('-beta.');
 }
 
 main();

--- a/common/scripts/bump-beta-version.js
+++ b/common/scripts/bump-beta-version.js
@@ -11,6 +11,8 @@ const main = () => {
   updateAllDepVersions(bumpBetaVersion, depNames);
 }
 
+// TODO: This needs to be updated. This does not work for all beta release scenarios outlined in documentation
+// https://skype.visualstudio.com/SPOOL/_wiki/wikis/SPOOL.wiki/43834/How-to-determine-the-next-web-UI-Library-package-version.
 const bumpBetaVersion = (currentVersion) => {
   const versionStrs = currentVersion.split('-beta.');
   const [major, minor] = versionStrs[0].split('.');

--- a/common/scripts/bump-beta-version.js
+++ b/common/scripts/bump-beta-version.js
@@ -13,23 +13,17 @@ const main = () => {
 
 const bumpBetaVersion = (currentVersion) => {
   const versionStrs = currentVersion.split('-beta.');
-  const [major, minor, patch] = versionStrs[0].split('.');
+  const [major, minor] = versionStrs[0].split('.');
   const betaVersion = versionStrs[1];
   
+  const newMinor = Number.parseInt(minor) + 1;
+
   if (betaVersion === undefined) {
-    const newMinor = Number.parseInt(minor) + 1;
     return `${major}.${newMinor}.0-beta.0`
   }
 
-  if (Number.parseInt(betaVersion) === 0) {
-    // We will bump the minor version when we create a beta on top of a stable one
-    const newMinor = Number.parseInt(minor) + 1;
-    const newBeta = Number.parseInt(betaVersion) + 1;
-    return `${major}.${newMinor}.0-beta.${newBeta}`
-  }
-
   const newBeta = Number.parseInt(betaVersion) + 1;
-  return `${major}.${minor}.${patch}-beta.${newBeta}`
+  return `${major}.${newMinor}.0-beta.${newBeta}`
 }
 
 main();

--- a/common/scripts/package.json
+++ b/common/scripts/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "@internal/scripts",
-  "version": "1.0.0",
-  "private": true,
-  "devDependencies": {
-    "semver": "~7.5.3"
-  }
-}

--- a/common/scripts/package.json
+++ b/common/scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@internal/scripts",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "semver": "~7.5.3"
+  }
+}


### PR DESCRIPTION
# What
Update script to bump beta version based on the discussion in 'Web UI group' chat

# Why
We have been doing our beta version bumps incorrectly. Need this to create pre-release branch for 1.7.0-beta.1 release

# How Tested
Tested new function in playcode:
https://github.com/Azure/communication-ui-library/assets/79475487/dbb17351-20cf-4dfb-ba6f-b6f8de4d1c2c

Tested script locally:
https://github.com/Azure/communication-ui-library/assets/79475487/31c0db19-001a-4b3f-a72f-65faf27932a2

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->