### PR TITLE
[Rooms] Filter out consumers from participant list and video gallery

### DIFF
--- a/change-beta/@azure-communication-react-185f3b34-d242-4c37-b311-21e942bc8877.json
+++ b/change-beta/@azure-communication-react-185f3b34-d242-4c37-b311-21e942bc8877.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "fix",
+  "workstream": "Rooms",
+  "comment": "Filter out consumers from remote participant list",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-185f3b34-d242-4c37-b311-21e942bc8877.json
+++ b/change/@azure-communication-react-185f3b34-d242-4c37-b311-21e942bc8877.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "fix",
+  "workstream": "Rooms",
+  "comment": "Filter out consumers from remote participant list",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/src/baseSelectors.ts
+++ b/packages/calling-component-bindings/src/baseSelectors.ts
@@ -86,6 +86,17 @@ export const getRemoteParticipants = (
       [keys: string]: RemoteParticipantState;
     }
   | undefined => {
+  /* @conditional-compile-remove(rooms) */
+  // Filter out consumers from remote participants
+  {
+    const remoteParticipants = { ...state.calls[props.callId]?.remoteParticipants };
+    Object.keys(remoteParticipants).forEach((k) => {
+      if (remoteParticipants[k].role === 'Consumer') {
+        delete remoteParticipants[k];
+      }
+    });
+    return remoteParticipants;
+  }
   return state.calls[props.callId]?.remoteParticipants;
 };
 

--- a/packages/react-composites/src/composites/CallComposite/selectors/baseSelectors.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/baseSelectors.ts
@@ -137,7 +137,20 @@ export const getRemoteParticipants = (
   | undefined
   | {
       [keys: string]: RemoteParticipantState;
-    } => state.call?.remoteParticipants;
+    } => {
+  /* @conditional-compile-remove(rooms) */
+  // Filter out consumers from remote participants
+  {
+    const remoteParticipants = { ...state.call?.remoteParticipants };
+    Object.keys(remoteParticipants).forEach((k) => {
+      if (remoteParticipants[k].role === 'Consumer') {
+        delete remoteParticipants[k];
+      }
+    });
+    return remoteParticipants;
+  }
+  return state.call?.remoteParticipants;
+};
 
 /* @conditional-compile-remove(unsupported-browser) */
 /**


### PR DESCRIPTION
# What
Filter out consumers from getRemoteParticipants selector

# Why
Remote participants that are originally not consumers but updated to consumers during the call are still shown in the participant list

# How Tested
Tested on bug bash app with custom button to change roles during a call

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->