### PR TITLE
Fix minor typo in storybook doc

### DIFF
--- a/packages/storybook/stories/Stateful Client/SettingUpReactHooks.stories.mdx
+++ b/packages/storybook/stories/Stateful Client/SettingUpReactHooks.stories.mdx
@@ -39,7 +39,7 @@ ReactDOM.render(
 
 ### Calling
 
-For your Chat app, use the `CallClientProvider`, `CallAgentProvider` and `CallProvider` to give hooks access to the `CallClient`, `CallAgentClient` and `Call`.
+For your Calling app, use the `CallClientProvider`, `CallAgentProvider` and `CallProvider` to give hooks access to the `CallClient`, `CallAgentClient` and `Call`.
 `statefulCallClient`, `callAgent` and `call` instances need to be passed to the Provider when you wrap your app.
 For more information on creating them, see [Overview](./?path=/docs/statefulclient-overview--page)
 


### PR DESCRIPTION
There is a small typo/copy-paste issue in the Storybook docs about React Hooks:
![image](https://github.com/Azure/communication-ui-library/assets/46465618/ae8de7ca-1d0c-4c69-992b-f1ed49d737bc)
