### PR TITLE
[Bugfix] Fix mobile participant removal

### DIFF
--- a/change-beta/@azure-communication-react-88b901bc-e801-48a5-9ebd-f2f41a2f9308.json
+++ b/change-beta/@azure-communication-react-88b901bc-e801-48a5-9ebd-f2f41a2f9308.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Rooms",
+  "comment": "Fixes issue where the local participant cannot remove others in a call",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-88b901bc-e801-48a5-9ebd-f2f41a2f9308.json
+++ b/change/@azure-communication-react-88b901bc-e801-48a5-9ebd-f2f41a2f9308.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Rooms",
+  "comment": "Fixes issue where the local participant cannot remove others in a call",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
+++ b/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
@@ -71,7 +71,6 @@ export const PeoplePaneContent = (props: {
 
   const participantListDefaultProps = usePropsFor(ParticipantList);
   const removeButtonAllowed = hasRemoveParticipantsPermissionTrampoline(adapter);
-  console.log('removeButtonAllowed', removeButtonAllowed);
   const setDrawerMenuItemsForParticipant: (participant?: ParticipantListParticipant) => void = useMemo(() => {
     return (participant?: ParticipantListParticipant) => {
       if (participant) {

--- a/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
+++ b/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
@@ -71,6 +71,7 @@ export const PeoplePaneContent = (props: {
 
   const participantListDefaultProps = usePropsFor(ParticipantList);
   const removeButtonAllowed = hasRemoveParticipantsPermissionTrampoline(adapter);
+  console.log('removeButtonAllowed', removeButtonAllowed);
   const setDrawerMenuItemsForParticipant: (participant?: ParticipantListParticipant) => void = useMemo(() => {
     return (participant?: ParticipantListParticipant) => {
       if (participant) {
@@ -203,7 +204,11 @@ const createDefaultContextualMenuItems = (
  */
 const hasRemoveParticipantsPermissionTrampoline = (adapter: CommonCallAdapter): boolean => {
   /* @conditional-compile-remove(rooms) */
-  return adapter.getState().call?.role === 'Presenter';
+  const role = adapter.getState().call?.role;
+  /* @conditional-compile-remove(rooms) */
+  const canRemove = role === 'Presenter' || role === 'Unknown' || role === undefined;
+  /* @conditional-compile-remove(rooms) */
+  return canRemove;
   // Return true if stable.
   return true;
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fixes issue where more button drawer is hidden depending on the role ACS Users in a groupcall do not have roles
# Why
<!--- What problem does this change solve? -->
Lets participants remove others
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3440612
# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated locally 
![image](https://github.com/Azure/communication-ui-library/assets/94866715/108d0eba-e25a-4305-88cd-01dc2d360862)
