### PR TITLE
Disable the camera button while the source is being switched

### DIFF
--- a/change-beta/@azure-communication-react-f615d99b-b239-4675-9f42-3bf5ebd54b04.json
+++ b/change-beta/@azure-communication-react-f615d99b-b239-4675-9f42-3bf5ebd54b04.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Disable the camera button while the source is being switched to prevent rapid successive clicks from causing the streams to lock up",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-f615d99b-b239-4675-9f42-3bf5ebd54b04.json
+++ b/change/@azure-communication-react-f615d99b-b239-4675-9f42-3bf5ebd54b04.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Disable the camera button while the source is being switched to prevent rapid successive clicks from causing the streams to lock up",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/src/handlers/createCommonHandlers.ts
+++ b/packages/calling-component-bindings/src/handlers/createCommonHandlers.ts
@@ -259,7 +259,17 @@ export const createDefaultCommonCallingHandlers = memoizeOne(
       if (call && _isInCall(call.state)) {
         deviceManager.selectCamera(device);
         const stream = call.localVideoStreams.find((stream) => stream.mediaStreamType === 'Video');
-        return stream?.switchSource(device);
+        const result = await stream?.switchSource(device);
+
+        /// ***TODO: TEMPORARY SOLUTION***
+        /// The Calling SDK needs to wait until the stream is ready before resolving the switchSource promise.
+        /// This is a temporary solution to wait for the stream to be ready before resolving the promise.
+        /// This allows the onSelectCamera to be throttled to prevent the streams from getting in to a frozen state
+        /// if the user switches cameras too rapidly.
+        /// This is to be removed once the Calling SDK has issued a fix.
+        await new Promise((resolve) => setTimeout(resolve, 250));
+
+        return result;
       } else {
         const previewOn = _isPreviewOn(callClient.getState().deviceManager);
 

--- a/packages/react-components/src/components/CameraButton.tsx
+++ b/packages/react-components/src/components/CameraButton.tsx
@@ -168,7 +168,7 @@ export interface CameraButtonProps extends ControlBarButtonProps {
  * @public
  */
 export const CameraButton = (props: CameraButtonProps): JSX.Element => {
-  const { localVideoViewOptions, onToggleCamera } = props;
+  const { localVideoViewOptions, onToggleCamera, onSelectCamera } = props;
   const [waitForCamera, setWaitForCamera] = useState(false);
   const localeStrings = useLocale().strings.cameraButton;
   const strings = { ...localeStrings, ...props.strings };
@@ -211,6 +211,21 @@ export const CameraButton = (props: CameraButtonProps): JSX.Element => {
       }
     }
   }, [cameraOn, localVideoViewOptions, onToggleCamera, toggleAnnouncerString]);
+
+  const onChangeCameraClick = useCallback(
+    async (device: OptionsDevice) => {
+      // Throttle changing camera to prevent too many callbacks
+      if (onSelectCamera) {
+        setWaitForCamera(true);
+        try {
+          await onSelectCamera(device);
+        } finally {
+          setWaitForCamera(false);
+        }
+      }
+    },
+    [onSelectCamera]
+  );
 
   const splitButtonMenuItems: IContextualMenuItem[] = [];
   /* @conditional-compile-remove(video-background-effects) */
@@ -273,7 +288,7 @@ export const CameraButton = (props: CameraButtonProps): JSX.Element => {
           props.menuProps ??
           (props.enableDeviceSelectionMenu
             ? generateDefaultDeviceMenuProps(
-                { ...props, styles: props.styles?.menuStyles },
+                { ...props, onSelectCamera: onChangeCameraClick, styles: props.styles?.menuStyles },
                 strings,
                 splitButtonPrimaryAction
               )

--- a/packages/react-components/src/components/DevicesButton.tsx
+++ b/packages/react-components/src/components/DevicesButton.tsx
@@ -294,9 +294,9 @@ export const generateDefaultDeviceMenuProps = (
                 },
                 canCheck: true,
                 isChecked: camera.id === selectedCamera?.id,
-                onClick: () => {
+                onClick: async () => {
                   if (camera.id !== selectedCamera?.id) {
-                    onSelectCamera(camera);
+                    await onSelectCamera(camera);
                   }
                 }
               }))

--- a/packages/react-components/src/components/styles/VideoGallery.styles.ts
+++ b/packages/react-components/src/components/styles/VideoGallery.styles.ts
@@ -37,6 +37,9 @@ export const localVideoCameraCycleButtonStyles = (theme: Theme, size?: 'small' |
       color: '#FFFFFF',
       background: 'rgba(0,0,0,0.4)' // sets opacity of background to be visible on all backdrops in video stream.
     },
+    rootDisabled: {
+      position: 'absolute'
+    },
     icon: {
       paddingLeft: _pxToRem(3),
       paddingRight: _pxToRem(3),


### PR DESCRIPTION
# What

- Disable the camera switcher buttons when the source is being changed by waiting on the switchSource promise.
- Add a manual throttle while a bug is being fixed on the calling sdk

# Why

Quick successive uses causes the camera to lock up

https://skype.visualstudio.com/SPOOL/_workitems/edit/3521866

# How Tested

Locally, verified switching the camera disables the button for arbitrary time and could no longer repro the camera locking up.