### PR TITLE
Correctly apply tablist and tablist behavior to mobile side pane tab headings

### DIFF
--- a/change-beta/@azure-communication-react-75bc78d9-1466-4d47-b1bc-3163704eb990.json
+++ b/change-beta/@azure-communication-react-75bc78d9-1466-4d47-b1bc-3163704eb990.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Correctly apply tablist role and tablist behavior to sidepane tab headings on mobile",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-75bc78d9-1466-4d47-b1bc-3163704eb990.json
+++ b/change/@azure-communication-react-75bc78d9-1466-4d47-b1bc-3163704eb990.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Correctly apply tablist role and tablist behavior to sidepane tab headings on mobile",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/TabHeader.tsx
+++ b/packages/react-composites/src/composites/common/TabHeader.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { concatStyleSets, DefaultButton, Stack } from '@fluentui/react';
+import { concatStyleSets, DefaultButton, FocusZone, FocusZoneDirection, mergeStyles, Stack } from '@fluentui/react';
 import { useTheme } from '@internal/react-components';
 import React, { useMemo } from 'react';
 import { CallWithChatCompositeIcon } from '../common/icons';
 import {
+  availableSpaceStyles,
   mobilePaneBackButtonStyles,
   mobilePaneButtonStyles,
   mobilePaneControlBarStyle,
@@ -74,33 +75,39 @@ export const PeopleAndChatHeader = (props: PeopleAndChatHeaderProps): JSX.Elemen
         onRenderIcon={() => <CallWithChatCompositeIcon iconName="ChevronLeft" />}
         autoFocus
       ></DefaultButton>
-      <Stack.Item grow>
-        {onChatButtonClicked && (
-          <DefaultButton
-            onClick={onChatButtonClicked}
-            styles={mobilePaneButtonStylesThemed}
-            checked={activeTab === 'chat'}
-            aria-selected={activeTab === 'chat'}
-            role={'tab'}
-            disabled={props.disableChatButton}
-          >
-            {strings.chatButtonLabel}
-          </DefaultButton>
-        )}
-      </Stack.Item>
-      <Stack.Item grow>
-        {onPeopleButtonClicked && (
-          <DefaultButton
-            onClick={onPeopleButtonClicked}
-            styles={mobilePaneButtonStylesThemed}
-            checked={activeTab === 'people'}
-            aria-selected={activeTab === 'people'}
-            role={'tab'}
-            disabled={props.disablePeopleButton}
-          >
-            {strings.peopleButtonLabel}
-          </DefaultButton>
-        )}
+      <Stack.Item grow role="tablist">
+        <FocusZone direction={FocusZoneDirection.horizontal} className={mergeStyles(availableSpaceStyles.root)}>
+          <Stack horizontal styles={availableSpaceStyles}>
+            <Stack.Item grow>
+              {onChatButtonClicked && (
+                <DefaultButton
+                  onClick={onChatButtonClicked}
+                  styles={mobilePaneButtonStylesThemed}
+                  checked={activeTab === 'chat'}
+                  aria-selected={activeTab === 'chat'}
+                  role={'tab'}
+                  disabled={props.disableChatButton}
+                >
+                  {strings.chatButtonLabel}
+                </DefaultButton>
+              )}
+            </Stack.Item>
+            <Stack.Item grow>
+              {onPeopleButtonClicked && (
+                <DefaultButton
+                  onClick={onPeopleButtonClicked}
+                  styles={mobilePaneButtonStylesThemed}
+                  checked={activeTab === 'people'}
+                  aria-selected={activeTab === 'people'}
+                  role={'tab'}
+                  disabled={props.disablePeopleButton}
+                >
+                  {strings.peopleButtonLabel}
+                </DefaultButton>
+              )}
+            </Stack.Item>
+          </Stack>
+        </FocusZone>
       </Stack.Item>
       {/* Hidden icon to take the same space as the actual back button on the left. */}
       <DefaultButton


### PR DESCRIPTION
# What

- Apply `tablist` role to mobile side pane headings
- Move tablist inside a focus zone to correctly follow A11y keyboard nav

# Why

A11y bugs:
- needed to read out "1 of 2" and "2 of 2" correctly instead of saying "1 of 1" (this is done by tablist)
- needed to correctly apply navigation using arrow keys on keyboard per https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tablist_Role#keyboard_interactions (this is done by focus zone)

https://skype.visualstudio.com/SPOOL/_workitems/edit/2790321

# How Tested

Verified locally narrator says: "People tab item, 2 of 2, selected"