### PR TITLE
[Chat] MessageThread scolling fix

### DIFF
--- a/change-beta/@azure-communication-react-d32b8e1a-2e27-466c-a5b9-7e5829712cd2.json
+++ b/change-beta/@azure-communication-react-d32b8e1a-2e27-466c-a5b9-7e5829712cd2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Chat",
+  "comment": "Fix for an infinite scrolling at top of Message Thread which existed in some cases",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-d32b8e1a-2e27-466c-a5b9-7e5829712cd2.json
+++ b/change/@azure-communication-react-d32b8e1a-2e27-466c-a5b9-7e5829712cd2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Chat",
+  "comment": "Fix for an infinite scrolling at top of Message Thread which existed in some cases",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -712,6 +712,9 @@ export const MessageThreadWrapper = (props: MessageThreadProps): JSX.Element => 
 
   const localeStrings = useLocale().strings.messageThread;
   const strings = useMemo(() => ({ ...localeStrings, ...props.strings }), [localeStrings, props.strings]);
+  // it is required to use useState for messages
+  // as the scrolling logic requires re - render at a specific point in time
+  const [messages, setMessages] = useState<Message[]>([]);
 
   // id for the latest deleted message
   const [latestDeletedMessageId, setLatestDeletedMessageId] = useState<string | undefined>(undefined);
@@ -758,10 +761,6 @@ export const MessageThreadWrapper = (props: MessageThreadProps): JSX.Element => 
   const chatScrollDivRef = useRef<HTMLDivElement>(null);
   const isLoadingChatMessagesRef = useRef(false);
 
-  const messages = useMemo(() => {
-    return newMessages;
-  }, [newMessages]);
-
   useEffect(() => {
     if (latestDeletedMessageId === undefined) {
       setDeletedMessageAriaLabel(undefined);
@@ -786,6 +785,7 @@ export const MessageThreadWrapper = (props: MessageThreadProps): JSX.Element => 
   const messagesRef = useRef(messages);
   const setMessagesRef = (messagesWithAttachedValue: Message[]): void => {
     messagesRef.current = messagesWithAttachedValue;
+    setMessages(messagesWithAttachedValue);
   };
 
   const isAtBottomOfScrollRef = useRef(isAtBottomOfScroll);


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fixed an issue when scrolling caused all previous messages to be delted.
Steps to test:
- open a chat with a lot of messages
- scroll to top
- see that only some of the messages are loadded and they continue be loaded when YOU scroll more

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
sample app, tests

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->