### PR TITLE
Enable `noImplicitAny` for acs-ui-common, calling-stateful-client and calling-component-bindings packlets

### DIFF
--- a/change-beta/@azure-communication-react-0267f342-dc2c-4146-8fd9-5ed3013dd2ae.json
+++ b/change-beta/@azure-communication-react-0267f342-dc2c-4146-8fd9-5ed3013dd2ae.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Enable noImplicitAny for calling stateful packages",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change-beta/@azure-communication-react-5ff8daf3-f304-4bf6-b675-1e442ec92406.json
+++ b/change-beta/@azure-communication-react-5ff8daf3-f304-4bf6-b675-1e442ec92406.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Fix function type signature of StatefulCallClient.selectCamera",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-0267f342-dc2c-4146-8fd9-5ed3013dd2ae.json
+++ b/change/@azure-communication-react-0267f342-dc2c-4146-8fd9-5ed3013dd2ae.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Enable noImplicitAny for calling stateful packages",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-5ff8daf3-f304-4bf6-b675-1e442ec92406.json
+++ b/change/@azure-communication-react-5ff8daf3-f304-4bf6-b675-1e442ec92406.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Fix function type signature of StatefulCallClient.selectCamera",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/acs-ui-common/src/telemetry.ts
+++ b/packages/acs-ui-common/src/telemetry.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as telemetryVersion from './telemetryVersion';
+import telemetryVersion from './telemetryVersion';
 
 /**
  * @private
@@ -64,6 +64,6 @@ export const _getApplicationId = (telemetryImplementationHint: _TelemetryImpleme
   const highLevelArtifact = 1;
   const specificImplementation = getTelemetryImplementationHint(telemetryImplementationHint);
   const implementationDetails = 0;
-  const version = telemetryVersion['default'];
+  const version = telemetryVersion;
   return sanitize(`acr${highLevelArtifact}${specificImplementation}${implementationDetails}/${version}`);
 };

--- a/packages/acs-ui-common/tsconfig.json
+++ b/packages/acs-ui-common/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../common/config/tsc/tsconfig.json",
   "compilerOptions": {
-    "noImplicitAny": false, // TODO: MAKE THIS true
+    "noImplicitAny": true,
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],

--- a/packages/acs-ui-common/tsconfig.preprocess.json
+++ b/packages/acs-ui-common/tsconfig.preprocess.json
@@ -2,7 +2,7 @@
   "extends": "../../common/config/tsc/tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./preprocessed",
-    "noImplicitAny": false, // TODO: MAKE THIS true
+    "noImplicitAny": true,
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],

--- a/packages/calling-component-bindings/src/participantListSelector.ts
+++ b/packages/calling-component-bindings/src/participantListSelector.ts
@@ -36,8 +36,9 @@ const convertRemoteParticipantsToParticipantListParticipants = (
   isHideAttendeeNamesEnabled?: boolean,
   localUserRole?: ParticipantRole
 ): CallParticipantListParticipant[] => {
-  /* eslint-disable @typescript-eslint/explicit-function-return-type */
-  const conversionCallback = (memoizeFn) => {
+  const conversionCallback = (
+    memoizeFn: (...args: any[]) => CallParticipantListParticipant
+  ): CallParticipantListParticipant[] => {
     return (
       remoteParticipants
         // Filter out MicrosoftBot participants

--- a/packages/calling-component-bindings/src/videoGallerySelector.ts
+++ b/packages/calling-component-bindings/src/videoGallerySelector.ts
@@ -100,7 +100,7 @@ export const videoGallerySelector: VideoGallerySelector = createSelector(
     const dominantSpeakerIds = _dominantSpeakersWithFlatId(dominantSpeakers);
     const dominantSpeakersMap: Record<string, number> = {};
     dominantSpeakerIds?.forEach((speaker, idx) => (dominantSpeakersMap[speaker] = idx));
-    const noRemoteParticipants = [];
+    const noRemoteParticipants: RemoteParticipantState[] = [];
 
     return {
       screenShareParticipant: screenShareRemoteParticipant

--- a/packages/calling-component-bindings/tsconfig.json
+++ b/packages/calling-component-bindings/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../common/config/tsc/tsconfig.json",
   "compilerOptions": {
-    "noImplicitAny": false, // TODO: MAKE THIS true
+    "noImplicitAny": true,
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],

--- a/packages/calling-stateful-client/review/beta/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/beta/calling-stateful-client.api.md
@@ -328,7 +328,7 @@ export type StatefulCallClientOptions = {
 // @public
 export interface StatefulDeviceManager extends DeviceManager {
     getUnparentedVideoStreams: () => LocalVideoStream[];
-    selectCamera: (VideoDeviceInfo: any) => void;
+    selectCamera: (device: VideoDeviceInfo) => void;
 }
 
 // @beta (undocumented)

--- a/packages/calling-stateful-client/review/stable/calling-stateful-client.api.md
+++ b/packages/calling-stateful-client/review/stable/calling-stateful-client.api.md
@@ -293,7 +293,7 @@ export type StatefulCallClientOptions = {
 // @public
 export interface StatefulDeviceManager extends DeviceManager {
     getUnparentedVideoStreams: () => LocalVideoStream[];
-    selectCamera: (VideoDeviceInfo: any) => void;
+    selectCamera: (device: VideoDeviceInfo) => void;
 }
 
 // @beta (undocumented)

--- a/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
+++ b/packages/calling-stateful-client/src/CallAgentDeclarative.test.ts
@@ -20,6 +20,7 @@ import {
 } from '@azure/communication-calling';
 /* @conditional-compile-remove(calling-beta-sdk) */
 import {
+  CallAgentFeature,
   MeetingLocator,
   GroupChatCallLocator,
   PushNotificationData,
@@ -78,7 +79,10 @@ class MockCallAgent implements CallAgent {
   connectionState = 'Disconnected' as ConnectionState;
   kind = 'CallAgent' as CallAgentKind;
   emitter = new EventEmitter();
-  feature;
+  /* @conditional-compile-remove(calling-beta-sdk) */
+  feature<TFeature extends CallAgentFeature>(): TFeature {
+    throw new Error('Method not implemented.');
+  }
   startCall(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     participants: (CommunicationUserIdentifier | PhoneNumberIdentifier | UnknownIdentifier)[],

--- a/packages/calling-stateful-client/src/Converter.ts
+++ b/packages/calling-stateful-client/src/Converter.ts
@@ -80,7 +80,7 @@ export function convertSdkRemoteStreamToDeclarativeRemoteStream(
 export function convertSdkParticipantToDeclarativeParticipant(
   participant: SdkRemoteParticipant
 ): DeclarativeRemoteParticipant {
-  const declarativeVideoStreams = {};
+  const declarativeVideoStreams: { [key: number]: DeclarativeRemoteVideoStream } = {};
   for (const videoStream of participant.videoStreams) {
     declarativeVideoStreams[videoStream.id] = convertSdkRemoteStreamToDeclarativeRemoteStream(videoStream);
   }
@@ -105,7 +105,7 @@ export function convertSdkParticipantToDeclarativeParticipant(
  * Note at the time of writing only one LocalVideoStream is supported by the SDK.
  */
 export function convertSdkCallToDeclarativeCall(call: CallCommon): CallState {
-  const declarativeRemoteParticipants = {};
+  const declarativeRemoteParticipants: { [key: string]: DeclarativeRemoteParticipant } = {};
   call.remoteParticipants.forEach((participant: SdkRemoteParticipant) => {
     declarativeRemoteParticipants[toFlatCommunicationIdentifier(participant.identifier)] =
       convertSdkParticipantToDeclarativeParticipant(participant);

--- a/packages/calling-stateful-client/src/DeviceManager.test.ts
+++ b/packages/calling-stateful-client/src/DeviceManager.test.ts
@@ -276,7 +276,7 @@ const createStatefulCallClientWithDeviceManager = (deviceManager: MockDeviceMana
 };
 
 interface MockDeviceManager extends Mutable<DeviceManager> {
-  emit(event: any, data?: any);
+  emit(eventName: string | symbol, ...args: any[]): boolean;
 }
 
 const createMockDeviceManagerWithCameras = (cameras: VideoDeviceInfo[]): MockDeviceManager => {

--- a/packages/calling-stateful-client/src/DeviceManagerDeclarative.ts
+++ b/packages/calling-stateful-client/src/DeviceManagerDeclarative.ts
@@ -18,7 +18,7 @@ export interface StatefulDeviceManager extends DeviceManager {
    * any way to {@link @azure/communication-calling#DeviceManager}. It is entirely contained in
    * {@link StatefulDeviceManager}. See also {@link DeviceManagerState.selectedCamera}.
    */
-  selectCamera: (VideoDeviceInfo) => void;
+  selectCamera: (device: VideoDeviceInfo) => void;
 
   /* @conditional-compile-remove(video-background-effects) */
   /**

--- a/packages/calling-stateful-client/src/TestUtils.ts
+++ b/packages/calling-stateful-client/src/TestUtils.ts
@@ -33,7 +33,7 @@ import { CallContext } from './CallContext';
 import { InternalCallContext } from './InternalCallContext';
 import { createStatefulCallClientWithDeps, StatefulCallClient } from './StatefulCallClient';
 
-let backupFreezeFunction;
+let backupFreezeFunction: typeof Object.freeze;
 
 /**
  * @private
@@ -41,7 +41,7 @@ let backupFreezeFunction;
 export function mockoutObjectFreeze(): void {
   beforeEach(() => {
     backupFreezeFunction = Object.freeze;
-    Object.freeze = function (obj) {
+    Object.freeze = function <T>(obj: T): T {
       return obj;
     };
   });
@@ -56,7 +56,7 @@ export function mockoutObjectFreeze(): void {
  */
 export interface MockEmitter {
   emitter: EventEmitter;
-  emit(event: any, data?: any);
+  emit(eventName: string | symbol, ...args: any[]): boolean;
 }
 
 /**
@@ -95,7 +95,7 @@ export const stubCommunicationTokenCredential = (): CommunicationTokenCredential
 export class MockRecordingCallFeatureImpl implements RecordingCallFeature {
   public name = 'Recording';
   public isRecordingActive = false;
-  public recordings;
+  public recordings: RecordingInfo[] = [];
   public emitter = new EventEmitter();
   on(event: 'isRecordingActiveChanged', listener: PropertyChangedEvent): void;
   on(event: 'recordingsUpdated', listener: CollectionUpdatedEvent<RecordingInfo>): void;
@@ -240,7 +240,7 @@ export function addMockEmitter(object: any): any {
  * @private
  */
 export interface MockCall extends Mutable<Call>, MockEmitter {
-  testHelperPushRemoteParticipant(participant: RemoteParticipant);
+  testHelperPushRemoteParticipant(participant: RemoteParticipant): void;
   testHelperPopRemoteParticipant(): RemoteParticipant;
   testHelperPushLocalVideoStream(stream: LocalVideoStream): void;
   testHelperPopLocalVideoStream(): LocalVideoStream;
@@ -290,7 +290,7 @@ export function createMockCall(mockCallId = 'defaultCallID'): MockCall {
  * @private
  */
 export interface MockRemoteParticipant extends Mutable<RemoteParticipant> {
-  emit(event: string, data?: any);
+  emit(eventName: string | symbol, ...args: any[]): boolean;
   testHelperPushVideoStream(stream: RemoteVideoStream): void;
   testHelperPopVideoStream(): RemoteVideoStream;
 }

--- a/packages/calling-stateful-client/tsconfig.json
+++ b/packages/calling-stateful-client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../common/config/tsc/tsconfig.json",
   "compilerOptions": {
-    "noImplicitAny": false, // TODO: MAKE THIS true
+    "noImplicitAny": true,
     "outDir": "./dist/dist-esm"
   },
   "typeRoots": ["./node_modules/@types"],

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -3837,7 +3837,7 @@ export type StatefulChatClientOptions = {
 // @public
 export interface StatefulDeviceManager extends DeviceManager {
     getUnparentedVideoStreams: () => LocalVideoStream[];
-    selectCamera: (VideoDeviceInfo: any) => void;
+    selectCamera: (device: VideoDeviceInfo) => void;
 }
 
 // @public

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -3060,7 +3060,7 @@ export type StatefulChatClientOptions = {
 // @public
 export interface StatefulDeviceManager extends DeviceManager {
     getUnparentedVideoStreams: () => LocalVideoStream[];
-    selectCamera: (VideoDeviceInfo: any) => void;
+    selectCamera: (device: VideoDeviceInfo) => void;
 }
 
 // @public


### PR DESCRIPTION
# What

- Enable `noImplicitAny` for acs-ui-common, calling-stateful-client and calling-component-bindings packlets
- **Important: Exposed a necessary stable breaking change in the StatefulCallClient.selectCamera.**
  - ARB should approve this as its type narrowing for functional safety

# Why

Work to enable noImplicitAny throughout repo

# How Tested

n/a - CI will run necessary tests.