### PR TITLE
[Bugfix] Add keyboard actioning 

### DIFF
--- a/change-beta/@azure-communication-react-887bd6cb-d577-4bed-ac4d-45f58e6824ef.json
+++ b/change-beta/@azure-communication-react-887bd6cb-d577-4bed-ac4d-45f58e6824ef.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Captions",
+  "comment": "Add ability start captions on mobile with keyboard with toggle on toplevel menu item and not secondary component",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-887bd6cb-d577-4bed-ac4d-45f58e6824ef.json
+++ b/change/@azure-communication-react-887bd6cb-d577-4bed-ac4d-45f58e6824ef.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Captions",
+  "comment": "Add ability start captions on mobile with keyboard with toggle on toplevel menu item and not secondary component",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/Drawer/MoreDrawer.tsx
+++ b/packages/react-composites/src/composites/common/Drawer/MoreDrawer.tsx
@@ -465,6 +465,7 @@ export const MoreDrawer = (props: MoreDrawerProps): JSX.Element => {
         iconName: captionSettingsProp.isCaptionsFeatureActive ? 'CaptionsOffIcon' : 'CaptionsIcon',
         styles: { root: { lineHeight: 0 } }
       },
+      onItemClick: onToggleChange,
       disabled: props.disableButtonsForHoldScreen,
       secondaryComponent: (
         <Stack verticalFill verticalAlign="center">


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Allows toggle on parent of mobile more drawer
# Why
<!--- What problem does this change solve? -->
Allows keyboard on mobile to directly action it without navigating to secondary button component.
![image](https://github.com/Azure/communication-ui-library/assets/94866715/be53f1ac-fb32-4e34-9d69-491be28fe987)
![image](https://github.com/Azure/communication-ui-library/assets/94866715/bacc4aad-8a4a-4714-a696-87ee8f3233be)

<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3386878
# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested locally