### PR TITLE
[Storybook] Fix storybook ChatComposite preview page for bot missing displayName

### DIFF
--- a/change-beta/@azure-communication-react-ce15e597-ba9e-498e-81cb-df162e374aa1.json
+++ b/change-beta/@azure-communication-react-ce15e597-ba9e-498e-81cb-df162e374aa1.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "storybook",
+  "comment": "Fix storybook bot missing displayName",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-ce15e597-ba9e-498e-81cb-df162e374aa1.json
+++ b/change/@azure-communication-react-ce15e597-ba9e-498e-81cb-df162e374aa1.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "storybook",
+  "comment": "Fix storybook bot missing displayName",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/ChatComposite/snippets/Utils.tsx
+++ b/packages/storybook/stories/ChatComposite/snippets/Utils.tsx
@@ -9,6 +9,8 @@ import React from 'react';
 import { CompositeConnectionParamsErrMessage } from '../../CompositeStringUtils';
 import { MICROSOFT_AZURE_ACCESS_TOKEN_QUICKSTART } from '../../constants';
 
+const botDisplayName = 'A simple bot';
+
 // Adds a bot to the thread that sends out provided canned messages one by one.
 export const addParrotBotToThread = async (
   userToken: string,
@@ -21,7 +23,7 @@ export const addParrotBotToThread = async (
   const botIdentifier: CommunicationUserIdentifier = { communicationUserId: botId };
   const chatClient = new ChatClient(endpointUrl, new AzureCommunicationTokenCredential(userToken));
   await chatClient.getChatThreadClient(threadId).addParticipants({
-    participants: [{ id: botIdentifier, displayName: 'A simple bot' }]
+    participants: [{ id: botIdentifier, displayName: botDisplayName }]
   });
 
   sendMessagesAsBot(botToken, endpointUrl, threadId, messages);
@@ -40,12 +42,12 @@ const sendMessagesAsBot = async (
   let index = 0;
   // Send first message immediately so users aren't staring at an empty chat thread.
   if (messages.length > 0) {
-    threadClient.sendMessage({ content: messages[index++] });
+    threadClient.sendMessage({ content: messages[index++] }, { senderDisplayName: botDisplayName });
   }
 
   setInterval(() => {
     if (index < messages.length) {
-      threadClient.sendMessage({ content: messages[index++] });
+      threadClient.sendMessage({ content: messages[index++] }, { senderDisplayName: botDisplayName });
     }
   }, 5000);
 };
@@ -54,12 +56,12 @@ export const sendMessagesAsBotWithAdapter = async (adapter: ChatAdapter, message
   let index = 0;
   // Send first message immediately so users aren't staring at an empty chat thread.
   if (messages.length > 0) {
-    adapter.sendMessage(messages[index++]);
+    adapter.sendMessage(messages[index++], { senderDisplayName: botDisplayName });
   }
 
   setInterval(() => {
     if (index < messages.length) {
-      adapter.sendMessage(messages[index++]);
+      adapter.sendMessage(messages[index++], { senderDisplayName: botDisplayName });
     }
   }, 5000);
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fix storybook ChatComposite preview page for bot missing displayName

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Before
<img width="1346" alt="image" src="https://github.com/Azure/communication-ui-library/assets/77021369/7d54b03a-e86e-429e-b841-187ef5ade5f8">

After
<img width="1242" alt="image" src="https://github.com/Azure/communication-ui-library/assets/77021369/a597862d-af9b-43bf-a6d9-504a4487ab88">

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->