### PR TITLE
Handle 413 err and increase the allowed server POST body amount

### DIFF
--- a/change-beta/@azure-communication-react-2d3598be-3496-4902-b267-bfb73127740f.json
+++ b/change-beta/@azure-communication-react-2d3598be-3496-4902-b267-bfb73127740f.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "KTLO",
+  "comment": "Handle 413 error when uploading logs in sample apps",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-2d3598be-3496-4902-b267-bfb73127740f.json
+++ b/change/@azure-communication-react-2d3598be-3496-4902-b267-bfb73127740f.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "KTLO",
+  "comment": "Handle 413 error when uploading logs in sample apps",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/samples/CallWithChat/src/app/utils/ShakeToSendLogs.tsx
+++ b/samples/CallWithChat/src/app/utils/ShakeToSendLogs.tsx
@@ -92,13 +92,15 @@ const sendLogs = async (): Promise<string | false> => {
   const logs = getRecordedLogs();
 
   const containerName = 'callwithchat-sample-logs';
-  const response = await fetch(`/uploadToAzureBlobStorage`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: safeJSONStringify({ containerName, logs })
-  });
+  let response = await postLogsToServer(containerName, logs);
+
+  // check for 413, which means the logs are too large to upload
+  if (response.status === 413) {
+    alert('Logs too large to upload. Trimming logs and retrying.');
+    const maxLogSize = 1000000;
+    const trimmedLogs = logs.slice(0, maxLogSize);
+    response = await postLogsToServer(containerName, trimmedLogs);
+  }
 
   if (!response.ok) {
     console.error('Failed to upload logs to Azure Blob Storage', response);
@@ -109,6 +111,15 @@ const sendLogs = async (): Promise<string | false> => {
   console.log(`Logs uploaded to ${blobUrl}`);
   return blobUrl;
 };
+
+const postLogsToServer = async (containerName: string, logs: string): Promise<Response> =>
+  fetch(`/uploadToAzureBlobStorage`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: safeJSONStringify({ containerName, logs })
+  });
 
 const PromptForShakePermission = (props: { onPermissionGranted: () => void }): JSX.Element => {
   const [showPrompt, setShowPrompt] = React.useState(true);

--- a/samples/CallWithChat/src/app/utils/ShakeToSendLogs.tsx
+++ b/samples/CallWithChat/src/app/utils/ShakeToSendLogs.tsx
@@ -98,7 +98,7 @@ const sendLogs = async (): Promise<string | false> => {
   if (response.status === 413) {
     alert('Logs too large to upload. Trimming logs and retrying.');
     const maxLogSize = 1000000;
-    const trimmedLogs = logs.slice(0, maxLogSize);
+    const trimmedLogs = logs.slice(-maxLogSize);
     response = await postLogsToServer(containerName, trimmedLogs);
   }
 

--- a/samples/Calling/src/app/utils/ShakeToSendLogs.tsx
+++ b/samples/Calling/src/app/utils/ShakeToSendLogs.tsx
@@ -91,14 +91,16 @@ const requestPermission = async (): Promise<'granted' | 'denied'> => {
 const sendLogs = async (): Promise<string | false> => {
   const logs = getRecordedLogs();
 
-  const containerName = 'calling-sample-logs';
-  const response = await fetch(`/uploadToAzureBlobStorage`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    body: safeJSONStringify({ containerName, logs })
-  });
+  const containerName = 'call-sample-logs';
+  let response = await postLogsToServer(containerName, logs);
+
+  // check for 413
+  if (response.status === 413) {
+    alert('Logs too large to upload. Trimming logs and retrying.');
+    const maxLogSize = 1000000;
+    const trimmedLogs = logs.slice(0, maxLogSize);
+    response = await postLogsToServer(containerName, trimmedLogs);
+  }
 
   if (!response.ok) {
     console.error('Failed to upload logs to Azure Blob Storage', response);
@@ -109,6 +111,15 @@ const sendLogs = async (): Promise<string | false> => {
   console.log(`Logs uploaded to ${blobUrl}`);
   return blobUrl;
 };
+
+const postLogsToServer = async (containerName: string, logs: string): Promise<Response> =>
+  fetch(`/uploadToAzureBlobStorage`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: safeJSONStringify({ containerName, logs })
+  });
 
 const PromptForShakePermission = (props: { onPermissionGranted: () => void }): JSX.Element => {
   const [showPrompt, setShowPrompt] = React.useState(true);

--- a/samples/Calling/src/app/utils/ShakeToSendLogs.tsx
+++ b/samples/Calling/src/app/utils/ShakeToSendLogs.tsx
@@ -10,6 +10,10 @@ import Shake from 'shake.js';
 const originalConsoleLog = console.log;
 const originalAzureLoggerLog = AzureLogger.log;
 const consoleLogs: string[] = ['---- LOGS START ----'];
+// Ensure we cap any single log line to prevent the server from rejecting the request.
+const logLineCharacterLimit = 1000;
+// If there is a failure to send logs due to size, typically due to a very long call, retry with a smaller size.
+const logLengthMaxSize = 1000000;
 
 /**
  * Track console logs for pushing to a debug location.
@@ -18,11 +22,11 @@ const consoleLogs: string[] = ['---- LOGS START ----'];
 const startRecordingLogs = (): void => {
   console.log = (...args: unknown[]) => {
     originalConsoleLog.apply(console, args);
-    consoleLogs.push(`${new Date().toISOString()} ${safeJSONStringify(args)}`);
+    consoleLogs.push(`${new Date().toISOString()} ${safeJSONStringify(args)}`.slice(0, logLineCharacterLimit));
   };
   AzureLogger.log = (...args: unknown[]) => {
     originalAzureLoggerLog.apply(console, args);
-    consoleLogs.push(`${new Date().toISOString()} ${safeJSONStringify(args)}`);
+    consoleLogs.push(`${new Date().toISOString()} ${safeJSONStringify(args)}`.slice(0, logLineCharacterLimit));
   };
 };
 
@@ -97,8 +101,7 @@ const sendLogs = async (): Promise<string | false> => {
   // check for 413
   if (response.status === 413) {
     alert('Logs too large to upload. Trimming logs and retrying.');
-    const maxLogSize = 1000000;
-    const trimmedLogs = logs.slice(-maxLogSize);
+    const trimmedLogs = logs.slice(-logLengthMaxSize);
     response = await postLogsToServer(containerName, trimmedLogs);
   }
 

--- a/samples/Calling/src/app/utils/ShakeToSendLogs.tsx
+++ b/samples/Calling/src/app/utils/ShakeToSendLogs.tsx
@@ -98,7 +98,7 @@ const sendLogs = async (): Promise<string | false> => {
   if (response.status === 413) {
     alert('Logs too large to upload. Trimming logs and retrying.');
     const maxLogSize = 1000000;
-    const trimmedLogs = logs.slice(0, maxLogSize);
+    const trimmedLogs = logs.slice(-maxLogSize);
     response = await postLogsToServer(containerName, trimmedLogs);
   }
 

--- a/samples/Chat/src/app/utils/ShakeToSendLogs.tsx
+++ b/samples/Chat/src/app/utils/ShakeToSendLogs.tsx
@@ -10,6 +10,10 @@ import Shake from 'shake.js';
 const originalConsoleLog = console.log;
 const originalAzureLoggerLog = AzureLogger.log;
 const consoleLogs: string[] = ['---- LOGS START ----'];
+// Ensure we cap any single log line to prevent the server from rejecting the request.
+const logLineCharacterLimit = 1000;
+// If there is a failure to send logs due to size, typically due to a very long call, retry with a smaller size.
+const logLengthMaxSize = 1000000;
 
 /**
  * Track console logs for pushing to a debug location.
@@ -18,11 +22,11 @@ const consoleLogs: string[] = ['---- LOGS START ----'];
 const startRecordingLogs = (): void => {
   console.log = (...args: unknown[]) => {
     originalConsoleLog.apply(console, args);
-    consoleLogs.push(`${new Date().toISOString()} ${safeJSONStringify(args)}`);
+    consoleLogs.push(`${new Date().toISOString()} ${safeJSONStringify(args)}`.slice(0, logLineCharacterLimit));
   };
   AzureLogger.log = (...args: unknown[]) => {
     originalAzureLoggerLog.apply(console, args);
-    consoleLogs.push(`${new Date().toISOString()} ${safeJSONStringify(args)}`);
+    consoleLogs.push(`${new Date().toISOString()} ${safeJSONStringify(args)}`.slice(0, logLineCharacterLimit));
   };
 };
 
@@ -97,8 +101,7 @@ const sendLogs = async (): Promise<string | false> => {
   // check for 413
   if (response.status === 413) {
     alert('Logs too large to upload. Trimming logs and retrying.');
-    const maxLogSize = 1000000;
-    const trimmedLogs = logs.slice(-maxLogSize);
+    const trimmedLogs = logs.slice(-logLengthMaxSize);
     response = await postLogsToServer(containerName, trimmedLogs);
   }
 

--- a/samples/Chat/src/app/utils/ShakeToSendLogs.tsx
+++ b/samples/Chat/src/app/utils/ShakeToSendLogs.tsx
@@ -98,7 +98,7 @@ const sendLogs = async (): Promise<string | false> => {
   if (response.status === 413) {
     alert('Logs too large to upload. Trimming logs and retrying.');
     const maxLogSize = 1000000;
-    const trimmedLogs = logs.slice(0, maxLogSize);
+    const trimmedLogs = logs.slice(-maxLogSize);
     response = await postLogsToServer(containerName, trimmedLogs);
   }
 

--- a/samples/Server/src/app.ts
+++ b/samples/Server/src/app.ts
@@ -21,7 +21,7 @@ import uploadToAzureBlobStorage from './routes/uploadToAzureBlobStorage';
 const app = express();
 
 app.use(logger('tiny'));
-app.use(express.json());
+app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.resolve(__dirname, 'build')));


### PR DESCRIPTION
Continuation of #3425 

## What

- Cap log lines to 1000 characters each
- Retry when 413 upload err occurs with smaller payload
- Increase the server post body allowance (default is 100KB)

## Why

Server returns 413 if there's a lot of logs. Alternative would be to stream logs instead