### PR TITLE
[Bugfix] Fix missing DownloadFileCards tooltip

### DIFF
--- a/change-beta/@azure-communication-react-ef1fe0ea-3e79-4e37-b27c-2557fc692c38.json
+++ b/change-beta/@azure-communication-react-ef1fe0ea-3e79-4e37-b27c-2557fc692c38.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Tooltip",
+  "comment": "Fix file card tooltip",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-ef1fe0ea-3e79-4e37-b27c-2557fc692c38.json
+++ b/change/@azure-communication-react-ef1fe0ea-3e79-4e37-b27c-2557fc692c38.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Tooltip",
+  "comment": "Fix file card tooltip",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/FileDownloadCards.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Icon, IconButton, Spinner, SpinnerSize } from '@fluentui/react';
+import { Icon, IconButton, Spinner, SpinnerSize, TooltipHost } from '@fluentui/react';
 import React, { useCallback, useState } from 'react';
 import { useMemo } from 'react';
 /* @conditional-compile-remove(file-sharing) */
@@ -271,23 +271,25 @@ export const _FileDownloadCards = (props: _FileDownloadCards): JSX.Element => {
               return true;
             })
             .map((file) => (
-              <_FileCard
-                fileName={file.name}
-                key={file.name}
-                fileExtension={file.extension}
-                actionIcon={
-                  showSpinner ? (
-                    <Spinner size={SpinnerSize.medium} aria-live={'polite'} role={'status'} />
-                  ) : true &&
-                    /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
-                    isShowDownloadIcon(file) ? (
-                    <IconButton className={iconButtonClassName} ariaLabel={downloadFileButtonString()}>
-                      <DownloadIconTrampoline />
-                    </IconButton>
-                  ) : undefined
-                }
-                actionHandler={() => fileDownloadHandler(userId, file)}
-              />
+              <TooltipHost content={downloadFileButtonString()} key={file.name}>
+                <_FileCard
+                  fileName={file.name}
+                  key={file.name}
+                  fileExtension={file.extension}
+                  actionIcon={
+                    showSpinner ? (
+                      <Spinner size={SpinnerSize.medium} aria-live={'polite'} role={'status'} />
+                    ) : true &&
+                      /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
+                      isShowDownloadIcon(file) ? (
+                      <IconButton className={iconButtonClassName} ariaLabel={downloadFileButtonString()}>
+                        <DownloadIconTrampoline />
+                      </IconButton>
+                    ) : undefined
+                  }
+                  actionHandler={() => fileDownloadHandler(userId, file)}
+                />
+              </TooltipHost>
             ))}
       </_FileCardGroup>
     </div>

--- a/packages/react-components/src/components/MessageThread.test.tsx
+++ b/packages/react-components/src/components/MessageThread.test.tsx
@@ -306,11 +306,11 @@ describe('Message should display image and attachment correctly', () => {
 
       // Frist attachment: previewUrl !== undefine, will not show DownloadFile Icon
       expect(fileDownloadCards?.children[0].innerHTML).not.toContain(DownloadFileIconName);
-      expect(fileDownloadCards?.children[0].textContent).toEqual(fildName1);
+      expect(fileDownloadCards?.children[0].children[0].textContent).toEqual(fildName1);
 
       // Second attachment: id === undefined, will show DownloadFile Icon
       expect(fileDownloadCards?.children[1].innerHTML).toContain(DownloadFileIconName);
-      expect(fileDownloadCards?.children[1].textContent).toEqual(fildName2);
+      expect(fileDownloadCards?.children[1].children[0].textContent).toEqual(fildName2);
 
       // Inline Image attachment
       expect(container.querySelector(`#${imgId1}`)?.getAttribute('src')).toEqual(expectedFilePreviewSrc1);


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Add missing DownloadFileCards tooltip (with existing localization support
- Tooltip is not working on Samples due to RestrictMode (related PR: https://github.com/Azure/communication-ui-library/pull/3659/files)
<img width="341" alt="image" src="https://github.com/Azure/communication-ui-library/assets/77021369/1f679564-60aa-4caf-bc50-43fcdbdeafa3">

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->