### PR TITLE
Fix for scaling mode of participants update when screen sharing is turned off by remote user

### DIFF
--- a/change-beta/@azure-communication-react-b4ca5447-c3fe-4a3e-9186-ccc4c1ecb181.json
+++ b/change-beta/@azure-communication-react-b4ca5447-c3fe-4a3e-9186-ccc4c1ecb181.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Calling",
+  "comment": "Scaling mode of participants update when screen sharing is turned off by remote user",
+  "packageName": "@azure/communication-react",
+  "email": "97124699+prabhjot-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-b4ca5447-c3fe-4a3e-9186-ccc4c1ecb181.json
+++ b/change/@azure-communication-react-b4ca5447-c3fe-4a3e-9186-ccc4c1ecb181.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Calling",
+  "comment": "Scaling mode of participants update when screen sharing is turned off by remote user",
+  "packageName": "@azure/communication-react",
+  "email": "97124699+prabhjot-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1768,6 +1768,7 @@ export const _RemoteVideoTile: React_2.MemoExoticComponent<(props: {
     drawerMenuHostId?: string | undefined;
     onPinParticipant?: ((userId: string) => void) | undefined;
     onUnpinParticipant?: ((userId: string) => void) | undefined;
+    onUpdateScalingMode?: ((userId: string, scalingMode: ViewScalingMode) => void) | undefined;
     isPinned?: boolean | undefined;
     disablePinMenuItem?: boolean | undefined;
     toggleAnnouncerString?: ((announcerString: string) => void) | undefined;

--- a/packages/react-components/review/stable/react-components.api.md
+++ b/packages/react-components/review/stable/react-components.api.md
@@ -1255,6 +1255,7 @@ export const _RemoteVideoTile: React_2.MemoExoticComponent<(props: {
     drawerMenuHostId?: string | undefined;
     onPinParticipant?: ((userId: string) => void) | undefined;
     onUnpinParticipant?: ((userId: string) => void) | undefined;
+    onUpdateScalingMode?: ((userId: string, scalingMode: ViewScalingMode) => void) | undefined;
     isPinned?: boolean | undefined;
     disablePinMenuItem?: boolean | undefined;
     toggleAnnouncerString?: ((announcerString: string) => void) | undefined;

--- a/packages/react-components/src/components/RemoteVideoTile.tsx
+++ b/packages/react-components/src/components/RemoteVideoTile.tsx
@@ -10,7 +10,8 @@ import {
   OnRenderAvatarCallback,
   ParticipantState,
   VideoGalleryRemoteParticipant,
-  VideoStreamOptions
+  VideoStreamOptions,
+  ViewScalingMode
 } from '../types';
 import { _DrawerMenu, _DrawerMenuItemProps } from './Drawer';
 import { StreamMedia } from './StreamMedia';
@@ -54,6 +55,7 @@ export const _RemoteVideoTile = React.memo(
     drawerMenuHostId?: string;
     onPinParticipant?: (userId: string) => void;
     onUnpinParticipant?: (userId: string) => void;
+    onUpdateScalingMode?: (userId: string, scalingMode: ViewScalingMode) => void;
     isPinned?: boolean;
     disablePinMenuItem?: boolean;
     toggleAnnouncerString?: (announcerString: string) => void;
@@ -75,6 +77,7 @@ export const _RemoteVideoTile = React.memo(
       isPinned,
       onPinParticipant,
       onUnpinParticipant,
+      onUpdateScalingMode,
       disablePinMenuItem,
       toggleAnnouncerString,
       strings
@@ -116,6 +119,7 @@ export const _RemoteVideoTile = React.memo(
       isPinned,
       onPinParticipant,
       onUnpinParticipant,
+      onUpdateScalingMode,
       disablePinMenuItem,
       toggleAnnouncerString
     });

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -18,6 +18,8 @@ import {
   VideoStreamOptions,
   CreateVideoStreamViewResult
 } from '../types';
+/* @conditional-compile-remove(pinned-participants) */
+import { ViewScalingMode } from '../types';
 import { HorizontalGalleryStyles } from './HorizontalGallery';
 import { _RemoteVideoTile } from './RemoteVideoTile';
 import { isNarrowWidth, _useContainerHeight, _useContainerWidth } from './utils/responsive';
@@ -374,6 +376,24 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
   /* @conditional-compile-remove(pinned-participants) */
   const [pinnedParticipantsState, setPinnedParticipantsState] = React.useState<string[]>([]);
   /* @conditional-compile-remove(pinned-participants) */
+  const [selectedScalingModeState, setselectedScalingModeState] = React.useState<Record<string, VideoStreamOptions>>(
+    {}
+  );
+
+  /* @conditional-compile-remove(pinned-participants) */
+  const onUpdateScalingMode = useCallback(
+    (remoteUserId: string, scalingMode: ViewScalingMode) => {
+      setselectedScalingModeState((current) => ({
+        ...current,
+        [remoteUserId]: {
+          scalingMode,
+          isMirrored: remoteVideoViewOptions?.isMirrored
+        }
+      }));
+    },
+    [remoteVideoViewOptions?.isMirrored]
+  );
+  /* @conditional-compile-remove(pinned-participants) */
   useEffect(() => {
     props.pinnedParticipants?.forEach((pinParticipant) => {
       if (!props.remoteParticipants?.find((t) => t.userId === pinParticipant)) {
@@ -511,11 +531,17 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
   const defaultOnRenderVideoTile = useCallback(
     (participant: VideoGalleryRemoteParticipant, isVideoParticipant?: boolean) => {
       const remoteVideoStream = participant.videoStream;
+      /* @conditional-compile-remove(pinned-participants) */
+      const selectedScalingMode = remoteVideoStream ? selectedScalingModeState[participant.userId] : undefined;
 
       /* @conditional-compile-remove(pinned-participants) */
       const isPinned = pinnedParticipants?.includes(participant.userId);
 
       const createViewOptions = (): VideoStreamOptions | undefined => {
+        /* @conditional-compile-remove(pinned-participants) */
+        if (selectedScalingMode) {
+          return selectedScalingMode;
+        }
         /* @conditional-compile-remove(pinned-participants) */
         return remoteVideoStream?.streamSize &&
           remoteVideoStream.streamSize?.height > remoteVideoStream.streamSize?.width
@@ -560,6 +586,8 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
           /* @conditional-compile-remove(pinned-participants) */
           onUnpinParticipant={onUnpinParticipant}
           /* @conditional-compile-remove(pinned-participants) */
+          onUpdateScalingMode={onUpdateScalingMode}
+          /* @conditional-compile-remove(pinned-participants) */
           isPinned={isPinned}
           /* @conditional-compile-remove(pinned-participants) */
           disablePinMenuItem={pinnedParticipants.length >= MAX_PINNED_REMOTE_VIDEO_TILES}
@@ -576,12 +604,14 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
       onRenderAvatar,
       showMuteIndicator,
       strings,
-      /* @conditional-compile-remove(pinned-participants) */ drawerMenuHostId,
+      /* @conditional-compile-remove(pinned-participants) */ selectedScalingModeState,
       /* @conditional-compile-remove(pinned-participants) */ remoteVideoTileMenuOptions,
       /* @conditional-compile-remove(pinned-participants) */ pinnedParticipants,
       /* @conditional-compile-remove(pinned-participants) */ onPinParticipant,
       /* @conditional-compile-remove(pinned-participants) */ onUnpinParticipant,
-      /* @conditional-compile-remove(pinned-participants) */ toggleAnnouncerString
+      /* @conditional-compile-remove(pinned-participants) */ toggleAnnouncerString,
+      /* @conditional-compile-remove(pinned-participants) */ drawerMenuHostId,
+      /* @conditional-compile-remove(pinned-participants) */ onUpdateScalingMode
     ]
   );
 

--- a/packages/react-components/src/components/VideoGallery/useVideoTileContextualMenuProps.ts
+++ b/packages/react-components/src/components/VideoGallery/useVideoTileContextualMenuProps.ts
@@ -27,6 +27,7 @@ export const useVideoTileContextualMenuProps = (props: {
   isPinned?: boolean;
   onPinParticipant?: (userId: string) => void;
   onUnpinParticipant?: (userId: string) => void;
+  onUpdateScalingMode?: (userId: string, scalingMode: ViewScalingMode) => void;
   disablePinMenuItem?: boolean;
   toggleAnnouncerString?: (announcerString: string) => void;
 }): IContextualMenuProps | undefined => {
@@ -37,6 +38,7 @@ export const useVideoTileContextualMenuProps = (props: {
     isPinned,
     onPinParticipant,
     onUnpinParticipant,
+    onUpdateScalingMode,
     disablePinMenuItem,
     toggleAnnouncerString
   } = props;
@@ -109,6 +111,7 @@ export const useVideoTileContextualMenuProps = (props: {
             styles: { root: { lineHeight: '1rem', textAlign: 'center' } }
           },
           onClick: () => {
+            onUpdateScalingMode?.(remoteParticipant.userId, 'Fit');
             view?.updateScalingMode('Fit');
           },
           'data-ui-id': 'video-tile-fit-to-frame',
@@ -124,6 +127,7 @@ export const useVideoTileContextualMenuProps = (props: {
               styles: { root: { lineHeight: '1rem', textAlign: 'center' } }
             },
             onClick: () => {
+              onUpdateScalingMode?.(remoteParticipant.userId, 'Crop');
               view?.updateScalingMode('Crop');
             },
             'data-ui-id': 'video-tile-fill-frame',
@@ -144,6 +148,7 @@ export const useVideoTileContextualMenuProps = (props: {
     isPinned,
     onPinParticipant,
     onUnpinParticipant,
+    onUpdateScalingMode,
     remoteParticipant.userId,
     remoteParticipant.displayName,
     disablePinMenuItem,


### PR DESCRIPTION
# What
Fix for scaling mode of participants update when screen sharing is turned off by remote user

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->