### PR TITLE
[A11y bugfix] Fix video effects pane tab ordering on call screen

### DIFF
--- a/packages/react-components/src/components/VideoEffects/VideoBackgroundEffectsPicker.tsx
+++ b/packages/react-components/src/components/VideoEffects/VideoBackgroundEffectsPicker.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IStyle, Label, mergeStyles, Stack } from '@fluentui/react';
+import { FocusZone, IStyle, Label, mergeStyles, Stack } from '@fluentui/react';
 import { useWarnings } from '@fluentui/react-hooks';
 import React from 'react';
 import { chunk } from '../utils';
@@ -136,7 +136,9 @@ export const _VideoBackgroundEffectsPicker = (props: _VideoBackgroundEffectsPick
           data-ui-id="video-effects-picker-row"
         >
           {options.map((option) => (
-            <_VideoEffectsItem {...option} key={option.itemKey} itemKey={option.itemKey} />
+            <FocusZone key={option.itemKey} shouldFocusOnMount={!!(option.itemKey === 'none')}>
+              <_VideoEffectsItem {...option} itemKey={option.itemKey} />
+            </FocusZone>
           ))}
           {fillCount > 0 &&
             rowIndex === optionsByRow.length - 1 &&


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Pulls focus to the video effects pane on the call screen when the side pane is opened
# Why
<!--- What problem does this change solve? -->
Moves focus from the camera button to the sidepane so the user can more efficiently select their video effect.
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3327121
# How Tested
<!--- How did you test your change. What tests have you added. -->
Locally in test apps