### PR TITLE
[Stable release blocking] Fix redundant presenter role notification when joining Teams interop

### DIFF
--- a/change-beta/@azure-communication-react-305a826e-1a08-49b8-8647-c1d2f8860af5.json
+++ b/change-beta/@azure-communication-react-305a826e-1a08-49b8-8647-c1d2f8860af5.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Capabilities",
+  "comment": "Fix redundant presenter role notification when joining Teams interop call",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-305a826e-1a08-49b8-8647-c1d2f8860af5.json
+++ b/change/@azure-communication-react-305a826e-1a08-49b8-8647-c1d2f8860af5.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Capabilities",
+  "comment": "Fix redundant presenter role notification when joining Teams interop call",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/CallComposite/utils/TrackCapabilityChangedNotifications.ts
+++ b/packages/react-composites/src/composites/CallComposite/utils/TrackCapabilityChangedNotifications.ts
@@ -148,21 +148,21 @@ type LatestCapabilityChangedNotificationRecord = Partial<
 /* @conditional-compile-remove(capabilities) */
 const updateLatestCapabilityChangedNotificationMap = (
   capabilitiesChangedInfoAndRole: CapabilitiesChangedInfoAndRole,
-  latestNotifications: LatestCapabilityChangedNotificationRecord
+  activeNotifications: LatestCapabilityChangedNotificationRecord
 ): LatestCapabilityChangedNotificationRecord => {
   if (!capabilitiesChangedInfoAndRole.capabilitiesChangeInfo) {
-    return latestNotifications;
+    return activeNotifications;
   }
 
   for (const [capabilityName, newCapabilityValue] of Object.entries(
     capabilitiesChangedInfoAndRole.capabilitiesChangeInfo.newValue
   )) {
-    // If the latest notification for a capability has the same `isPresent` value for the same reason we will not
-    // create a new notification
+    // If the active notification for a capability has the same `isPresent` value and the same reason as the new
+    // capability value from the SDK then we will not create a new notification to avoid redundancy
     if (
-      latestNotifications[capabilityName] &&
-      newCapabilityValue.isPresent === latestNotifications[capabilityName].isPresent &&
-      capabilitiesChangedInfoAndRole.capabilitiesChangeInfo.reason === latestNotifications[capabilityName].changedReason
+      activeNotifications[capabilityName] &&
+      newCapabilityValue.isPresent === activeNotifications[capabilityName].isPresent &&
+      capabilitiesChangedInfoAndRole.capabilitiesChangeInfo.reason === activeNotifications[capabilityName].changedReason
     ) {
       continue;
     }
@@ -173,7 +173,7 @@ const updateLatestCapabilityChangedNotificationMap = (
       role: capabilitiesChangedInfoAndRole.participantRole,
       timestamp: new Date(Date.now())
     };
-    latestNotifications[capabilityName] = newCapabilityChangeNotification;
+    activeNotifications[capabilityName] = newCapabilityChangeNotification;
   }
-  return latestNotifications;
+  return activeNotifications;
 };


### PR DESCRIPTION
# What
Fix redundant presenter role notification when joining Teams interop. The capability changed info comes from the Calling SDK
at the start of a Teams interop call and is now ignored as it is redundant and assumed.

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3405770

# How Tested
Local calling sample testing:
https://github.com/Azure/communication-ui-library/assets/79475487/3f159cd5-c1dc-4f64-aad4-01609727a669

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->