### PR TITLE
Adding Feature request through Microsoft Q&A template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Propose a Feature!
+    url: https://learn.microsoft.com/en-us/search/?terms=Azure%20Communication%20Services%20UI%20Library&category=QnA
+    about: Upvote if someone has already proposed your feature or write your own feature ask!

--- a/change-beta/@azure-communication-react-94e1394d-e16f-434e-bf0c-043a6847cd2f.json
+++ b/change-beta/@azure-communication-react-94e1394d-e16f-434e-bf0c-043a6847cd2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Adding Feature request through Microsoft QNA template",
+  "packageName": "@azure/communication-react",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-94e1394d-e16f-434e-bf0c-043a6847cd2f.json
+++ b/change/@azure-communication-react-94e1394d-e16f-434e-bf0c-043a6847cd2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Adding Feature request through Microsoft QNA template",
+  "packageName": "@azure/communication-react",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
# What
Adding in a suggest a Feature button that will take us to Microsoft Q&A instead

# Why
We have support engineers monitoring microsoft Q&A and we can better support our developers in Microsoft Q&A instead. While this may be different from most open source repositories, we need to be able to scale and make best use of Microsoft in order for us to be successful.

# How Tested
Unable to test till this change goes into main :(