### PR TITLE
[BugFix] Update MyMessage options menu to correct size/visibility on mobile browsers

### DIFF
--- a/change-beta/@azure-communication-react-bb6d5502-a3b8-44ea-8d64-ca46a6b009a9.json
+++ b/change-beta/@azure-communication-react-bb6d5502-a3b8-44ea-8d64-ca46a6b009a9.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Mobile Options Menu fix",
+  "comment": "Fix up menu size and appearance on mobile",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-bb6d5502-a3b8-44ea-8d64-ca46a6b009a9.json
+++ b/change/@azure-communication-react-bb6d5502-a3b8-44ea-8d64-ca46a6b009a9.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Mobile Options Menu fix",
+  "comment": "Fix up menu size and appearance on mobile",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
@@ -173,8 +173,6 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
 
   // Track if the action menu was opened by touch - if so we increase the touch targets for the items
   const [wasInteractionByTouch, setWasInteractionByTouch] = useState(false);
-  // `focused` state is used for show/hide actionMenu
-  const [focused, setFocused] = React.useState<boolean>(false);
 
   // The chat message action flyout should target the Chat.Message action menu if clicked,
   // or target the chat message if opened via touch press.
@@ -192,22 +190,20 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
     /* @conditional-compile-remove(data-loss-prevention) */ message.messageType !== 'blocked';
   const [messageReadBy, setMessageReadBy] = useState<{ id: string; displayName: string }[]>([]);
 
-  const actionMenuProps = wasInteractionByTouch
-    ? undefined
-    : chatMessageActionMenuProps({
-        ariaLabel: strings.actionMenuMoreOptions ?? '',
-        enabled: chatActionsEnabled,
-        menuButtonRef: messageActionButtonRef,
-        // Force show the action button while the flyout is open (otherwise this will dismiss when the pointer is hovered over the flyout)
-        forceShow: chatMessageActionFlyoutTarget === messageActionButtonRef,
-        onActionButtonClick: () => {
-          if (message.messageType === 'chat') {
-            props.onActionButtonClick(message, setMessageReadBy);
-            setChatMessageActionFlyoutTarget(messageActionButtonRef);
-          }
-        },
-        theme
-      });
+  const actionMenuProps = chatMessageActionMenuProps({
+    ariaLabel: strings.actionMenuMoreOptions ?? '',
+    enabled: chatActionsEnabled,
+    menuButtonRef: messageActionButtonRef,
+    // Force show the action button while the flyout is open (otherwise this will dismiss when the pointer is hovered over the flyout)
+    forceShow: chatMessageActionFlyoutTarget === messageActionButtonRef,
+    onActionButtonClick: () => {
+      if (message.messageType === 'chat') {
+        props.onActionButtonClick(message, setMessageReadBy);
+        setChatMessageActionFlyoutTarget(messageActionButtonRef);
+      }
+    },
+    theme
+  });
 
   const onActionFlyoutDismiss = useCallback((): void => {
     // When the flyout dismiss is called, since we control if the action flyout is visible
@@ -338,20 +334,6 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
             }}
             root={{
               className: chatMyMessageStyles.root,
-              onBlur: (e) => {
-                // copy behavior from North*
-                // `focused` controls is focused the whole `ChatMessage` or any of its children. When we're navigating
-                // with keyboard the focused element will be changed and there is no way to use `:focus` selector
-                const shouldPreserveFocusState = e.currentTarget.contains(e.relatedTarget);
-
-                setFocused(shouldPreserveFocusState);
-              },
-              onFocus: () => {
-                // copy behavior from North*
-                // react onFocus is called even when nested component receives focus (i.e. it bubbles)
-                // so when focus moves within actionMenu, the `focus` state in chatMessage remains true, and keeps actionMenu visible
-                setFocused(true);
-              },
               role: 'none',
               tabIndex: -1
             }}
@@ -372,7 +354,7 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
               className: mergeClasses(
                 chatMyMessageStyles.menu,
                 // Make actions menu visible when the message is focused or the flyout is shown
-                focused || chatMessageActionFlyoutTarget
+                chatMessageActionFlyoutTarget?.current
                   ? chatMyMessageStyles.menuVisible
                   : chatMyMessageStyles.menuHidden,
                 attached !== 'top' ? chatMyMessageStyles.menuAttached : undefined
@@ -381,19 +363,17 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
             onTouchStart={() => setWasInteractionByTouch(true)}
             onPointerDown={() => setWasInteractionByTouch(false)}
             onKeyDown={() => setWasInteractionByTouch(false)}
-            onBlur={() => setWasInteractionByTouch(false)} // onBlur is applied to body, not root
             onClick={() => {
-              if (!wasInteractionByTouch) {
-                return;
-              }
               // If the message was touched via touch we immediately open the menu
               // flyout (when using mouse the 3-dot menu that appears on hover
               // must be clicked to open the flyout).
               // In doing so here we set the target of the flyout to be the message and
               // not the 3-dot menu button to position the flyout correctly.
-              setChatMessageActionFlyoutTarget(messageRef);
-              if (message.messageType === 'chat') {
-                props.onActionButtonClick(message, setMessageReadBy);
+              if (!chatMessageActionFlyoutTarget) {
+                setChatMessageActionFlyoutTarget(messageRef);
+                if (message.messageType === 'chat') {
+                  props.onActionButtonClick(message, setMessageReadBy);
+                }
               }
             }}
           >

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
@@ -173,6 +173,8 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
 
   // Track if the action menu was opened by touch - if so we increase the touch targets for the items
   const [wasInteractionByTouch, setWasInteractionByTouch] = useState(false);
+  // `focused` state is used for show/hide actionMenu
+  const [focused, setFocused] = React.useState<boolean>(false);
 
   // The chat message action flyout should target the Chat.Message action menu if clicked,
   // or target the chat message if opened via touch press.
@@ -334,6 +336,20 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
             }}
             root={{
               className: chatMyMessageStyles.root,
+              onBlur: (e) => {
+                // copy behavior from North*
+                // `focused` controls is focused the whole `ChatMessage` or any of its children. When we're navigating
+                // with keyboard the focused element will be changed and there is no way to use `:focus` selector
+                const shouldPreserveFocusState = e.currentTarget.contains(e.relatedTarget);
+
+                setFocused(shouldPreserveFocusState);
+              },
+              onFocus: () => {
+                // copy behavior from North*
+                // react onFocus is called even when nested component receives focus (i.e. it bubbles)
+                // so when focus moves within actionMenu, the `focus` state in chatMessage remains true, and keeps actionMenu visible
+                setFocused(true);
+              },
               role: 'none',
               tabIndex: -1
             }}
@@ -354,7 +370,7 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
               className: mergeClasses(
                 chatMyMessageStyles.menu,
                 // Make actions menu visible when the message is focused or the flyout is shown
-                chatMessageActionFlyoutTarget?.current
+                focused || chatMessageActionFlyoutTarget?.current
                   ? chatMyMessageStyles.menuVisible
                   : chatMyMessageStyles.menuHidden,
                 attached !== 'top' ? chatMyMessageStyles.menuAttached : undefined
@@ -364,16 +380,17 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
             onPointerDown={() => setWasInteractionByTouch(false)}
             onKeyDown={() => setWasInteractionByTouch(false)}
             onClick={() => {
+              if (!wasInteractionByTouch) {
+                return;
+              }
               // If the message was touched via touch we immediately open the menu
               // flyout (when using mouse the 3-dot menu that appears on hover
               // must be clicked to open the flyout).
               // In doing so here we set the target of the flyout to be the message and
               // not the 3-dot menu button to position the flyout correctly.
-              if (!chatMessageActionFlyoutTarget) {
-                setChatMessageActionFlyoutTarget(messageRef);
-                if (message.messageType === 'chat') {
-                  props.onActionButtonClick(message, setMessageReadBy);
-                }
+              setChatMessageActionFlyoutTarget(messageRef);
+              if (message.messageType === 'chat') {
+                props.onActionButtonClick(message, setMessageReadBy);
               }
             }}
           >


### PR DESCRIPTION
# What
Ensure that menu options are the correct size and consistent

# Why
Refactor to fluent-contrib-chat meant some changes

# How Tested
Storybook; browser emulation of mobile

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->