### PR TITLE
Fix: Breaking change check failing on release branch because it does not install packages

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Install beta dependencies
         if: ${{ matrix.flavor == 'beta' && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
         run: rush switch-flavor:beta
+      - name: Install beta-release dependencies
+        if: ${{ matrix.flavor == 'beta-release' && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+        run: rush switch-flavor:beta-release
       - name: Install stable dependencies
         if: ${{ matrix.flavor == 'stable' && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
         run: rush switch-flavor:stable

--- a/change-beta/@azure-communication-react-ebecfe7f-972a-459c-9a2c-af3738c4fdfd.json
+++ b/change-beta/@azure-communication-react-ebecfe7f-972a-459c-9a2c-af3738c4fdfd.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "",
+  "comment": "ensure beta-release version is checked out",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-ebecfe7f-972a-459c-9a2c-af3738c4fdfd.json
+++ b/change/@azure-communication-react-ebecfe7f-972a-459c-9a2c-af3738c4fdfd.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "",
+  "comment": "ensure beta-release version is checked out",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
# What

Ensure breakcing-change-check checks out the beta-release flavor if intented.

# Why

![image](https://github.com/Azure/communication-ui-library/assets/2684369/2632f7cf-1ff8-4b41-b6ac-ba2790ffb996)

More info: [Bug 3484477](https://skype.visualstudio.com/SPOOL/_workitems/edit/3484477): [Web] Breaking change check failing on release branch because it does not install packages

