### PR TITLE
[Chat] Fixed Video Not Scale Properly

### DIFF
--- a/change-beta/@azure-communication-react-e2c245ba-da68-430e-ac6e-eecb6a37bfe0.json
+++ b/change-beta/@azure-communication-react-e2c245ba-da68-430e-ac6e-eecb6a37bfe0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Addressed the issue where video not scale properly in message content",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-e2c245ba-da68-430e-ac6e-eecb6a37bfe0.json
+++ b/change/@azure-communication-react-e2c245ba-da68-430e-ac6e-eecb6a37bfe0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Addressed the issue where video not scale properly in message content",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/MessageThread.styles.ts
+++ b/packages/react-components/src/components/styles/MessageThread.styles.ts
@@ -129,6 +129,10 @@ export const defaultChatMessageContainer = (theme: Theme): ComponentSlotStyle =>
     maxWidth: '100% !important', // Add !important to make sure it won't be overridden by style defined in element
     height: 'auto !important'
   },
+  '& video': {
+    maxWidth: '100% !important', // Add !important to make sure it won't be overridden by style defined in element
+    height: 'auto !important'
+  },
   '& p': {
     // Deal with awkward padding seen in messages from Teams.
     // For more info see https://github.com/Azure/communication-ui-library/pull/1507


### PR DESCRIPTION
# What
Addressed the issue where video messages not being scaled properly in message container.

Note that currently the video content would appear to be blank and this is expected and it needs to be addressed in the backend.

# Why

|  Before  | After  |
|---|---|
|  <img width="358" alt="image" src="https://github.com/Azure/communication-ui-library/assets/109105353/779db6a9-85a3-43f2-8250-e96ee876fdda"> | <img width="371" alt="image" src="https://github.com/Azure/communication-ui-library/assets/109105353/51a73afa-63e3-4ffc-a2c5-8549c7373a1d">  |

# How Tested
run call with chat sample, join a Teams call, send a video message from Teams side, verify if blank video tag is scaled properly in container.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [X] I have updated the project documentation to reflect my changes if necessary.
- [X] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->