### PR TITLE
[Chat] Remove file card group message from stable API

### DIFF
--- a/change-beta/@azure-communication-react-271e1156-3766-4b14-99c4-12db881e1dad.json
+++ b/change-beta/@azure-communication-react-271e1156-3766-4b14-99c4-12db881e1dad.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "improvement",
+  "workstream": "InlineImageGA",
+  "comment": "Remove FileCardGroupMessage From Stable API",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-271e1156-3766-4b14-99c4-12db881e1dad.json
+++ b/change/@azure-communication-react-271e1156-3766-4b14-99c4-12db881e1dad.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "improvement",
+  "workstream": "InlineImageGA",
+  "comment": "Remove FileCardGroupMessage From Stable API",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -2568,7 +2568,6 @@ export interface MessageThreadStrings {
     editedTag: string;
     editMessage: string;
     failToSendTag?: string;
-    fileCardGroupMessage: string;
     friday: string;
     liveAuthorIntro: string;
     messageContentAriaText: string;

--- a/packages/react-components/review/stable/react-components.api.md
+++ b/packages/react-components/review/stable/react-components.api.md
@@ -1288,7 +1288,6 @@ export interface MessageThreadStrings {
     editedTag: string;
     editMessage: string;
     failToSendTag?: string;
-    fileCardGroupMessage: string;
     friday: string;
     liveAuthorIntro: string;
     messageContentAriaText: string;

--- a/packages/react-components/src/components/FileDownloadCards.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.tsx
@@ -298,5 +298,8 @@ const DownloadIconTrampoline = (): JSX.Element => {
 const useLocaleStringsTrampoline = (): _FileDownloadCardsStrings => {
   /* @conditional-compile-remove(file-sharing) */
   return useLocale().strings.messageThread;
-  return { downloadFile: '', fileCardGroupMessage: '' };
+  let msg = '' 
+  /* @conditional-compile-remove(file-sharing) */ 
+  msg = useLocale().strings.messageThread.fileCardGroupMessage
+  return { downloadFile: '', fileCardGroupMessage: msg };
 };

--- a/packages/react-components/src/components/FileDownloadCards.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.tsx
@@ -4,6 +4,7 @@
 import { Icon, IconButton, Spinner, SpinnerSize, TooltipHost } from '@fluentui/react';
 import React, { useCallback, useState } from 'react';
 import { useMemo } from 'react';
+/* @conditional-compile-remove(file-sharing) */
 import { useLocale } from '../localization';
 import { _FileCard } from './FileCard';
 import { _FileCardGroup } from './FileCardGroup';
@@ -209,6 +210,7 @@ export const _FileDownloadCards = (props: _FileDownloadCardsProps): JSX.Element 
     return true;
   }, []);
 
+  /* @conditional-compile-remove(file-sharing) */
   const fileCardGroupDescription = useMemo(
     () => () => {
       const fileGroupLocaleString = props.strings?.fileCardGroupMessage ?? localeStrings.fileCardGroupMessage;
@@ -250,7 +252,7 @@ export const _FileDownloadCards = (props: _FileDownloadCardsProps): JSX.Element 
 
   return (
     <div style={fileDownloadCardsStyle} data-ui-id="file-download-card-group">
-      <_FileCardGroup ariaLabel={fileCardGroupDescription()}>
+      <_FileCardGroup /* @conditional-compile-remove(file-sharing) */ ariaLabel={fileCardGroupDescription()}>
         {fileMetadata &&
           fileMetadata
             .filter((attachment) => {
@@ -294,7 +296,7 @@ const DownloadIconTrampoline = (): JSX.Element => {
 };
 
 const useLocaleStringsTrampoline = (): _FileDownloadCardsStrings => {
-  // @conditional-compile-remove(file-sharing)
+  /* @conditional-compile-remove(file-sharing) */
   return useLocale().strings.messageThread;
-  return { downloadFile: '', fileCardGroupMessage: useLocale().strings.messageThread.fileCardGroupMessage };
+  return { downloadFile: '', fileCardGroupMessage: '' };
 };

--- a/packages/react-components/src/components/FileDownloadCards.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.tsx
@@ -298,8 +298,5 @@ const DownloadIconTrampoline = (): JSX.Element => {
 const useLocaleStringsTrampoline = (): _FileDownloadCardsStrings => {
   /* @conditional-compile-remove(file-sharing) */
   return useLocale().strings.messageThread;
-  let msg = '' 
-  /* @conditional-compile-remove(file-sharing) */ 
-  msg = useLocale().strings.messageThread.fileCardGroupMessage
-  return { downloadFile: '', fileCardGroupMessage: msg };
+  return { downloadFile: '', fileCardGroupMessage: '' };
 };

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -220,6 +220,7 @@ export interface MessageThreadStrings {
   /* @conditional-compile-remove(data-loss-prevention) */
   /** String for policy violation message removal details link */
   blockedWarningLinkText: string;
+  /* @conditional-compile-remove(file-sharing) */
   /** String for aria text in file attachment group*/
   fileCardGroupMessage: string;
 }


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Remove FileCardGroupMessage From Stable API

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->