### PR TITLE
[Chat] Add documentation for how to cover the safe area on iOS devices

### DIFF
--- a/change-beta/@azure-communication-react-0bcf85c5-e5db-4296-96f4-2269902570cb.json
+++ b/change-beta/@azure-communication-react-0bcf85c5-e5db-4296-96f4-2269902570cb.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "ImageGallery",
+  "comment": "Add documentation for how to cover the safe area on iOS devices",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-0bcf85c5-e5db-4296-96f4-2269902570cb.json
+++ b/change/@azure-communication-react-0bcf85c5-e5db-4296-96f4-2269902570cb.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "ImageGallery",
+  "comment": "Add documentation for how to cover the safe area on iOS devices",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/storybook/stories/INTERNAL/ImageGallery/ImageGallery.stories.tsx
+++ b/packages/storybook/stories/INTERNAL/ImageGallery/ImageGallery.stories.tsx
@@ -33,7 +33,7 @@ const getDocs: () => JSX.Element = () => {
       </Canvas>
       <Heading>Cover iOS safe area</Heading>
       <Description>
-        To have the image gallery covers the safeArea on iOS devices, we can add `viewport-fit=cover` to the viewport
+        To have the image gallery cover the safeArea on iOS devices, we can add `viewport-fit=cover` to the viewport
         meta tag of the app.
       </Description>
       <Source code={metaTagExample} />

--- a/packages/storybook/stories/INTERNAL/ImageGallery/ImageGallery.stories.tsx
+++ b/packages/storybook/stories/INTERNAL/ImageGallery/ImageGallery.stories.tsx
@@ -11,6 +11,7 @@ import { COMPONENT_FOLDER_PREFIX } from '../../constants';
 import { ImageGalleryExample } from './snippets/ImageGallery.snippet';
 const ImageGalleryExampleText = require('!!raw-loader!./snippets/ImageGallery.snippet.tsx').default;
 const importStatement = `import { ImageGallery } from '@azure/communication-react';`;
+const metaTagExample = `<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">`;
 
 const getDocs: () => JSX.Element = () => {
   return (
@@ -30,6 +31,12 @@ const getDocs: () => JSX.Element = () => {
       <Canvas mdxSource={ImageGalleryExampleText}>
         <ImageGalleryExample />
       </Canvas>
+      <Heading>Cover iOS safe area</Heading>
+      <Description>
+        To have the image gallery covers the safeArea on iOS devices, we can add `viewport-fit=cover` to the viewport
+        meta tag of the app.
+      </Description>
+      <Source code={metaTagExample} />
       <Heading>Props</Heading>
       <ArgsTable of={ImageGalleryComponent} />
     </>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
To have the image gallery covers the safeArea on iOS devices, the only way is through modifying the global meta tag.
We don't want to add this to our composite since the control should be given to the Contoso's app.
Adding documentation to demo how Contosos can make Image Gallery covers the safe area on iOS devices.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->