### PR TITLE
[Chat] Fix mention popover content view is not wrapped up in the scroll view when the list is long

### DIFF
--- a/change-beta/@azure-communication-react-00d721c4-8922-4e27-a504-61ec5546c6e1.json
+++ b/change-beta/@azure-communication-react-00d721c4-8922-4e27-a504-61ec5546c6e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix mention popover content view is not wrapped up in the scroll view when the list is long",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-00d721c4-8922-4e27-a504-61ec5546c6e1.json
+++ b/change/@azure-communication-react-00d721c4-8922-4e27-a504-61ec5546c6e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix mention popover content view is not wrapped up in the scroll view when the list is long",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/MentionPopover.style.ts
+++ b/packages/react-components/src/components/styles/MentionPopover.style.ts
@@ -47,7 +47,8 @@ export const suggestionListContainerStyle = mergeStyles({
  */
 export const suggestionListStyle = mergeStyles({
   padding: '0.25rem 0rem 0',
-  overflow: 'visible'
+  overflow: 'visible',
+  overflowY: 'scroll'
 });
 
 /**

--- a/packages/storybook/stories/SendBox/snippets/Mentions.snippet.tsx
+++ b/packages/storybook/stories/SendBox/snippets/Mentions.snippet.tsx
@@ -19,6 +19,50 @@ const suggestions: Mention[] = [
     displayText: 'Your user'
   },
   {
+    id: '5',
+    displayText: 'Milton Dyer'
+  },
+  {
+    id: '6',
+    displayText: 'Ella Stewart'
+  },
+  {
+    id: '7',
+    displayText: 'Todd Nelson'
+  },
+  {
+    id: '8',
+    displayText: 'Bertie Holman'
+  },
+  {
+    id: '9',
+    displayText: 'Chloe Alvarez'
+  },
+  {
+    id: '10',
+    displayText: 'Hannah Gibson'
+  },
+  {
+    id: '11',
+    displayText: "Amelia O'Connor"
+  },
+  {
+    id: '12',
+    displayText: "Amelia O'Connor"
+  },
+  {
+    id: '13',
+    displayText: 'Imogen Morris'
+  },
+  {
+    id: '14',
+    displayText: 'Freya Hayes'
+  },
+  {
+    id: '15',
+    displayText: 'Ellie Collins'
+  },
+  {
     id: 'everyone',
     displayText: 'Everyone'
   }
@@ -37,7 +81,7 @@ export const MentionsExample: () => JSX.Element = () => {
 
   return (
     <FluentThemeProvider>
-      <div style={{ width: '31.25rem', marginTop: '12rem' }}>
+      <div style={{ width: '31.25rem', marginTop: '15rem' }}>
         <SendBox
           onSendMessage={async (message) => {
             timeoutRef.current = setTimeout(() => {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
1. Adding more mention suggestions to the Storybook page
2. Fix on the Storybook page, the top of the mentionPopover is cut off
3. Fix the content view is not wrapped up in the scroll view

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Before: 
<img  src="https://github.com/Azure/communication-ui-library/assets/107075081/ddf211df-fa4f-4f9f-98cc-10d8fac16956">

After:
<img  src="https://github.com/Azure/communication-ui-library/assets/107075081/962d91be-78ce-45a2-bfe1-e70b6386a7dc">

# How Tested


<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->