### PR TITLE
[Chat] Fix triple click selection for TextFieldithMention when mention is added in the beginning of the text

### DIFF
--- a/change-beta/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
+++ b/change-beta/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix for the entire text selection in TextFieldWithMention\u001c\\",
+  "comment": "Fix for the text selection in TextFieldWithMention",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change-beta/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
+++ b/change-beta/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix for the text selection in TextFieldWithMention",
+  "comment": "Fix for the text selection for triple click in TextFieldWithMention",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change-beta/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
+++ b/change-beta/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix for the entire text selection in TextFieldWithMention\u001c\\",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
+++ b/change/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix for the entire text selection in TextFieldWithMention\u001c\\",
+  "comment": "Fix for the text selection in TextFieldWithMention",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
+++ b/change/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix for the text selection in TextFieldWithMention",
+  "comment": "Fix for the text selection for triple click in TextFieldWithMention",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
+++ b/change/@azure-communication-react-7b4814b9-efd9-4260-80cb-d88667c8e5d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix for the entire text selection in TextFieldWithMention\u001c\\",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/SendBox.test.tsx
+++ b/packages/react-components/src/components/SendBox.test.tsx
@@ -296,7 +296,7 @@ describe('Clicks/Touch should select mention', () => {
     await act(async () => {
       triggerMouseEvent(input, 'mousedown');
     });
-    // Triple click a letter at 12-th index
+    // Triple click a letter at 14-th index
     await userEvent.pointer({
       keys: '[MouseLeft][MouseLeft][MouseLeft]',
       target: input,

--- a/packages/react-components/src/components/SendBox.test.tsx
+++ b/packages/react-components/src/components/SendBox.test.tsx
@@ -272,6 +272,40 @@ describe('Clicks/Touch should select mention', () => {
     expect(input.selectionEnd).toBe((value + suggestions[0].displayText).length);
   });
 
+  test('Mouse triple click when text starts from mention should select the text in the input field', async () => {
+    renderSendBox();
+    // Find the input field
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    act(() => {
+      // Focus on the input field
+      input.focus();
+    });
+    await waitFor(async () => {
+      // Type into the input field
+      await userEvent.keyboard(trigger);
+    });
+    // Select the suggestion
+    await selectFirstMention();
+    expect(input.value).toBe(trigger + suggestions[0].displayText);
+    await waitFor(async () => {
+      // Type into the input field
+      await userEvent.keyboard(' and');
+    });
+    const typedValue = trigger + suggestions[0].displayText + ' and';
+    // Fix for mousedown issue in userEvent when `document` become null unexpectedly
+    await act(async () => {
+      triggerMouseEvent(input, 'mousedown');
+    });
+    // Triple click a letter at 12-th index
+    await userEvent.pointer({
+      keys: '[MouseLeft][MouseLeft][MouseLeft]',
+      target: input,
+      offset: 14
+    });
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(typedValue.length);
+  });
+
   test('Mouse selection of first word in a mention should select only first word in the mention', async () => {
     renderSendBox();
     // Find the input field

--- a/packages/react-components/src/components/TextFieldWithMention/TextFieldWithMention.tsx
+++ b/packages/react-components/src/components/TextFieldWithMention/TextFieldWithMention.tsx
@@ -393,7 +393,13 @@ export const TextFieldWithMention = (props: TextFieldWithMentionProps): JSX.Elem
       selectionEndValue?: number;
       interactionStartSelection?: { start: number | undefined; end: number | undefined };
     }): void => {
-      if (shouldHandleOnMouseDownDuringSelect) {
+      if (event.currentTarget.selectionStart === 0 && event.currentTarget.selectionEnd === inputTextValue.length) {
+        // entire text is selected, no need to change anything
+        setSelectionStartValue(event.currentTarget.selectionStart);
+        setSelectionEndValue(event.currentTarget.selectionEnd);
+        setInteractionStartSelection(undefined);
+        setShouldHandleOnMouseDownDuringSelect(false);
+      } else if (shouldHandleOnMouseDownDuringSelect) {
         if (
           interactionStartSelection !== undefined &&
           (interactionStartSelection.start !== event.currentTarget.selectionStart ||

--- a/packages/react-components/src/components/TextFieldWithMention/TextFieldWithMention.tsx
+++ b/packages/react-components/src/components/TextFieldWithMention/TextFieldWithMention.tsx
@@ -429,15 +429,32 @@ export const TextFieldWithMention = (props: TextFieldWithMentionProps): JSX.Elem
           });
           setInteractionStartSelection(undefined);
           setShouldHandleOnMouseDownDuringSelect(false);
-        } else if (event.currentTarget.selectionStart !== null) {
+        } else if (event.currentTarget.selectionStart !== null && event.currentTarget.selectionEnd !== null) {
           // on select was triggered by mouse down/up with no movement
           const mentionTag = findMentionTagForSelection(tags, event.currentTarget.selectionStart);
           if (mentionTag !== undefined && mentionTag.plainTextBeginIndex !== undefined) {
             // handle mention click by selecting the whole mention
             // if the selection is not on the bounds of the mention
-            const mentionEndIndex = mentionTag.plainTextEndIndex ?? mentionTag.plainTextBeginIndex;
             // disable selection for clicks on mention bounds
+            const mentionEndIndex = mentionTag.plainTextEndIndex ?? mentionTag.plainTextBeginIndex;
+
             if (
+              event.currentTarget.selectionStart !== event.currentTarget.selectionEnd &&
+              event.currentTarget.selectionEnd > mentionEndIndex
+            ) {
+              // handle triple click when the text starts from mention
+              if (event.currentTarget.selectionDirection === null) {
+                event.currentTarget.setSelectionRange(mentionTag.plainTextBeginIndex, event.currentTarget.selectionEnd);
+              } else {
+                event.currentTarget.setSelectionRange(
+                  mentionTag.plainTextBeginIndex,
+                  event.currentTarget.selectionEnd,
+                  event.currentTarget.selectionDirection
+                );
+              }
+              setSelectionStartValue(mentionTag.plainTextBeginIndex);
+              setSelectionEndValue(event.currentTarget.selectionEnd);
+            } else if (
               event.currentTarget.selectionStart !== event.currentTarget.selectionEnd ||
               (event.currentTarget.selectionStart !== mentionTag.plainTextBeginIndex &&
                 event.currentTarget.selectionStart !== mentionEndIndex)
@@ -464,7 +481,6 @@ export const TextFieldWithMention = (props: TextFieldWithMentionProps): JSX.Elem
             setSelectionEndValue(nullToUndefined(event.currentTarget.selectionEnd));
           }
           setInteractionStartSelection(undefined);
-          setShouldHandleOnMouseDownDuringSelect(false);
         }
       } else {
         // selection was changed by keyboard


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Fixed functionality to handle triple click selection
- Added unit test to check this behavior

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Previously, when a mention is added in the beginning of the text and triple action was done, only mention was selected.

# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->