### PR TITLE
[DTMF Dialler] Enable DTMF mode and dialing out mode in dialpad

### DIFF
--- a/change-beta/@azure-communication-react-9dbf5871-898c-403d-b5e7-99a29e88b117.json
+++ b/change-beta/@azure-communication-react-9dbf5871-898c-403d-b5e7-99a29e88b117.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Dialpad",
+  "comment": "Enable the ability for user to edit value in text field with keyboard",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-9dbf5871-898c-403d-b5e7-99a29e88b117.json
+++ b/change/@azure-communication-react-9dbf5871-898c-403d-b5e7-99a29e88b117.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Dialpad",
+  "comment": "Enable the ability for user to edit value in text field with keyboard",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2638,6 +2638,7 @@ export const Dialpad: (props: DialpadProps) => JSX.Element;
 // @beta
 export interface DialpadProps {
     disableDtmfPlayback?: boolean;
+    enableInputEditing?: boolean;
     isMobile?: boolean;
     onChange?: (input: string) => void;
     onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
@@ -2645,7 +2646,6 @@ export interface DialpadProps {
     showDeleteButton?: boolean;
     // (undocumented)
     strings?: DialpadStrings;
-    // (undocumented)
     styles?: DialpadStyles;
     textFieldValue?: string;
 }

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -961,6 +961,7 @@ export const Dialpad: (props: DialpadProps) => JSX.Element;
 // @beta
 export interface DialpadProps {
     disableDtmfPlayback?: boolean;
+    enableInputEditing?: boolean;
     isMobile?: boolean;
     onChange?: (input: string) => void;
     onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
@@ -968,7 +969,6 @@ export interface DialpadProps {
     showDeleteButton?: boolean;
     // (undocumented)
     strings?: DialpadStrings;
-    // (undocumented)
     styles?: DialpadStyles;
     textFieldValue?: string;
 }

--- a/packages/react-components/review/stable/react-components.api.md
+++ b/packages/react-components/review/stable/react-components.api.md
@@ -761,6 +761,8 @@ export const Dialpad: (props: DialpadProps) => JSX.Element;
 
 // @beta
 export interface DialpadProps {
+    disableDtmfPlayback?: boolean;
+    enableInputEditing?: boolean;
     isMobile?: boolean;
     onChange?: (input: string) => void;
     onClickDialpadButton?: (buttonValue: string, buttonIndex: number) => void;
@@ -768,7 +770,6 @@ export interface DialpadProps {
     showDeleteButton?: boolean;
     // (undocumented)
     strings?: DialpadStrings;
-    // (undocumented)
     styles?: DialpadStyles;
     textFieldValue?: string;
 }

--- a/packages/react-components/src/components/Dialpad/Dialpad.test.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.test.tsx
@@ -87,7 +87,7 @@ describe('Dialpad tests', () => {
   });
 
   test('Dialpad input box should be editable by keyboard', async () => {
-    render(<Dialpad />);
+    render(<Dialpad enableInputEditing={true} />);
     const input = screen.getByRole('textbox');
 
     act(() => {
@@ -98,7 +98,7 @@ describe('Dialpad tests', () => {
   });
 
   test('Dialpad input box should filter out non-valid input', async () => {
-    render(<Dialpad />);
+    render(<Dialpad enableInputEditing={true} />);
     const input = screen.getByRole('textbox');
 
     act(() => {
@@ -109,7 +109,7 @@ describe('Dialpad tests', () => {
   });
 
   test('Typing in 12345678900 should show 1 (234) 567-8900 in input box', async () => {
-    render(<Dialpad />);
+    render(<Dialpad enableInputEditing={true} />);
     const input = screen.getByRole('textbox');
 
     act(() => {
@@ -120,7 +120,7 @@ describe('Dialpad tests', () => {
   });
 
   test('Typing in 2345678900 should show (234) 567-8900 in input box', async () => {
-    render(<Dialpad />);
+    render(<Dialpad enableInputEditing={true} />);
     const input = screen.getByRole('textbox');
 
     act(() => {
@@ -131,7 +131,7 @@ describe('Dialpad tests', () => {
   });
 
   test('Typing in 23456789000 should show  23456789000 in input box', async () => {
-    render(<Dialpad />);
+    render(<Dialpad enableInputEditing={true} />);
     const input = screen.getByRole('textbox');
 
     act(() => {

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -346,15 +346,6 @@ const DialpadContainer = (props: {
         onChange={(e: any) => {
           setText(e.target.value);
         }}
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        onClick={(e: any) => {
-          const input = e.target;
-          const end = input.value.length;
-
-          // Move focus to end of input field
-          input.setSelectionRange(end, end);
-          input.focus();
-        }}
         placeholder={props.strings.placeholderText}
         data-test-id="dialpad-input"
         onRenderSuffix={(): JSX.Element => (

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { Component, useEffect } from 'react';
+import React, { useEffect } from 'react';
 /* @conditional-compile-remove(dtmf-dialer) */
 import { useRef } from 'react';
-import { IStyle, IButtonStyles, ITextFieldStyles, ITextField } from '@fluentui/react';
+import { IStyle, IButtonStyles, ITextFieldStyles } from '@fluentui/react';
 
 import { IconButton } from '@fluentui/react';
 import {
@@ -316,7 +316,6 @@ const DialpadContainer = (props: {
   } = props;
 
   const [plainTextValue, setPlainTextValue] = useState(textFieldValue ?? '');
-  const inputBoxReference = useRef<ITextField>(null);
   /* @conditional-compile-remove(dtmf-dialer) */
   const dtmfToneAudioContext = useRef(new AudioContext());
 
@@ -374,7 +373,6 @@ const DialpadContainer = (props: {
     >
       <TextField
         styles={concatStyleSets(textFieldStyles(theme), props.styles?.textField)}
-        componentRef={inputBoxReference}
         value={
           textFieldValue ? textFieldValue : enableInputEditing ? formatPhoneNumber(plainTextValue) : plainTextValue
         }

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { useEffect } from 'react';
+import React, { Component, useEffect } from 'react';
 /* @conditional-compile-remove(dtmf-dialer) */
 import { useRef } from 'react';
 import { IStyle, IButtonStyles, ITextFieldStyles, ITextField } from '@fluentui/react';
@@ -316,7 +316,6 @@ const DialpadContainer = (props: {
   } = props;
 
   const [plainTextValue, setPlainTextValue] = useState(textFieldValue ?? '');
-  const [currentSelection, setCurrentSelection] = useState<number>();
   const inputBoxReference = useRef<ITextField>(null);
   /* @conditional-compile-remove(dtmf-dialer) */
   const dtmfToneAudioContext = useRef(new AudioContext());
@@ -325,30 +324,7 @@ const DialpadContainer = (props: {
     if (onChange) {
       onChange(plainTextValue);
     }
-    /**
-     * This is to advance the current selection of the user to where they would be editing
-     * next in the input box after editing the value manually
-     */
-    if (
-      inputBoxReference.current &&
-      currentSelection &&
-      inputBoxReference.current.selectionStart !== currentSelection
-    ) {
-      if (
-        inputBoxReference.current.value &&
-        (inputBoxReference.current.value[currentSelection] === ' ' ||
-          inputBoxReference.current.value[currentSelection] === '(')
-      ) {
-        console.log(inputBoxReference.current?.value[currentSelection]);
-        if (inputBoxReference.current.value[currentSelection] === ')') {
-          setCurrentSelection(currentSelection + 2);
-        } else {
-          setCurrentSelection(currentSelection + 1);
-        }
-      }
-      inputBoxReference.current.setSelectionRange(currentSelection, currentSelection);
-    }
-  }, [plainTextValue, onChange, currentSelection]);
+  }, [plainTextValue, onChange]);
 
   useEffect(() => {
     setText(textFieldValue ?? '');
@@ -404,11 +380,12 @@ const DialpadContainer = (props: {
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         onChange={(e: any) => {
-          const input = e.target;
           if (enableInputEditing) {
-            setCurrentSelection(input.selectionStart);
             setText(e.target.value);
-          } else {
+          }
+        }}
+        onClick={(e) => {
+          if (!enableInputEditing) {
             e.preventDefault();
           }
         }}

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import React, { useEffect } from 'react';
-/* @conditional-compile-remove(dtmf-dialer) */
+
 import { useRef } from 'react';
 import { IStyle, IButtonStyles, ITextFieldStyles } from '@fluentui/react';
 
@@ -31,7 +31,7 @@ import {
 } from '../styles/Dialpad.styles';
 import { formatPhoneNumber } from '../utils/formatPhoneNumber';
 import useLongPress from '../utils/useLongPress';
-/* @conditional-compile-remove(dtmf-dialer) */
+
 import { dtmfFrequencies, Tone } from './DTMFToneGenerator';
 
 /**
@@ -117,13 +117,11 @@ export interface DialpadProps {
    * Styles for customizing the dialpad component
    */
   styles?: DialpadStyles;
-  /* @conditional-compile-remove(dtmf-dialer) */
   /**
    * Disables DTMF sounds when dialpad buttons are pressed. the actual
    * tones are still sent to the call.
    */
   disableDtmfPlayback?: boolean;
-  /* @conditional-compile-remove(dtmf-dialer) */
   /**
    * Enable the ability to edit the number in the text box.
    * This mode is for when dailing someone to call to that the user can edit the number before calling if needed.
@@ -178,26 +176,14 @@ const DialpadButton = (props: {
   onClick: (input: string, index: number) => void;
   onLongPress: (input: string, index: number) => void;
   isMobile?: boolean;
-  /* @conditional-compile-remove(dtmf-dialer) */
   dtmfToneAudioContext: AudioContext;
-  /* @conditional-compile-remove(dtmf-dialer) */
   disableDtmfPlayback?: boolean;
 }): JSX.Element => {
   const theme = useTheme();
 
-  const {
-    digit,
-    index,
-    onClick,
-    onLongPress,
-    isMobile = false,
-    /* @conditional-compile-remove(dtmf-dialer) */ dtmfToneAudioContext,
-    /* @conditional-compile-remove(dtmf-dialer) */ disableDtmfPlayback
-  } = props;
-  /* @conditional-compile-remove(dtmf-dialer) */
+  const { digit, index, onClick, onLongPress, isMobile = false, dtmfToneAudioContext, disableDtmfPlayback } = props;
   const [buttonPressed, setButtonPressed] = useState(false);
 
-  /* @conditional-compile-remove(dtmf-dialer) */
   const dtmfToneSound = useRef<Tone>(
     new Tone(dtmfToneAudioContext, dtmfFrequencies[digit].f1, dtmfFrequencies[digit].f2)
   );
@@ -223,7 +209,6 @@ const DialpadButton = (props: {
       styles={concatStyleSets(buttonStyles(theme), props.styles?.button)}
       {...longPressHandlers}
       onKeyDown={(e) => {
-        /* @conditional-compile-remove(dtmf-dialer) */
         if ((e.key === 'Enter' || e.key === ' ') && !buttonPressed) {
           if (!disableDtmfPlayback) {
             dtmfToneSound.current.play();
@@ -235,7 +220,6 @@ const DialpadButton = (props: {
         longPressHandlers.onKeyDown();
       }}
       onKeyUp={(e) => {
-        /* @conditional-compile-remove(dtmf-dialer) */
         if ((e.key === 'Enter' || e.key === ' ') && buttonPressed) {
           dtmfToneSound.current.stop();
           longPressHandlers.onKeyUp();
@@ -244,30 +228,25 @@ const DialpadButton = (props: {
         longPressHandlers.onKeyUp();
       }}
       onMouseDown={() => {
-        /* @conditional-compile-remove(dtmf-dialer) */
         if (!disableDtmfPlayback) {
           dtmfToneSound.current.play();
         }
         longPressHandlers.onMouseDown();
       }}
       onMouseUp={() => {
-        /* @conditional-compile-remove(dtmf-dialer) */
         dtmfToneSound.current.stop();
         longPressHandlers.onMouseUp();
       }}
       onMouseLeave={() => {
-        /* @conditional-compile-remove(dtmf-dialer) */
         dtmfToneSound.current.stop();
       }}
       onTouchStart={() => {
-        /* @conditional-compile-remove(dtmf-dialer) */
         if (!disableDtmfPlayback) {
           dtmfToneSound.current.play();
         }
         longPressHandlers.onTouchStart();
       }}
       onTouchEnd={() => {
-        /* @conditional-compile-remove(dtmf-dialer) */
         dtmfToneSound.current.stop();
         longPressHandlers.onTouchEnd();
       }}
@@ -295,9 +274,9 @@ const DialpadContainer = (props: {
   /**  boolean input to determine if dialpad is in mobile view, default false */
   isMobile?: boolean;
   styles?: DialpadStyles;
-  /* @conditional-compile-remove(dtmf-dialer) */
+
   disableDtmfPlayback?: boolean;
-  /* @conditional-compile-remove(dtmf-dialer) */
+
   enableInputEditing?: boolean;
 }): JSX.Element => {
   const theme = useTheme();
@@ -309,14 +288,14 @@ const DialpadContainer = (props: {
     onChange,
     showDeleteButton = true,
     isMobile = false,
-    /* @conditional-compile-remove(dtmf-dialer) */
+
     disableDtmfPlayback,
-    /* @conditional-compile-remove(dtmf-dialer) */
+
     enableInputEditing
   } = props;
 
   const [plainTextValue, setPlainTextValue] = useState(textFieldValue ?? '');
-  /* @conditional-compile-remove(dtmf-dialer) */
+
   const dtmfToneAudioContext = useRef(new AudioContext());
 
   useEffect(() => {
@@ -433,9 +412,7 @@ const DialpadContainer = (props: {
                   onClick={onClickDialpad}
                   onLongPress={onLongPressDialpad}
                   isMobile={isMobile}
-                  /* @conditional-compile-remove(dtmf-dialer) */
                   dtmfToneAudioContext={dtmfToneAudioContext.current}
-                  /* @conditional-compile-remove(dtmf-dialer) */
                   disableDtmfPlayback={disableDtmfPlayback}
                 />
               ))}

--- a/packages/storybook/stories/Dialpad/snippets/CustomDialpad.snippet.tsx
+++ b/packages/storybook/stories/Dialpad/snippets/CustomDialpad.snippet.tsx
@@ -54,6 +54,7 @@ export const CustomDialpadExample: () => JSX.Element = () => {
           onClickDialpadButton={onClickDialpadButton}
           onChange={onChange}
           disableDtmfPlayback={true}
+          enableInputEditing={true}
         />
       </Stack>
     </FluentThemeProvider>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Remove code that forces user's keyboard to end of phone number
# Why
<!--- What problem does this change solve? -->
allows contoso to edit the phone number with the devices keyboard
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3553803
# How Tested
<!--- How did you test your change. What tests have you added. -->
Locally in sample and storybook