### PR TITLE
[Chat] Fix for a race condition for "The message is deleted" announcement

### DIFF
--- a/change-beta/@azure-communication-react-09bb9bd5-6808-44dd-94d1-4a6bc9cc2581.json
+++ b/change-beta/@azure-communication-react-09bb9bd5-6808-44dd-94d1-4a6bc9cc2581.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Accessibility",
+  "comment": "Fix for a race condition for \"The message is deleted\" announcement",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-09bb9bd5-6808-44dd-94d1-4a6bc9cc2581.json
+++ b/change/@azure-communication-react-09bb9bd5-6808-44dd-94d1-4a6bc9cc2581.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Accessibility",
+  "comment": "Fix for a race condition for \"The message is deleted\" announcement",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -728,10 +728,10 @@ export const MessageThreadWrapper = (props: MessageThreadProps): JSX.Element => 
         return;
       }
       try {
-        await onDeleteMessage(messageId);
         // reset deleted message label in case if there was a value already (messages are deleted 1 after another)
         setDeletedMessageAriaLabel(undefined);
         setLatestDeletedMessageId(messageId);
+        await onDeleteMessage(messageId);
       } catch (e) {
         console.log('onDeleteMessage failed: messageId', messageId, 'error', e);
       }

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -731,6 +731,8 @@ export const MessageThreadWrapper = (props: MessageThreadProps): JSX.Element => 
         // reset deleted message label in case if there was a value already (messages are deleted 1 after another)
         setDeletedMessageAriaLabel(undefined);
         setLatestDeletedMessageId(messageId);
+        // we should set up latestDeletedMessageId before the onDeleteMessage call
+        // as otherwise in very rare cases the messages array can be updated before latestDeletedMessageId
         await onDeleteMessage(messageId);
       } catch (e) {
         console.log('onDeleteMessage failed: messageId', messageId, 'error', e);


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
A race condition for lastDeletedMessageId was found in 1 of the partners app, this PR will fix it.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Checked with the partner team that solution works for them. Tested with sample that it didn't break things for us.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->