### PR TITLE
[Chat] Fix mention popover position incorrect when insert mention in the middle of long text

### DIFF
--- a/change-beta/@azure-communication-react-5d3c3a90-b296-4be7-b53a-e813450aed36.json
+++ b/change-beta/@azure-communication-react-5d3c3a90-b296-4be7-b53a-e813450aed36.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Mention Popover's position is too low when insert mention in the middle of a very long text",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-5d3c3a90-b296-4be7-b53a-e813450aed36.json
+++ b/change/@azure-communication-react-5d3c3a90-b296-4be7-b53a-e813450aed36.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Mention Popover's position is too low when insert mention in the middle of a very long text",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/TextFieldWithMention/TextFieldWithMention.tsx
+++ b/packages/react-components/src/components/TextFieldWithMention/TextFieldWithMention.tsx
@@ -562,9 +562,8 @@ export const TextFieldWithMention = (props: TextFieldWithMentionProps): JSX.Elem
         // Update the caret position, used for positioning the suggestions popover
         const textField = event.currentTarget;
         const relativePosition = Caret.getRelativePosition(textField);
-        const adjustOffset = Math.max(0, textField.scrollHeight - textField.clientHeight);
-        if (relativePosition.top > adjustOffset) {
-          relativePosition.top -= adjustOffset;
+        if (textField.scrollHeight > textField.clientHeight) {
+          relativePosition.top -= textField.scrollTop;
         }
         setCaretPosition(relativePosition);
         if (triggerPriorIndex !== undefined) {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
The top prop of the relativePosition we get back from the Caret library is the distance between the top of the scroll view to the cursor position.
We use to adjust this value by subtract the difference between the scrollView height - the contentHeight.
The problem of this approach is that it's not considering the current scroll position.
Instead, when the view is scrollable, we should use relativePosition.top subtracted by scrollTop to get the relative position to the content view

From MDN:
The Element.scrollTop property gets or sets the number of pixels that an element's content is scrolled vertically.
An element's scrollTop value is a measurement of the distance from the element's top to its topmost visible content. When an element's content does not generate a vertical scrollbar, then its scrollTop value is 0.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Fix mention popover position incorrect when insert mention in the middle of long text

# How Tested
<!--- How did you test your change. What tests have you added. -->
Steps:

1. add a very long text
2. scroll to the middle of the text
3. add a mention
Observe the position of the Mention Popover


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->