### PR TITLE
Removed workaround for mouseDown event in jest tests

### DIFF
--- a/change-beta/@azure-communication-react-d0492f53-bae0-4425-bbad-a83d039c3ad2.json
+++ b/change-beta/@azure-communication-react-d0492f53-bae0-4425-bbad-a83d039c3ad2.json
@@ -2,7 +2,7 @@
   "type": "none",
   "area": "fix",
   "workstream": "",
-  "comment": "Removed workaround for mouseDown event in jest tests. Removed duplicated strict mode tool from Calling sample app",
+  "comment": "Removed workaround for mouseDown event in jest tests. Removed duplicated strict mode from Calling sample app",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change-beta/@azure-communication-react-d0492f53-bae0-4425-bbad-a83d039c3ad2.json
+++ b/change-beta/@azure-communication-react-d0492f53-bae0-4425-bbad-a83d039c3ad2.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Removed workaround for mouseDown event in jest tests. Removed duplicated strict mode tool from Calling sample app",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-d0492f53-bae0-4425-bbad-a83d039c3ad2.json
+++ b/change/@azure-communication-react-d0492f53-bae0-4425-bbad-a83d039c3ad2.json
@@ -2,7 +2,7 @@
   "type": "none",
   "area": "fix",
   "workstream": "",
-  "comment": "Removed workaround for mouseDown event in jest tests. Removed duplicated strict mode tool from Calling sample app",
+  "comment": "Removed workaround for mouseDown event in jest tests. Removed duplicated strict mode from Calling sample app",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change/@azure-communication-react-d0492f53-bae0-4425-bbad-a83d039c3ad2.json
+++ b/change/@azure-communication-react-d0492f53-bae0-4425-bbad-a83d039c3ad2.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Removed workaround for mouseDown event in jest tests. Removed duplicated strict mode tool from Calling sample app",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/SendBox.test.tsx
+++ b/packages/react-components/src/components/SendBox.test.tsx
@@ -12,7 +12,6 @@ import { render, waitFor, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 /* @conditional-compile-remove(mention) */
 import { Mention } from './MentionPopover';
-/* @conditional-compile-remove(mention) */
 
 describe('SendBox strings should be localizable and overridable', () => {
   beforeAll(() => {

--- a/packages/react-components/src/components/SendBox.test.tsx
+++ b/packages/react-components/src/components/SendBox.test.tsx
@@ -13,7 +13,6 @@ import userEvent from '@testing-library/user-event';
 /* @conditional-compile-remove(mention) */
 import { Mention } from './MentionPopover';
 /* @conditional-compile-remove(mention) */
-import { triggerMouseEvent } from './utils/testUtils';
 
 describe('SendBox strings should be localizable and overridable', () => {
   beforeAll(() => {
@@ -206,10 +205,6 @@ describe('Clicks/Touch should select mention', () => {
     // Select the suggestion
     await selectFirstMention();
     expect(input.value).toBe(value + suggestions[0].displayText);
-    // Fix for mousedown issue in userEvent when `document` become null unexpectedly
-    await act(async () => {
-      triggerMouseEvent(input, 'mousedown');
-    });
   };
 
   test('Mouse click on first word in mention should select mention', async () => {
@@ -292,10 +287,6 @@ describe('Clicks/Touch should select mention', () => {
       await userEvent.keyboard(' and');
     });
     const typedValue = trigger + suggestions[0].displayText + ' and';
-    // Fix for mousedown issue in userEvent when `document` become null unexpectedly
-    await act(async () => {
-      triggerMouseEvent(input, 'mousedown');
-    });
     // Triple click a letter at 14-th index
     await userEvent.pointer({
       keys: '[MouseLeft][MouseLeft][MouseLeft]',
@@ -446,10 +437,6 @@ describe('Keyboard events should be handled for mentions', () => {
     // Select the suggestion
     await selectMention(0);
     expect(input.value).toBe(value + suggestions[0].displayText);
-    // Fix for mousedown issue in userEvent when `document` become null unexpectedly
-    await act(async () => {
-      triggerMouseEvent(input, 'mousedown');
-    });
   };
 
   test('Keyboard navigation with arrows should navigate mention by words', async () => {

--- a/packages/react-components/src/components/utils/testUtils.tsx
+++ b/packages/react-components/src/components/utils/testUtils.tsx
@@ -56,14 +56,3 @@ export const createTestLocale = (testStrings: PartialDeep<ComponentStrings>): Co
   });
   return { strings };
 };
-
-/** @private */
-// Trigger a mouse event manually to fix mouseDown event in userEvent
-// when `document` become null unexpectedly
-// https://github.com/jestjs/jest/issues/12670
-export const triggerMouseEvent = (node: HTMLElement, eventType: string): void => {
-  const clickEvent = new MouseEvent(eventType, {
-    view: window
-  });
-  node.dispatchEvent(clickEvent);
-};

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -204,18 +204,16 @@ const App = (): JSX.Element => {
         return <Spinner label={'Getting user credentials from server'} ariaLive="assertive" labelPosition="top" />;
       }
       return (
-        <React.StrictMode>
-          <CallScreen
-            token={token}
-            userId={userId}
-            displayName={displayName}
-            callLocator={callLocator}
-            /* @conditional-compile-remove(PSTN-calls) */
-            alternateCallerId={alternateCallerId}
-            /* @conditional-compile-remove(teams-identity-support) */
-            isTeamsIdentityCall={isTeamsCall}
-          />
-        </React.StrictMode>
+        <CallScreen
+          token={token}
+          userId={userId}
+          displayName={displayName}
+          callLocator={callLocator}
+          /* @conditional-compile-remove(PSTN-calls) */
+          alternateCallerId={alternateCallerId}
+          /* @conditional-compile-remove(teams-identity-support) */
+          isTeamsIdentityCall={isTeamsCall}
+        />
       );
     }
     default:


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Removed workaround for mouseDown event in jest tests
- Removed duplicated strict mode from Calling sample app

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Ran tests

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->