### PR TITLE
Prevent loop of switching between scrollable and paginated horizontal gallery

### DIFF
--- a/change-beta/@azure-communication-react-8d637679-4d5b-4c50-826a-ce0acdd7c66d.json
+++ b/change-beta/@azure-communication-react-8d637679-4d5b-4c50-826a-ce0acdd7c66d.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "VideoGallery",
+  "comment": "Prevent possible endless loop of switching between scrollable and paginated horizontal gallery in VideoGallery",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-8d637679-4d5b-4c50-826a-ce0acdd7c66d.json
+++ b/change/@azure-communication-react-8d637679-4d5b-4c50-826a-ce0acdd7c66d.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "VideoGallery",
+  "comment": "Prevent possible endless loop of switching between scrollable and paginated horizontal gallery in VideoGallery",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -218,6 +218,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
         onChildrenPerPageChange={(n: number) => {
           childrenPerPage.current = n;
         }}
+        parentWidth={parentWidth}
       />
     );
   }, [
@@ -228,7 +229,8 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
     styles?.horizontalGallery,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryPosition,
     setIndexesToRender,
-    /* @conditional-compile-remove(vertical-gallery) */ styles?.verticalGallery
+    /* @conditional-compile-remove(vertical-gallery) */ styles?.verticalGallery,
+    parentWidth
   ]);
 
   return (

--- a/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/OverflowGallery.tsx
@@ -24,6 +24,8 @@ import {
   verticalGalleryContainerStyle,
   verticalGalleryStyle
 } from './styles/VideoGalleryResponsiveVerticalGallery.styles';
+import { SMALL_FLOATING_MODAL_SIZE_REM } from './styles/FloatingLocalVideo.styles';
+import { _convertRemToPx } from '@internal/acs-ui-common';
 
 /**
  * A ResponsiveHorizontalGallery styled for the {@link VideoGallery}
@@ -45,6 +47,7 @@ export const OverflowGallery = (props: {
   onChildrenPerPageChange?: (childrenPerPage: number) => void;
   /* @conditional-compile-remove(gallery-layouts) */
   layout?: VideoGalleryLayout;
+  parentWidth?: number;
 }): JSX.Element => {
   const {
     shouldFloatLocalVideo = false,
@@ -56,7 +59,8 @@ export const OverflowGallery = (props: {
     horizontalGalleryStyles,
     /* @conditional-compile-remove(vertical-gallery) */ overflowGalleryPosition = 'horizontalBottom',
     /* @conditional-compile-remove(vertical-gallery) */ verticalGalleryStyles,
-    onChildrenPerPageChange
+    onChildrenPerPageChange,
+    parentWidth
   } = props;
 
   const containerStyles = useMemo(() => {
@@ -114,8 +118,13 @@ export const OverflowGallery = (props: {
         horizontalGalleryElements={overflowGalleryElements ? overflowGalleryElements : [<></>]}
         onFetchTilesToRender={onFetchTilesToRender}
         key="scrollable-horizontal-gallery"
-        /* @conditional-compile-remove(gallery-layouts) */
-        layout={props.layout}
+        containerStyles={{
+          width: parentWidth
+            ? props.layout === 'default'
+              ? `${parentWidth}px`
+              : `${parentWidth - _convertRemToPx(SMALL_FLOATING_MODAL_SIZE_REM.width)}px`
+            : '100%'
+        }}
       />
     );
   }

--- a/packages/react-components/src/components/VideoGallery/ScrollableHorizontalGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery/ScrollableHorizontalGallery.tsx
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Stack } from '@fluentui/react';
+import { IStyle, Stack, mergeStyles } from '@fluentui/react';
 import React, { useEffect, useRef } from 'react';
 import { useDraggable } from 'react-use-draggable-scroll';
 import {
   scrollableHorizontalGalleryContainerStyles,
   scrollableHorizontalGalleryStyles
 } from './styles/ScrollableHorizontalGallery.style';
-/* @conditional-compile-remove(gallery-layouts) */
-import { VideoGalleryLayout } from '../VideoGallery';
 
 /**
  * Component to display elements horizontally in a scrollable container
@@ -18,17 +16,9 @@ import { VideoGalleryLayout } from '../VideoGallery';
 export const ScrollableHorizontalGallery = (props: {
   horizontalGalleryElements?: JSX.Element[];
   onFetchTilesToRender?: (indexes: number[]) => void;
-  /* @conditional-compile-remove(gallery-layouts) */
-  layout?: VideoGalleryLayout;
+  containerStyles: IStyle;
 }): JSX.Element => {
-  const { horizontalGalleryElements, onFetchTilesToRender, /* @conditional-compile-remove(gallery-layouts) */ layout } =
-    props;
-
-  const useFullWidthTrampoline = (): boolean => {
-    /* @conditional-compile-remove(gallery-layouts) */
-    return layout === 'default' ? true : false;
-    return false;
-  };
+  const { horizontalGalleryElements, onFetchTilesToRender, containerStyles } = props;
 
   useEffect(() => {
     const indexesArray = [...Array(horizontalGalleryElements?.length).keys()];
@@ -44,7 +34,7 @@ export const ScrollableHorizontalGallery = (props: {
     <div
       ref={ref}
       {...dragabbleEvents}
-      className={scrollableHorizontalGalleryContainerStyles(useFullWidthTrampoline())}
+      className={mergeStyles(scrollableHorizontalGalleryContainerStyles, containerStyles)}
     >
       <Stack
         data-ui-id="scrollable-horizontal-gallery"

--- a/packages/react-components/src/components/VideoGallery/styles/ScrollableHorizontalGallery.style.ts
+++ b/packages/react-components/src/components/VideoGallery/styles/ScrollableHorizontalGallery.style.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { IStackStyles, mergeStyles } from '@fluentui/react';
-import { SMALL_FLOATING_MODAL_SIZE_REM } from './FloatingLocalVideo.styles';
+import { IStackStyles, IStyle } from '@fluentui/react';
 import {
   SMALL_HORIZONTAL_GALLERY_TILE_SIZE_REM,
   SMALL_HORIZONTAL_GALLERY_TILE_STYLE
@@ -23,14 +22,11 @@ export const scrollableHorizontalGalleryStyles: IStackStyles = {
 /**
  * @private
  */
-export const scrollableHorizontalGalleryContainerStyles = (fullWidth: boolean): string => {
-  return mergeStyles({
-    display: 'flex',
-    width: fullWidth ? '100%' : `calc(100% - ${SMALL_FLOATING_MODAL_SIZE_REM.width}rem)`,
-    minHeight: `${SMALL_HORIZONTAL_GALLERY_TILE_SIZE_REM.height}rem`,
-    overflow: 'scroll',
-    '-ms-overflow-style': 'none',
-    'scrollbar-width': 'none',
-    '::-webkit-scrollbar': { display: 'none' }
-  });
+export const scrollableHorizontalGalleryContainerStyles: IStyle = {
+  display: 'flex',
+  minHeight: `${SMALL_HORIZONTAL_GALLERY_TILE_SIZE_REM.height}rem`,
+  overflow: 'scroll',
+  '-ms-overflow-style': 'none',
+  'scrollbar-width': 'none',
+  '::-webkit-scrollbar': { display: 'none' }
 };


### PR DESCRIPTION
# What
Fix loop of switching between scrollable and paginated horizontal gallery

# Why
Could potentially fix Teladoc issue detailed in this bug https://skype.visualstudio.com/SPOOL/_workitems/edit/3461020

# How Tested
Elicited looping between scrollable and paginated horizontal gallery by omitting a style in Stack component outside of the VideoGallery like shown in this video:
https://github.com/Azure/communication-ui-library/assets/79475487/49e0a512-e5f7-4fb2-91f0-029836cc9dd8

Tested this branch as shown in following video to confirm that the loop is prevented:
https://github.com/Azure/communication-ui-library/assets/79475487/d579f44e-ff0d-4e4a-bcb3-13eab5011c70

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->