### PR TITLE
[bugfix] Mobile configuration page enable devices button when camera or microphone is available

### DIFF
--- a/change-beta/@azure-communication-react-edeccae0-dcdf-4a87-b2ca-465f6367ffc6.json
+++ b/change-beta/@azure-communication-react-edeccae0-dcdf-4a87-b2ca-465f6367ffc6.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "LocalPreview",
+  "comment": "Mobile configuration page enable device button when either microphone or camera is available",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-edeccae0-dcdf-4a87-b2ca-465f6367ffc6.json
+++ b/change/@azure-communication-react-edeccae0-dcdf-4a87-b2ca-465f6367ffc6.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "LocalPreview",
+  "comment": "Mobile configuration page enable device button when either microphone or camera is available",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/LocalPreview.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LocalPreview.tsx
@@ -54,6 +54,7 @@ export const LocalPreview = (props: LocalPreviewProps): JSX.Element => {
     isLocalMicrophoneEnabled ? adapter.mute() : adapter.unmute();
   }, [adapter, isLocalMicrophoneEnabled]);
 
+  const hasNoSpeakers = !devicesButtonProps.speakers.length;
   const hasNoDevices =
     devicesButtonProps.cameras.length === 0 &&
     devicesButtonProps.microphones.length === 0 &&
@@ -149,7 +150,7 @@ export const LocalPreview = (props: LocalPreviewProps): JSX.Element => {
               data-ui-id="call-composite-local-device-settings-options-button"
               {...devicesButtonProps}
               // disable button whilst all other buttons are disabled
-              disabled={(!microphonePermissionGranted && !cameraPermissionGranted) || hasNoDevices}
+              disabled={(!microphonePermissionGranted && !cameraPermissionGranted && hasNoSpeakers) || hasNoDevices}
               showLabel={true}
               // disable tooltip as it obscures list of devices on mobile
               strings={props.mobileView ? { tooltipContent: '' } : {}}

--- a/packages/react-composites/src/composites/CallComposite/components/LocalPreview.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LocalPreview.tsx
@@ -149,7 +149,7 @@ export const LocalPreview = (props: LocalPreviewProps): JSX.Element => {
               data-ui-id="call-composite-local-device-settings-options-button"
               {...devicesButtonProps}
               // disable button whilst all other buttons are disabled
-              disabled={!microphonePermissionGranted || !cameraPermissionGranted || hasNoDevices}
+              disabled={(!microphonePermissionGranted && !cameraPermissionGranted) || hasNoDevices}
               showLabel={true}
               // disable tooltip as it obscures list of devices on mobile
               strings={props.mobileView ? { tooltipContent: '' } : {}}


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Enable devices button on localpreview on mobile configuration page when either microphone or camera is available

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3520771

|  Before | After | 
|---|---|
| ![image](https://github.com/Azure/communication-ui-library/assets/97130533/a92d40b8-6ed3-403a-9726-a8e7eecfadc4) |  ![device button enabled](https://github.com/Azure/communication-ui-library/assets/97130533/35229dc0-138d-464a-93a5-5ec9d2f146ea) |

# How Tested
<!--- How did you test your change. What tests have you added. -->
MacOS - Chrome - Calling Sample - Mobile view

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->