### PR TITLE
[Calling sounds] Sound api update 

### DIFF
--- a/change-beta/@azure-communication-react-16de663b-13e4-48f4-8095-3eabcf3346ce.json
+++ b/change-beta/@azure-communication-react-16de663b-13e4-48f4-8095-3eabcf3346ce.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "feature",
+  "workstream": "Calling sounds",
+  "comment": "Flatten API so that we can introduce chat sounds in a similar way in the future on the chat adapter",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-16de663b-13e4-48f4-8095-3eabcf3346ce.json
+++ b/change/@azure-communication-react-16de663b-13e4-48f4-8095-3eabcf3346ce.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "feature",
+  "workstream": "Calling sounds",
+  "comment": "Flatten API so that we can introduce chat sounds in a similar way in the future on the chat adapter",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1757,9 +1757,7 @@ export type CommonCallAdapterOptions = {
         onResolveDependency?: () => Promise<VideoBackgroundEffectsDependency>;
     };
     onFetchProfile?: OnFetchProfileCallback;
-    soundOptions?: {
-        callingSounds?: CallingSounds;
-    };
+    callingSounds?: CallingSounds;
 };
 
 // @public
@@ -3696,7 +3694,6 @@ export interface SitePermissionsStyles extends BaseCustomStyles {
 // @beta
 export type SoundEffect = {
     path: string;
-    fileType?: 'mp3' | 'wav' | 'ogg' | 'aac' | 'flac';
 };
 
 // @public

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -1126,9 +1126,7 @@ export type CommonCallAdapterOptions = {
         onResolveDependency?: () => Promise<VideoBackgroundEffectsDependency>;
     };
     onFetchProfile?: OnFetchProfileCallback;
-    soundOptions?: {
-        callingSounds?: CallingSounds;
-    };
+    callingSounds?: CallingSounds;
 };
 
 // @public
@@ -1766,7 +1764,6 @@ export interface RemoteVideoTileMenuOptions {
 // @beta
 export type SoundEffect = {
     path: string;
-    fileType?: 'mp3' | 'wav' | 'ogg' | 'aac' | 'flac';
 };
 
 // @public

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.test.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.test.ts
@@ -32,12 +32,10 @@ describe('Adapter is created as expected', () => {
     const mockCallAgent = new MockCallAgent();
     const locator = { participantIds: ['some user id'] };
     const options: CommonCallAdapterOptions = {
-      soundOptions: {
-        callingSounds: {
-          callEnded: { path: 'test/path/ended' },
-          callRinging: { path: 'test/path/ringing' },
-          callBusy: { path: 'test/path/busy' }
-        }
+      callingSounds: {
+        callEnded: { path: 'test/path/ended' },
+        callRinging: { path: 'test/path/ringing' },
+        callBusy: { path: 'test/path/busy' }
       }
     };
 
@@ -63,10 +61,8 @@ describe('Adapter is created as expected', () => {
     const mockCallAgent = new MockCallAgent();
     const locator = { participantIds: ['some user id'] };
     const options: CommonCallAdapterOptions = {
-      soundOptions: {
-        callingSounds: {
-          callEnded: { path: 'test/path/ended' }
-        }
+      callingSounds: {
+        callEnded: { path: 'test/path/ended' }
       }
     };
 

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -144,9 +144,7 @@ class CallContext {
         onResolveDependency?: () => Promise<VideoBackgroundEffectsDependency>;
       };
       /* @conditional-compile-remove(calling-sounds) */
-      soundOptions?: {
-        callingSounds?: CallingSounds;
-      };
+      callingSounds?: CallingSounds;
     }
   ) {
     this.state = {
@@ -168,7 +166,7 @@ class CallContext {
       onResolveVideoEffectDependency: options?.videoBackgroundOptions?.onResolveDependency,
       /* @conditional-compile-remove(video-background-effects) */ selectedVideoBackgroundEffect: undefined,
       cameraStatus: undefined,
-      /* @conditional-compile-remove(calling-sounds) */ sounds: options?.soundOptions?.callingSounds
+      /* @conditional-compile-remove(calling-sounds) */ sounds: options?.callingSounds
     };
     this.emitter.setMaxListeners(options?.maxListeners ?? 50);
     this.bindPublicMethods();

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -1313,14 +1313,9 @@ export type CommonCallAdapterOptions = {
   onFetchProfile?: OnFetchProfileCallback;
   /* @conditional-compile-remove(calling-sounds) */
   /**
-   * Options for calling sounds
+   * Sounds to use for calling events
    */
-  soundOptions?: {
-    /**
-     * Sounds to use for calling events
-     */
-    callingSounds?: CallingSounds;
-  };
+  callingSounds?: CallingSounds;
 };
 
 /**

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -285,10 +285,6 @@ export type SoundEffect = {
    * Path to sound effect
    */
   path: string;
-  /**
-   * type of file format for the sound effect
-   */
-  fileType?: 'mp3' | 'wav' | 'ogg' | 'aac' | 'flac';
 };
 
 /**

--- a/packages/storybook/stories/snippets/CallingSoundsSnippet.snippet.tsx
+++ b/packages/storybook/stories/snippets/CallingSoundsSnippet.snippet.tsx
@@ -43,9 +43,7 @@ export const ContosoCallContainer = (props: ContainerProps): JSX.Element => {
       credential,
       locator: { groupId },
       options: {
-        soundOptions: {
-          callingSounds: callingSounds
-        }
+        callingSounds: callingSounds
       }
     };
   }, [credential, groupId, userId]);

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -155,12 +155,10 @@ const AzureCommunicationCallScreen = (props: AzureCommunicationCallScreenProps):
         onResolveDependency: onResolveVideoEffectDependencyLazy
       },
       /* @conditional-compile-remove(calling-sounds) */
-      soundOptions: {
-        callingSounds: {
-          callEnded: { path: '/sounds/callEnded.mp3' },
-          callRinging: { path: '/sounds/callRinging.mp3' },
-          callBusy: { path: '/sounds/callBusy.mp3' }
-        }
+      callingSounds: {
+        callEnded: { path: '/sounds/callEnded.mp3' },
+        callRinging: { path: '/sounds/callRinging.mp3' },
+        callBusy: { path: '/sounds/callBusy.mp3' }
       }
     };
   }, []);


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Flatten the shape of the sounds API on the call adapter so chat can do the same on the chat adapter
# Why
<!--- What problem does this change solve? -->
API was originally designed for chat to get added to the `soundOptions` bag. This doesn't extend well without a breaking change so making it flat allows for Chat to do the same in the future and maybe wrap them together for CWC adapter.
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested changes work locally and update API files.