### PR TITLE
[Chat] Increase mention popover's z-index

### DIFF
--- a/change-beta/@azure-communication-react-53c802f6-0258-42c6-a58c-405cb2e63b30.json
+++ b/change-beta/@azure-communication-react-53c802f6-0258-42c6-a58c-405cb2e63b30.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Mention",
+  "comment": "Increase mention popover's z-index",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-53c802f6-0258-42c6-a58c-405cb2e63b30.json
+++ b/change/@azure-communication-react-53c802f6-0258-42c6-a58c-405cb2e63b30.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Mention",
+  "comment": "Increase mention popover's z-index",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/MentionPopover.style.ts
+++ b/packages/react-components/src/components/styles/MentionPopover.style.ts
@@ -5,20 +5,16 @@ import { IStackStyles, mergeStyles, Theme } from '@fluentui/react';
 
 /**
  * @private
- * z-index to ensure that chat container has lower z-index than mention popover
- */
-export const CHAT_CONTAINER_ZINDEX = 1;
-
-/**
- * @private
  */
 export const mentionPopoverContainerStyle = (theme: Theme): string =>
   mergeStyles({
     boxShadow: theme.effects.elevation16,
     background: theme.semanticColors.bodyBackground,
     overflow: 'visible',
-    // zIndex to set the mentionPopover above the chat container
-    zIndex: CHAT_CONTAINER_ZINDEX + 1
+    // zIndex to set the mentionPopover
+    // Temporary set to a hardcoded high number to make sure it is on top of the other components
+    // Will be replaced by a proper z-index solution after the Fluent 9 migration
+    zIndex: 10000
   });
 /**
  * @private


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Temporary set to a hardcoded high number to make sure it is on top of the other components
Will be replaced by a proper z-index solution after the Fluent 9 migration

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->