### PR TITLE
[Chat] Add vertical offset for mention popover

### DIFF
--- a/change-beta/@azure-communication-react-1db7a146-c037-4934-90f8-c3564535e671.json
+++ b/change-beta/@azure-communication-react-1db7a146-c037-4934-90f8-c3564535e671.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add vertical offset for mention popover",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-1db7a146-c037-4934-90f8-c3564535e671.json
+++ b/change/@azure-communication-react-1db7a146-c037-4934-90f8-c3564535e671.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add vertical offset for mention popover",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/MentionPopover.test.tsx
+++ b/packages/react-components/src/components/MentionPopover.test.tsx
@@ -81,7 +81,7 @@ describe('Display mention popover in the correct position', () => {
     expect(style.left).toBe('100px');
     expect(style.right).toBe('');
     expect(style.top).toBe('');
-    expect(style.bottom).toBe('150px');
+    expect(style.bottom).toBe('154px');
   });
 
   test('Show mention popover above the cursor when popover does not fit horizontally of the target', async () => {
@@ -97,7 +97,7 @@ describe('Display mention popover in the correct position', () => {
     expect(style.left).toBe('');
     expect(style.right).toBe('150px');
     expect(style.top).toBe('');
-    expect(style.bottom).toBe('150px');
+    expect(style.bottom).toBe('154px');
   });
 
   test('Show mention popover below the cursor when popover fits horizontally of the target', async () => {
@@ -112,7 +112,7 @@ describe('Display mention popover in the correct position', () => {
     expect(style.maxWidth).toBe('200px');
     expect(style.left).toBe('100px');
     expect(style.right).toBe('');
-    expect(style.top).toBe('250px');
+    expect(style.top).toBe('254px');
     expect(style.bottom).toBe('');
   });
 
@@ -128,7 +128,7 @@ describe('Display mention popover in the correct position', () => {
     expect(style.maxWidth).toBe('200px');
     expect(style.left).toBe('');
     expect(style.right).toBe('100px');
-    expect(style.top).toBe('250px');
+    expect(style.top).toBe('254px');
     expect(style.bottom).toBe('');
   });
 
@@ -143,6 +143,6 @@ describe('Display mention popover in the correct position', () => {
     expect(style.left).toBe('0px');
     expect(style.right).toBe('');
     expect(style.top).toBe('');
-    expect(style.bottom).toBe('200px');
+    expect(style.bottom).toBe('204px');
   });
 });

--- a/packages/react-components/src/components/MentionPopover.tsx
+++ b/packages/react-components/src/components/MentionPopover.tsx
@@ -207,12 +207,13 @@ export const _MentionPopover = (props: _MentionPopoverProps): JSX.Element => {
     } else {
       finalPosition.left = leftOffset;
     }
-
+    // Offset between cursor and mention popover
+    const verticalOffset = 4;
     if (location === 'below') {
-      finalPosition.top = (rect?.height ?? 0) + (targetPositionOffset?.top ?? 0);
+      finalPosition.top = (rect?.height ?? 0) + (targetPositionOffset?.top ?? 0) + verticalOffset;
     } else {
       // (location === 'above')
-      finalPosition.bottom = (rect?.height ?? 0) - (targetPositionOffset?.top ?? 0);
+      finalPosition.bottom = (rect?.height ?? 0) - (targetPositionOffset?.top ?? 0) + verticalOffset;
     }
     setPosition(finalPosition);
   }, [location, target, targetPositionOffset]);


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Increase vertical offset for 4px

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
| Previously | Now |
| --- | --- |
| ![image](https://github.com/Azure/communication-ui-library/assets/98852890/d7645003-ceaa-4f1d-90db-7fb68696cf6b) | ![image](https://github.com/Azure/communication-ui-library/assets/98852890/5332fe4e-1d35-4a3c-a6e2-1305f41ad419) | 
# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->