### PR TITLE
Fix storybook 'Join existing call' preview to account for room Id

### DIFF
--- a/change-beta/@azure-communication-react-59df8376-8970-41d9-9918-a21c4871b574.json
+++ b/change-beta/@azure-communication-react-59df8376-8970-41d9-9918-a21c4871b574.json
@@ -2,7 +2,7 @@
   "type": "none",
   "area": "fix",
   "workstream": "Storybook preview",
-  "comment": "Trim locator entered in storybook 'Join Existing Call' preview and validate if it is a roomsId",
+  "comment": "Validate if locator entered in storybook 'Join Existing Call' preview is a room Id",
   "packageName": "@azure/communication-react",
   "email": "79475487+mgamis-msft@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change-beta/@azure-communication-react-59df8376-8970-41d9-9918-a21c4871b574.json
+++ b/change-beta/@azure-communication-react-59df8376-8970-41d9-9918-a21c4871b574.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Storybook preview",
+  "comment": "Trim locator entered in storybook 'Join Existing Call' preview and validate if it is a roomsId",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-59df8376-8970-41d9-9918-a21c4871b574.json
+++ b/change/@azure-communication-react-59df8376-8970-41d9-9918-a21c4871b574.json
@@ -2,7 +2,7 @@
   "type": "none",
   "area": "fix",
   "workstream": "Storybook preview",
-  "comment": "Trim locator entered in storybook 'Join Existing Call' preview and validate if it is a roomsId",
+  "comment": "Validate if locator entered in storybook 'Join Existing Call' preview is a room Id",
   "packageName": "@azure/communication-react",
   "email": "79475487+mgamis-msft@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change/@azure-communication-react-59df8376-8970-41d9-9918-a21c4871b574.json
+++ b/change/@azure-communication-react-59df8376-8970-41d9-9918-a21c4871b574.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Storybook preview",
+  "comment": "Trim locator entered in storybook 'Join Existing Call' preview and validate if it is a roomsId",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
@@ -29,9 +29,7 @@ const isTeamsMeetingLink = (link: string): boolean => link.startsWith('https://t
 const isGroupID = (id: string): boolean => validateUUID(id);
 
 const createCallAdapterLocator = (locator: string): CallAdapterLocator | undefined => {
-  if (locator === '') {
-    return undefined;
-  } else if (isTeamsMeetingLink(locator)) {
+  if (isTeamsMeetingLink(locator)) {
     return { meetingLink: locator };
   } else if (isGroupID(locator)) {
     return { groupId: locator };
@@ -51,7 +49,7 @@ export const ContosoCallContainer = (props: ContainerProps): JSX.Element => {
     }
   }, [props.token]);
 
-  const locator = useMemo(() => createCallAdapterLocator(props.locator.trim()), [props.locator]);
+  const locator = useMemo(() => createCallAdapterLocator(props.locator), [props.locator]);
 
   const adapter = useAzureCommunicationCallAdapter(
     {

--- a/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
+++ b/packages/storybook/stories/CallComposite/snippets/Container.snippet.tsx
@@ -29,10 +29,14 @@ const isTeamsMeetingLink = (link: string): boolean => link.startsWith('https://t
 const isGroupID = (id: string): boolean => validateUUID(id);
 
 const createCallAdapterLocator = (locator: string): CallAdapterLocator | undefined => {
-  if (isTeamsMeetingLink(locator)) {
+  if (locator === '') {
+    return undefined;
+  } else if (isTeamsMeetingLink(locator)) {
     return { meetingLink: locator };
   } else if (isGroupID(locator)) {
     return { groupId: locator };
+  } else if (/^\d+$/.test(locator)) {
+    return { roomId: locator };
   }
   return undefined;
 };
@@ -47,7 +51,7 @@ export const ContosoCallContainer = (props: ContainerProps): JSX.Element => {
     }
   }, [props.token]);
 
-  const locator = useMemo(() => createCallAdapterLocator(props.locator), [props.locator]);
+  const locator = useMemo(() => createCallAdapterLocator(props.locator.trim()), [props.locator]);
 
   const adapter = useAzureCommunicationCallAdapter(
     {


### PR DESCRIPTION
# What
Fix storybook 'Join existing call' preview to account for room Id

# Why
Bug reported in ACS UI SDK Teams channel
[Avishek Arora: UI Library not working for Joining Rooms](https://teams.microsoft.com/l/message/19:56e8e1411d1a490dbeeaeb91014b74e8@thread.tacv2/1692946391221?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=1a0e37b9-14aa-4045-b3f0-6ec676e8e945&parentMessageId=1692946391221&teamName=ACS%20-%20Microsoft%20Community&channelName=UI%20SDK&createdTime=1692946391221)

# How Tested
Local storybook testing

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->