### PR TITLE
Ensure Chat and People toggle buttons in CallComposites have aria-pressed property

### DIFF
--- a/change-beta/@azure-communication-react-bc0c290f-ea00-43ef-b042-0f9a402923f2.json
+++ b/change-beta/@azure-communication-react-bc0c290f-ea00-43ef-b042-0f9a402923f2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Ensure Chat and People toggle buttons in CallComposites have aria-pressed property",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-bc0c290f-ea00-43ef-b042-0f9a402923f2.json
+++ b/change/@azure-communication-react-bc0c290f-ea00-43ef-b042-0f9a402923f2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Ensure Chat and People toggle buttons in CallComposites have aria-pressed property",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ControlBarButton.tsx
+++ b/packages/react-components/src/components/ControlBarButton.tsx
@@ -153,6 +153,7 @@ export const ControlBarButton = (props: ControlBarButtonProps): JSX.Element => {
         allowDisabledFocus={props.allowDisabledFocus ?? true}
         menuTriggerKeyCode={KeyCodes.down} // explicitly sets the keypress to activiate the split button drop down.
         text={undefined} // this is handled as a child of the button, without this the `showLabel` prop may be ignored.
+        toggle={props.toggle ?? (props['aria-pressed'] as boolean | undefined)} // Fluent handles aria-pressed with the toggle field: https://github.com/microsoft/fluentui/issues/6353
       >
         {props.showLabel ? labelText : <></>}
       </DefaultButton>

--- a/packages/react-composites/src/composites/CallComposite/components/buttons/People.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/buttons/People.tsx
@@ -36,6 +36,7 @@ export const People = (props: ControlBarButtonProps): JSX.Element => {
     <ControlBarButton
       {...props}
       data-ui-id="call-composite-participants-button"
+      aria-pressed={props.checked}
       strings={strings}
       labelKey={'peopleButtonLabelKey'}
       onRenderOnIcon={onRenderOnIcon ?? icon}

--- a/packages/react-composites/src/composites/CallWithChatComposite/ChatButton/ChatButton.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/ChatButton/ChatButton.tsx
@@ -26,6 +26,7 @@ export const ChatButton = (props: ControlBarButtonProps): JSX.Element => {
   return (
     <ControlBarButton
       {...props}
+      aria-pressed={props.checked}
       labelKey={'chatButtonLabelKey'}
       strings={strings}
       onClick={props.onClick}

--- a/packages/react-composites/src/composites/common/ControlBar/PeopleButton.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/PeopleButton.tsx
@@ -30,6 +30,7 @@ export const PeopleButton = (props: ControlBarButtonProps): JSX.Element => {
   return (
     <ControlBarButton
       {...props}
+      aria-pressed={props.checked}
       strings={strings}
       labelKey={'peopleButtonLabelKey'}
       onRenderOnIcon={onRenderOnIcon ?? icon}


### PR DESCRIPTION
# What
Add  aria-pressed property to `Chat` and `People` toggle buttons 

# Why
A11y bug
https://skype.visualstudio.com/SPOOL/_workitems/edit/2790321

# How Tested
Verified it showed in DOM
![image](https://github.com/Azure/communication-ui-library/assets/2684369/34effa29-8df8-4838-9c39-1c05e532910d)
