### PR TITLE
Fix calling sample displayname field logic

### DIFF
--- a/change-beta/@azure-communication-react-2f4b1682-b27a-4bc5-89ad-80ee84944a36.json
+++ b/change-beta/@azure-communication-react-2f4b1682-b27a-4bc5-89ad-80ee84944a36.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Calling sample app",
+  "comment": "Fixed logic of when to show display name field in Calling sample app",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-2f4b1682-b27a-4bc5-89ad-80ee84944a36.json
+++ b/change/@azure-communication-react-2f4b1682-b27a-4bc5-89ad-80ee84944a36.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Calling sample app",
+  "comment": "Fixed logic of when to show display name field in Calling sample app",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/samples/Calling/src/app/views/HomeScreen.tsx
+++ b/samples/Calling/src/app/views/HomeScreen.tsx
@@ -181,7 +181,7 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
   const outboundTeamsUsersTextFieldLabelId: string = useId('outbound-teams-users-text-field');
 
   let showDisplayNameField = true;
-  /* @conditional-compile-remove(teams-adhoc-call) */
+  /* @conditional-compile-remove(teams-identity-support) */
   showDisplayNameField = !teamsIdentityChosen;
 
   return (

--- a/samples/Calling/src/app/views/HomeScreen.tsx
+++ b/samples/Calling/src/app/views/HomeScreen.tsx
@@ -180,6 +180,10 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
   /* @conditional-compile-remove(teams-adhoc-call) */
   const outboundTeamsUsersTextFieldLabelId: string = useId('outbound-teams-users-text-field');
 
+  let showDisplayNameField = true;
+  /* @conditional-compile-remove(teams-adhoc-call) */
+  showDisplayNameField = !teamsIdentityChosen;
+
   return (
     <Stack
       horizontal

--- a/samples/Calling/src/app/views/HomeScreen.tsx
+++ b/samples/Calling/src/app/views/HomeScreen.tsx
@@ -350,8 +350,7 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
               )
             }
           </Stack>
-          {<DisplayNameField defaultName={displayName} setName={setDisplayName} /> &&
-            /* @conditional-compile-remove(teams-identity-support) */ !teamsIdentityChosen}
+          {showDisplayNameField && <DisplayNameField defaultName={displayName} setName={setDisplayName} />}
           <PrimaryButton
             disabled={!buttonEnabled}
             className={buttonStyle}


### PR DESCRIPTION
# What
Redo fix for #3390. Component has to be last when using Logical AND (&&).

# Why
![image](https://github.com/Azure/communication-ui-library/assets/79475487/0882c665-de76-4f3d-a63a-52ce0e66c0bd)

# How Tested
Local calling sample test (beta and stable)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->