### PR TITLE
[BugFix] Default message timestamp to use locales

### DIFF
--- a/change-beta/@azure-communication-react-9e4c6c5c-4ada-4684-ba24-abc8a8aa1281.json
+++ b/change-beta/@azure-communication-react-9e4c6c5c-4ada-4684-ba24-abc8a8aa1281.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Chat message default timestamp localization",
+  "comment": "Enable localized default date/timestamp",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-9e4c6c5c-4ada-4684-ba24-abc8a8aa1281.json
+++ b/change/@azure-communication-react-9e4c6c5c-4ada-4684-ba24-abc8a8aa1281.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Chat message default timestamp localization",
+  "comment": "Enable localized default date/timestamp",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/utils/Datetime.test.ts
+++ b/packages/react-components/src/components/utils/Datetime.test.ts
@@ -4,68 +4,76 @@
 import { formatDateForChatMessage, formatTimeForChatMessage, formatTimestampForChatMessage } from './Datetime';
 import { COMPONENT_LOCALE_EN_US } from '../../localization/locales';
 
-const createMockDate = (datetime: {
+const createMockDate = (dateTime: {
   year?: number;
   month?: number;
   day?: number;
   hour?: number;
   min?: number;
   sec?: number;
-  milli?: number;
 }): Date =>
   new Date(
-    datetime.year ?? 2000,
-    datetime.month ?? 0,
-    datetime.day ?? 1,
-    datetime.hour ?? 0,
-    datetime.min ?? 0,
-    datetime.sec ?? 0,
-    datetime.milli ?? 0
+    dateTime.year ?? 2000,
+    dateTime.month ?? 0,
+    dateTime.day ?? 1,
+    dateTime.hour ?? 0,
+    dateTime.min ?? 0,
+    dateTime.sec ?? 0
   );
 
 describe('datetime tests', () => {
-  test('datetime.formatTimeForChatMessage should formatTime for am properly', () => {
-    expect(formatTimeForChatMessage(createMockDate({ hour: 11, min: 11 }))).toEqual('11:11 a.m.');
+  test('datetime.formatTimeForChatMessage should formatTime with seconds properly', () => {
+    const messageDate = createMockDate({ hour: 11, min: 11, sec: 11 });
+    expect(formatTimeForChatMessage(messageDate)).toEqual(
+      messageDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    );
   });
 
-  test('datetime.formatTimeForChatMessage should formatTime for pm properly', () => {
-    expect(formatTimeForChatMessage(createMockDate({ hour: 20, min: 20 }))).toEqual('8:20 p.m.');
+  test('datetime.formatTimeForChatMessage should formatTime properly', () => {
+    const messageDate = createMockDate({ hour: 20, min: 20 });
+    expect(formatTimeForChatMessage(messageDate)).toEqual(
+      messageDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    );
   });
 
   test('datetime.formatTimeForChatMessage should account for single digit minutes', () => {
-    expect(formatTimeForChatMessage(createMockDate({ hour: 20, min: 1 }))).toEqual('8:01 p.m.');
+    const messageDate = createMockDate({ hour: 20, min: 1 });
+    expect(formatTimeForChatMessage(messageDate)).toEqual(
+      messageDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    );
   });
 
   test('datetime.formatTimeForChatMessage should work for single digit hours', () => {
-    expect(formatTimeForChatMessage(createMockDate({ hour: 2, min: 1 }))).toEqual('2:01 a.m.');
+    const messageDate = createMockDate({ hour: 2, min: 1 });
+    expect(formatTimeForChatMessage(messageDate)).toEqual(
+      messageDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+    );
   });
 
   test('datetime.formatDateForChatMessage should format date properly with month starting at 0', () => {
-    expect(formatDateForChatMessage(createMockDate({ year: 2000, month: 0, day: 30, hour: 0, min: 0 }))).toEqual(
-      '2000-01-30'
-    );
+    const date = createMockDate({ year: 2000, month: 0, day: 30, hour: 0, min: 0 });
+    expect(formatDateForChatMessage(date)).toEqual(date.toLocaleDateString());
   });
 
   test('datetime.formatDateForChatMessage should format date properly with single digit day', () => {
-    expect(formatDateForChatMessage(createMockDate({ year: 2000, month: 0, day: 1, hour: 0, min: 0 }))).toEqual(
-      '2000-01-01'
-    );
+    const date = createMockDate({ year: 2000, month: 0, day: 1, hour: 0, min: 0 });
+    expect(formatDateForChatMessage(date)).toEqual(date.toLocaleDateString());
   });
 
   test('datetime.formatDateForChatMessage should format date properly with multiple digit month', () => {
-    expect(formatDateForChatMessage(createMockDate({ year: 2000, month: 10, day: 1, hour: 0, min: 0 }))).toEqual(
-      '2000-11-01'
-    );
+    const date = createMockDate({ year: 2000, month: 10, day: 1, hour: 0, min: 0 });
+    expect(formatDateForChatMessage(date)).toEqual(date.toLocaleDateString());
   });
 
   test('datetime.formatTimestampForChatMessage should format date from same day properly', () => {
+    const messageDate = createMockDate({ year: 2000, month: 10, day: 1, hour: 4, min: 0 });
     expect(
       formatTimestampForChatMessage(
-        createMockDate({ year: 2000, month: 10, day: 1, hour: 4, min: 0 }),
+        messageDate,
         createMockDate({ year: 2000, month: 10, day: 1, hour: 5, min: 0 }),
         COMPONENT_LOCALE_EN_US.strings.messageThread
       )
-    ).toEqual('4:00 a.m.');
+    ).toEqual(messageDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }));
   });
 
   test('datetime.formatTimestampForChatMessage should format date from yesterday properly', () => {
@@ -75,7 +83,7 @@ describe('datetime tests', () => {
         createMockDate({ year: 2000, month: 10, day: 10, hour: 5, min: 0 }),
         COMPONENT_LOCALE_EN_US.strings.messageThread
       )
-    ).toEqual('Yesterday 4:00 a.m.');
+    ).toEqual('Yesterday 4:00 AM');
   });
 
   test('datetime.formatTimestampForChatMessage should format date from same week properly', () => {
@@ -85,16 +93,17 @@ describe('datetime tests', () => {
         createMockDate({ year: 2000, month: 10, day: 10, hour: 5, min: 0 }),
         COMPONENT_LOCALE_EN_US.strings.messageThread
       )
-    ).toEqual('Wednesday 4:00 a.m.');
+    ).toEqual('Wednesday 4:00 AM');
   });
 
   test('datetime.formatTimestampForChatMessage should format date from long time ago properly', () => {
+    const messageDate = createMockDate({ year: 1999, month: 10, day: 8, hour: 4, min: 0 });
     expect(
       formatTimestampForChatMessage(
-        createMockDate({ year: 1999, month: 10, day: 8, hour: 4, min: 0 }),
+        messageDate,
         createMockDate({ year: 2000, month: 10, day: 10, hour: 5, min: 0 }),
         COMPONENT_LOCALE_EN_US.strings.messageThread
       )
-    ).toEqual('1999-11-08 4:00 a.m.');
+    ).toEqual(`${messageDate.toLocaleDateString()} 4:00 AM`);
   });
 });

--- a/packages/react-components/src/components/utils/Datetime.ts
+++ b/packages/react-components/src/components/utils/Datetime.ts
@@ -7,50 +7,26 @@ import { MessageThreadStrings } from '../MessageThread';
  * @private
  */
 export const formatTimeForChatMessage = (messageDate: Date): string => {
-  let hours = messageDate.getHours();
-  let minutes = messageDate.getMinutes().toString();
-  const isAm = hours < 12;
-  if (hours > 12) {
-    hours = hours - 12;
-  }
-  if (hours === 0) {
-    hours = 12;
-  }
-  if (minutes.length < 2) {
-    minutes = '0' + minutes;
-  }
-  return hours.toString() + ':' + minutes + ' ' + (isAm ? 'a.m.' : 'p.m.');
+  return messageDate.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 };
 
 /**
  * @private
  */
 export const formatDateForChatMessage = (messageDate: Date): string => {
-  const year = messageDate.getFullYear().toString();
-  let month = (messageDate.getMonth() + 1).toString();
-  let day = messageDate.getDate().toString();
-
-  if (month.length === 1) {
-    month = '0' + month;
-  }
-  if (day.length === 1) {
-    day = '0' + day;
-  }
-
-  return year + '-' + month + '-' + day;
+  return messageDate.toLocaleDateString();
 };
 
 /**
- * Given a message date object in ISO8601 and a current date object, generates a user friendly timestamp text like the
- * following:
- *
- * 1:30 p.m.
- * Yesterday 1:30 p.m.
- * Monday 1:30 p.m.
- * 2021-01-10 1:30 p.m.
+ * Given a message date object in ISO8601 and a current date object, generates a user friendly timestamp text
+ * using the system locale.
+ * <time in locale format>.
+ * Yesterday <time in locale format>.
+ * <dateStrings day of week> <time in locale format>.
+ * <date in locale format> <time in locale format>.
  *
  * If message is after yesterday, then only show the time.
- * If message is before yesteray and after day before yesterday, then show 'Yesterday' plus the time.
+ * If message is before yesterday and after day before yesterday, then show 'Yesterday' plus the time.
  * If message is before day before yesterday and within the current week, then show 'Monday/Tuesday/etc' plus the time.
  *   - We consider start of the week as Sunday. If current day is Sunday, then any time before that is in previous week.
  * If message is in previous or older weeks, then show date string plus the time.


### PR DESCRIPTION
# What
Use the `toLocale[Time/Date]String()` methods on `Date` to obtain a properly localized default message timestamp string

# Why
Current implementation is English 12hr format only and for anything else, users must override the renderer.

# How Tested
Storybook, CI

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->