### PR TITLE
Fix erroneous error saying failed to turn off video when starting a call in react18 strict mode

### DIFF
--- a/change-beta/@azure-communication-react-fa44ad02-5cf3-420c-ae72-89e84b8103ca.json
+++ b/change-beta/@azure-communication-react-fa44ad02-5cf3-420c-ae72-89e84b8103ca.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Bug Fix",
+  "comment": "Fix erroneous error saying failed to turn off video when starting a call in react18 strict mode",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-fa44ad02-5cf3-420c-ae72-89e84b8103ca.json
+++ b/change/@azure-communication-react-fa44ad02-5cf3-420c-ae72-89e84b8103ca.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Bug Fix",
+  "comment": "Fix erroneous error saying failed to turn off video when starting a call in react18 strict mode",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -393,7 +393,10 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
         <ConfigurationPage
           mobileView={props.mobileView}
           startCallHandler={(): void => {
-            adapter.joinCall();
+            adapter.joinCall({
+              microphoneOn: 'keep',
+              cameraOn: 'keep'
+            });
           }}
           updateSidePaneRenderer={setSidePaneRenderer}
           latestErrors={latestErrors}

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -601,18 +601,16 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | BetaTea
       let shouldMicrophoneBeOnInCall = this.getState().isLocalPreviewMicrophoneEnabled;
 
       // Apply override arguments
-      if (typeof options !== 'object') {
-        // Deprecated joinCall API (boolen | undefined)
-        if (options === true) {
-          shouldMicrophoneBeOnInCall = true;
-        }
-      } else {
+      if (typeof options === 'boolean') {
+        // Deprecated joinCall API (boolen)
+        shouldMicrophoneBeOnInCall = options;
+      } else if (typeof options === 'object') {
         // Options bag API
-        if (options.microphoneOn === true) {
-          shouldMicrophoneBeOnInCall = true;
+        if (options.microphoneOn && options.microphoneOn !== 'keep') {
+          shouldMicrophoneBeOnInCall = options.microphoneOn;
         }
-        if (options.cameraOn === true) {
-          shouldCameraBeOnInCall = true;
+        if (options.cameraOn && options.cameraOn !== 'keep') {
+          shouldCameraBeOnInCall = options.cameraOn;
         }
       }
 

--- a/packages/react-composites/src/composites/CallComposite/components/MediaGallery.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/MediaGallery.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { CSSProperties, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { CSSProperties, useCallback, useMemo } from 'react';
 /* @conditional-compile-remove(vertical-gallery) */ /* @conditional-compile-remove(rooms) */
 import { useRef } from 'react';
 import { VideoGallery, VideoStreamOptions, CustomAvatarOptions, Announcer } from '@internal/react-components';
@@ -13,7 +13,6 @@ import { VideoTileContextualMenuProps, VideoTileDrawerMenuProps } from '@interna
 import { usePropsFor } from '../hooks/usePropsFor';
 import { AvatarPersona, AvatarPersonaDataCallback } from '../../common/AvatarPersona';
 import { mergeStyles, Stack } from '@fluentui/react';
-import { getIsPreviewCameraOn } from '../selectors/baseSelectors';
 import { useHandlers } from '../hooks/useHandlers';
 import { useSelector } from '../hooks/useSelector';
 import { localVideoCameraCycleButtonSelector } from '../selectors/LocalVideoTileSelector';
@@ -115,8 +114,6 @@ export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
     [props.onFetchAvatarPersonaData]
   );
 
-  useLocalVideoStartTrigger(!!props.isVideoStreamOn);
-
   /* @conditional-compile-remove(pinned-participants) */
   const remoteVideoTileMenuOptions: false | VideoTileContextualMenuProps | VideoTileDrawerMenuProps = useMemo(() => {
     return props.remoteVideoTileMenuOptions?.isHidden
@@ -200,33 +197,6 @@ export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
       {VideoGalleryMemoized}
     </div>
   );
-};
-
-/**
- * @private
- *
- * `shouldTransition` is an extra predicate that controls whether this hooks actually transitions the call.
- * The rule of hooks disallows calling the hook conditionally, so this predicate can be used to make the decision.
- */
-export const useLocalVideoStartTrigger = (isLocalVideoAvailable: boolean, shouldTransition?: boolean): void => {
-  // Once a call is joined, we need to transition the local preview camera setting into the call.
-  // This logic is needed on any screen that we might join a call from:
-  // - The Media gallery
-  // - The lobby page
-  // - The networkReconnect interstitial that may show at the start of a call.
-  //
-  // @TODO: Can we simply have the callHandlers handle this transition logic.
-  const [isButtonStatusSynced, setIsButtonStatusSynced] = useState(false);
-  const isPreviewCameraOn = useSelector(getIsPreviewCameraOn);
-  const mediaGalleryHandlers = useHandlers(MediaGallery);
-  useEffect(() => {
-    if (shouldTransition !== false) {
-      if (isPreviewCameraOn && !isLocalVideoAvailable && !isButtonStatusSynced) {
-        mediaGalleryHandlers.onStartLocalVideo();
-      }
-      setIsButtonStatusSynced(true);
-    }
-  }, [shouldTransition, isButtonStatusSynced, isPreviewCameraOn, isLocalVideoAvailable, mediaGalleryHandlers]);
 };
 
 const mediaGalleryContainerStyles: CSSProperties = { width: '100%', height: '100%' };

--- a/packages/react-composites/src/composites/CallComposite/components/NetworkReconnectTile.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/NetworkReconnectTile.tsx
@@ -13,7 +13,6 @@ import {
   titleStyle
 } from '../styles/NetworkReconnectTile.styles';
 import { useHandlers } from '../hooks/useHandlers';
-import { useLocalVideoStartTrigger } from './MediaGallery';
 import { CallCompositeIcon } from '../../common/icons';
 
 /**
@@ -33,9 +32,6 @@ export const NetworkReconnectTile = (props: NetworkReconnectTileProps): JSX.Elem
   const strings = useLocale().strings.call;
 
   const handlers = useHandlers(ExpandedLocalVideoTile);
-  // This tile may be shown at the beginning of a call.
-  // So we need to transition local video to the call.
-  useLocalVideoStartTrigger(!!props.localParticipantVideoStream.isAvailable);
 
   return (
     <ExpandedLocalVideoTile

--- a/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/LobbyPage.tsx
@@ -13,7 +13,6 @@ import { getCallStatus, getRemoteParticipants } from '../selectors/baseSelectors
 import { disableCallControls, reduceCallControlsForMobile } from '../utils';
 import { CallCompositeStrings } from '../Strings';
 import { useLocale } from '../../localization';
-import { useLocalVideoStartTrigger } from '../components/MediaGallery';
 import { CallCompositeIcon } from '../../common/icons';
 import { isPhoneNumberIdentifier, PhoneNumberIdentifier } from '@azure/communication-common';
 import { RemoteParticipantState } from '@internal/calling-stateful-client';
@@ -49,8 +48,6 @@ export const LobbyPage = (props: LobbyPageProps): JSX.Element => {
   const inLobby = callState === 'InLobby';
 
   const participants = useSelector(getRemoteParticipants) ?? {};
-
-  useLocalVideoStartTrigger(lobbyProps.localParticipantVideoStream.isAvailable, inLobby);
 
   // Reduce the controls shown when mobile view is enabled.
   let callControlOptions = props.mobileView


### PR DESCRIPTION
# What

- Remove hook where we manually restarted the video if the camera was on in the configuration page
- Instead correctly pass the localvideostream into the call agent when starting a call.

# Why

In react18 strict mode the double hook execution was causing errors

# How Tested

Locally, verified joining a call with and without both camera and mic.