### PR TITLE
[Bugfix] Remote screenshare scalingmode fix

### DIFF
--- a/change-beta/@azure-communication-react-86e71514-bc0f-4749-9d8e-64a16f09068a.json
+++ b/change-beta/@azure-communication-react-86e71514-bc0f-4749-9d8e-64a16f09068a.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Bug Fix",
+  "comment": "Update remote screen share component to respect scaling",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-86e71514-bc0f-4749-9d8e-64a16f09068a.json
+++ b/change/@azure-communication-react-86e71514-bc0f-4749-9d8e-64a16f09068a.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Bug Fix",
+  "comment": "Update remote screen share component to respect scaling",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -544,7 +544,6 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
       const remoteVideoStream = participant.videoStream;
       /* @conditional-compile-remove(pinned-participants) */
       const selectedScalingMode = remoteVideoStream ? selectedScalingModeState[participant.userId] : undefined;
-
       /* @conditional-compile-remove(pinned-participants) */
       const isPinned = pinnedParticipants?.includes(participant.userId);
 
@@ -574,7 +573,7 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
           isAvailable={isVideoParticipant ? remoteVideoStream?.isAvailable : false}
           isReceiving={isVideoParticipant ? remoteVideoStream?.isReceiving : false}
           renderElement={isVideoParticipant ? remoteVideoStream?.renderElement : undefined}
-          remoteVideoViewOptions={isVideoParticipant && createViewOptions() ? createViewOptions() : undefined}
+          remoteVideoViewOptions={createViewOptions()}
           onRenderAvatar={onRenderAvatar}
           showMuteIndicator={showMuteIndicator}
           strings={strings}
@@ -637,6 +636,7 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
       onCreateRemoteStreamView={onCreateRemoteStreamView}
       onDisposeRemoteStreamView={onDisposeRemoteScreenShareStreamView}
       isReceiving={screenShareParticipant.screenShareStream?.isReceiving}
+      participantVideoScalingMode={selectedScalingModeState[screenShareParticipant.userId]}
     />
   );
 

--- a/packages/react-components/src/components/VideoGallery/RemoteScreenShare.tsx
+++ b/packages/react-components/src/components/VideoGallery/RemoteScreenShare.tsx
@@ -29,6 +29,7 @@ export const RemoteScreenShare = React.memo(
     isMuted?: boolean;
     isSpeaking?: boolean;
     renderElement?: HTMLElement;
+    participantVideoScalingMode?: VideoStreamOptions;
   }) => {
     const {
       userId,
@@ -37,12 +38,21 @@ export const RemoteScreenShare = React.memo(
       renderElement,
       onCreateRemoteStreamView,
       onDisposeRemoteStreamView,
-      isReceiving
+      isReceiving,
+      participantVideoScalingMode
     } = props;
     const locale = useLocale();
 
     if (!renderElement) {
-      onCreateRemoteStreamView && onCreateRemoteStreamView(userId);
+      /**
+       * TODO: We need to pass in the scaling mode of the screen share participant to this function because when we
+       * call this it will recreate both streams (video and screen share) and we need to make sure that the scaling
+       * mode is the same as before we started the screen share.
+       *
+       * We should deprecate the current function and replace it with a
+       * createRemoteScreenShareStreamView and createRemoteVideoStreamView.
+       */
+      onCreateRemoteStreamView && onCreateRemoteStreamView(userId, participantVideoScalingMode);
     }
 
     useEffect(() => {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Make the RemoteScreenshare component respect the scaling mode of the remote participant sharing their screen
# Why
<!--- What problem does this change solve? -->
Allows the local participant to always be able to update the scaling mode of the remote participant
![image](https://github.com/Azure/communication-ui-library/assets/94866715/5c58509b-f071-4566-9b5a-95af3899ec14)

<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3519631
# How Tested
<!--- How did you test your change. What tests have you added. -->
Inspected locally