### PR TITLE
Show the hand raise order on the local video tile when on mobile

### DIFF
--- a/change-beta/@azure-communication-react-ca5238f1-98ce-4db0-814c-1a041c63dc06.json
+++ b/change-beta/@azure-communication-react-ca5238f1-98ce-4db0-814c-1a041c63dc06.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Show the hand raise order on the local video tile when on mobile",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-ca5238f1-98ce-4db0-814c-1a041c63dc06.json
+++ b/change/@azure-communication-react-ca5238f1-98ce-4db0-814c-1a041c63dc06.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Show the hand raise order on the local video tile when on mobile",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -38,6 +38,8 @@ import { DirectionalHint, IContextualMenuProps } from '@fluentui/react';
 import useLongPress from './utils/useLongPress';
 /* @conditional-compile-remove(pinned-participants) */
 import { moreButtonStyles } from './styles/VideoTile.styles';
+/* @conditional-compile-remove(raise-hand) */
+import { raiseHandContainerStyles } from './styles/VideoTile.styles';
 
 /**
  * Strings of {@link VideoTile} that can be overridden.
@@ -448,20 +450,11 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
           <Stack className={mergeStyles(overlayContainerStyles, styles?.overlayContainer)}>{children}</Stack>
         )}
         {
-          /* @conditional-compile-remove(raise-hand) */ raisedHand && canShowLabel && (
+          /* @conditional-compile-remove(raise-hand) */ raisedHand && (
             <Stack
               horizontal={true}
               tokens={{ childrenGap: '0.2rem' }}
-              style={{
-                alignItems: 'center',
-                padding: '0.2rem 0.3rem',
-                backgroundColor: theme.palette.white,
-                opacity: 0.9,
-                borderRadius: '1rem',
-                margin: '0.5rem',
-                width: 'fit-content',
-                position: 'absolute'
-              }}
+              className={raiseHandContainerStyles(theme, !canShowLabel)}
             >
               <Stack.Item>
                 <Text>{raisedHand.raisedHandOrderPosition}</Text>

--- a/packages/react-components/src/components/styles/VideoTile.styles.ts
+++ b/packages/react-components/src/components/styles/VideoTile.styles.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { IButtonStyles, IStyle, mergeStyles, Theme } from '@fluentui/react';
+import { IButtonStyles, IStyle, ITheme, mergeStyles, Theme } from '@fluentui/react';
 
 /**
  * @private
@@ -141,4 +141,35 @@ export const moreButtonStyles: IButtonStyles = {
   rootExpanded: {
     background: 'none'
   }
+};
+
+/**
+ * @private
+ */
+export const raiseHandContainerStyles = (theme: ITheme, limitedSpace: boolean): string =>
+  mergeStyles(
+    {
+      alignItems: 'center',
+      padding: '0.2rem 0.3rem',
+      backgroundColor: theme.palette.white,
+      opacity: 0.9,
+      borderRadius: '1rem',
+      margin: '0.5rem',
+      width: 'fit-content',
+      position: 'absolute'
+    },
+    limitedSpace && raiseHandLimitedSpaceStyles
+  );
+
+/**
+ * @private
+ */
+export const raiseHandLimitedSpaceStyles: IStyle = {
+  // position centrally
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  left: 0,
+  right: 0,
+  // position at the bottom
+  bottom: 0
 };


### PR DESCRIPTION
# What

Update the local video tile to show the raise hand at the bottom center

# Why

Mobile users could not see their own position in the raise hand queue

# How Tested
Locally

| before | after |
| -- | -- |
| ![image](https://github.com/Azure/communication-ui-library/assets/2684369/2d34fa01-44e9-47e6-9557-5b34ed499f78) | ![image](https://github.com/Azure/communication-ui-library/assets/2684369/bc86332e-afa1-4740-964f-1ad6ce66d9c1) |