### PR TITLE
[Bug fix]Decrease captions banner width when screen is too small to prevent more button overlapping with scroll bar 

### DIFF
--- a/change-beta/@azure-communication-react-9a4850dd-bc1a-4842-a3e9-d7c01705b2f7.json
+++ b/change-beta/@azure-communication-react-9a4850dd-bc1a-4842-a3e9-d7c01705b2f7.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Bug fix",
+  "comment": "When screen is too small, decrease captions banner size so scroll bar and more button doesnot overlap",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-9a4850dd-bc1a-4842-a3e9-d7c01705b2f7.json
+++ b/change/@azure-communication-react-9a4850dd-bc1a-4842-a3e9-d7c01705b2f7.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Bug fix",
+  "comment": "When screen is too small, decrease captions banner size so scroll bar and more button doesnot overlap",
+  "packageName": "@azure/communication-react",
+  "email": "carolinecao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/CaptionsBanner.tsx
+++ b/packages/react-composites/src/composites/common/CaptionsBanner.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 /* @conditional-compile-remove(close-captions) */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 /* @conditional-compile-remove(close-captions) */
 import { _CaptionsBanner, _CaptionsBannerStrings } from '@internal/react-components';
 /* @conditional-compile-remove(close-captions) */
@@ -26,8 +26,6 @@ import { useLocale } from '../localization';
 
 /* @conditional-compile-remove(close-captions) */
 const mobileViewBannerWidth = '90%';
-/* @conditional-compile-remove(close-captions) */
-const desktopViewBannerWidth = '35rem';
 
 /** @private */
 export const CaptionsBanner = (props: { isMobile: boolean }): JSX.Element => {
@@ -63,6 +61,23 @@ export const CaptionsBanner = (props: { isMobile: boolean }): JSX.Element => {
   const captionsBannerStrings: _CaptionsBannerStrings = {
     captionsBannerSpinnerText: strings.captionsBannerSpinnerText
   };
+  /* @conditional-compile-remove(close-captions) */
+  const { innerWidth: width } = window;
+  /* @conditional-compile-remove(close-captions) */
+  const [windowWidth, setWindowWidth] = useState(width);
+  /* @conditional-compile-remove(close-captions) */
+  useEffect(() => {
+    function handleResize(): void {
+      setWindowWidth(window.innerWidth);
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  /* @conditional-compile-remove(close-captions) */
+  const desktopViewBannerWidth = windowWidth > 620 ? '35rem' : '80%';
+
   return (
     <>
       {


### PR DESCRIPTION
# What
Decrease captions banner width when screen is too small to prevent more button overlapping with scroll bar 

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3413763

# How Tested

https://github.com/Azure/communication-ui-library/assets/96077406/1ac53032-744e-4d7a-b22c-2e66ae4f1cd6





# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->