### PR TITLE
[Chat]Fix image gallery modal not covering iOS safe area

### DIFF
--- a/change-beta/@azure-communication-react-f75c7e8a-5f8f-40d7-a777-6227a9f09c73.json
+++ b/change-beta/@azure-communication-react-f75c7e8a-5f8f-40d7-a777-6227a9f09c73.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "ImageGallery",
+  "comment": "Fix image gallery modal not covering iOS safe area",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-f75c7e8a-5f8f-40d7-a777-6227a9f09c73.json
+++ b/change/@azure-communication-react-f75c7e8a-5f8f-40d7-a777-6227a9f09c73.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "ImageGallery",
+  "comment": "Fix image gallery modal not covering iOS safe area",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/ImageGallery.tsx
+++ b/packages/react-components/src/components/ImageGallery.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /* @conditional-compile-remove(image-gallery) */
-import { DefaultButton, FocusTrapZone, Icon, IconButton, Modal, Stack, mergeStyles } from '@fluentui/react';
+import { DefaultButton, FocusTrapZone, Icon, IconButton, Modal, Stack, isIOS, mergeStyles } from '@fluentui/react';
 /* @conditional-compile-remove(image-gallery) */
 import React, { SyntheticEvent, useState } from 'react';
 /* @conditional-compile-remove(image-gallery) */
@@ -120,7 +120,7 @@ export const ImageGallery = (props: ImageGalleryProps): JSX.Element => {
   const image = images[startIndex];
   const renderHeaderBar = (): JSX.Element => {
     return (
-      <Stack className={mergeStyles(headerStyle)}>
+      <Stack className={mergeStyles(headerStyle(isIOS()))}>
         <Stack className={mergeStyles(titleBarContainerStyle)}>
           {image.titleIcon}
           <Stack.Item className={mergeStyles(titleStyle(theme, isDarkTheme))} aria-label={image.title}>

--- a/packages/react-components/src/components/styles/ImageGallery.style.ts
+++ b/packages/react-components/src/components/styles/ImageGallery.style.ts
@@ -57,14 +57,19 @@ export const scrollableContentStyle: IStyle = {
 /**
  * @private
  */
-export const headerStyle: IStyle = {
-  fontSize: 'inherit',
-  margin: '0',
-  width: '100%',
-  height: '3.5rem',
-  flexDirection: 'row',
-  justifyContent: 'space-between',
-  padding: '0.25rem 0.75rem'
+export const headerStyle = (isIOS: boolean): IStyle => {
+  return {
+    fontSize: 'inherit',
+    margin: '0',
+    width: '100%',
+    height: '3.5rem',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    padding: '0.25rem 0.75rem',
+    '@media (max-height: 25rem)': {
+      padding: isIOS ? '0.25rem 2rem' : '0.25rem 0.75rem'
+    }
+  };
 };
 
 /**

--- a/packages/react-composites/src/composites/common/BaseComposite.tsx
+++ b/packages/react-composites/src/composites/common/BaseComposite.tsx
@@ -110,7 +110,10 @@ export const BaseProvider = (
   // which stop polluting global dom tree and increase compatibility with react-full-screen
   const CompositeElement = (
     <FluentThemeProvider fluentTheme={fluentTheme} rtl={rtl}>
-      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0 viewport-fit=cover"
+      />
       <Customizer scopedSettings={{ Layer: { hostId: globalLayerHostId } }}>
         <WithBackgroundColor>{props.children}</WithBackgroundColor>
       </Customizer>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
In landscape mode, the ImageGallery modal not covering the iOS safe area
![IMG_0154](https://github.com/Azure/communication-ui-library/assets/107075081/241dcca7-aa58-4f1c-b6fd-8959698f2b3a)

After the fix:

![IMG_0176](https://github.com/Azure/communication-ui-library/assets/107075081/ac9fcc38-e257-4fb9-8ddc-dd11729180ca)
![IMG_0177](https://github.com/Azure/communication-ui-library/assets/107075081/9be0e600-63a3-4762-b9c8-b9472381add6)

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->