### PR TITLE
[BugFix] Remove visual flicker on presenting mention suggestions popover

### DIFF
--- a/change-beta/@azure-communication-react-3c8b4d1b-4194-4793-8046-30135c6dcb08.json
+++ b/change-beta/@azure-communication-react-3c8b4d1b-4194-4793-8046-30135c6dcb08.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure popover position is set prior to rendering.",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-3c8b4d1b-4194-4793-8046-30135c6dcb08.json
+++ b/change/@azure-communication-react-3c8b4d1b-4194-4793-8046-30135c6dcb08.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure popover position is set prior to rendering.",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/MentionPopover.tsx
+++ b/packages/react-components/src/components/MentionPopover.tsx
@@ -165,7 +165,7 @@ export const _MentionPopover = (props: _MentionPopoverProps): JSX.Element => {
   const localeStrings = useLocale().strings;
   const popoverRef = useRef() as React.MutableRefObject<HTMLDivElement>;
 
-  const [position, setPosition] = useState<Position>({ left: 0 });
+  const [position, setPosition] = useState<Position | undefined>();
   const [hoveredSuggestion, setHoveredSuggestion] = useState<Mention | undefined>(undefined);
   const [changedSelection, setChangedSelection] = useState<boolean | undefined>(undefined); // Selection UI as per teams
 
@@ -298,36 +298,38 @@ export const _MentionPopover = (props: _MentionPopoverProps): JSX.Element => {
 
   return (
     <div ref={popoverRef}>
-      <Stack
-        data-testid={'mention-suggestion-list-container'}
-        className={mergeStyles(
-          {
-            maxHeight: 212,
-            maxWidth: position.maxWidth
-          },
-          mentionPopoverContainerStyle(theme),
-          {
-            ...position,
-            position: 'absolute'
-          }
-        )}
-      >
-        <Stack.Item styles={headerStyleThemed(theme)} aria-label={title}>
-          {getHeaderTitle()}
-        </Stack.Item>
+      {position && (
         <Stack
-          /* @conditional-compile-remove(mention) */
-          data-ui-id={ids.mentionSuggestionList}
-          className={suggestionListStyle}
+          data-testid={'mention-suggestion-list-container'}
+          className={mergeStyles(
+            {
+              maxHeight: 212,
+              maxWidth: position.maxWidth
+            },
+            mentionPopoverContainerStyle(theme),
+            {
+              ...position,
+              position: 'absolute'
+            }
+          )}
         >
-          {suggestions.map((suggestion, index) => {
-            const active = index === activeSuggestionIndex;
-            return onRenderSuggestionItem
-              ? onRenderSuggestionItem(suggestion, onSuggestionSelected, active)
-              : defaultOnRenderSuggestionItem(suggestion, onSuggestionSelected, active);
-          })}
+          <Stack.Item styles={headerStyleThemed(theme)} aria-label={title}>
+            {getHeaderTitle()}
+          </Stack.Item>
+          <Stack
+            /* @conditional-compile-remove(mention) */
+            data-ui-id={ids.mentionSuggestionList}
+            className={suggestionListStyle}
+          >
+            {suggestions.map((suggestion, index) => {
+              const active = index === activeSuggestionIndex;
+              return onRenderSuggestionItem
+                ? onRenderSuggestionItem(suggestion, onSuggestionSelected, active)
+                : defaultOnRenderSuggestionItem(suggestion, onSuggestionSelected, active);
+            })}
+          </Stack>
         </Stack>
-      </Stack>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# What
Mention suggestions caused a brief visual flicker during rendering.

# Why
The offset position was not calculated prior to the first render and rendered it at 0,0 - inside the text area. It then very quickly jumped to the correct calculated location. 

# How Tested
Storybook.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->