### PR TITLE
[Release] Update dependencies

### DIFF
--- a/change-beta/@azure-communication-react-bdd7d2d2-2b19-4885-ab15-7a87c29a0d34.json
+++ b/change-beta/@azure-communication-react-bdd7d2d2-2b19-4885-ab15-7a87c29a0d34.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "Update chat SDK dependency",
+  "comment": "Update dep formally to chat 1.3.1 stable",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-bdd7d2d2-2b19-4885-ab15-7a87c29a0d34.json
+++ b/change/@azure-communication-react-bdd7d2d2-2b19-4885-ab15-7a87c29a0d34.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "Update chat SDK dependency",
+  "comment": "Update dep formally to chat 1.3.1 stable",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/chat-component-bindings/package.json
+++ b/packages/chat-component-bindings/package.json
@@ -39,12 +39,12 @@
     "memoize-one": "~5.2.1"
   },
   "peerDependencies": {
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@types/react": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",
     "@microsoft/api-documenter": "~7.12.11",

--- a/packages/chat-stateful-client/package.json
+++ b/packages/chat-stateful-client/package.json
@@ -39,10 +39,10 @@
     "nanoid": "3.3.6"
   },
   "peerDependencies": {
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0"
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1"
   },
   "devDependencies": {
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/communication-signaling": "1.0.0-beta.19",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "@azure/communication-calling": "1.15.1-beta.1 || >=1.14.1",
     "@azure/communication-calling-effects": "1.0.0-beta.2",
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",
@@ -91,7 +91,7 @@
   "devDependencies": {
     "@azure/communication-calling": "1.15.1-beta.1 || >=1.14.1",
     "@azure/communication-calling-effects": "1.0.0-beta.2",
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/core-auth": "^1.4.0",
     "@babel/cli": "~7.16.0",
     "@babel/core": "~7.16.0",

--- a/packages/fake-backends/package.json
+++ b/packages/fake-backends/package.json
@@ -29,7 +29,7 @@
     "_test:by-flavor": "(rushx _if-preprocess && rushx preprocess || if-env COMMUNICATION_REACT_FLAVOR=beta && echo \"skip preprocess\") && jest --passWithNoTests"
   },
   "dependencies": {
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/communication-common": "3.0.0-beta.1 || ^2.2.1",
     "@azure/communication-signaling": "1.0.0-beta.19",
     "@azure/core-paging": "^1.5.0",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -74,7 +74,7 @@
   "peerDependencies": {
     "@azure/communication-calling": "1.15.1-beta.1 || >=1.14.1",
     "@azure/communication-calling-effects": "1.0.0-beta.2",
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@azure/communication-calling": "1.15.1-beta.1 || >=1.14.1",
     "@azure/communication-calling-effects": "1.0.0-beta.2",
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/communication-identity": "^1.2.0",
     "@azure/communication-signaling": "1.0.0-beta.19",
     "@babel/cli": "~7.16.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@azure/communication-calling": "1.15.1-beta.1 || >=1.14.1",
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/communication-common": "3.0.0-beta.1 || ^2.2.1",
     "@azure/communication-identity": "^1.2.0",
     "@azure/communication-react": "1.7.0-beta.1",

--- a/rush.json
+++ b/rush.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
   "rushVersion": "5.100.1",
   "pnpmVersion": "8.6.9",
-  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.19.0 <19.0.0",
+  "nodeSupportedVersionRange": ">=14.15.0 <15.0.0 || >=16.19.0 <21.0.0",
   "ensureConsistentVersions": true,
   "gitPolicy": {
     "versionBumpCommitMessage": "Applying package updates. [skip-ci]",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -31,7 +31,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.2.0",
     "@azure/communication-calling": "1.15.1-beta.1 || >=1.14.1",
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/communication-react": "1.7.0-beta.1",
     "@azure/communication-common": "3.0.0-beta.1 || ^2.2.1",
     "@azure/logger": "^1.0.4",

--- a/samples/Chat/package.json
+++ b/samples/Chat/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/communication-common": "3.0.0-beta.1 || ^2.2.1",
     "@azure/communication-identity": "^1.2.0",
     "@azure/communication-react": "1.7.0-beta.1",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -22,7 +22,7 @@
     "_typecheck": "rushx _by-flavor \"rushx _if-preprocess && echo skip || (if-env COMMUNICATION_REACT_FLAVOR=beta && tsc)\""
   },
   "dependencies": {
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/communication-calling": "1.15.1-beta.1 || >=1.14.1",
     "@azure/communication-common": "3.0.0-beta.1 || ^2.2.1",
     "@azure/communication-identity": "^1.2.0",

--- a/samples/Server/package.json
+++ b/samples/Server/package.json
@@ -19,7 +19,7 @@
     "lint:quiet": "eslint */**/*.{ts,tsx} --quiet"
   },
   "dependencies": {
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/communication-common": "3.0.0-beta.1 || ^2.2.1",
     "@azure/communication-identity": "^1.2.0",
     "@azure/storage-blob": "^12.15.0",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -25,7 +25,7 @@
     "@azure/communication-react": "1.7.0-beta.1",
     "@azure/communication-common": "3.0.0-beta.1 || ^2.2.1",
     "@azure/communication-calling": "1.15.1-beta.1 || >=1.14.1",
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@fluentui/react": "~8.110.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -20,13 +20,13 @@
   "license": "MIT",
   "dependencies": {
     "@azure/communication-calling": "1.15.1-beta.1 || >=1.14.1",
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/communication-common": "3.0.0-beta.1 || ^2.2.1",
     "uuid": "^9.0.0",
     "cross-env": "~7.0.3"
   },
   "devDependencies": {
-    "@azure/communication-chat": "1.3.2-beta.3 || >=1.2.0",
+    "@azure/communication-chat": "1.3.2-beta.3 || >=1.3.1",
     "@azure/communication-identity": "^1.2.0",
     "@playwright/test": "~1.35.1",
     "@types/node": "^16.11.7",


### PR DESCRIPTION
# What
Bump stable chat dependency to current release version
Enable node 20 tooling

# Why
rush-managed version was set but not the package version.

# How Tested
CI

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->