### PR TITLE
Disable Changelog step for create-release-branch script

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -93,8 +93,10 @@ jobs:
       - name: Synchronize package version reported to telemetry
         run: node common/scripts/sync-telemetry-package-version
 
-      - name: Add changelog
-        run: node ./common/scripts/changelog/change.mjs -m 'Create release branch and update SDK versions' --type none
+      - name: Disabled - DO THIS MANUALLY! Add changelog
+        run: |
+          echo "This step should be enabled when parameters can be added to the changelog command
+          Previous version of the command: node ./common/scripts/changelog/change.mjs -m 'Create release branch and update SDK versions' --type none"
 
       # Commit new dependencies
       - name: Commit changes

--- a/change-beta/@azure-communication-react-47707f0a-52e6-473f-89c0-fad8f3944926.json
+++ b/change-beta/@azure-communication-react-47707f0a-52e6-473f-89c0-fad8f3944926.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "Release",
+  "comment": "Disable Changelog step for release branch script",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-47707f0a-52e6-473f-89c0-fad8f3944926.json
+++ b/change/@azure-communication-react-47707f0a-52e6-473f-89c0-fad8f3944926.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "Release",
+  "comment": "Disable Changelog step for release branch script",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
create-release-branch script update

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
The changelog command can't be used as it is right now as it requires some manual input

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->