### PR TITLE
[bugfix] Add heading role to SidePaneHeader

### DIFF
--- a/change-beta/@azure-communication-react-e3181cc7-3ce8-44d3-ae27-f595b8a93efe.json
+++ b/change-beta/@azure-communication-react-e3181cc7-3ce8-44d3-ae27-f595b8a93efe.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "SidePane",
+  "comment": "Update role for sidepane headers",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-e3181cc7-3ce8-44d3-ae27-f595b8a93efe.json
+++ b/change/@azure-communication-react-e3181cc7-3ce8-44d3-ae27-f595b8a93efe.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "SidePane",
+  "comment": "Update role for sidepane headers",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/SidePaneHeader.tsx
+++ b/packages/react-composites/src/composites/common/SidePaneHeader.tsx
@@ -45,7 +45,7 @@ export const SidePaneHeader = (props: {
 
   return (
     <Stack horizontal horizontalAlign="space-between" styles={sidePaneHeaderContainerStyles} verticalAlign="center">
-      <Stack.Item styles={sidePaneHeaderStyles}>{props.headingText}</Stack.Item>
+      <Stack.Item role="heading" styles={sidePaneHeaderStyles}>{props.headingText}</Stack.Item>
       <Stack.Item>
         <CommandBarButton
           ariaLabel={props.dismissSidePaneButtonAriaLabel}

--- a/packages/react-composites/src/composites/common/SidePaneHeader.tsx
+++ b/packages/react-composites/src/composites/common/SidePaneHeader.tsx
@@ -45,7 +45,9 @@ export const SidePaneHeader = (props: {
 
   return (
     <Stack horizontal horizontalAlign="space-between" styles={sidePaneHeaderContainerStyles} verticalAlign="center">
-      <Stack.Item role="heading" styles={sidePaneHeaderStyles}>{props.headingText}</Stack.Item>
+      <Stack.Item role="heading" styles={sidePaneHeaderStyles}>
+        {props.headingText}
+      </Stack.Item>
       <Stack.Item>
         <CommandBarButton
           ariaLabel={props.dismissSidePaneButtonAriaLabel}


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add heading role to SidePaneHeader

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3323329
No role was defined for SidePaneHeaders like People and Effects

# How Tested
<!--- How did you test your change. What tests have you added. -->
MacOS Chrome Calling sample

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->