### PR TITLE
[Chat] cleaning up some unused property for FileMetaData

### DIFF
--- a/change-beta/@azure-communication-react-070ad661-6c41-4d60-9193-0d4e915431da.json
+++ b/change-beta/@azure-communication-react-070ad661-6c41-4d60-9193-0d4e915431da.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "[FileDownloadCards] cleaning up some unused property",
+  "packageName": "@azure/communication-react",
+  "email": "joshlai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-070ad661-6c41-4d60-9193-0d4e915431da.json
+++ b/change/@azure-communication-react-070ad661-6c41-4d60-9193-0d4e915431da.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "[FileDownloadCards] cleaning up some unused property",
+  "packageName": "@azure/communication-react",
+  "email": "joshlai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2544,14 +2544,14 @@ export type FileDownloadHandler = (userId: string, fileMetadata: FileMetadata) =
 export type FileMetadata = FileSharingMetadata | /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ ImageFileMetadata;
 
 // @beta (undocumented)
-export type FileMetadataAttachmentType = 'fileSharing' | /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ 'inlineImage' | /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ 'attachedImage' | 'unknown';
+export type FileMetadataAttachmentType = 'fileSharing' | /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ 'inlineImage' | 'unknown';
 
 // @beta
 export interface FileSharingMetadata extends BaseFileMetadata {
     // (undocumented)
     attachmentType: 'fileSharing';
     // (undocumented)
-    payload?: Record<string, string> | undefined;
+    payload?: Record<string, string>;
 }
 
 // @beta
@@ -2715,7 +2715,7 @@ export interface _Identifiers {
 // @beta
 export interface ImageFileMetadata extends BaseFileMetadata {
     // (undocumented)
-    attachmentType: 'inlineImage' | 'attachedImage';
+    attachmentType: 'inlineImage';
     // (undocumented)
     previewUrl?: string;
 }

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1092,14 +1092,14 @@ export type FileDownloadHandler = (userId: string, fileMetadata: FileMetadata) =
 export type FileMetadata = FileSharingMetadata | /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ ImageFileMetadata;
 
 // @beta (undocumented)
-export type FileMetadataAttachmentType = 'fileSharing' | /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ 'inlineImage' | /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ 'attachedImage' | 'unknown';
+export type FileMetadataAttachmentType = 'fileSharing' | /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ 'inlineImage' | 'unknown';
 
 // @beta
 export interface FileSharingMetadata extends BaseFileMetadata {
     // (undocumented)
     attachmentType: 'fileSharing';
     // (undocumented)
-    payload?: Record<string, string> | undefined;
+    payload?: Record<string, string>;
 }
 
 // @internal
@@ -1212,7 +1212,7 @@ export interface _Identifiers {
 // @beta
 export interface ImageFileMetadata extends BaseFileMetadata {
     // (undocumented)
-    attachmentType: 'inlineImage' | 'attachedImage';
+    attachmentType: 'inlineImage';
     // (undocumented)
     previewUrl?: string;
 }

--- a/packages/react-components/src/components/FileDownloadCards.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.tsx
@@ -17,7 +17,6 @@ import { _formatString } from '@internal/acs-ui-common';
 export type FileMetadataAttachmentType =
   | 'fileSharing'
   | /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ 'inlineImage'
-  | /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ 'attachedImage'
   | 'unknown';
 
 /**
@@ -63,7 +62,7 @@ export interface FileSharingMetadata extends BaseFileMetadata {
   /*
    * Optional dictionary of meta data asscoiated with the file.
    */
-  payload?: Record<string, string> | undefined;
+  payload?: Record<string, string>;
 }
 
 /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
@@ -77,7 +76,7 @@ export interface ImageFileMetadata extends BaseFileMetadata {
    * Attachment type of the file.
    * Possible values {@link FileDownloadHandler}.
    */
-  attachmentType: 'inlineImage' | 'attachedImage';
+  attachmentType: 'inlineImage';
   /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
   /*
    * Preview URL for the file.

--- a/packages/react-components/src/components/MessageThread.test.tsx
+++ b/packages/react-components/src/components/MessageThread.test.tsx
@@ -288,10 +288,7 @@ describe.only('Message should display image and attachment correctly', () => {
     };
     const onFetchAttachment = async (attachment: FileMetadata): Promise<AttachmentDownloadResult[]> => {
       onFetchAttachmentCount++;
-      const url =
-        attachment.attachmentType === 'inlineImage' || attachment.attachmentType === 'attachedImage'
-          ? attachment.previewUrl ?? ''
-          : '';
+      const url = attachment.attachmentType === 'inlineImage' ? attachment.previewUrl ?? '' : '';
       return [
         {
           blobUrl: url


### PR DESCRIPTION
# What
Clean up unused properties in the API 
# Why

# How Tested

# Process & policy checklist

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->