### PR TITLE
[Storybook] Update min node version in storybook and remove references to not supported react 18

### DIFF
--- a/change-beta/@azure-communication-react-de18a1d1-f6af-4c23-8d77-b50dfedde3bc.json
+++ b/change-beta/@azure-communication-react-de18a1d1-f6af-4c23-8d77-b50dfedde3bc.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Update min node version in storybook",
+  "packageName": "@azure/communication-react",
+  "email": "73612854+palatter@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-de18a1d1-f6af-4c23-8d77-b50dfedde3bc.json
+++ b/change/@azure-communication-react-de18a1d1-f6af-4c23-8d77-b50dfedde3bc.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Update min node version in storybook",
+  "packageName": "@azure/communication-react",
+  "email": "73612854+palatter@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/CallComposite/Quickstart1ToNDocs.stories.mdx
+++ b/packages/storybook/stories/CallComposite/Quickstart1ToNDocs.stories.mdx
@@ -32,7 +32,7 @@ Download the [UI Library quickstart composites](https://github.com/Azure-Samples
 ## Prerequisites
 
 - An Azure account with an active subscription. [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 16.19.0 and above).
+- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 18.0.0 and above).
 - An active Communication Services resource. [Create a Communication Services resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp).
 - Identities with VoIP scope. Generate an identity using the [Azure Portal](https://docs.microsoft.com/azure/communication-services/quickstarts/identity/quick-create-identity).
 

--- a/packages/storybook/stories/CallComposite/QuickstartPSTNDocs.stories.mdx
+++ b/packages/storybook/stories/CallComposite/QuickstartPSTNDocs.stories.mdx
@@ -34,7 +34,7 @@ Download the [UI Library quickstart composites](https://github.com/Azure-Samples
 ## Prerequisites
 
 - An Azure account with an active subscription. [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 16.19.0 and above).
+- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 18.0.0 and above).
 - An active Communication Services resource. [Create a Communication Services resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp).
 - An identity with VoIP scope. Generate an identity using the [Azure Portal](https://docs.microsoft.com/azure/communication-services/quickstarts/identity/quick-create-identity).
 - A [phone number](https://docs.microsoft.com/en-us/azure/communication-services/quickstarts/telephony/get-phone-number) created within the active Communication Service resource.

--- a/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
@@ -47,9 +47,6 @@ Access Tokens can be generated using this [Azure Portal quickstart](https://docs
 UI Library requires a React environment to be setup. Follow the [setup page](./?path=/docs/setup-communication-react--page) to get started
 with your new app.
 
-If you are on react 18 or higher and experiencing issues with starting your app,
-visit our [setup page](./?path=/docs/setup-communication-react--page) to troubleshoot the issue.
-
 If you are creating a new application run the following command to make a new app setup with the core dependencies needed for the UI library.
 You will still need to install the `uuid` package like below.
 

--- a/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartComposite.stories.mdx
@@ -25,7 +25,7 @@ You can find the completed code for this quickstart here: [Get started with Comp
 ## Prerequisites
 
 - An Azure account with an active subscription. [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 16.19.0 and above).
+- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 18.0.0 and above).
 - An active Communication Services resource. [Create a Communication Services resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp).
 - An identity with both VoIP and Chat scopes. Generate an identity using the [Azure Portal](https://docs.microsoft.com/azure/communication-services/quickstarts/identity/quick-create-identity).
 

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
@@ -49,8 +49,7 @@ Access Tokens can be generated using this [Azure Portal quickstart](https://docs
 
 ## Setting Up
 
-UI Library requires a React environment to be setup. Next we will do that. If you are creating a new app or are
-having issues since your app is running react 18 or higher visit our [setup page](./?path=/docs/setup-communication-react--page).
+UI Library requires a React environment to be setup. Next we will do that.
 
 ### Install the Package
 

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulCall.stories.mdx
@@ -26,7 +26,7 @@ You can find the completed code for this quickstart here: [Get started with Call
 ## Prerequisites
 
 - An Azure account with an active subscription. [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 16.19.0 and above).
+- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 18.0.0 and above).
 - An active Communication Services resource. [Create a Communication Services resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp).
 - An identity with Call scope. Generate an identity using the [Azure Portal](https://docs.microsoft.com/azure/communication-services/quickstarts/identity/quick-create-identity).
 

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulChat.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulChat.stories.mdx
@@ -50,8 +50,7 @@ Access Tokens can be generated using this [Azure Portal quickstart](https://docs
 
 ## Setting Up
 
-UI Library requires a React environment to be setup. Next we will do that. If you are creating a new app or are
-having issues since your app is running react 18 or higher visit our [setup page](./?path=/docs/setup-communication-react--page).
+UI Library requires a React environment to be setup. Next we will do that.
 
 ### Install the Package
 

--- a/packages/storybook/stories/QuickStarts/QuickstartStatefulChat.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartStatefulChat.stories.mdx
@@ -26,7 +26,7 @@ You can find the completed code for this quickstart here: [Get started with Chat
 ## Prerequisites
 
 - An Azure account with an active subscription. [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 16.19.0 and above).
+- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 18.0.0 and above).
 - An active Communication Services resource. [Create a Communication Services resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp).
 - An identity with Chat scope. Generate an identity using the [Azure Portal](https://docs.microsoft.com/azure/communication-services/quickstarts/identity/quick-create-identity).
 

--- a/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
@@ -27,7 +27,7 @@ You can find the completed code for this quickstart here: [Get started with UI C
 ## Prerequisites
 
 - An Azure account with an active subscription. [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 16.19.0 and above).
+- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 18.0.0 and above).
 
 ## Setting Up
 

--- a/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
+++ b/packages/storybook/stories/QuickStarts/QuickstartUIComponents.stories.mdx
@@ -31,8 +31,7 @@ You can find the completed code for this quickstart here: [Get started with UI C
 
 ## Setting Up
 
-UI Library requires a React environment to be setup. Next we will do that. If you are creating a new app or are
-having issues since your app is running react 18 or higher visit our [setup page](./?path=/docs/setup-communication-react--page).
+UI Library requires a React environment to be setup. Next we will do that.
 
 ### Install the Package
 

--- a/packages/storybook/stories/Setup.stories.mdx
+++ b/packages/storybook/stories/Setup.stories.mdx
@@ -8,11 +8,7 @@ import { Meta } from '@storybook/addon-docs';
 
 # Setting up your app to use Azure Communications UI Library
 
-Currently the Azure Communications UI library supports react versions `>=16.8.0` and `< 18`
-
-When following this setup guide, the react version bundled with the `create-react-app` will need
-to be downgraded from react 18 to a supported react version. This page will cover which packages that need downgrading and files
-that need to be edited to get you up and running.
+Currently the Azure Communications UI library supports react versions `>=16.8.0` and `<19.0.0`
 
 ## Prerequisites
 

--- a/packages/storybook/stories/Setup.stories.mdx
+++ b/packages/storybook/stories/Setup.stories.mdx
@@ -8,8 +8,6 @@ import { Meta } from '@storybook/addon-docs';
 
 # Setting up your app to use Azure Communications UI Library
 
-Currently the Azure Communications UI library supports react versions `>=16.8.0` and `<19.0.0`
-
 ## Prerequisites
 
 Before you get started make sure you have all the following prerequisites set up and ready to go.

--- a/packages/storybook/stories/Setup.stories.mdx
+++ b/packages/storybook/stories/Setup.stories.mdx
@@ -19,7 +19,7 @@ that need to be edited to get you up and running.
 Before you get started make sure you have all the following prerequisites set up and ready to go.
 
 - An Azure account with an active subscription. [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 16.19.0 and above).
+- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 18.0.0 and above).
 - An active Communication Services resource. [Create a Communication Services resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp).
 - An identity with both VoIP and Chat scopes. Generate an identity using the [Azure Portal](https://docs.microsoft.com/azure/communication-services/quickstarts/identity/quick-create-identity).
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
With latest versions of communcation-react, node 18 is required.

![image](https://github.com/Azure/communication-ui-library/assets/73612854/69013714-562e-41cc-b1d8-6fc2820417b6)

Also removed references to not supported React 18


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->