### PR TITLE
[A11y bugfix] Refocus the people button when closing side pane with keyboard

### DIFF
--- a/change-beta/@azure-communication-react-50491160-50c0-4fc1-9859-a7d602b846c1.json
+++ b/change-beta/@azure-communication-react-50491160-50c0-4fc1-9859-a7d602b846c1.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y bug",
+  "comment": "Fixes side pane to refocus the people button when user closes the people pane with keyboard.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-50491160-50c0-4fc1-9859-a7d602b846c1.json
+++ b/change/@azure-communication-react-50491160-50c0-4fc1-9859-a7d602b846c1.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y bug",
+  "comment": "Fixes side pane to refocus the people button when user closes the people pane with keyboard.",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { mergeStyles, Stack } from '@fluentui/react';
+import { IButton, mergeStyles, Stack } from '@fluentui/react';
 import { _isInCall, _isInLobbyOrConnecting } from '@internal/calling-component-bindings';
 import {
   _ComplianceBanner,
@@ -109,6 +109,8 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
     [theme.palette.neutralLighterAlt]
   );
 
+  const peopleButtonRef = useRef<IButton>(null);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const containerWidth = _useContainerWidth(containerRef);
   const containerHeight = _useContainerHeight(containerRef);
@@ -137,7 +139,8 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
       /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) */
       onFetchAvatarPersonaData: props.onFetchAvatarPersonaData,
       onFetchParticipantMenuItems: props.callControlProps?.onFetchParticipantMenuItems,
-      mobileView: props.mobileView
+      mobileView: props.mobileView,
+      peopleButtonRef
     }),
     [
       updateSidePaneRenderer,
@@ -145,7 +148,8 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
       props.callControlProps?.onFetchParticipantMenuItems,
       /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) */
       props.onFetchAvatarPersonaData,
-      props.mobileView
+      props.mobileView,
+      peopleButtonRef
     ]
   );
   const { isPeoplePaneOpen, openPeoplePane, closePeoplePane } = usePeoplePane(peoplePaneProps);
@@ -309,6 +313,7 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
                   /* @conditional-compile-remove(PSTN-calls) */
                   onClickShowDialpad={alternateCallerId ? onClickShowDialpad : undefined}
                   displayVertical={verticalControlBar}
+                  peopleButtonRef={peopleButtonRef}
                 />
               )}
             </Stack>

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -110,6 +110,7 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
   );
 
   const peopleButtonRef = useRef<IButton>(null);
+  const cameraButtonRef = useRef<IButton>(null);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const containerWidth = _useContainerWidth(containerRef);
@@ -196,7 +197,8 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
     props.updateSidePaneRenderer,
     props.mobileView,
     props.latestErrors,
-    props.onDismissError
+    props.onDismissError,
+    cameraButtonRef
   );
   const [showDrawer, setShowDrawer] = useState(false);
   const onMoreButtonClicked = useCallback(() => {
@@ -314,6 +316,7 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
                   onClickShowDialpad={alternateCallerId ? onClickShowDialpad : undefined}
                   displayVertical={verticalControlBar}
                   peopleButtonRef={peopleButtonRef}
+                  cameraButtonRef={cameraButtonRef}
                 />
               )}
             </Stack>

--- a/packages/react-composites/src/composites/CallComposite/components/SidePane/usePeoplePane.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/SidePane/usePeoplePane.tsx
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { RefObject, useCallback, useEffect, useMemo } from 'react';
 import { SidePaneRenderer, useIsParticularSidePaneOpen } from './SidePaneProvider';
 import { SidePaneHeader } from '../../../common/SidePaneHeader';
 import { PeoplePaneContent } from '../../../common/PeoplePaneContent';
 import { CompositeLocale, useLocale } from '../../../localization';
 import { ParticipantMenuItemsCallback, _DrawerMenuItemProps } from '@internal/react-components';
 import { AvatarPersonaDataCallback } from '../../../common/AvatarPersona';
+import { IButton } from '@fluentui/react';
 
 const PEOPLE_SIDE_PANE_ID = 'people';
 
@@ -19,6 +20,7 @@ export const usePeoplePane = (props: {
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
   mobileView?: boolean;
+  peopleButtonRef?: RefObject<IButton>;
 }): {
   openPeoplePane: () => void;
   closePeoplePane: () => void;
@@ -30,12 +32,14 @@ export const usePeoplePane = (props: {
     onFetchAvatarPersonaData,
     onFetchParticipantMenuItems,
     setDrawerMenuItems,
-    mobileView
+    mobileView,
+    peopleButtonRef
   } = props;
 
   const closePane = useCallback(() => {
     updateSidePaneRenderer(undefined);
-  }, [updateSidePaneRenderer]);
+    peopleButtonRef?.current?.focus();
+  }, [peopleButtonRef, updateSidePaneRenderer]);
 
   const localeStrings = localeTrampoline(useLocale());
 

--- a/packages/react-composites/src/composites/CallComposite/components/SidePane/useVideoEffectsPane.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/SidePane/useVideoEffectsPane.tsx
@@ -8,6 +8,7 @@ import { SidePaneHeader } from '../../../common/SidePaneHeader';
 import { useLocale } from '../../../localization';
 import { VideoEffectsPaneContent } from '../../../common/VideoEffectsPane';
 import { ActiveErrorMessage } from '@internal/react-components';
+import { IButton } from '@fluentui/react';
 
 /** @private */
 export const VIDEO_EFFECTS_SIDE_PANE_ID = 'videoeffects';
@@ -20,7 +21,8 @@ export const useVideoEffectsPane = (
   updateSidePaneRenderer: (renderer: SidePaneRenderer | undefined) => void,
   mobileView: boolean,
   latestErrors: ActiveErrorMessage[],
-  onDismissError: (error: ActiveErrorMessage) => void
+  onDismissError: (error: ActiveErrorMessage) => void,
+  cameraButtonRef?: React.RefObject<IButton>
 ): {
   openVideoEffectsPane: () => void;
   closeVideoEffectsPane: () => void;
@@ -29,7 +31,8 @@ export const useVideoEffectsPane = (
 } => {
   const closePane = useCallback(() => {
     updateSidePaneRenderer(undefined);
-  }, [updateSidePaneRenderer]);
+    cameraButtonRef?.current?.focus();
+  }, [cameraButtonRef, updateSidePaneRenderer]);
 
   /* @conditional-compile-remove(video-background-effects) */
   const locale = useLocale();

--- a/packages/react-composites/src/composites/CallComposite/components/buttons/Camera.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/buttons/Camera.tsx
@@ -8,6 +8,7 @@ import { usePropsFor } from '../../hooks/usePropsFor';
 import { concatButtonBaseStyles } from '../../styles/Buttons.styles';
 /* @conditional-compile-remove(rooms) */
 import { useAdapter } from '../../adapter/CallAdapterProvider';
+import { IButton } from '@fluentui/react';
 
 /**
  * @private
@@ -19,6 +20,7 @@ export const Camera = (props: {
   disabled?: boolean;
   /* @conditional-compile-remove(video-background-effects) */
   onShowVideoEffectsPicker?: (showVideoEffectsOptions: boolean) => void;
+  componentRef?: React.RefObject<IButton>;
 }): JSX.Element => {
   const cameraButtonProps = usePropsFor(CameraButton);
   const styles = useMemo(() => concatButtonBaseStyles(props.styles ?? {}), [props.styles]);
@@ -40,6 +42,7 @@ export const Camera = (props: {
       }
       /* @conditional-compile-remove(video-background-effects) */
       onShowVideoEffectsPicker={props.onShowVideoEffectsPicker}
+      componentRef={props.componentRef}
     />
   );
 };

--- a/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
@@ -8,7 +8,6 @@ import { PeopleButton } from './PeopleButton';
 import {
   concatStyleSets,
   IButton,
-  IRefObject,
   IStyle,
   ITheme,
   mergeStyles,

--- a/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
@@ -5,7 +5,17 @@ import React, { useMemo, useRef, useEffect, useState, useCallback } from 'react'
 import { CallAdapterProvider } from '../../CallComposite/adapter/CallAdapterProvider';
 import { CallAdapter } from '../../CallComposite';
 import { PeopleButton } from './PeopleButton';
-import { concatStyleSets, IStyle, ITheme, mergeStyles, mergeStyleSets, Stack, useTheme } from '@fluentui/react';
+import {
+  concatStyleSets,
+  IButton,
+  IRefObject,
+  IStyle,
+  ITheme,
+  mergeStyles,
+  mergeStyleSets,
+  Stack,
+  useTheme
+} from '@fluentui/react';
 import { controlBarContainerStyles } from '../../CallComposite/styles/CallControls.styles';
 import { callControlsContainerStyles } from '../../CallComposite/styles/CallPage.styles';
 import { useCallWithChatCompositeStrings } from '../../CallWithChatComposite/hooks/useCallWithChatCompositeStrings';
@@ -50,6 +60,7 @@ export interface CommonCallControlBarProps {
   /* @conditional-compile-remove(close-captions) */
   isCaptionsSupported?: boolean;
   displayVertical?: boolean;
+  peopleButtonRef?: React.RefObject<IButton>;
 }
 
 const inferCommonCallControlOptions = (
@@ -352,6 +363,7 @@ export const CommonCallControlBar = (props: CommonCallControlBarProps & Containe
                     }
                     strings={peopleButtonStrings}
                     styles={commonButtonStyles}
+                    componentRef={props.peopleButtonRef}
                   />
                 )}
                 {customButtons['secondary']

--- a/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
@@ -60,6 +60,7 @@ export interface CommonCallControlBarProps {
   isCaptionsSupported?: boolean;
   displayVertical?: boolean;
   peopleButtonRef?: React.RefObject<IButton>;
+  cameraButtonRef?: React.RefObject<IButton>;
 }
 
 const inferCommonCallControlOptions = (
@@ -281,6 +282,7 @@ export const CommonCallControlBar = (props: CommonCallControlBarProps & Containe
                         disabled={props.disableButtonsForHoldScreen || isDisabled(options.cameraButton)}
                         /* @conditional-compile-remove(video-background-effects) */
                         onShowVideoEffectsPicker={props.onShowVideoEffectsPicker}
+                        componentRef={props.cameraButtonRef}
                       />
                     )}
                     {screenShareButtonIsEnabled && (


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
adds a ref to the people button that causes the sidepane to pull focus there when it closes the people pane.

fixes this problem for both side panes:
- people <- returns to people button
- calling effects <- returns to camera button
# Why

https://github.com/Azure/communication-ui-library/assets/94866715/44c42af8-9e33-44b9-af4d-18bf6a52c3ea

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3330754
# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested locally, see video