### PR TITLE
Fix speaker icon in contextual menu of microphone and devices button

### DIFF
--- a/change-beta/@azure-communication-react-f87ea73f-9fa4-4eb7-997c-9e51b1a2a966.json
+++ b/change-beta/@azure-communication-react-f87ea73f-9fa4-4eb7-997c-9e51b1a2a966.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix speaker icon in contextual menu of microphone and devices button",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-f87ea73f-9fa4-4eb7-997c-9e51b1a2a966.json
+++ b/change/@azure-communication-react-f87ea73f-9fa4-4eb7-997c-9e51b1a2a966.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix speaker icon in contextual menu of microphone and devices button",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2182,6 +2182,7 @@ export const DEFAULT_COMPONENT_ICONS: {
     ChangeSpokenLanguageIcon: JSX.Element;
     ContextMenuCameraIcon: JSX.Element;
     ContextMenuMicIcon: JSX.Element;
+    ContextMenuSpeakerIcon: JSX.Element;
 };
 
 // @public
@@ -2296,6 +2297,7 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ChangeSpokenLanguageIcon: JSX.Element;
     ContextMenuCameraIcon: JSX.Element;
     ContextMenuMicIcon: JSX.Element;
+    ContextMenuSpeakerIcon: JSX.Element;
 };
 
 // @beta

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -787,6 +787,7 @@ export const DEFAULT_COMPONENT_ICONS: {
     ChangeSpokenLanguageIcon: JSX.Element;
     ContextMenuCameraIcon: JSX.Element;
     ContextMenuMicIcon: JSX.Element;
+    ContextMenuSpeakerIcon: JSX.Element;
 };
 
 // @internal

--- a/packages/react-components/src/components/DevicesButton.tsx
+++ b/packages/react-components/src/components/DevicesButton.tsx
@@ -378,7 +378,7 @@ export const generateDefaultDeviceMenuProps = (
                   styles: menuItemStyles
                 },
                 iconProps: {
-                  iconName: 'ContextMenuMicIcon',
+                  iconName: 'ContextMenuSpeakerIcon',
                   styles: { root: { lineHeight: 0 } }
                 },
                 canCheck: true,

--- a/packages/react-components/src/theming/icons.tsx
+++ b/packages/react-components/src/theming/icons.tsx
@@ -331,5 +331,6 @@ export const DEFAULT_COMPONENT_ICONS = {
   /* @conditional-compile-remove(close-captions) */
   ChangeSpokenLanguageIcon: <PersonVoice20Regular />,
   ContextMenuCameraIcon: <Video20Regular />,
-  ContextMenuMicIcon: <Mic20Regular />
+  ContextMenuMicIcon: <Mic20Regular />,
+  ContextMenuSpeakerIcon: <Speaker220Regular />
 };

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -1292,6 +1292,7 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ChangeSpokenLanguageIcon: JSX.Element;
     ContextMenuCameraIcon: JSX.Element;
     ContextMenuMicIcon: JSX.Element;
+    ContextMenuSpeakerIcon: JSX.Element;
 };
 
 // @beta


### PR DESCRIPTION
# What
Add speaker icon for contextual menu of microphone and devices button

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3323978

# How Tested
Local call with chat sample testing
before:
https://github.com/Azure/communication-ui-library/assets/79475487/eced8e7c-82b7-4e4b-8b67-df5db6705b22

after:
https://github.com/Azure/communication-ui-library/assets/79475487/6b91fa07-3dc8-4003-aeb4-b5c7941b44f8

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->