### PR TITLE
[Chat] Storybook Adapter page add beta property for chatAdapter

### DIFF
--- a/change-beta/@azure-communication-react-bce96543-9731-4d9f-8522-6c7e6c6f203d.json
+++ b/change-beta/@azure-communication-react-bce96543-9731-4d9f-8522-6c7e6c6f203d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add downloadAttachment method for adapter storbook page",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-bce96543-9731-4d9f-8522-6c7e6c6f203d.json
+++ b/change/@azure-communication-react-bce96543-9731-4d9f-8522-6c7e6c6f203d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add downloadAttachment method for adapter storbook page",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/Adapters/Adapters.stories.mdx
+++ b/packages/storybook/stories/Adapters/Adapters.stories.mdx
@@ -135,22 +135,22 @@ The ChatAdapter and the ChatComposite are purpose-built to support single chat t
 
 ### ChatAdapter
 
-| Method                               | Details                                                                                                           | Signature                                                                        |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| **`fetchInitialData`**               | Fetch initial state for the Chat adapter. Performs the minimal fetch necessary for ChatComposite and API methods. | `() => Promise<void>`                                                            |
-| **`onStateChange`**                  | Subscribes the handler to stateChanged events.                                                                    | `(handler: (state: `[`ChatAdapterState`](#chatadapterstate)`) => void) => void`  |
-| **`offStateChange`**                 | Unsubscribes the handler to stateChanged events.                                                                  | `(handler: (state: `[`ChatAdapterState`](#chatadapterstate)`) => void) => void`  |
-| **`getState`**                       | Get the current State                                                                                             | `() => `[`ChatAdapterState`](#chatadapterstate)                                  |
-| **`dispose`**                        | Dispose of the Composite                                                                                          | `() => void`                                                                     |
-| **`sendMessage`**                    | Send a message in the thread.                                                                                     | `(content: string) => Promise<void>`                                             |
-| **`sendReadReceipt`**                | Send a read receipt for a message.                                                                                | `(chatMessageId: string) => Promise<void>`                                       |
-| **`sendTypingIndicator`**            | Send typing indicator in the thread.                                                                              | `() => Promise<void>`                                                            |
-| **`removeParticipant`**              | Remove a participant in the thread.                                                                               | `(userId: string) => Promise<void>`                                              |
-| **`setTopic`**                       | Set the topic for the thread.                                                                                     | `(topicName: string) => Promise<void>`                                           |
-| **`updateMessage`**                  | Update a message content.                                                                                         | `(messageId: string, content: string) => Promise<void>`                          |
-| **`deleteMessage`**                  | Delete a message in the thread.                                                                                   | `(messageId: string) => Promise<void>`                                           |
-| **`loadPreviousChatMessages`**       | Load more previous messages in the chat thread history.                                                           | `(messagesToLoad: number) => Promise<boolean>`                                   |
-| **`downloadAttachments`** **(Beta)** | Download a list of attachments. Add your download logic and authentication here as needed.                        | `(options: { attachmentUrls: string[] }) => Promise<AttachmentDownloadResult[]>` |
+| Method                               | Details                                                                                                           | Signature                                                                                                              |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **`fetchInitialData`**               | Fetch initial state for the Chat adapter. Performs the minimal fetch necessary for ChatComposite and API methods. | `() => Promise<void>`                                                                                                  |
+| **`onStateChange`**                  | Subscribes the handler to stateChanged events.                                                                    | `(handler: (state: `[`ChatAdapterState`](#chatadapterstate)`) => void) => void`                                        |
+| **`offStateChange`**                 | Unsubscribes the handler to stateChanged events.                                                                  | `(handler: (state: `[`ChatAdapterState`](#chatadapterstate)`) => void) => void`                                        |
+| **`getState`**                       | Get the current State                                                                                             | `() => `[`ChatAdapterState`](#chatadapterstate)                                                                        |
+| **`dispose`**                        | Dispose of the Composite                                                                                          | `() => void`                                                                                                           |
+| **`sendMessage`**                    | Send a message in the thread.                                                                                     | `(content: string) => Promise<void>`                                                                                   |
+| **`sendReadReceipt`**                | Send a read receipt for a message.                                                                                | `(chatMessageId: string) => Promise<void>`                                                                             |
+| **`sendTypingIndicator`**            | Send typing indicator in the thread.                                                                              | `() => Promise<void>`                                                                                                  |
+| **`removeParticipant`**              | Remove a participant in the thread.                                                                               | `(userId: string) => Promise<void>`                                                                                    |
+| **`setTopic`**                       | Set the topic for the thread.                                                                                     | `(topicName: string) => Promise<void>`                                                                                 |
+| **`updateMessage`**                  | Update a message content.                                                                                         | `(messageId: string, content: string) => Promise<void>`                                                                |
+| **`deleteMessage`**                  | Delete a message in the thread.                                                                                   | `(messageId: string) => Promise<void>`                                                                                 |
+| **`loadPreviousChatMessages`**       | Load more previous messages in the chat thread history.                                                           | `(messagesToLoad: number) => Promise<boolean>`                                                                         |
+| **`downloadAttachments`** **(Beta)** | Download a list of attachments. Add your download logic and authentication here as needed.                        | `(options: { attachmentUrls: string[] }) => Promise<`[`AttachmentDownloadResult`](#attachmentdownloadresult-beta)`[]>` |
 
 ### ChatAdapterState
 
@@ -161,6 +161,12 @@ The ChatAdapter and the ChatComposite are purpose-built to support single chat t
 | **`displayName`**  | `string`                                                                                                                                 |
 | **`thread`**       | [`ChatThreadClientState`](https://learn.microsoft.com/en-us/javascript/api/@azure/communication-react/chatthreadclientstate)             |
 | **`latestErrors`** | `ChatAdapterErrors` <br /><br />Latest error encountered for each operation performed via the adapter                                    |
+
+### AttachmentDownloadResult (Beta)
+
+| Property      | Type                                              |
+| ------------- | ------------------------------------------------- |
+| **`blobUrl`** | `string` <br /><br />Blob url for the attachment. |
 
 ## Functions
 

--- a/packages/storybook/stories/Adapters/Adapters.stories.mdx
+++ b/packages/storybook/stories/Adapters/Adapters.stories.mdx
@@ -135,21 +135,22 @@ The ChatAdapter and the ChatComposite are purpose-built to support single chat t
 
 ### ChatAdapter
 
-| Method                         | Details                                                                                                           | Signature                                                                       |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| **`fetchInitialData`**         | Fetch initial state for the Chat adapter. Performs the minimal fetch necessary for ChatComposite and API methods. | `() => Promise<void>`                                                           |
-| **`onStateChange`**            | Subscribes the handler to stateChanged events.                                                                    | `(handler: (state: `[`ChatAdapterState`](#chatadapterstate)`) => void) => void` |
-| **`offStateChange`**           | Unsubscribes the handler to stateChanged events.                                                                  | `(handler: (state: `[`ChatAdapterState`](#chatadapterstate)`) => void) => void` |
-| **`getState`**                 | Get the current State                                                                                             | `() => `[`ChatAdapterState`](#chatadapterstate)                                 |
-| **`dispose`**                  | Dispose of the Composite                                                                                          | `() => void`                                                                    |
-| **`sendMessage`**              | Send a message in the thread.                                                                                     | `(content: string) => Promise<void>`                                            |
-| **`sendReadReceipt`**          | Send a read receipt for a message.                                                                                | `(chatMessageId: string) => Promise<void>`                                      |
-| **`sendTypingIndicator`**      | Send typing indicator in the thread.                                                                              | `() => Promise<void>`                                                           |
-| **`removeParticipant`**        | Remove a participant in the thread.                                                                               | `(userId: string) => Promise<void>`                                             |
-| **`setTopic`**                 | Set the topic for the thread.                                                                                     | `(topicName: string) => Promise<void>`                                          |
-| **`updateMessage`**            | Update a message content.                                                                                         | `(messageId: string, content: string) => Promise<void>`                         |
-| **`deleteMessage`**            | Delete a message in the thread.                                                                                   | `(messageId: string) => Promise<void>`                                          |
-| **`loadPreviousChatMessages`** | Load more previous messages in the chat thread history.                                                           | `(messagesToLoad: number) => Promise<boolean>`                                  |
+| Method                               | Details                                                                                                           | Signature                                                                        |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **`fetchInitialData`**               | Fetch initial state for the Chat adapter. Performs the minimal fetch necessary for ChatComposite and API methods. | `() => Promise<void>`                                                            |
+| **`onStateChange`**                  | Subscribes the handler to stateChanged events.                                                                    | `(handler: (state: `[`ChatAdapterState`](#chatadapterstate)`) => void) => void`  |
+| **`offStateChange`**                 | Unsubscribes the handler to stateChanged events.                                                                  | `(handler: (state: `[`ChatAdapterState`](#chatadapterstate)`) => void) => void`  |
+| **`getState`**                       | Get the current State                                                                                             | `() => `[`ChatAdapterState`](#chatadapterstate)                                  |
+| **`dispose`**                        | Dispose of the Composite                                                                                          | `() => void`                                                                     |
+| **`sendMessage`**                    | Send a message in the thread.                                                                                     | `(content: string) => Promise<void>`                                             |
+| **`sendReadReceipt`**                | Send a read receipt for a message.                                                                                | `(chatMessageId: string) => Promise<void>`                                       |
+| **`sendTypingIndicator`**            | Send typing indicator in the thread.                                                                              | `() => Promise<void>`                                                            |
+| **`removeParticipant`**              | Remove a participant in the thread.                                                                               | `(userId: string) => Promise<void>`                                              |
+| **`setTopic`**                       | Set the topic for the thread.                                                                                     | `(topicName: string) => Promise<void>`                                           |
+| **`updateMessage`**                  | Update a message content.                                                                                         | `(messageId: string, content: string) => Promise<void>`                          |
+| **`deleteMessage`**                  | Delete a message in the thread.                                                                                   | `(messageId: string) => Promise<void>`                                           |
+| **`loadPreviousChatMessages`**       | Load more previous messages in the chat thread history.                                                           | `(messagesToLoad: number) => Promise<boolean>`                                   |
+| **`downloadAttachments`** **(Beta)** | Download a list of attachments. Add your download logic and authentication here as needed.                        | `(options: { attachmentUrls: string[] }) => Promise<AttachmentDownloadResult[]>` |
 
 ### ChatAdapterState
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
-Storybook Adapter page add beta property (downloadAttachments) for chatAdapter

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->