### PR TITLE
Add FluentV9ThemeProvider for future v9 components

### DIFF
--- a/change-beta/@azure-communication-react-ba9de2fd-3971-48e6-aeed-1bf9a933c7de.json
+++ b/change-beta/@azure-communication-react-ba9de2fd-3971-48e6-aeed-1bf9a933c7de.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "FluentUI v9",
+  "comment": "Added FluentV9ThemeProvider",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-ba9de2fd-3971-48e6-aeed-1bf9a933c7de.json
+++ b/change/@azure-communication-react-ba9de2fd-3971-48e6-aeed-1bf9a933c7de.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "FluentUI v9",
+  "comment": "Added FluentV9ThemeProvider",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -3,7 +3,7 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Chat } from '@fluentui-contrib/react-chat';
-import { mergeClasses, FluentProvider } from '@fluentui/react-components';
+import { mergeClasses } from '@fluentui/react-components';
 import {
   DownIconStyle,
   newMessageButtonContainerStyle,
@@ -49,7 +49,7 @@ import { FileMetadata } from './FileDownloadCards';
 /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
 import { AttachmentDownloadResult } from './FileDownloadCards';
 import { useTheme } from '../theming';
-import { createV9Theme, useFluentV9Wrapper } from './../theming/v9ThemeShim';
+import { FluentV9ThemeProvider } from './../theming/FluentV9ThemeProvider';
 import LiveAnnouncer from './Announcer/LiveAnnouncer';
 /* @conditional-compile-remove(mention) */
 import { MentionOptions } from './MentionPopover';
@@ -1137,7 +1137,6 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
   );
 
   const theme = useTheme();
-  const v9Theme = createV9Theme(theme);
   const messagesToDisplay = useMemo(
     () =>
       memoizeAllMessages((memoizedMessageFn) => {
@@ -1231,22 +1230,21 @@ export const MessageThread = (props: MessageThreadProps): JSX.Element => {
   );
 
   const classes = useChatStyles();
-  const fluentV9Wrapper = useFluentV9Wrapper();
 
   const chatBody = useMemo(() => {
     return (
       <LiveAnnouncer>
-        <FluentProvider className={fluentV9Wrapper.body} theme={v9Theme} dir={theme.rtl ? 'rtl' : 'ltr'}>
+        <FluentV9ThemeProvider v8Theme={theme}>
           <Chat
             className={mergeClasses(classes.root, mergeStyles(linkStyles(theme), styles?.chatContainer))}
             ref={chatScrollDivRef}
           >
             {messagesToDisplay}
           </Chat>
-        </FluentProvider>
+        </FluentV9ThemeProvider>
       </LiveAnnouncer>
     );
-  }, [theme, fluentV9Wrapper.body, classes.root, styles?.chatContainer, messagesToDisplay, v9Theme]);
+  }, [theme, classes.root, styles?.chatContainer, messagesToDisplay]);
 
   return (
     <div className={mergeStyles(messageThreadContainerStyle, styles?.root)} ref={chatThreadRef}>

--- a/packages/react-components/src/theming/FluentV9ThemeProvider.tsx
+++ b/packages/react-components/src/theming/FluentV9ThemeProvider.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { makeStyles, shorthands, FluentProvider } from '@fluentui/react-components';
+import { Theme as ThemeV8 } from '@fluentui/react';
+import { createV9Theme } from './../theming/v9ThemeShim';
+
+/**
+ * Props for {@link FluentThemeProvider}.
+ *
+ * @private
+ */
+export interface FluentV9ThemeProviderProps {
+  /** Children to be themed. */
+  children: React.ReactNode;
+  /** FluentUI v8 theme to be mapped to FluentUI v9 theme */
+  v8Theme: ThemeV8;
+}
+
+/**
+ * @private
+ */
+export const useFluentV9Wrapper = makeStyles({
+  body: {
+    height: '100%',
+    ...shorthands.margin(0),
+    ...shorthands.overflow('hidden'),
+    ...shorthands.padding(0),
+    width: '100%'
+  }
+});
+
+/**
+ * Provider to apply a Fluent V9 theme to react components.
+ *
+ *
+ * @private
+ */
+export const FluentV9ThemeProvider = (props: FluentV9ThemeProviderProps): JSX.Element => {
+  const { v8Theme, children } = props;
+  const fluentV9Wrapper = useFluentV9Wrapper();
+  const v9Theme = createV9Theme(v8Theme);
+
+  return (
+    <FluentProvider className={fluentV9Wrapper.body} theme={v9Theme} dir={v8Theme.rtl ? 'rtl' : 'ltr'}>
+      {children}
+    </FluentProvider>
+  );
+};

--- a/packages/react-components/src/theming/v9ThemeShim.ts
+++ b/packages/react-components/src/theming/v9ThemeShim.ts
@@ -6,9 +6,7 @@ import {
   ColorTokens,
   ShadowTokens,
   Theme as ThemeV9,
-  webLightTheme,
-  makeStyles,
-  shorthands
+  webLightTheme
 } from '@fluentui/react-components';
 import { blackAlpha, whiteAlpha, grey, grey10Alpha, grey12Alpha } from './themeDuplicates';
 
@@ -206,32 +204,21 @@ const mapBorderRadiusTokens = (effects: IEffects): Partial<BorderRadiusTokens> =
 };
 
 /**
- * Chat message actions flyout that contains actions such as Edit Message, or Remove Message.
+ * Creates a v9 theme from a v8 theme and base v9 theme.
+ * FluentUI webLightTheme is used in case if no baseThemeV9 is provided.
  *
  * @private
  */
-export const createV9Theme = (themeV8: ThemeV8): ThemeV9 & { errorText: string } => {
-  const baseTheme: ThemeV9 & { errorText: string } = {
-    ...webLightTheme,
+export const createV9Theme = (themeV8: ThemeV8, baseThemeV9?: ThemeV9): ThemeV9 & { errorText: string } => {
+  const baseTheme = baseThemeV9 ?? webLightTheme;
+  const updatedBaseTheme: ThemeV9 & { errorText: string } = {
+    ...baseTheme,
     errorText: themeV8.semanticColors.errorText
   };
   return {
-    ...baseTheme,
+    ...updatedBaseTheme,
     ...mapAliasColors(themeV8.palette, themeV8.isInverted),
     ...mapShadowTokens(themeV8.effects),
     ...mapBorderRadiusTokens(themeV8.effects)
   };
 };
-
-/**
- * @private
- */
-export const useFluentV9Wrapper = makeStyles({
-  body: {
-    height: '100%',
-    ...shorthands.margin(0),
-    ...shorthands.overflow('hidden'),
-    ...shorthands.padding(0),
-    width: '100%'
-  }
-});


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Added FluentV9ThemeProvider that can be reused during the future development of new v9 components (before breaking changes)

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->