### PR TITLE
Remove legacyControlBarExperience prop from CallComposite

### DIFF
--- a/common/config/babel/.babelrc.js
+++ b/common/config/babel/.babelrc.js
@@ -71,7 +71,9 @@ process.env['COMMUNICATION_REACT_FLAVOR'] !== 'beta' &&
         // Feature for custom video gallery layouts
         'gallery-layouts',
         // Feature image gallery
-        'image-gallery'
+        'image-gallery',
+        // Legacy control bar
+        'legacy-control-bar'
       ],      
       // A list of in progress beta feature.
       // These features are still beta feature but "in progress"

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -547,7 +547,6 @@ export type CallControlOptions = (CommonCallControlOptions & {
     participantsButton?: boolean | {
         disabled: boolean;
     };
-    legacyControlBarExperience?: boolean;
 });
 
 // @public

--- a/packages/react-composites/review/stable/react-composites.api.md
+++ b/packages/react-composites/review/stable/react-composites.api.md
@@ -448,7 +448,6 @@ export type CallControlOptions = (CommonCallControlOptions & {
     participantsButton?: boolean | {
         disabled: boolean;
     };
-    legacyControlBarExperience?: boolean;
 });
 
 // @public

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -466,7 +466,13 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
 };
 
 const isLegacyCallControlEnabled = (options?: boolean | CallControlOptions): boolean => {
+  /* @conditional-compile-remove(legacy-control-bar) */
   return !!options && options !== true && (options as _CallControlOptions)?.legacyControlBarExperience === true;
+
+  // In stable builds, we default to legacy until new-call-control-bar feature is stablized.
+  return (
+    options === undefined || options === true || (options as _CallControlOptions)?.legacyControlBarExperience !== false
+  );
 };
 
 const shouldShowPeopleTabHeaderButton = (callControls?: boolean | CommonCallControlOptions): boolean => {

--- a/packages/react-composites/src/composites/CallComposite/types/CallControlOptions.ts
+++ b/packages/react-composites/src/composites/CallComposite/types/CallControlOptions.ts
@@ -21,6 +21,7 @@ export type CallControlOptions =
        * @defaultValue true
        */
       participantsButton?: boolean | { disabled: boolean };
+      /* @conditional-compile-remove(legacy-control-bar) */
       legacyControlBarExperience?: boolean;
     };
 

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatTypeAssertions.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatTypeAssertions.ts
@@ -52,7 +52,7 @@ type CallWithChatControlOptionsInternal = Omit<
   | 'devicesButton'
   | /* @conditional-compile-remove(control-bar-button-injection) */ 'onFetchCustomButtonProps'
   | 'participantsButton'
-  | 'legacyControlBarExperience'
+  | /* @conditional-compile-remove(legacy-control-bar) */ 'legacyControlBarExperience'
 >;
 
 const CallWithChatControlOptionsTypeAssertion = (


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->