### PR TITLE
[bugfix] Remove shadow from new controlBar in mobile landscape mode

### DIFF
--- a/change-beta/@azure-communication-react-05230861-ccc4-41f2-9985-f7d9203cddb0.json
+++ b/change-beta/@azure-communication-react-05230861-ccc4-41f2-9985-f7d9203cddb0.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "control-bar",
+  "comment": "Remove controlBar shadow in landscape mobile view",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-05230861-ccc4-41f2-9985-f7d9203cddb0.json
+++ b/change/@azure-communication-react-05230861-ccc4-41f2-9985-f7d9203cddb0.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "control-bar",
+  "comment": "Remove controlBar shadow in landscape mobile view",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/styles/CallControls.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/CallControls.styles.ts
@@ -6,10 +6,5 @@ import { IStyle } from '@fluentui/react';
 /** @private */
 export const controlBarContainerStyles: IStyle = {
   paddingTop: '0.25rem',
-  paddingBottom: '0.25rem',
-  // @TODO: this should be exposed through a custom CallComposite Theme API that extends the fluent theme with semantic values
-  boxShadow: `
-    0px 6.400000095367432px 14.399999618530273px 0px #00000021;
-    0px 1.2000000476837158px 3.5999999046325684px 0px #0000001A;
-  `
+  paddingBottom: '0.25rem'
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Remove unused, not wanted shadow from control bar. No views should have shadow for the controlBar
<img src="https://github.com/Azure/communication-ui-library/assets/97130533/0f851abb-2108-4172-80bf-42bcde2c99fb" width="50%"/>

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Shadow seen only in landscape mobile with the new controlBar. We do not want to see shadows at all in accordance to the figma designs
<img src="https://github.com/Azure/communication-ui-library/assets/97130533/03d01f8b-0456-4742-a890-aae30b136a3e" width="50%"/>


# How Tested
<!--- How did you test your change. What tests have you added. -->
MacOS Calling sample mobile landscape view

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->