### PR TITLE
Hide screenshare button for iOS

### DIFF
--- a/change-beta/@azure-communication-react-aec4f243-84ab-4bb4-aad5-4e73d5ff20c2.json
+++ b/change-beta/@azure-communication-react-aec4f243-84ab-4bb4-aad5-4e73d5ff20c2.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Calling and CallWithChat samples",
+  "comment": "Hide screenshare button in Calling and CallWithChat samples when on iOS",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-aec4f243-84ab-4bb4-aad5-4e73d5ff20c2.json
+++ b/change/@azure-communication-react-aec4f243-84ab-4bb4-aad5-4e73d5ff20c2.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Calling and CallWithChat samples",
+  "comment": "Hide screenshare button in Calling and CallWithChat samples when on iOS",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/samples/CallWithChat/src/app/utils/utils.ts
+++ b/samples/CallWithChat/src/app/utils/utils.ts
@@ -44,3 +44,9 @@ export const getBackgroundColor = (avatar: string): { backgroundColor: string } 
       };
   }
 };
+
+/**
+ * Function to detect iOS devices like IPhones, IPads, and IPods
+ */
+export const isIOS = (): boolean =>
+  /iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);

--- a/samples/CallWithChat/src/app/views/CallScreen.tsx
+++ b/samples/CallWithChat/src/app/views/CallScreen.tsx
@@ -9,7 +9,8 @@ import {
   CallAndChatLocator,
   CallWithChatAdapterState,
   CallWithChatComposite,
-  CallWithChatAdapter
+  CallWithChatAdapter,
+  CallWithChatCompositeOptions
 } from '@azure/communication-react';
 /* @conditional-compile-remove(video-background-effects) */
 import { onResolveVideoEffectDependencyLazy, AzureCommunicationCallAdapterOptions } from '@azure/communication-react';
@@ -19,6 +20,7 @@ import { useSwitchableFluentTheme } from '../theming/SwitchableFluentThemeProvid
 import { createAutoRefreshingCredential } from '../utils/credential';
 import { WEB_APP_TITLE } from '../utils/constants';
 import { useIsMobile } from '../utils/useIsMobile';
+import { isIOS } from 'app/utils/utils';
 
 export interface CallScreenProps {
   token: string;
@@ -144,6 +146,17 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     afterAdapterCreate
   );
 
+  const shouldDisableScreenShare = isIOS();
+
+  const options: CallWithChatCompositeOptions = useMemo(
+    () => ({
+      callControls: {
+        screenShareButton: !shouldDisableScreenShare
+      }
+    }),
+    [shouldDisableScreenShare]
+  );
+
   // Dispose of the adapter in the window's before unload event.
   // This ensures the service knows the user intentionally left the call if the user
   // closed the browser tab during an active call.
@@ -163,6 +176,7 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
       fluentTheme={currentTheme.theme}
       rtl={currentRtl}
       joinInvitationURL={window.location.href}
+      options={options}
       formFactor={isMobileSession ? 'mobile' : 'desktop'}
     />
   );

--- a/samples/Calling/src/app/utils/utils.ts
+++ b/samples/Calling/src/app/utils/utils.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Function to detect iOS devices like IPhones, IPads, and IPods
+ */
+export const isIOS = (): boolean =>
+  /iPad|iPhone|iPod/.test(navigator.platform) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);

--- a/samples/Calling/src/app/views/CallCompositeContainer.tsx
+++ b/samples/Calling/src/app/views/CallCompositeContainer.tsx
@@ -2,15 +2,14 @@
 // Licensed under the MIT License.
 
 import { CommonCallAdapter, CallComposite } from '@azure/communication-react';
-/* @conditional-compile-remove(call-readiness) */
 import { CallCompositeOptions } from '@azure/communication-react';
 import { Spinner } from '@fluentui/react';
 import { useSwitchableFluentTheme } from '../theming/SwitchableFluentThemeProvider';
 import { useIsMobile } from '../utils/useIsMobile';
 import React, { useEffect } from 'react';
-/* @conditional-compile-remove(call-readiness) */
 import { useMemo } from 'react';
 import { CallScreenProps } from './CallScreen';
+import { isIOS } from 'app/utils/utils';
 
 export type CallCompositeContainerProps = CallScreenProps & { adapter?: CommonCallAdapter };
 
@@ -18,17 +17,17 @@ export const CallCompositeContainer = (props: CallCompositeContainerProps): JSX.
   const { adapter } = props;
   const { currentTheme, currentRtl } = useSwitchableFluentTheme();
   const isMobileSession = useIsMobile();
+  const shouldDisableScreenShare = isIOS();
 
-  /* @conditional-compile-remove(call-readiness) */
   const options: CallCompositeOptions = useMemo(
     () => ({
-      onPermissionsTroubleshootingClick,
-      onNetworkingTroubleShootingClick,
+      /* @conditional-compile-remove(call-readiness) */ onPermissionsTroubleshootingClick,
+      /* @conditional-compile-remove(call-readiness) */ onNetworkingTroubleShootingClick,
       callControls: {
-        legacyControlBarExperience: false
+        screenShareButton: !shouldDisableScreenShare
       }
     }),
-    []
+    [shouldDisableScreenShare]
   );
 
   // Dispose of the adapter in the window's before unload event.
@@ -58,7 +57,6 @@ export const CallCompositeContainer = (props: CallCompositeContainerProps): JSX.
       rtl={currentRtl}
       callInvitationUrl={callInvitationUrl}
       formFactor={isMobileSession ? 'mobile' : 'desktop'}
-      /* @conditional-compile-remove(call-readiness) */
       options={options}
     />
   );


### PR DESCRIPTION
# What
Hide screenshare button for iOS including IPads where the screensharing is not possible.

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3405782

# How Tested
Tested local Calling sample and CallWithChat sample on IPad

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->