### PR TITLE
Fix breaking change check by ensuring dependencies are installed for the base branch

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -48,11 +48,11 @@ jobs:
         with:
           fetch-depth: 0
       # Ensure node version is great enough
-      - name: Use Node.js v14.x
+      - name: Use Node.js v18.x
         if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
       # Try get node_modules from cache
       - name: Restore node_modules from cache
         if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
@@ -60,26 +60,22 @@ jobs:
         with:
           path: common/temp/pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('common/config/rush/pnpm-lock.yaml') }}
-      # Install dependencies
+      # Install rush
       - name: Install rush
         if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
         run: npm install -g @microsoft/rush@5.100.1
-      - name: Install dependencies
-        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
-        run: rush install --max-install-attempts 3
-      # Switch flavor if necessary
-      - name: Switch flavor for stable build
-        id: switch-flavor
-        if: ${{ matrix.flavor == 'stable' && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
-        run: |
-          rush switch-flavor:stable
-      - name: Check result of flavor switch
-        if: ${{ always() && steps.switch-flavor.outcome == 'failure' }}
-        run: echo "Failed to switch to stable flavor, please make sure you run 'rush update:stable' if dependencies were updated." && exit 1
       # Checkout the branch to be merged into in PR
       - name: Checkout base branch
         if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
         run: git checkout ${{ github.event.pull_request.base.ref }}
+      # Install dependencies for the base branch
+      - name: Install beta dependencies
+        if: ${{ matrix.flavor == 'beta' && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+        run: rush switch-flavor:beta
+      - name: Install stable dependencies
+        if: ${{ matrix.flavor == 'stable' && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+        run: rush switch-flavor:stable
+      # Build base branch to generate base api file
       - name: Build base api file
         if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
         run: rush build -t @azure/communication-react
@@ -89,18 +85,28 @@ jobs:
         run: |
           mkdir -p breaking-change-check/snapshots/
           cp dist/communication-react.d.ts breaking-change-check/snapshots/
+      # Checkout branch to be merged in PR
       - name: Checkout current branch
         if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
         run: git checkout ${{ github.event.pull_request.head.ref }}
-      # Builds
+      # Install dependencies for the current branch
+      - name: Install beta dependencies
+        if: ${{ matrix.flavor == 'beta' && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+        run: rush switch-flavor:beta
+      - name: Install stable dependencies
+        if: ${{ matrix.flavor == 'stable' && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+        run: rush switch-flavor:stable
+      # Build current branch to generate current api file
       - name: Build current api file
         if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
         run: rush build -t @azure/communication-react
+      # Compare api files and check for breaking changes
       - name: Check breaking changes
         if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
         working-directory: packages/communication-react/
         id: breaking-changes
         run: rushx check-breaking-change
+      # Report result of breaking changes check
       - name: Check result of breaking change check
         if: ${{ always() && steps.breaking-changes.outcome == 'failure' }}
         run: echo "Breaking changes detected, make sure if that is expected change, then add 'breaking-change' label to PR." && exit 1

--- a/change-beta/@azure-communication-react-586ff6a3-bf98-423f-8819-d7be4a298b8e.json
+++ b/change-beta/@azure-communication-react-586ff6a3-bf98-423f-8819-d7be4a298b8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix breaking change check by ensuring dependencies are installed for the base branch",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-586ff6a3-bf98-423f-8819-d7be4a298b8e.json
+++ b/change/@azure-communication-react-586ff6a3-bf98-423f-8819-d7be4a298b8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix breaking change check by ensuring dependencies are installed for the base branch",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
# What

- Ensure dependencies are installed for the base branch before generating base branch api

# Why

- If dependencies vary significantly (e.g. updating a new SDK beta version) then the base branch build could break

Unblocks #3355 

# How Tested
n/a