### PR TITLE
[FluentUI] RTL Fix

### DIFF
--- a/packages/react-components/src/theming/FluentThemeProvider.tsx
+++ b/packages/react-components/src/theming/FluentThemeProvider.tsx
@@ -48,6 +48,7 @@ const defaultTheme: Theme = {
 
 /** Theme context for library's react components */
 const ThemeContext = createContext<Theme>(defaultTheme);
+const ProviderContext = createContext<boolean>(false);
 
 /**
  * Provider to apply a Fluent theme across this library's react components.
@@ -60,15 +61,28 @@ const ThemeContext = createContext<Theme>(defaultTheme);
 export const FluentThemeProvider = (props: FluentThemeProviderProps): JSX.Element => {
   const { fluentTheme, rtl, children } = props;
 
+  /**
+   * Pass only the children if we previously wrapped.
+   * This is to prevent the provider from being applied
+   * multiple times and wiping out configuration like RTL
+   * FluentThemeProvider
+   */
+  const alreadyWrapped = useProvider();
+  if (alreadyWrapped) {
+    return <>{children}</>;
+  }
+
   let fluentV8Theme: Theme = mergeThemes(defaultTheme, fluentTheme);
-  // merge in rtl from FluentThemeProviderProps
   fluentV8Theme = mergeThemes(fluentV8Theme, { rtl });
+
   return (
-    <ThemeContext.Provider value={fluentV8Theme}>
-      <ThemeProvider theme={fluentV8Theme} className={wrapper}>
-        {children}
-      </ThemeProvider>
-    </ThemeContext.Provider>
+    <ProviderContext.Provider value={true}>
+      <ThemeContext.Provider value={fluentV8Theme}>
+        <ThemeProvider theme={fluentV8Theme} className={wrapper}>
+          {children}
+        </ThemeProvider>
+      </ThemeContext.Provider>
+    </ProviderContext.Provider>
   );
 };
 
@@ -78,3 +92,10 @@ export const FluentThemeProvider = (props: FluentThemeProviderProps): JSX.Elemen
  * @public
  */
 export const useTheme = (): Theme => useContext(ThemeContext);
+
+/**
+ * This is used to prevent the provider from being applied multiple times.
+ *
+ * @private
+ */
+const useProvider = (): boolean => useContext(ProviderContext);


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

If a fluentUI theme is applied outside of the composite, it will be overidden by the fluentUI theme in the baseComposite. Props like 'rtl' will be lost then if not also given to chat composite. Added logic to prevent the provider from being applied multiple times.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->