### PR TITLE
[Chat] Fix for image placeholder issue for GA release

### DIFF
--- a/change-beta/@azure-communication-react-bd803e15-0466-423a-9236-286d712b34b1.json
+++ b/change-beta/@azure-communication-react-bd803e15-0466-423a-9236-286d712b34b1.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Inline image",
+  "comment": "Fixed an issue with image placeholder for GA release",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-bd803e15-0466-423a-9236-286d712b34b1.json
+++ b/change-beta/@azure-communication-react-bd803e15-0466-423a-9236-286d712b34b1.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "Inline image",
-  "comment": "Fixed an issue with image placeholder for GA release",
+  "comment": "Fix for image placeholder issue for GA release",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@azure-communication-react-bd803e15-0466-423a-9236-286d712b34b1.json
+++ b/change/@azure-communication-react-bd803e15-0466-423a-9236-286d712b34b1.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Inline image",
+  "comment": "Fixed an issue with image placeholder for GA release",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-bd803e15-0466-423a-9236-286d712b34b1.json
+++ b/change/@azure-communication-react-bd803e15-0466-423a-9236-286d712b34b1.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "Inline image",
-  "comment": "Fixed an issue with image placeholder for GA release",
+  "comment": "Fix for image placeholder issue for GA release",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsMessageBubble.tsx
@@ -298,6 +298,9 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
   const chatItemMessageContainerClassName = mergeClasses(
     // messageContainerStyle used in className and style prop as style prop can't handle CSS selectors
     chatMessageStyles.body,
+    // disable placeholder functionality for GA releases as it might confuse users
+    /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
+    chatMessageStyles.bodyWithPlaceholderImage,
     isBlockedMessage
       ? chatMessageCommonStyles.blocked
       : props.message.status === 'failed'

--- a/packages/react-components/src/components/styles/MessageThread.styles.ts
+++ b/packages/react-components/src/components/styles/MessageThread.styles.ts
@@ -251,22 +251,6 @@ export const useChatMessageStyles = makeStyles({
       color: tokens.colorStatusWarningBackground3,
       fontWeight: tokens.fontWeightSemibold
     },
-    '& img[src=""]': {
-      display: 'block',
-      position: 'relative',
-      marginBottom: '5px'
-    },
-    '& img[src=""]:after': {
-      backgroundColor: tokens.colorNeutralBackground1Selected,
-      content: `url("data:image/gif;base64,R0lGODlhAQABAAAAACw=")`,
-      backgroundSize: 'center',
-      position: 'absolute',
-      width: '100%',
-      height: '100%',
-      top: '0',
-      left: '0',
-      display: 'block'
-    },
     '& img': {
       maxWidth: '100% !important', // Add !important to make sure it won't be overridden by style defined in element
       height: 'auto !important'
@@ -316,6 +300,24 @@ export const useChatMessageStyles = makeStyles({
           paddingRight: '5px'
         }
       }
+    }
+  },
+  bodyWithPlaceholderImage: {
+    '& img[src=""]': {
+      display: 'block',
+      position: 'relative',
+      marginBottom: '5px'
+    },
+    '& img[src=""]:after': {
+      backgroundColor: tokens.colorNeutralBackground1Selected,
+      content: `url("data:image/gif;base64,R0lGODlhAQABAAAAACw=")`,
+      backgroundSize: 'center',
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+      top: '0',
+      left: '0',
+      display: 'block'
     }
   },
   bodyWithoutAvatar: {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fixed an issue when grey placeholder was shown for images for GA release

Current implementation with the fix:
- beta

https://github.com/Azure/communication-ui-library/assets/98852890/c942809a-0fcb-459a-b868-8bfa7fdec780

- stable:

https://github.com/Azure/communication-ui-library/assets/98852890/73aa8813-ba89-42af-a8d3-bd684a630ad8


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->