### PR TITLE
Move test-only `@azure/core-rest-pipeline` to dev dependencies

### DIFF
--- a/change-beta/@azure-communication-react-c3fc9dd9-9dcc-4464-a518-038f21f1b5cf.json
+++ b/change-beta/@azure-communication-react-c3fc9dd9-9dcc-4464-a518-038f21f1b5cf.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Move @azure/core-rest-pipeline to dev dependency",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-c3fc9dd9-9dcc-4464-a518-038f21f1b5cf.json
+++ b/change/@azure-communication-react-c3fc9dd9-9dcc-4464-a518-038f21f1b5cf.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Move @azure/core-rest-pipeline to dev dependency",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -26,7 +26,6 @@
     "@azure/communication-common": "^2.3.0",
     "@azure/core-client": "^1.7.3",
     "@azure/core-paging": "^1.5.0",
-    "@azure/core-rest-pipeline": "^1.13.0",
     "@azure/logger": "^1.0.4",
     "@fluentui/react-components": "^9.42.0",
     "@fluentui/react": "^8.112.9",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -96,6 +96,7 @@
     "@azure/communication-calling-effects": "1.0.1",
     "@azure/communication-chat": "1.5.0-beta.1 || ^1.4.0",
     "@azure/core-auth": "^1.4.0",
+    "@azure/core-rest-pipeline": "^1.13.0",
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.5",
     "@internal/calling-component-bindings": "1.11.0-beta.1",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "@azure/communication-common": "^2.3.0",
     "@azure/core-paging": "^1.5.0",
-    "@azure/core-rest-pipeline": "^1.13.0",
     "@azure/logger": "^1.0.4",
     "@fluentui/react-file-type-icons": "8.10.4",
     "@fluentui/react-hooks": "^8.6.33",
@@ -87,6 +86,7 @@
     "@azure/communication-chat": "1.5.0-beta.1 || ^1.4.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-signaling": "1.0.0-beta.23 || 1.0.0-beta.22",
+    "@azure/core-rest-pipeline": "^1.13.0",
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.5",
     "@babel/preset-env": "7.23.5",

--- a/packages/react-composites/rollup.config.mjs
+++ b/packages/react-composites/rollup.config.mjs
@@ -9,5 +9,6 @@ const common = commonConfig(packageJson);
 
 export default {
   ...common,
+  input: './dist/dist-esm/index-public.js',
   external: [...(common.external || []), '@internal/fake-backends']
 };


### PR DESCRIPTION
# What

- Move `@azure/core-rest-pipeline` to dev dependencies and remove from the npm package
- Ensure rollup only runs over the public index to ensure dev deps from internal-only exports don't get pulled into the final npm package

# Why

Only used in react-composites tests

# How Tested

CI only