### PR TITLE
[Chat] Revert chat sdk version update

### DIFF
--- a/change-beta/@azure-communication-react-65a10e9b-153b-42be-8709-e2238f4b7f59.json
+++ b/change-beta/@azure-communication-react-65a10e9b-153b-42be-8709-e2238f4b7f59.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "DenpendencyUpdate",
+  "comment": "Revert chat sdk version update",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change-beta/@azure-communication-react-9d7d36fd-7604-40e3-a7bf-0bee4c222fda.json
+++ b/change-beta/@azure-communication-react-9d7d36fd-7604-40e3-a7bf-0bee4c222fda.json
@@ -1,9 +1,0 @@
-{
-  "type": "none",
-  "area": "improvement",
-  "workstream": "UpdateDependency",
-  "comment": "Update communication-chat stable to 1.4.0",
-  "packageName": "@azure/communication-react",
-  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change-beta/@azure-communication-react-9d7d36fd-7604-40e3-a7bf-0bee4c222fda.json
+++ b/change-beta/@azure-communication-react-9d7d36fd-7604-40e3-a7bf-0bee4c222fda.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "UpdateDependency",
+  "comment": "Update communication-chat stable to 1.4.0",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-65a10e9b-153b-42be-8709-e2238f4b7f59.json
+++ b/change/@azure-communication-react-65a10e9b-153b-42be-8709-e2238f4b7f59.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "DenpendencyUpdate",
+  "comment": "Revert chat sdk version update",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/rush/variants/stable/common-versions.json
+++ b/common/config/rush/variants/stable/common-versions.json
@@ -27,7 +27,7 @@
     // This is the version for stable build (please also update allowedAlternativeVersions below)
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-common": "2.3.0",
-    "@azure/communication-chat": "^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/communication-signaling": "1.0.0-beta.20"
   },
 
@@ -59,7 +59,7 @@
     // This is the version for stable build (please also update preferredVersions above)
     "@azure/communication-calling": ["^1.19.1"],
     "@azure/communication-common": ["2.3.0"],
-    "@azure/communication-chat": ["^1.3.2"],
+    "@azure/communication-chat": ["^1.4.0"],
     "@azure/communication-signaling": ["1.0.0-beta.20"],
     "typescript": [
       // All projects should use this version by default

--- a/common/config/rush/variants/stable/common-versions.json
+++ b/common/config/rush/variants/stable/common-versions.json
@@ -27,7 +27,7 @@
     // This is the version for stable build (please also update allowedAlternativeVersions below)
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-common": "2.3.0",
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "^1.3.2",
     "@azure/communication-signaling": "1.0.0-beta.20"
   },
 
@@ -59,7 +59,7 @@
     // This is the version for stable build (please also update preferredVersions above)
     "@azure/communication-calling": ["^1.19.1"],
     "@azure/communication-common": ["2.3.0"],
-    "@azure/communication-chat": ["^1.4.0"],
+    "@azure/communication-chat": ["^1.3.2"],
     "@azure/communication-signaling": ["1.0.0-beta.20"],
     "typescript": [
       // All projects should use this version by default

--- a/packages/chat-component-bindings/package.json
+++ b/packages/chat-component-bindings/package.json
@@ -40,12 +40,12 @@
     "memoize-one": "^5.2.1"
   },
   "peerDependencies": {
-    "@azure/communication-chat": ">=1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || >=1.3.2",
     "@types/react": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.5",
     "@microsoft/api-documenter": "~7.23.14",

--- a/packages/chat-component-bindings/package.json
+++ b/packages/chat-component-bindings/package.json
@@ -40,12 +40,12 @@
     "memoize-one": "^5.2.1"
   },
   "peerDependencies": {
-    "@azure/communication-chat": "1.4.0-beta.2 || >=1.3.2",
+    "@azure/communication-chat": ">=1.4.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.5",
     "@microsoft/api-documenter": "~7.23.14",

--- a/packages/chat-stateful-client/package.json
+++ b/packages/chat-stateful-client/package.json
@@ -40,10 +40,10 @@
     "nanoid": "3.3.6"
   },
   "peerDependencies": {
-    "@azure/communication-chat": ">=1.4.0"
+    "@azure/communication-chat": "1.4.0-beta.2 || >=1.3.2"
   },
   "devDependencies": {
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@azure/communication-signaling": "1.0.0-beta.21 || 1.0.0-beta.20",
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.5",

--- a/packages/chat-stateful-client/package.json
+++ b/packages/chat-stateful-client/package.json
@@ -40,10 +40,10 @@
     "nanoid": "3.3.6"
   },
   "peerDependencies": {
-    "@azure/communication-chat": "1.4.0-beta.2 || >=1.3.2"
+    "@azure/communication-chat": ">=1.4.0"
   },
   "devDependencies": {
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/communication-signaling": "1.0.0-beta.21 || 1.0.0-beta.20",
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.5",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-calling-effects": "1.0.1",
-    "@azure/communication-chat": ">=1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || >=1.3.2",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",
@@ -95,7 +95,7 @@
   "devDependencies": {
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-calling-effects": "1.0.1",
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@azure/core-auth": "^1.4.0",
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.5",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-calling-effects": "1.0.1",
-    "@azure/communication-chat": "1.4.0-beta.2 || >=1.3.2",
+    "@azure/communication-chat": ">=1.4.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",
@@ -95,7 +95,7 @@
   "devDependencies": {
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-calling-effects": "1.0.1",
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/core-auth": "^1.4.0",
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.5",

--- a/packages/fake-backends/package.json
+++ b/packages/fake-backends/package.json
@@ -30,7 +30,7 @@
     "_test:by-flavor": "(npm run _if-preprocess && rushx preprocess || if-env COMMUNICATION_REACT_FLAVOR=beta && echo \"skip preprocess\") && jest --passWithNoTests"
   },
   "dependencies": {
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-signaling": "1.0.0-beta.21 || 1.0.0-beta.20",
     "@azure/core-paging": "^1.5.0",

--- a/packages/fake-backends/package.json
+++ b/packages/fake-backends/package.json
@@ -30,7 +30,7 @@
     "_test:by-flavor": "(npm run _if-preprocess && rushx preprocess || if-env COMMUNICATION_REACT_FLAVOR=beta && echo \"skip preprocess\") && jest --passWithNoTests"
   },
   "dependencies": {
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-signaling": "1.0.0-beta.21 || 1.0.0-beta.20",
     "@azure/core-paging": "^1.5.0",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -75,7 +75,7 @@
   "peerDependencies": {
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-calling-effects": "1.0.1",
-    "@azure/communication-chat": ">=1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || >=1.3.2",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",
@@ -84,7 +84,7 @@
   "devDependencies": {
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-calling-effects": "1.0.1",
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-signaling": "1.0.0-beta.21 || 1.0.0-beta.20",
     "@babel/cli": "^7.23.4",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -75,7 +75,7 @@
   "peerDependencies": {
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-calling-effects": "1.0.1",
-    "@azure/communication-chat": "1.4.0-beta.2 || >=1.3.2",
+    "@azure/communication-chat": ">=1.4.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0",
@@ -84,7 +84,7 @@
   "devDependencies": {
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-calling-effects": "1.0.1",
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-signaling": "1.0.0-beta.21 || 1.0.0-beta.20",
     "@babel/cli": "^7.23.4",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@azure/communication-calling": "^1.19.1",
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.11.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@azure/communication-calling": "^1.19.1",
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.11.0",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -32,7 +32,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-calling": "^1.19.1",
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@azure/communication-react": "1.11.0",
     "@azure/communication-common": "^2.3.0",
     "@azure/logger": "^1.0.4",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -32,7 +32,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-calling": "^1.19.1",
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/communication-react": "1.11.0",
     "@azure/communication-common": "^2.3.0",
     "@azure/logger": "^1.0.4",

--- a/samples/Chat/package.json
+++ b/samples/Chat/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.11.0",

--- a/samples/Chat/package.json
+++ b/samples/Chat/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.11.0",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -23,7 +23,7 @@
     "_typecheck": "rushx _by-flavor \"npm run _if-preprocess && echo skip || (if-env COMMUNICATION_REACT_FLAVOR=beta && tsc)\""
   },
   "dependencies": {
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-identity": "^1.3.0",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -23,7 +23,7 @@
     "_typecheck": "rushx _by-flavor \"npm run _if-preprocess && echo skip || (if-env COMMUNICATION_REACT_FLAVOR=beta && tsc)\""
   },
   "dependencies": {
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/communication-calling": "^1.19.1",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-identity": "^1.3.0",

--- a/samples/Server/package.json
+++ b/samples/Server/package.json
@@ -20,7 +20,7 @@
     "lint:quiet": "eslint */**/*.{ts,tsx} --quiet"
   },
   "dependencies": {
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/storage-blob": "^12.15.0",

--- a/samples/Server/package.json
+++ b/samples/Server/package.json
@@ -20,7 +20,7 @@
     "lint:quiet": "eslint */**/*.{ts,tsx} --quiet"
   },
   "dependencies": {
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/storage-blob": "^12.15.0",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -26,7 +26,7 @@
     "@azure/communication-react": "1.11.0",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-calling": "^1.19.1",
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@fluentui/react": "^8.112.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -26,7 +26,7 @@
     "@azure/communication-react": "1.11.0",
     "@azure/communication-common": "^2.3.0",
     "@azure/communication-calling": "^1.19.1",
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@fluentui/react": "^8.112.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/communication-calling": "^1.19.1",
-    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
+    "@azure/communication-chat": "^1.4.0",
     "@azure/communication-common": "^2.3.0",
     "uuid": "^9.0.0",
     "cross-env": "^7.0.3"

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@azure/communication-calling": "^1.19.1",
-    "@azure/communication-chat": "^1.4.0",
+    "@azure/communication-chat": "1.4.0-beta.2 || ^1.3.2",
     "@azure/communication-common": "^2.3.0",
     "uuid": "^9.0.0",
     "cross-env": "^7.0.3"


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Revert Chat SDK version back to 1.4.0-beta.2 || >=1.3.2

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->