### PR TITLE
[CI fix] downgrade playwright

### DIFF
--- a/change-beta/@azure-communication-react-890b72a5-482b-4c71-886b-39cf867a49d9.json
+++ b/change-beta/@azure-communication-react-890b72a5-482b-4c71-886b-39cf867a49d9.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Fixes playwright issues by downgrading the version",
+  "comment": "downgrade playwright",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-890b72a5-482b-4c71-886b-39cf867a49d9.json
+++ b/change/@azure-communication-react-890b72a5-482b-4c71-886b-39cf867a49d9.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Fixes playwright issues by downgrading the version",
+  "comment": "downgrade playwright",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -293,7 +293,7 @@ packages:
       '@types/node-fetch': 2.6.5
       '@types/tunnel': 0.0.3
       form-data: 4.0.0
-      node-fetch: 2.6.7
+      node-fetch: 2.7.0
       process: 0.11.10
       tslib: 2.6.2
       tunnel: 0.0.6
@@ -855,7 +855,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.12.9)
     dev: false
@@ -1037,7 +1037,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.20):
@@ -2381,7 +2381,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       jest-mock: 29.7.0
     dev: false
 
@@ -2408,7 +2408,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -2551,7 +2551,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/yargs': 15.0.15
       chalk: 4.1.2
     dev: false
@@ -2563,7 +2563,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/yargs': 17.0.24
       chalk: 4.1.2
     dev: false
@@ -3008,12 +3008,15 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: false
 
-  /@playwright/test@1.38.0:
-    resolution: {integrity: sha512-xis/RXXsLxwThKnlIXouxmIvvT3zvQj1JE39GsNieMUrMpb3/GySHDh2j8itCG22qKVD4MYLBp7xB73cUW/UUw==}
+  /@playwright/test@1.35.1:
+    resolution: {integrity: sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      playwright: 1.38.0
+      '@types/node': 20.6.2
+      playwright-core: 1.35.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: false
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.11(react-refresh@0.11.0)(webpack@5.76.0):
@@ -5099,13 +5102,13 @@ packages:
     resolution: {integrity: sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==}
     dependencies:
       '@types/connect': 3.4.36
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/bonjour@3.5.11:
     resolution: {integrity: sha512-isGhjmBtLIxdHBDl2xGwUzEM8AOyOvWsADWq7rqirdi/ZQoHnLWErHvsThcEzTX8juDRiZtzp2Qkv5bgNh6mAg==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/classnames@2.3.1:
@@ -5119,13 +5122,13 @@ packages:
     resolution: {integrity: sha512-iaQslNbARe8fctL5Lk+DsmgWOM83lM+7FzP0eQUJs1jd3kBE8NWqBTIT2S8SqQOJjxvt2eyIjpOuYeRXq2AdMw==}
     dependencies:
       '@types/express-serve-static-core': 4.17.36
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/connect@3.4.36:
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/cookie-parser@1.4.4:
@@ -5147,7 +5150,7 @@ packages:
   /@types/cors@2.8.14:
     resolution: {integrity: sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/dompurify@3.0.2:
@@ -5160,13 +5163,13 @@ packages:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
       '@types/eslint': 8.44.2
-      '@types/estree': 0.0.51
+      '@types/estree': 1.0.1
     dev: false
 
   /@types/eslint@8.44.2:
     resolution: {integrity: sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==}
     dependencies:
-      '@types/estree': 0.0.51
+      '@types/estree': 1.0.1
       '@types/json-schema': 7.0.13
     dev: false
 
@@ -5185,7 +5188,7 @@ packages:
   /@types/express-serve-static-core@4.17.36:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/qs': 6.9.8
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -5204,14 +5207,14 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/glob@8.1.0:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/graceful-fs@4.1.6:
@@ -5245,7 +5248,7 @@ packages:
   /@types/http-proxy@1.17.12:
     resolution: {integrity: sha512-kQtujO08dVtQ2wXAuSFfk9ASy3sug4+ogFR8Kd8UgP8PEuc1/G/8yjYRmp//PcDNJEUKOza/MrQu15bouEUCiw==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/is-function@1.0.1:
@@ -5291,7 +5294,7 @@ packages:
   /@types/jsdom@20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/tough-cookie': 4.0.3
       parse5: 7.1.2
     dev: false
@@ -5337,7 +5340,7 @@ packages:
   /@types/morgan@1.9.5:
     resolution: {integrity: sha512-5TgfIWm0lcTGnbCZExwc19dCOMOMmAiiBZQj8Ko3NRxsVDgRxf+AEGRQTqNVA5Yh2xfdWp4clbAEMbYP+jkOqg==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/node-fetch@2.6.5:
@@ -5351,7 +5354,7 @@ packages:
     resolution: {integrity: sha512-x7sdQAUeY4ePtiId8xbizFcADxFbJrJh7xk1Hepns884rDOflU/JRAf2cRSIrlf0fv8TSAK/XKbdKEKpC3K94A==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/node@10.17.13:
@@ -5401,7 +5404,7 @@ packages:
   /@types/puppeteer@5.4.7:
     resolution: {integrity: sha512-JdGWZZYL0vKapXF4oQTC5hLVNfOgdPrqeZ1BiQnGk5cB7HeE91EWUiTdVSdQPobRN8rIcdffjiOgCYJ/S8QrnQ==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/qs@6.9.8:
@@ -5444,7 +5447,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/serve-index@1.9.1:
@@ -5458,13 +5461,13 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.2
       '@types/mime': 3.0.1
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/sockjs@0.3.33:
     resolution: {integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/source-list-map@0.1.2:
@@ -5487,7 +5490,7 @@ packages:
     resolution: {integrity: sha512-LOWgpacIV8GHhrsQU+QMZuomfqXiqzz3ILLkCtKx3Us6AmomFViuzKT9D693QTKgyut2oCytMG8/efOop+DB+w==}
     dependencies:
       '@types/cookiejar': 2.1.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/supertest@2.0.12:
@@ -5541,7 +5544,7 @@ packages:
   /@types/webpack-node-externals@2.5.3(webpack-cli@4.10.0):
     resolution: {integrity: sha512-A9JxaR8QXoYT95egET4AmCFuChyTlP8d18ZAnmSHuIMsFdS7QlCQQ8pmN/+FHgLIkm+ViE/VngltT5avLACY9A==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       webpack: 5.76.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - '@swc/core'
@@ -5553,7 +5556,7 @@ packages:
   /@types/webpack-sources@3.2.0:
     resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
     dev: false
@@ -5561,7 +5564,7 @@ packages:
   /@types/webpack@4.41.33:
     resolution: {integrity: sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/tapable': 1.0.9
       '@types/uglify-js': 3.17.2
       '@types/webpack-sources': 3.2.0
@@ -5572,7 +5575,7 @@ packages:
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/yargs-parser@21.0.0:
@@ -5601,7 +5604,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
     optional: true
 
@@ -6990,6 +6993,7 @@ packages:
 
   /bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: false
@@ -9710,7 +9714,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.4(supports-color@5.5.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -9931,6 +9935,7 @@ packages:
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -11064,7 +11069,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.1
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12073,7 +12078,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -12120,7 +12125,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12227,7 +12232,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       jest-util: 29.7.0
     dev: false
 
@@ -12367,7 +12372,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       graceful-fs: 4.2.11
     dev: false
 
@@ -12435,7 +12440,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       chalk: 4.1.2
       graceful-fs: 4.2.11
       is-ci: 2.0.0
@@ -12447,7 +12452,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -12484,7 +12489,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: false
@@ -12493,7 +12498,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -14334,20 +14339,10 @@ packages:
       find-up: 5.0.0
     dev: false
 
-  /playwright-core@1.38.0:
-    resolution: {integrity: sha512-f8z1y8J9zvmHoEhKgspmCvOExF2XdcxMW8jNRuX4vkQFrzV4MlZ55iwb5QeyiFQgOFCUolXiRHgpjSEnqvO48g==}
+  /playwright-core@1.35.1:
+    resolution: {integrity: sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==}
     engines: {node: '>=16'}
     hasBin: true
-    dev: false
-
-  /playwright@1.38.0:
-    resolution: {integrity: sha512-fJGw+HO0YY+fU/F1N57DMO+TmXHTrmr905J05zwAQE9xkuwP/QLDk63rVhmyxh03dYnEhnRbsdbH9B0UVVRB3A==}
-    engines: {node: '>=16'}
-    hasBin: true
-    dependencies:
-      playwright-core: 1.38.0
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: false
 
   /please-upgrade-node@3.2.0:
@@ -15032,7 +15027,7 @@ packages:
     dependencies:
       object-assign: 4.1.1
       react: 18.2.0
-      react-is: 17.0.2
+      react-is: 18.2.0
     dev: false
 
   /react-test-renderer@17.0.2(react@18.2.0):
@@ -18635,7 +18630,7 @@ packages:
     dev: false
 
   file:projects/calling-component-bindings.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-Q3sc5Wzqheus5Y3R+MViQp99mk7jvKJNqG1qQifW8cGjONQqHUfXSden5tgqxqRGldYW1qE1fatM8SKCbkOj+A==, tarball: file:projects/calling-component-bindings.tgz}
+    resolution: {integrity: sha512-Y1qQMZICv8BIss+mLvNQY+TzA00/zQj3/koTwLSL568GRP+cvvO7qRyaViM5E8B29lMXlW6yXODlKkTEPhjo7A==, tarball: file:projects/calling-component-bindings.tgz}
     id: file:projects/calling-component-bindings.tgz
     name: '@rush-temp/calling-component-bindings'
     version: 0.0.0
@@ -18684,7 +18679,7 @@ packages:
     dev: false
 
   file:projects/calling-stateful-client.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-kzE/Q8BSYCLk1YZRmf4pQrsGfmZoQ++ZTpqlsGsDzyonmRrurqXWJvCibK5Y1bANOqA3szjfsTLCxIj5awTh5A==, tarball: file:projects/calling-stateful-client.tgz}
+    resolution: {integrity: sha512-dt66HBmwWqY5pgh2AXHA2CcDH8Ab7UJKlXiRHzcwSdTVXi9X1782Xt25Wcnm7Zs0J4i8uBlGFuB0KBAsGI70oA==, tarball: file:projects/calling-stateful-client.tgz}
     id: file:projects/calling-stateful-client.tgz
     name: '@rush-temp/calling-stateful-client'
     version: 0.0.0
@@ -18733,7 +18728,7 @@ packages:
     dev: false
 
   file:projects/calling.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-Uvi6KhV7uV0Nwwcc1IQlA4eX85TZaC3yKZhNZ/D0gVnMYv6EqsBi2IGMDcOrOXGTG2QEPBYig+qPGb6JrKyciw==, tarball: file:projects/calling.tgz}
+    resolution: {integrity: sha512-D3znOGRdSUKphg8rowCjz7bNkl1KnS2+cJl1i3vmX2WF06c8fzBpj7sUT4TZWAuFqFJyCY3HqBGgovHkzjBfyg==, tarball: file:projects/calling.tgz}
     id: file:projects/calling.tgz
     name: '@rush-temp/calling'
     version: 0.0.0
@@ -18824,7 +18819,7 @@ packages:
     dev: false
 
   file:projects/callwithchat.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-5ADL5y1O9W6jZ1PPDdD7gdHde/L2zNJ5Mgx926jRg0ni/q5oNhJ63FKngxHbY7ZcmuCdLeocjXvg9FX05VR19g==, tarball: file:projects/callwithchat.tgz}
+    resolution: {integrity: sha512-jVTsNvPavZwL7ZK0VcvIE7ZVaDtQYG5Dj/4PctO42s84vQNAmB/DK5i5ueZfMnKB+ijI7WYmo8EJvB5vI9r/nw==, tarball: file:projects/callwithchat.tgz}
     id: file:projects/callwithchat.tgz
     name: '@rush-temp/callwithchat'
     version: 0.0.0
@@ -18913,7 +18908,7 @@ packages:
     dev: false
 
   file:projects/chat-component-bindings.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-Gv2ZvGbldmIOM2KKWro7wGk7XyOGJAVkGVeAdWEXSQq7GwZLrK/Z3oOhRXuteT322bLyty33E2rbOo1hadVHdw==, tarball: file:projects/chat-component-bindings.tgz}
+    resolution: {integrity: sha512-2N2RoI0ZbDN+f47ndx4iX27/VmAR/ndD6XKQISL/hyvXYc8jkz+Shq674pNAsMrrQX+ffDUB93nyQWSsGESfpA==, tarball: file:projects/chat-component-bindings.tgz}
     id: file:projects/chat-component-bindings.tgz
     name: '@rush-temp/chat-component-bindings'
     version: 0.0.0
@@ -18957,7 +18952,7 @@ packages:
     dev: false
 
   file:projects/chat-stateful-client.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-R+XSK/hMU0f1Ho6Vt0uiFxcelTtHdDaezR0fEIf890qB4Ebk1Uc8JX7wubHhrcBAO07D2zqr3Sgp9OMpTXUsJQ==, tarball: file:projects/chat-stateful-client.tgz}
+    resolution: {integrity: sha512-6ocXgfsUwOZ2vTN02UuBGCJhnMamsV9OK7SSJ6NaFmLo1pe2la9Gh04POa0jwBxRMKmMAChnL7/NlQhmAT4KzQ==, tarball: file:projects/chat-stateful-client.tgz}
     id: file:projects/chat-stateful-client.tgz
     name: '@rush-temp/chat-stateful-client'
     version: 0.0.0
@@ -19009,7 +19004,7 @@ packages:
     dev: false
 
   file:projects/chat.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-vZGPqaD/srX8eGBtxeNuV5smIGlYhGFCbfJ4KxVrGmPhZdoqNgIsJ7w/BeSdvB708nCFi1h7YfhU5BgYo+5uBw==, tarball: file:projects/chat.tgz}
+    resolution: {integrity: sha512-q/iJ7MPA/RE9sK3yBkxf+dtgBNaigOSF94aH59Efq8TIPmxPyrNgeQGxx1jRN5fnzLBzeqZ2SCbdpl8K2PQV3Q==, tarball: file:projects/chat.tgz}
     id: file:projects/chat.tgz
     name: '@rush-temp/chat'
     version: 0.0.0
@@ -19093,7 +19088,7 @@ packages:
     dev: false
 
   file:projects/check-treeshaking.tgz:
-    resolution: {integrity: sha512-Lo+ArVocraDWr26m6H972qTgKKxMA3jThACAk4bq2gPXGG/bbBOzfbaFI9aSv+EkAgrBaBxDsrFUlvd1jZ33DQ==, tarball: file:projects/check-treeshaking.tgz}
+    resolution: {integrity: sha512-cTqr/Qrh3pQeoWg9eGNkP9O0iVUx83xw4c03H0tSdKo2j5KwrWlO27K0Tb/XfZf54TrYjt3Bb4LGKxNOK58o4w==, tarball: file:projects/check-treeshaking.tgz}
     name: '@rush-temp/check-treeshaking'
     version: 0.0.0
     dependencies:
@@ -19121,7 +19116,7 @@ packages:
     dev: false
 
   file:projects/check-typescript-regression.tgz:
-    resolution: {integrity: sha512-+3Dt0l2fcUQr4QKglwC0ghXp6qFtN8c+lCLL/Rg9tzo1n8DGpXWgqQddqo83p6+Ap9VSYb7hc6D0hBAjxfUVrg==, tarball: file:projects/check-typescript-regression.tgz}
+    resolution: {integrity: sha512-DnONaezOVWo7DSwwd1yCbNIz9QZLNhkyC3KWuRPA/iU32BBYi57wk5luMbQD9yMiLf+CwVxLNribVOP9V5S3CA==, tarball: file:projects/check-typescript-regression.tgz}
     name: '@rush-temp/check-typescript-regression'
     version: 0.0.0
     dependencies:
@@ -19138,7 +19133,7 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-xSA2c0tgNOhIv3H0omYlji1Z/RWWXjiLpm5yiZMw/eJ0nA7X6DjsNqmIJav/vxKgOcLn6VBytfy2BOWdNGOHXA==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-xf+8p+rwwFIBQ3MVQEBWuy74+luJH/zLrWerYbCzSSMfJFU8kVikgAc4K9jJ7BIdMNk6rC8XXNEkyqRO11y9gw==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
@@ -19233,7 +19228,7 @@ packages:
     dev: false
 
   file:projects/component-examples.tgz:
-    resolution: {integrity: sha512-JpAkYETesoKaj4E7090N7j5yfFn8KUM25bnANW5Eq1AEgTE8j+LOQVg2zyXvi684mnNQ216Ma1V2gyndegUVZA==, tarball: file:projects/component-examples.tgz}
+    resolution: {integrity: sha512-0yIVrJdW1RDN1+NScBXvkktSPIq99CtGe8mOjRNRcdmV6Y8liEzc2+cL+VfIrA4gwx5w0FD8AAdnV0kdAsYnnw==, tarball: file:projects/component-examples.tgz}
     name: '@rush-temp/component-examples'
     version: 0.0.0
     dependencies:
@@ -19315,7 +19310,7 @@ packages:
     dev: false
 
   file:projects/fake-backends.tgz(ts-node@9.1.1)(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-rLdJL+4v/fMSZtXDO9n/is4bzMMVtzdkWJ25J5qYNuNAg4LfYcPmxxkq+6Ie/bKY+MpXxscf1LkWRrSpSPHspw==, tarball: file:projects/fake-backends.tgz}
+    resolution: {integrity: sha512-0vEBP1wpsDCjRQ0M+aLnhOjSHKo64lBVL+SVaJ8mCnN40MXjXZbQWkuG6l/TFQH6cWcMsbPTmiEvDAB+phSQTg==, tarball: file:projects/fake-backends.tgz}
     id: file:projects/fake-backends.tgz
     name: '@rush-temp/fake-backends'
     version: 0.0.0
@@ -19403,7 +19398,7 @@ packages:
     dev: false
 
   file:projects/react-components.tgz(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-U6C+aV4CZ2Jm1jFb3OHNof7LjX6TVxOCnx1S4ek7RY5JAxfntGCmvLe9IG+4SmLNz5gjhYbrDsrhutNmLXVwfw==, tarball: file:projects/react-components.tgz}
+    resolution: {integrity: sha512-A+iy/nmwSovWofo+UjjwYB/ivw57yuPKk9NKp/sbd+sGl9NnbMrtn5rtSQbKUS/HRX5OODImoVIpAJ4fXOFy8w==, tarball: file:projects/react-components.tgz}
     id: file:projects/react-components.tgz
     name: '@rush-temp/react-components'
     version: 0.0.0
@@ -19501,7 +19496,7 @@ packages:
     dev: false
 
   file:projects/react-composites.tgz:
-    resolution: {integrity: sha512-y9xGGotPA7IxObbLlvzH5fi9zI2x82Zic9KuumGvzVIWm1qW8KKGTvFg32V2qjipKQ7JTemW2/NDh+RIKHGhJQ==, tarball: file:projects/react-composites.tgz}
+    resolution: {integrity: sha512-mc06RgandGOKVBfN6YDbMIn72l5XS441eToaaLlMtu8nKtTOFYE4Vs3dBSGYLmFrn1hel2ZLw6JstUC+xJxEMA==, tarball: file:projects/react-composites.tgz}
     name: '@rush-temp/react-composites'
     version: 0.0.0
     dependencies:
@@ -19523,7 +19518,7 @@ packages:
       '@fluentui/react-icons': 2.0.216(react@18.2.0)
       '@microsoft/api-documenter': 7.12.22
       '@microsoft/api-extractor': 7.18.21
-      '@playwright/test': 1.38.0
+      '@playwright/test': 1.35.1
       '@testing-library/jest-dom': 5.17.0
       '@testing-library/react': 14.0.0(react-dom@18.2.0)(react@18.2.0)
       '@types/copy-webpack-plugin': 6.4.3
@@ -19620,7 +19615,7 @@ packages:
     dev: false
 
   file:projects/sample-automation-tests.tgz:
-    resolution: {integrity: sha512-SzWQO1KXGLbulT2V9U0JoEQ+WJdd3rTXvGbCnFUR4CVYi3YIwR4iHdlodYPe1LNSxDhDAVlCsNZEVjauU0CJeg==, tarball: file:projects/sample-automation-tests.tgz}
+    resolution: {integrity: sha512-2ldxN0qLZCBO8XnRxvK2d+fsIzALkk240YROK7JoEa/9G9pKbKiSvC+mC8dBGzjAAg/kRufxoy65P5BirpPujA==, tarball: file:projects/sample-automation-tests.tgz}
     name: '@rush-temp/sample-automation-tests'
     version: 0.0.0
     dependencies:
@@ -19628,7 +19623,7 @@ packages:
       '@azure/communication-chat': 1.4.0-beta.1
       '@azure/communication-common': 3.0.0-beta.1
       '@azure/communication-identity': 1.2.0
-      '@playwright/test': 1.38.0
+      '@playwright/test': 1.35.1
       '@types/node': 16.18.52
       '@types/node-static': 0.7.8
       cross-env: 7.0.3
@@ -19645,7 +19640,7 @@ packages:
     dev: false
 
   file:projects/sample-static-html-composites.tgz:
-    resolution: {integrity: sha512-G59l6oAqMKxgyz0QVfYZxNKgdGG9Jgtxt1QfJ86KOd+YBgvzjHXGallaAZMACJSbfG4rK3LdS/UzzqzxzpbMSw==, tarball: file:projects/sample-static-html-composites.tgz}
+    resolution: {integrity: sha512-Rs8h3aDQ7Ch9n0k6bhe9rFkITdkRlt8Qvusly3IZtFEXMF/8GPzL6YlactDlSoothKZCH07+i67xEin79IvLnQ==, tarball: file:projects/sample-static-html-composites.tgz}
     name: '@rush-temp/sample-static-html-composites'
     version: 0.0.0
     dependencies:
@@ -19656,7 +19651,7 @@ packages:
       '@babel/cli': 7.22.15(@babel/core@7.22.20)
       '@babel/core': 7.22.20
       '@fluentui/react': 8.111.2(@types/react-dom@18.2.1)(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)
-      '@playwright/test': 1.38.0
+      '@playwright/test': 1.35.1
       '@types/copy-webpack-plugin': 6.4.3
       '@types/node': 16.18.52
       '@types/node-static': 0.7.8
@@ -19766,7 +19761,7 @@ packages:
     dev: false
 
   file:projects/storybook.tgz(history@5.3.0)(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-atgnXu063a7EezDFDqUAhcAARRXQ9va5nqizD2ISzGyq4Y73GCXn1fLML2fYq+ir9RF4kLgx+Bvnjvm4KjFx5w==, tarball: file:projects/storybook.tgz}
+    resolution: {integrity: sha512-I/BTQwSgad4TJ276McCJCUnWN9sEa6WlymWn2i8kDJTZmt39Gws1wMEpU9n3OB5tatblF19v6azXeu/CHYoCQA==, tarball: file:projects/storybook.tgz}
     id: file:projects/storybook.tgz
     name: '@rush-temp/storybook'
     version: 0.0.0

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -277,7 +277,7 @@ packages:
       '@types/node-fetch': 2.6.5
       '@types/tunnel': 0.0.3
       form-data: 4.0.0
-      node-fetch: 2.6.7
+      node-fetch: 2.7.0
       process: 0.11.10
       tslib: 2.6.2
       tunnel: 0.0.6
@@ -839,7 +839,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.12.9)
     dev: false
@@ -2365,7 +2365,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       jest-mock: 29.7.0
     dev: false
 
@@ -2392,7 +2392,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -2535,7 +2535,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/yargs': 15.0.15
       chalk: 4.1.2
     dev: false
@@ -2992,12 +2992,15 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: false
 
-  /@playwright/test@1.38.0:
-    resolution: {integrity: sha512-xis/RXXsLxwThKnlIXouxmIvvT3zvQj1JE39GsNieMUrMpb3/GySHDh2j8itCG22qKVD4MYLBp7xB73cUW/UUw==}
+  /@playwright/test@1.35.1:
+    resolution: {integrity: sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
-      playwright: 1.38.0
+      '@types/node': 20.6.2
+      playwright-core: 1.35.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: false
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.11(react-refresh@0.11.0)(webpack@5.76.0):
@@ -5083,13 +5086,13 @@ packages:
     resolution: {integrity: sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==}
     dependencies:
       '@types/connect': 3.4.36
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/bonjour@3.5.11:
     resolution: {integrity: sha512-isGhjmBtLIxdHBDl2xGwUzEM8AOyOvWsADWq7rqirdi/ZQoHnLWErHvsThcEzTX8juDRiZtzp2Qkv5bgNh6mAg==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/classnames@2.3.1:
@@ -5103,13 +5106,13 @@ packages:
     resolution: {integrity: sha512-iaQslNbARe8fctL5Lk+DsmgWOM83lM+7FzP0eQUJs1jd3kBE8NWqBTIT2S8SqQOJjxvt2eyIjpOuYeRXq2AdMw==}
     dependencies:
       '@types/express-serve-static-core': 4.17.36
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/connect@3.4.36:
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/cookie-parser@1.4.4:
@@ -5131,7 +5134,7 @@ packages:
   /@types/cors@2.8.14:
     resolution: {integrity: sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/dompurify@3.0.2:
@@ -5144,13 +5147,13 @@ packages:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
       '@types/eslint': 8.44.2
-      '@types/estree': 0.0.51
+      '@types/estree': 1.0.1
     dev: false
 
   /@types/eslint@8.44.2:
     resolution: {integrity: sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==}
     dependencies:
-      '@types/estree': 0.0.51
+      '@types/estree': 1.0.1
       '@types/json-schema': 7.0.13
     dev: false
 
@@ -5169,7 +5172,7 @@ packages:
   /@types/express-serve-static-core@4.17.36:
     resolution: {integrity: sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/qs': 6.9.8
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -5188,20 +5191,20 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/glob@8.1.0:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/hast@2.3.6:
@@ -5229,7 +5232,7 @@ packages:
   /@types/http-proxy@1.17.12:
     resolution: {integrity: sha512-kQtujO08dVtQ2wXAuSFfk9ASy3sug4+ogFR8Kd8UgP8PEuc1/G/8yjYRmp//PcDNJEUKOza/MrQu15bouEUCiw==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/is-function@1.0.1:
@@ -5275,7 +5278,7 @@ packages:
   /@types/jsdom@20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/tough-cookie': 4.0.3
       parse5: 7.1.2
     dev: false
@@ -5321,7 +5324,7 @@ packages:
   /@types/morgan@1.9.5:
     resolution: {integrity: sha512-5TgfIWm0lcTGnbCZExwc19dCOMOMmAiiBZQj8Ko3NRxsVDgRxf+AEGRQTqNVA5Yh2xfdWp4clbAEMbYP+jkOqg==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/node-fetch@2.6.5:
@@ -5335,7 +5338,7 @@ packages:
     resolution: {integrity: sha512-x7sdQAUeY4ePtiId8xbizFcADxFbJrJh7xk1Hepns884rDOflU/JRAf2cRSIrlf0fv8TSAK/XKbdKEKpC3K94A==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/node@10.17.13:
@@ -5385,7 +5388,7 @@ packages:
   /@types/puppeteer@5.4.7:
     resolution: {integrity: sha512-JdGWZZYL0vKapXF4oQTC5hLVNfOgdPrqeZ1BiQnGk5cB7HeE91EWUiTdVSdQPobRN8rIcdffjiOgCYJ/S8QrnQ==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/qs@6.9.8:
@@ -5428,7 +5431,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/serve-index@1.9.1:
@@ -5442,13 +5445,13 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.2
       '@types/mime': 3.0.1
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/sockjs@0.3.33:
     resolution: {integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/source-list-map@0.1.2:
@@ -5471,7 +5474,7 @@ packages:
     resolution: {integrity: sha512-LOWgpacIV8GHhrsQU+QMZuomfqXiqzz3ILLkCtKx3Us6AmomFViuzKT9D693QTKgyut2oCytMG8/efOop+DB+w==}
     dependencies:
       '@types/cookiejar': 2.1.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/supertest@2.0.12:
@@ -5525,7 +5528,7 @@ packages:
   /@types/webpack-node-externals@2.5.3(webpack-cli@4.10.0):
     resolution: {integrity: sha512-A9JxaR8QXoYT95egET4AmCFuChyTlP8d18ZAnmSHuIMsFdS7QlCQQ8pmN/+FHgLIkm+ViE/VngltT5avLACY9A==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       webpack: 5.76.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - '@swc/core'
@@ -5537,7 +5540,7 @@ packages:
   /@types/webpack-sources@3.2.0:
     resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
     dev: false
@@ -5545,7 +5548,7 @@ packages:
   /@types/webpack@4.41.33:
     resolution: {integrity: sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       '@types/tapable': 1.0.9
       '@types/uglify-js': 3.17.2
       '@types/webpack-sources': 3.2.0
@@ -5556,7 +5559,7 @@ packages:
   /@types/ws@8.5.5:
     resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
 
   /@types/yargs-parser@21.0.0:
@@ -5585,7 +5588,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
     dev: false
     optional: true
 
@@ -6974,6 +6977,7 @@ packages:
 
   /bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: false
@@ -9694,7 +9698,7 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.4(supports-color@5.5.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -9915,6 +9919,7 @@ packages:
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -11048,7 +11053,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.1
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -12057,7 +12062,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -12104,7 +12109,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12125,7 +12130,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.6
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12211,7 +12216,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       jest-util: 29.7.0
     dev: false
 
@@ -12351,7 +12356,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       graceful-fs: 4.2.11
     dev: false
 
@@ -12419,7 +12424,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       chalk: 4.1.2
       graceful-fs: 4.2.11
       is-ci: 2.0.0
@@ -12468,7 +12473,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: false
@@ -12477,7 +12482,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -12486,7 +12491,7 @@ packages:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 16.18.52
+      '@types/node': 20.6.2
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -14318,20 +14323,10 @@ packages:
       find-up: 5.0.0
     dev: false
 
-  /playwright-core@1.38.0:
-    resolution: {integrity: sha512-f8z1y8J9zvmHoEhKgspmCvOExF2XdcxMW8jNRuX4vkQFrzV4MlZ55iwb5QeyiFQgOFCUolXiRHgpjSEnqvO48g==}
+  /playwright-core@1.35.1:
+    resolution: {integrity: sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==}
     engines: {node: '>=16'}
     hasBin: true
-    dev: false
-
-  /playwright@1.38.0:
-    resolution: {integrity: sha512-fJGw+HO0YY+fU/F1N57DMO+TmXHTrmr905J05zwAQE9xkuwP/QLDk63rVhmyxh03dYnEhnRbsdbH9B0UVVRB3A==}
-    engines: {node: '>=16'}
-    hasBin: true
-    dependencies:
-      playwright-core: 1.38.0
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: false
 
   /please-upgrade-node@3.2.0:
@@ -15016,7 +15011,7 @@ packages:
     dependencies:
       object-assign: 4.1.1
       react: 18.2.0
-      react-is: 17.0.2
+      react-is: 18.2.0
     dev: false
 
   /react-test-renderer@17.0.2(react@18.2.0):
@@ -18619,7 +18614,7 @@ packages:
     dev: false
 
   file:projects/calling-component-bindings.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-Q3sc5Wzqheus5Y3R+MViQp99mk7jvKJNqG1qQifW8cGjONQqHUfXSden5tgqxqRGldYW1qE1fatM8SKCbkOj+A==, tarball: file:projects/calling-component-bindings.tgz}
+    resolution: {integrity: sha512-Y1qQMZICv8BIss+mLvNQY+TzA00/zQj3/koTwLSL568GRP+cvvO7qRyaViM5E8B29lMXlW6yXODlKkTEPhjo7A==, tarball: file:projects/calling-component-bindings.tgz}
     id: file:projects/calling-component-bindings.tgz
     name: '@rush-temp/calling-component-bindings'
     version: 0.0.0
@@ -18668,7 +18663,7 @@ packages:
     dev: false
 
   file:projects/calling-stateful-client.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-kzE/Q8BSYCLk1YZRmf4pQrsGfmZoQ++ZTpqlsGsDzyonmRrurqXWJvCibK5Y1bANOqA3szjfsTLCxIj5awTh5A==, tarball: file:projects/calling-stateful-client.tgz}
+    resolution: {integrity: sha512-dt66HBmwWqY5pgh2AXHA2CcDH8Ab7UJKlXiRHzcwSdTVXi9X1782Xt25Wcnm7Zs0J4i8uBlGFuB0KBAsGI70oA==, tarball: file:projects/calling-stateful-client.tgz}
     id: file:projects/calling-stateful-client.tgz
     name: '@rush-temp/calling-stateful-client'
     version: 0.0.0
@@ -18717,7 +18712,7 @@ packages:
     dev: false
 
   file:projects/calling.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-Uvi6KhV7uV0Nwwcc1IQlA4eX85TZaC3yKZhNZ/D0gVnMYv6EqsBi2IGMDcOrOXGTG2QEPBYig+qPGb6JrKyciw==, tarball: file:projects/calling.tgz}
+    resolution: {integrity: sha512-D3znOGRdSUKphg8rowCjz7bNkl1KnS2+cJl1i3vmX2WF06c8fzBpj7sUT4TZWAuFqFJyCY3HqBGgovHkzjBfyg==, tarball: file:projects/calling.tgz}
     id: file:projects/calling.tgz
     name: '@rush-temp/calling'
     version: 0.0.0
@@ -18808,7 +18803,7 @@ packages:
     dev: false
 
   file:projects/callwithchat.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-5ADL5y1O9W6jZ1PPDdD7gdHde/L2zNJ5Mgx926jRg0ni/q5oNhJ63FKngxHbY7ZcmuCdLeocjXvg9FX05VR19g==, tarball: file:projects/callwithchat.tgz}
+    resolution: {integrity: sha512-jVTsNvPavZwL7ZK0VcvIE7ZVaDtQYG5Dj/4PctO42s84vQNAmB/DK5i5ueZfMnKB+ijI7WYmo8EJvB5vI9r/nw==, tarball: file:projects/callwithchat.tgz}
     id: file:projects/callwithchat.tgz
     name: '@rush-temp/callwithchat'
     version: 0.0.0
@@ -18897,7 +18892,7 @@ packages:
     dev: false
 
   file:projects/chat-component-bindings.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-Gv2ZvGbldmIOM2KKWro7wGk7XyOGJAVkGVeAdWEXSQq7GwZLrK/Z3oOhRXuteT322bLyty33E2rbOo1hadVHdw==, tarball: file:projects/chat-component-bindings.tgz}
+    resolution: {integrity: sha512-2N2RoI0ZbDN+f47ndx4iX27/VmAR/ndD6XKQISL/hyvXYc8jkz+Shq674pNAsMrrQX+ffDUB93nyQWSsGESfpA==, tarball: file:projects/chat-component-bindings.tgz}
     id: file:projects/chat-component-bindings.tgz
     name: '@rush-temp/chat-component-bindings'
     version: 0.0.0
@@ -18941,7 +18936,7 @@ packages:
     dev: false
 
   file:projects/chat-stateful-client.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-R+XSK/hMU0f1Ho6Vt0uiFxcelTtHdDaezR0fEIf890qB4Ebk1Uc8JX7wubHhrcBAO07D2zqr3Sgp9OMpTXUsJQ==, tarball: file:projects/chat-stateful-client.tgz}
+    resolution: {integrity: sha512-6ocXgfsUwOZ2vTN02UuBGCJhnMamsV9OK7SSJ6NaFmLo1pe2la9Gh04POa0jwBxRMKmMAChnL7/NlQhmAT4KzQ==, tarball: file:projects/chat-stateful-client.tgz}
     id: file:projects/chat-stateful-client.tgz
     name: '@rush-temp/chat-stateful-client'
     version: 0.0.0
@@ -18993,7 +18988,7 @@ packages:
     dev: false
 
   file:projects/chat.tgz(ts-node@9.1.1):
-    resolution: {integrity: sha512-vZGPqaD/srX8eGBtxeNuV5smIGlYhGFCbfJ4KxVrGmPhZdoqNgIsJ7w/BeSdvB708nCFi1h7YfhU5BgYo+5uBw==, tarball: file:projects/chat.tgz}
+    resolution: {integrity: sha512-q/iJ7MPA/RE9sK3yBkxf+dtgBNaigOSF94aH59Efq8TIPmxPyrNgeQGxx1jRN5fnzLBzeqZ2SCbdpl8K2PQV3Q==, tarball: file:projects/chat.tgz}
     id: file:projects/chat.tgz
     name: '@rush-temp/chat'
     version: 0.0.0
@@ -19077,7 +19072,7 @@ packages:
     dev: false
 
   file:projects/check-treeshaking.tgz:
-    resolution: {integrity: sha512-Lo+ArVocraDWr26m6H972qTgKKxMA3jThACAk4bq2gPXGG/bbBOzfbaFI9aSv+EkAgrBaBxDsrFUlvd1jZ33DQ==, tarball: file:projects/check-treeshaking.tgz}
+    resolution: {integrity: sha512-cTqr/Qrh3pQeoWg9eGNkP9O0iVUx83xw4c03H0tSdKo2j5KwrWlO27K0Tb/XfZf54TrYjt3Bb4LGKxNOK58o4w==, tarball: file:projects/check-treeshaking.tgz}
     name: '@rush-temp/check-treeshaking'
     version: 0.0.0
     dependencies:
@@ -19105,7 +19100,7 @@ packages:
     dev: false
 
   file:projects/check-typescript-regression.tgz:
-    resolution: {integrity: sha512-+3Dt0l2fcUQr4QKglwC0ghXp6qFtN8c+lCLL/Rg9tzo1n8DGpXWgqQddqo83p6+Ap9VSYb7hc6D0hBAjxfUVrg==, tarball: file:projects/check-typescript-regression.tgz}
+    resolution: {integrity: sha512-DnONaezOVWo7DSwwd1yCbNIz9QZLNhkyC3KWuRPA/iU32BBYi57wk5luMbQD9yMiLf+CwVxLNribVOP9V5S3CA==, tarball: file:projects/check-typescript-regression.tgz}
     name: '@rush-temp/check-typescript-regression'
     version: 0.0.0
     dependencies:
@@ -19122,7 +19117,7 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-xSA2c0tgNOhIv3H0omYlji1Z/RWWXjiLpm5yiZMw/eJ0nA7X6DjsNqmIJav/vxKgOcLn6VBytfy2BOWdNGOHXA==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-xf+8p+rwwFIBQ3MVQEBWuy74+luJH/zLrWerYbCzSSMfJFU8kVikgAc4K9jJ7BIdMNk6rC8XXNEkyqRO11y9gw==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
@@ -19217,7 +19212,7 @@ packages:
     dev: false
 
   file:projects/component-examples.tgz:
-    resolution: {integrity: sha512-JpAkYETesoKaj4E7090N7j5yfFn8KUM25bnANW5Eq1AEgTE8j+LOQVg2zyXvi684mnNQ216Ma1V2gyndegUVZA==, tarball: file:projects/component-examples.tgz}
+    resolution: {integrity: sha512-0yIVrJdW1RDN1+NScBXvkktSPIq99CtGe8mOjRNRcdmV6Y8liEzc2+cL+VfIrA4gwx5w0FD8AAdnV0kdAsYnnw==, tarball: file:projects/component-examples.tgz}
     name: '@rush-temp/component-examples'
     version: 0.0.0
     dependencies:
@@ -19299,7 +19294,7 @@ packages:
     dev: false
 
   file:projects/fake-backends.tgz(ts-node@9.1.1)(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-rLdJL+4v/fMSZtXDO9n/is4bzMMVtzdkWJ25J5qYNuNAg4LfYcPmxxkq+6Ie/bKY+MpXxscf1LkWRrSpSPHspw==, tarball: file:projects/fake-backends.tgz}
+    resolution: {integrity: sha512-0vEBP1wpsDCjRQ0M+aLnhOjSHKo64lBVL+SVaJ8mCnN40MXjXZbQWkuG6l/TFQH6cWcMsbPTmiEvDAB+phSQTg==, tarball: file:projects/fake-backends.tgz}
     id: file:projects/fake-backends.tgz
     name: '@rush-temp/fake-backends'
     version: 0.0.0
@@ -19387,7 +19382,7 @@ packages:
     dev: false
 
   file:projects/react-components.tgz(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-U6C+aV4CZ2Jm1jFb3OHNof7LjX6TVxOCnx1S4ek7RY5JAxfntGCmvLe9IG+4SmLNz5gjhYbrDsrhutNmLXVwfw==, tarball: file:projects/react-components.tgz}
+    resolution: {integrity: sha512-A+iy/nmwSovWofo+UjjwYB/ivw57yuPKk9NKp/sbd+sGl9NnbMrtn5rtSQbKUS/HRX5OODImoVIpAJ4fXOFy8w==, tarball: file:projects/react-components.tgz}
     id: file:projects/react-components.tgz
     name: '@rush-temp/react-components'
     version: 0.0.0
@@ -19485,7 +19480,7 @@ packages:
     dev: false
 
   file:projects/react-composites.tgz:
-    resolution: {integrity: sha512-y9xGGotPA7IxObbLlvzH5fi9zI2x82Zic9KuumGvzVIWm1qW8KKGTvFg32V2qjipKQ7JTemW2/NDh+RIKHGhJQ==, tarball: file:projects/react-composites.tgz}
+    resolution: {integrity: sha512-mc06RgandGOKVBfN6YDbMIn72l5XS441eToaaLlMtu8nKtTOFYE4Vs3dBSGYLmFrn1hel2ZLw6JstUC+xJxEMA==, tarball: file:projects/react-composites.tgz}
     name: '@rush-temp/react-composites'
     version: 0.0.0
     dependencies:
@@ -19507,7 +19502,7 @@ packages:
       '@fluentui/react-icons': 2.0.216(react@18.2.0)
       '@microsoft/api-documenter': 7.12.22
       '@microsoft/api-extractor': 7.18.21
-      '@playwright/test': 1.38.0
+      '@playwright/test': 1.35.1
       '@testing-library/jest-dom': 5.17.0
       '@testing-library/react': 14.0.0(react-dom@18.2.0)(react@18.2.0)
       '@types/copy-webpack-plugin': 6.4.3
@@ -19604,7 +19599,7 @@ packages:
     dev: false
 
   file:projects/sample-automation-tests.tgz:
-    resolution: {integrity: sha512-SzWQO1KXGLbulT2V9U0JoEQ+WJdd3rTXvGbCnFUR4CVYi3YIwR4iHdlodYPe1LNSxDhDAVlCsNZEVjauU0CJeg==, tarball: file:projects/sample-automation-tests.tgz}
+    resolution: {integrity: sha512-2ldxN0qLZCBO8XnRxvK2d+fsIzALkk240YROK7JoEa/9G9pKbKiSvC+mC8dBGzjAAg/kRufxoy65P5BirpPujA==, tarball: file:projects/sample-automation-tests.tgz}
     name: '@rush-temp/sample-automation-tests'
     version: 0.0.0
     dependencies:
@@ -19612,7 +19607,7 @@ packages:
       '@azure/communication-chat': 1.3.2
       '@azure/communication-common': 2.2.1
       '@azure/communication-identity': 1.2.0
-      '@playwright/test': 1.38.0
+      '@playwright/test': 1.35.1
       '@types/node': 16.18.52
       '@types/node-static': 0.7.8
       cross-env: 7.0.3
@@ -19629,7 +19624,7 @@ packages:
     dev: false
 
   file:projects/sample-static-html-composites.tgz:
-    resolution: {integrity: sha512-G59l6oAqMKxgyz0QVfYZxNKgdGG9Jgtxt1QfJ86KOd+YBgvzjHXGallaAZMACJSbfG4rK3LdS/UzzqzxzpbMSw==, tarball: file:projects/sample-static-html-composites.tgz}
+    resolution: {integrity: sha512-Rs8h3aDQ7Ch9n0k6bhe9rFkITdkRlt8Qvusly3IZtFEXMF/8GPzL6YlactDlSoothKZCH07+i67xEin79IvLnQ==, tarball: file:projects/sample-static-html-composites.tgz}
     name: '@rush-temp/sample-static-html-composites'
     version: 0.0.0
     dependencies:
@@ -19640,7 +19635,7 @@ packages:
       '@babel/cli': 7.22.15(@babel/core@7.22.20)
       '@babel/core': 7.22.20
       '@fluentui/react': 8.111.2(@types/react-dom@18.2.1)(@types/react@18.2.0)(react-dom@18.2.0)(react@18.2.0)
-      '@playwright/test': 1.38.0
+      '@playwright/test': 1.35.1
       '@types/copy-webpack-plugin': 6.4.3
       '@types/node': 16.18.52
       '@types/node-static': 0.7.8
@@ -19750,7 +19745,7 @@ packages:
     dev: false
 
   file:projects/storybook.tgz(history@5.3.0)(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-atgnXu063a7EezDFDqUAhcAARRXQ9va5nqizD2ISzGyq4Y73GCXn1fLML2fYq+ir9RF4kLgx+Bvnjvm4KjFx5w==, tarball: file:projects/storybook.tgz}
+    resolution: {integrity: sha512-I/BTQwSgad4TJ276McCJCUnWN9sEa6WlymWn2i8kDJTZmt39Gws1wMEpU9n3OB5tatblF19v6azXeu/CHYoCQA==, tarball: file:projects/storybook.tgz}
     id: file:projects/storybook.tgz
     name: '@rush-temp/storybook'
     version: 0.0.0

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -93,7 +93,7 @@
     "@internal/fake-backends": "1.8.1-beta.0",
     "@microsoft/api-documenter": "~7.12.11",
     "@microsoft/api-extractor": "~7.18.0",
-    "@playwright/test": "^1.35.1",
+    "@playwright/test": "~1.35.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@types/copy-webpack-plugin": "^6.4.0",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@azure/communication-identity": "^1.2.0",
     "@babel/core": "^7.16.0",
-    "@playwright/test": "^1.35.1",
+    "@playwright/test": "~1.35.1",
     "@types/copy-webpack-plugin": "^6.4.0",
     "@types/node": "^16.11.7",
     "@types/node-static": "^0.7.7",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@azure/communication-identity": "^1.2.0",
-    "@playwright/test": "^1.35.1",
+    "@playwright/test": "~1.35.1",
     "@types/node": "^16.11.7",
     "@types/node-static": "^0.7.7",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
^ changes had us getting a new minor version of playwright this returns it to ~
# Why
<!--- What problem does this change solve? -->
something in the new minor version `1.38.1`  breaks the static tests
![image](https://github.com/Azure/communication-ui-library/assets/94866715/fe96d70b-5b50-4155-958b-8afe3677c7bd)

<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated the package downgrade fixes the tests locally