### PR TITLE
Alkwa/fix on hold label

### DIFF
--- a/change-beta/@azure-communication-react-99564163-f23c-4134-aaf4-5287833d95f7.json
+++ b/change-beta/@azure-communication-react-99564163-f23c-4134-aaf4-5287833d95f7.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Icons are displaced when on hold",
+  "comment": "hiding participant list item icons if on hold",
+  "packageName": "@azure/communication-react",
+  "email": "alkwa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-99564163-f23c-4134-aaf4-5287833d95f7.json
+++ b/change/@azure-communication-react-99564163-f23c-4134-aaf4-5287833d95f7.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Icons are displaced when on hold",
+  "comment": "hiding participant list item icons if on hold",
+  "packageName": "@azure/communication-react",
+  "email": "alkwa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/src/participantListSelector.ts
+++ b/packages/calling-component-bindings/src/participantListSelector.ts
@@ -9,10 +9,11 @@ import {
   getRemoteParticipants,
   getIsScreenSharingOn,
   getIsMuted,
-  CallingBaseSelectorProps
+  CallingBaseSelectorProps,
+  getCallState
 } from './baseSelectors';
 import { getRole } from './baseSelectors';
-import { CallParticipantListParticipant } from '@internal/react-components';
+import { CallParticipantListParticipant, ParticipantState } from '@internal/react-components';
 import { _isRingingPSTNParticipant, _updateUserDisplayNames } from './utils/callUtils';
 import { memoizedConvertAllremoteParticipants } from './utils/participantListSelectorUtils';
 /* @conditional-compile-remove(rooms) */
@@ -118,7 +119,8 @@ export const participantListSelector: ParticipantListSelector = createSelector(
     getIsMuted,
     /* @conditional-compile-remove(raise-hand) */ getLocalParticipantRaisedHand,
     getRole,
-    getParticipantCount
+    getParticipantCount,
+    getCallState
   ],
   (
     userId,
@@ -129,7 +131,8 @@ export const participantListSelector: ParticipantListSelector = createSelector(
     /* @conditional-compile-remove(raise-hand) */
     raisedHand,
     role,
-    partitipantCount
+    partitipantCount,
+    callState
   ): {
     participants: CallParticipantListParticipant[];
     myUserId: string;
@@ -149,7 +152,7 @@ export const participantListSelector: ParticipantListSelector = createSelector(
       isMuted: isMuted,
       /* @conditional-compile-remove(raise-hand) */
       raisedHand: raisedHand,
-      state: 'Connected',
+      state: callState === 'LocalHold' ? 'Hold' : 'Connected',
       // Local participant can never remove themselves.
       isRemovable: false
     });

--- a/packages/react-components/src/components/ParticipantItem.tsx
+++ b/packages/react-components/src/components/ParticipantItem.tsx
@@ -25,6 +25,7 @@ import {
   meContainerStyle,
   menuButtonContainerStyle,
   participantItemContainerStyle,
+  participantOnHoldStyle,
   participantStateMaxWidth,
   participantStateStringStyles
 } from './styles/ParticipantItem.styles';
@@ -236,6 +237,10 @@ export const ParticipantItem = (props: ParticipantItemProps): JSX.Element => {
   };
 
   const participantStateString = participantStateStringTrampoline(props, strings);
+  const connectingParticipant = participantStateString === strings?.participantStateRinging;
+  const connectedParticipant = !connectingParticipant;
+  const isOnHold = participantStateString === strings?.participantStateHold;
+
   return (
     <div
       ref={containerRef}
@@ -254,7 +259,10 @@ export const ParticipantItem = (props: ParticipantItemProps): JSX.Element => {
       onFocus={() => setItemFocused(true)}
       onBlur={() => setItemFocused(false)}
       onClick={() => {
-        if (!participantStateString) {
+        {
+          /* We can show a menu to remove the user if they are connected to a call */
+        }
+        if (connectedParticipant) {
           setItemHovered(true);
           setMenuHidden(false);
           onClick?.(props);
@@ -275,36 +283,41 @@ export const ParticipantItem = (props: ParticipantItemProps): JSX.Element => {
       >
         {avatar}
         {me && <Text className={meTextStyle}>{strings.isMeText}</Text>}
-        <Stack horizontal className={mergeStyles(infoContainerStyle)}>
-          {onRenderIcon && onRenderIcon(props)}
-        </Stack>
+        {!isOnHold && (
+          <Stack horizontal className={mergeStyles(infoContainerStyle)}>
+            {onRenderIcon && onRenderIcon(props)}
+          </Stack>
+        )}
       </Stack>
-      {/* When the participantStateString has a value, we don't show the menu  */}
-      {!me && participantStateString ? (
-        <Text data-ui-id="participant-item-state-string" className={mergeStyles(participantStateStringStyles)}>
+      {/* When the participant is not connected, we don't need to allocate space for a menu */}
+      {!me && participantStateString && (
+        <Text
+          data-ui-id="participant-item-state-string"
+          className={mergeStyles(connectedParticipant ? participantOnHoldStyle : participantStateStringStyles)}
+        >
           {participantStateString}
         </Text>
-      ) : (
-        <div>
-          {menuItems && menuItems.length > 0 && (
-            <>
-              {menuButton}
-              <ContextualMenu
-                items={menuItems}
-                hidden={menuHidden}
-                target={containerRef}
-                onItemClick={onDismissMenu}
-                onDismiss={onDismissMenu}
-                directionalHint={DirectionalHint.bottomRightEdge}
-                className={contextualMenuStyle}
-                calloutProps={{
-                  preventDismissOnEvent
-                }}
-              />
-            </>
-          )}
-        </div>
       )}
+      <div>
+        {/* Menu is only available for connected participants*/}
+        {connectedParticipant && menuItems && menuItems.length > 0 && (
+          <>
+            {menuButton}
+            <ContextualMenu
+              items={menuItems}
+              hidden={menuHidden}
+              target={containerRef}
+              onItemClick={onDismissMenu}
+              onDismiss={onDismissMenu}
+              directionalHint={DirectionalHint.bottomRightEdge}
+              className={contextualMenuStyle}
+              calloutProps={{
+                preventDismissOnEvent
+              }}
+            />
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/react-components/src/components/ParticipantItem.tsx
+++ b/packages/react-components/src/components/ParticipantItem.tsx
@@ -291,7 +291,7 @@ export const ParticipantItem = (props: ParticipantItemProps): JSX.Element => {
         )}
       </Stack>
       {/* When the participant is not connected, we don't need to allocate space for a menu */}
-      {!me && participantStateString && (
+      {participantStateString && (
         <Text
           data-ui-id="participant-item-state-string"
           className={mergeStyles(connectedParticipant ? participantOnHoldStyle : participantStateStringStyles)}

--- a/packages/react-components/src/components/ParticipantItem.tsx
+++ b/packages/react-components/src/components/ParticipantItem.tsx
@@ -34,6 +34,7 @@ import { _preventDismissOnEvent as preventDismissOnEvent } from '@internal/acs-u
 /* @conditional-compile-remove(PSTN-calls) */
 import { ParticipantState } from '../types';
 import { useId } from '@fluentui/react-hooks';
+import { bracketedParticipantString } from './utils/common';
 
 /**
  * Fluent styles for {@link ParticipantItem}.
@@ -295,7 +296,7 @@ export const ParticipantItem = (props: ParticipantItemProps): JSX.Element => {
           data-ui-id="participant-item-state-string"
           className={mergeStyles(connectedParticipant ? participantOnHoldStyle : participantStateStringStyles)}
         >
-          {participantStateString}
+          {bracketedParticipantString(participantStateString, connectedParticipant)}
         </Text>
       )}
       <div>

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -38,6 +38,7 @@ import { DirectionalHint, IContextualMenuProps } from '@fluentui/react';
 import useLongPress from './utils/useLongPress';
 /* @conditional-compile-remove(pinned-participants) */
 import { moreButtonStyles } from './styles/VideoTile.styles';
+import { bracketedParticipantString } from './utils/common';
 
 /**
  * Strings of {@link VideoTile} that can be overridden.
@@ -496,8 +497,4 @@ const tileInfoContainerTokens = {
   // A horizontal Stack sets the left margin to 0 for all it's children.
   // We need to allow the children to set their own margins
   childrenGap: 'none'
-};
-
-const bracketedParticipantString = (participantString: string, withBrackets: boolean): string => {
-  return withBrackets ? `(${participantString})` : participantString;
 };

--- a/packages/react-components/src/components/styles/ParticipantItem.styles.ts
+++ b/packages/react-components/src/components/styles/ParticipantItem.styles.ts
@@ -38,7 +38,6 @@ export const participantStateMaxWidth = '5rem';
 export const participantOnHoldStyle: IStyle = {
   maxWidth: participantStateMaxWidth,
   overflow: 'hidden',
-  textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
   lineHeight: 'normal',
   marginLeft: 'auto',

--- a/packages/react-components/src/components/styles/ParticipantItem.styles.ts
+++ b/packages/react-components/src/components/styles/ParticipantItem.styles.ts
@@ -37,7 +37,6 @@ export const participantStateMaxWidth = '5rem';
  */
 export const participantOnHoldStyle: IStyle = {
   maxWidth: participantStateMaxWidth,
-  overflow: 'hidden',
   whiteSpace: 'nowrap',
   lineHeight: 'normal',
   marginLeft: 'auto',
@@ -46,7 +45,6 @@ export const participantOnHoldStyle: IStyle = {
 
 export const participantStateStringStyles: IStyle = {
   maxWidth: participantStateMaxWidth,
-  overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
   lineHeight: 'normal',

--- a/packages/react-components/src/components/styles/ParticipantItem.styles.ts
+++ b/packages/react-components/src/components/styles/ParticipantItem.styles.ts
@@ -35,6 +35,16 @@ export const participantStateMaxWidth = '5rem';
 /**
  * @private
  */
+export const participantOnHoldStyle: IStyle = {
+  maxWidth: participantStateMaxWidth,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  lineHeight: 'normal',
+  marginLeft: 'auto',
+  marginRight: 0
+};
+
 export const participantStateStringStyles: IStyle = {
   maxWidth: participantStateMaxWidth,
   overflow: 'hidden',

--- a/packages/react-components/src/components/utils/common.ts
+++ b/packages/react-components/src/components/utils/common.ts
@@ -26,3 +26,11 @@ export const useLocaleFileCardStringsTrampoline = (): _FileUploadCardsStrings =>
 export const _isParticipantStateCallingOrHold = (participantState?: ParticipantState): boolean => {
   return !!participantState && ['Idle', 'Connecting', 'EarlyMedia', 'Ringing', 'Hold'].includes(participantState);
 };
+
+/**
+ * Adds parenthesis around a string when used in a label
+ * @returns modified participant string based on if we wanted brackets around it or not
+ */
+export const bracketedParticipantString = (participantString: string, withBrackets: boolean): string => {
+  return withBrackets ? `(${participantString})` : participantString;
+};


### PR DESCRIPTION
# What
When on hold we are not showing the other status icons of the participant. Teams replaces everything with "hold" and we are doing the same thing.  We also need to maintain the menu if the user is on hold. Before the only states that were possible from the function in this file was ringing and hold which were being handled the same (don't show the menu). 

1. If a user is connected you should see the current mute state, screen share state, raised hand. If this participant is not you, you can access the context menu to remove this participant ✅
2. If you are a user that is connected you see the current mute state, screenshare state, raised hand. You will see (You) to indicate this user is you. You will not have access to the context menu that will remove this participant. ✅
3. If a user is on hold, we do not show any of their call state icons. We should they are (On hold) and we also have access to the context menu to remove them since they are connected to the call. ✅
**(not covered, we need to get information from the call object )**
4. If you are a user that is on hold, you should not see any of your current call state icons. You will see (You) to indicate this participant is you. You should see an (On hold) label. You should not have access to the context menu. 🚧

(Does it look odd that the "On hold" for you has a different alignment than the one for other people due to the lack of context menu?)
![image](https://github.com/Azure/communication-ui-library/assets/79329532/ed3d5086-4f89-405f-ab6a-59b5830b0904)


Realistically you should be able to remove someone on hold if you really wanted to and so we should look at the reason a user is not seeing the menu based on if they are connected to the call or not.

# Why
Alignment with Teams

