### PR TITLE
Add messageEdited and messagedDeleted events to ChatAdapter. Update the unread message badge when a message is deleted.

### DIFF
--- a/change-beta/@azure-communication-react-0bde713d-dea9-4c4f-818d-5bcde6286354.json
+++ b/change-beta/@azure-communication-react-0bde713d-dea9-4c4f-818d-5bcde6286354.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Update the unread messages count on the CallWithChatComposite when a message is deleted.",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-9086d50f-1734-491f-b814-ea14a009446e.json
+++ b/change-beta/@azure-communication-react-9086d50f-1734-491f-b814-ea14a009446e.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Add messageEdited and messageDeleted events to the ChatAdapter",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-0bde713d-dea9-4c4f-818d-5bcde6286354.json
+++ b/change/@azure-communication-react-0bde713d-dea9-4c4f-818d-5bcde6286354.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Update the unread messages count on the CallWithChatComposite when a message is deleted.",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-9086d50f-1734-491f-b814-ea14a009446e.json
+++ b/change/@azure-communication-react-9086d50f-1734-491f-b814-ea14a009446e.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Add messageEdited and messageDeleted events to the ChatAdapter",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1071,6 +1071,10 @@ export interface CallWithChatAdapterSubscriptions {
     // (undocumented)
     off(event: 'messageReceived', listener: MessageReceivedListener): void;
     // (undocumented)
+    off(event: 'messageEdited', listener: MessageEditedListener): void;
+    // (undocumented)
+    off(event: 'messageDeleted', listener: MessageDeletedListener): void;
+    // (undocumented)
     off(event: 'messageSent', listener: MessageSentListener): void;
     // (undocumented)
     off(event: 'messageRead', listener: MessageReadListener): void;
@@ -1114,6 +1118,10 @@ export interface CallWithChatAdapterSubscriptions {
     on(event: 'capabilitiesChanged', listener: CapabilitiesChangedListener): void;
     // (undocumented)
     on(event: 'messageReceived', listener: MessageReceivedListener): void;
+    // (undocumented)
+    on(event: 'messageEdited', listener: MessageEditedListener): void;
+    // (undocumented)
+    on(event: 'messageDeleted', listener: MessageDeletedListener): void;
     // (undocumented)
     on(event: 'messageSent', listener: MessageSentListener): void;
     // (undocumented)
@@ -1323,7 +1331,7 @@ export interface CallWithChatControlOptions extends CommonCallControlOptions {
 }
 
 // @public
-export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | /* @conditional-compile-remove(close-captions) */ 'isCaptionLanguageChanged' | /* @conditional-compile-remove(close-captions) */ 'isSpokenLanguageChanged' | /* @conditional-compile-remove(capabilities) */ 'capabilitiesChanged' | 'messageReceived' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
+export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | /* @conditional-compile-remove(close-captions) */ 'isCaptionLanguageChanged' | /* @conditional-compile-remove(close-captions) */ 'isSpokenLanguageChanged' | /* @conditional-compile-remove(capabilities) */ 'capabilitiesChanged' | 'messageReceived' | 'messageEdited' | 'messageDeleted' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
 
 // @beta
 export const CameraAndMicrophoneSitePermissions: (props: CameraAndMicrophoneSitePermissionsProps) => JSX.Element;
@@ -1543,6 +1551,8 @@ export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
 // @public
 export interface ChatAdapterSubscribers {
     off(event: 'messageReceived', listener: MessageReceivedListener): void;
+    off(event: 'messageEdited', listener: MessageEditedListener): void;
+    off(event: 'messageDeleted', listener: MessageDeletedListener): void;
     off(event: 'messageSent', listener: MessageSentListener): void;
     off(event: 'messageRead', listener: MessageReadListener): void;
     off(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
@@ -1550,6 +1560,8 @@ export interface ChatAdapterSubscribers {
     off(event: 'topicChanged', listener: TopicChangedListener): void;
     off(event: 'error', listener: (e: AdapterError) => void): void;
     on(event: 'messageReceived', listener: MessageReceivedListener): void;
+    on(event: 'messageEdited', listener: MessageEditedListener): void;
+    on(event: 'messageDeleted', listener: MessageDeletedListener): void;
     on(event: 'messageSent', listener: MessageSentListener): void;
     on(event: 'messageRead', listener: MessageReadListener): void;
     on(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
@@ -2542,6 +2554,9 @@ export const DEFAULT_COMPOSITE_ICONS: {
     SurveyStarIconFilled: React_2.JSX.Element;
 };
 
+// @public (undocumented)
+export type DeletedChatMessage = Omit<ChatMessage_2, 'message' | 'metadata'>;
+
 // @beta
 export interface DeviceCheckOptions {
     camera: 'required' | 'optional' | 'doNotPrompt';
@@ -3122,6 +3137,18 @@ export interface MessageCommon {
 
 // @public
 export type MessageContentType = 'text' | 'html' | 'richtext/html' | 'unknown';
+
+// @public
+export type MessageDeletedListener = (event: {
+    message: DeletedChatMessage;
+    deletedOn: Date;
+}) => void;
+
+// @public
+export type MessageEditedListener = (event: {
+    message: ChatMessage_2;
+    editedOn: Date;
+}) => void;
 
 // @public
 export type MessageProps = {

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2554,9 +2554,6 @@ export const DEFAULT_COMPOSITE_ICONS: {
     SurveyStarIconFilled: React_2.JSX.Element;
 };
 
-// @public (undocumented)
-export type DeletedChatMessage = Omit<ChatMessage_2, 'message' | 'metadata'>;
-
 // @beta
 export interface DeviceCheckOptions {
     camera: 'required' | 'optional' | 'doNotPrompt';
@@ -3139,16 +3136,10 @@ export interface MessageCommon {
 export type MessageContentType = 'text' | 'html' | 'richtext/html' | 'unknown';
 
 // @public
-export type MessageDeletedListener = (event: {
-    message: DeletedChatMessage;
-    deletedOn: Date;
-}) => void;
+export type MessageDeletedListener = MessageReceivedListener;
 
 // @public
-export type MessageEditedListener = (event: {
-    message: ChatMessage_2;
-    editedOn: Date;
-}) => void;
+export type MessageEditedListener = MessageReceivedListener;
 
 // @public
 export type MessageProps = {

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -2082,9 +2082,6 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ContextMenuSpeakerIcon: React_2.JSX.Element;
 };
 
-// @public (undocumented)
-export type DeletedChatMessage = Omit<ChatMessage_2, 'message' | 'metadata'>;
-
 // @public
 export type DeviceManagerState = {
     isSpeakerSelectionAvailable: boolean;
@@ -2476,16 +2473,10 @@ export interface MessageCommon {
 export type MessageContentType = 'text' | 'html' | 'richtext/html' | 'unknown';
 
 // @public
-export type MessageDeletedListener = (event: {
-    message: DeletedChatMessage;
-    deletedOn: Date;
-}) => void;
+export type MessageDeletedListener = MessageReceivedListener;
 
 // @public
-export type MessageEditedListener = (event: {
-    message: ChatMessage_2;
-    editedOn: Date;
-}) => void;
+export type MessageEditedListener = MessageReceivedListener;
 
 // @public
 export type MessageProps = {

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -805,6 +805,10 @@ export interface CallWithChatAdapterSubscriptions {
     // (undocumented)
     off(event: 'messageReceived', listener: MessageReceivedListener): void;
     // (undocumented)
+    off(event: 'messageEdited', listener: MessageEditedListener): void;
+    // (undocumented)
+    off(event: 'messageDeleted', listener: MessageDeletedListener): void;
+    // (undocumented)
     off(event: 'messageSent', listener: MessageSentListener): void;
     // (undocumented)
     off(event: 'messageRead', listener: MessageReadListener): void;
@@ -848,6 +852,10 @@ export interface CallWithChatAdapterSubscriptions {
     on(event: 'capabilitiesChanged', listener: CapabilitiesChangedListener): void;
     // (undocumented)
     on(event: 'messageReceived', listener: MessageReceivedListener): void;
+    // (undocumented)
+    on(event: 'messageEdited', listener: MessageEditedListener): void;
+    // (undocumented)
+    on(event: 'messageDeleted', listener: MessageDeletedListener): void;
     // (undocumented)
     on(event: 'messageSent', listener: MessageSentListener): void;
     // (undocumented)
@@ -1012,7 +1020,7 @@ export interface CallWithChatControlOptions extends CommonCallControlOptions {
 }
 
 // @public
-export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | /* @conditional-compile-remove(close-captions) */ 'isCaptionLanguageChanged' | /* @conditional-compile-remove(close-captions) */ 'isSpokenLanguageChanged' | /* @conditional-compile-remove(capabilities) */ 'capabilitiesChanged' | 'messageReceived' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
+export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | /* @conditional-compile-remove(close-captions) */ 'isCaptionLanguageChanged' | /* @conditional-compile-remove(close-captions) */ 'isSpokenLanguageChanged' | /* @conditional-compile-remove(capabilities) */ 'capabilitiesChanged' | 'messageReceived' | 'messageEdited' | 'messageDeleted' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
 
 // @public
 export const CameraButton: (props: CameraButtonProps) => JSX.Element;
@@ -1206,6 +1214,8 @@ export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
 // @public
 export interface ChatAdapterSubscribers {
     off(event: 'messageReceived', listener: MessageReceivedListener): void;
+    off(event: 'messageEdited', listener: MessageEditedListener): void;
+    off(event: 'messageDeleted', listener: MessageDeletedListener): void;
     off(event: 'messageSent', listener: MessageSentListener): void;
     off(event: 'messageRead', listener: MessageReadListener): void;
     off(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
@@ -1213,6 +1223,8 @@ export interface ChatAdapterSubscribers {
     off(event: 'topicChanged', listener: TopicChangedListener): void;
     off(event: 'error', listener: (e: AdapterError) => void): void;
     on(event: 'messageReceived', listener: MessageReceivedListener): void;
+    on(event: 'messageEdited', listener: MessageEditedListener): void;
+    on(event: 'messageDeleted', listener: MessageDeletedListener): void;
     on(event: 'messageSent', listener: MessageSentListener): void;
     on(event: 'messageRead', listener: MessageReadListener): void;
     on(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
@@ -2070,6 +2082,9 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ContextMenuSpeakerIcon: React_2.JSX.Element;
 };
 
+// @public (undocumented)
+export type DeletedChatMessage = Omit<ChatMessage_2, 'message' | 'metadata'>;
+
 // @public
 export type DeviceManagerState = {
     isSpeakerSelectionAvailable: boolean;
@@ -2459,6 +2474,18 @@ export interface MessageCommon {
 
 // @public
 export type MessageContentType = 'text' | 'html' | 'richtext/html' | 'unknown';
+
+// @public
+export type MessageDeletedListener = (event: {
+    message: DeletedChatMessage;
+    deletedOn: Date;
+}) => void;
+
+// @public
+export type MessageEditedListener = (event: {
+    message: ChatMessage_2;
+    editedOn: Date;
+}) => void;
 
 // @public
 export type MessageProps = {

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -1514,9 +1514,6 @@ export const DEFAULT_COMPOSITE_ICONS: {
     SurveyStarIconFilled: React_2.JSX.Element;
 };
 
-// @public (undocumented)
-export type DeletedChatMessage = Omit<ChatMessage, 'message' | 'metadata'>;
-
 // @beta
 export interface DeviceCheckOptions {
     camera: 'required' | 'optional' | 'doNotPrompt';
@@ -1676,16 +1673,10 @@ export type MediaDiagnosticChangedEvent = MediaDiagnosticChangedEventArgs & {
 };
 
 // @public
-export type MessageDeletedListener = (event: {
-    message: DeletedChatMessage;
-    deletedOn: Date;
-}) => void;
+export type MessageDeletedListener = MessageReceivedListener;
 
 // @public
-export type MessageEditedListener = (event: {
-    message: ChatMessage;
-    editedOn: Date;
-}) => void;
+export type MessageEditedListener = MessageReceivedListener;
 
 // @public
 export type MessageReadListener = (event: {

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -772,6 +772,10 @@ export interface CallWithChatAdapterSubscriptions {
     // (undocumented)
     off(event: 'messageReceived', listener: MessageReceivedListener): void;
     // (undocumented)
+    off(event: 'messageEdited', listener: MessageEditedListener): void;
+    // (undocumented)
+    off(event: 'messageDeleted', listener: MessageDeletedListener): void;
+    // (undocumented)
     off(event: 'messageSent', listener: MessageSentListener): void;
     // (undocumented)
     off(event: 'messageRead', listener: MessageReadListener): void;
@@ -815,6 +819,10 @@ export interface CallWithChatAdapterSubscriptions {
     on(event: 'capabilitiesChanged', listener: CapabilitiesChangedListener): void;
     // (undocumented)
     on(event: 'messageReceived', listener: MessageReceivedListener): void;
+    // (undocumented)
+    on(event: 'messageEdited', listener: MessageEditedListener): void;
+    // (undocumented)
+    on(event: 'messageDeleted', listener: MessageDeletedListener): void;
     // (undocumented)
     on(event: 'messageSent', listener: MessageSentListener): void;
     // (undocumented)
@@ -1024,7 +1032,7 @@ export interface CallWithChatControlOptions extends CommonCallControlOptions {
 }
 
 // @public
-export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | /* @conditional-compile-remove(close-captions) */ 'isCaptionLanguageChanged' | /* @conditional-compile-remove(close-captions) */ 'isSpokenLanguageChanged' | /* @conditional-compile-remove(capabilities) */ 'capabilitiesChanged' | 'messageReceived' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
+export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | /* @conditional-compile-remove(close-captions) */ 'isCaptionLanguageChanged' | /* @conditional-compile-remove(close-captions) */ 'isSpokenLanguageChanged' | /* @conditional-compile-remove(capabilities) */ 'capabilitiesChanged' | 'messageReceived' | 'messageEdited' | 'messageDeleted' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
 
 // @public
 export type CapabilitiesChangedListener = (data: CapabilitiesChangeInfo) => void;
@@ -1059,6 +1067,8 @@ export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
 // @public
 export interface ChatAdapterSubscribers {
     off(event: 'messageReceived', listener: MessageReceivedListener): void;
+    off(event: 'messageEdited', listener: MessageEditedListener): void;
+    off(event: 'messageDeleted', listener: MessageDeletedListener): void;
     off(event: 'messageSent', listener: MessageSentListener): void;
     off(event: 'messageRead', listener: MessageReadListener): void;
     off(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
@@ -1066,6 +1076,8 @@ export interface ChatAdapterSubscribers {
     off(event: 'topicChanged', listener: TopicChangedListener): void;
     off(event: 'error', listener: (e: AdapterError) => void): void;
     on(event: 'messageReceived', listener: MessageReceivedListener): void;
+    on(event: 'messageEdited', listener: MessageEditedListener): void;
+    on(event: 'messageDeleted', listener: MessageDeletedListener): void;
     on(event: 'messageSent', listener: MessageSentListener): void;
     on(event: 'messageRead', listener: MessageReadListener): void;
     on(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
@@ -1502,6 +1514,9 @@ export const DEFAULT_COMPOSITE_ICONS: {
     SurveyStarIconFilled: React_2.JSX.Element;
 };
 
+// @public (undocumented)
+export type DeletedChatMessage = Omit<ChatMessage, 'message' | 'metadata'>;
+
 // @beta
 export interface DeviceCheckOptions {
     camera: 'required' | 'optional' | 'doNotPrompt';
@@ -1659,6 +1674,18 @@ export interface LocalVideoTileOptions {
 export type MediaDiagnosticChangedEvent = MediaDiagnosticChangedEventArgs & {
     type: 'media';
 };
+
+// @public
+export type MessageDeletedListener = (event: {
+    message: DeletedChatMessage;
+    deletedOn: Date;
+}) => void;
+
+// @public
+export type MessageEditedListener = (event: {
+    message: ChatMessage;
+    editedOn: Date;
+}) => void;
 
 // @public
 export type MessageReadListener = (event: {

--- a/packages/react-composites/review/stable/react-composites.api.md
+++ b/packages/react-composites/review/stable/react-composites.api.md
@@ -605,6 +605,10 @@ export interface CallWithChatAdapterSubscriptions {
     // (undocumented)
     off(event: 'messageReceived', listener: MessageReceivedListener): void;
     // (undocumented)
+    off(event: 'messageEdited', listener: MessageEditedListener): void;
+    // (undocumented)
+    off(event: 'messageDeleted', listener: MessageDeletedListener): void;
+    // (undocumented)
     off(event: 'messageSent', listener: MessageSentListener): void;
     // (undocumented)
     off(event: 'messageRead', listener: MessageReadListener): void;
@@ -648,6 +652,10 @@ export interface CallWithChatAdapterSubscriptions {
     on(event: 'capabilitiesChanged', listener: CapabilitiesChangedListener): void;
     // (undocumented)
     on(event: 'messageReceived', listener: MessageReceivedListener): void;
+    // (undocumented)
+    on(event: 'messageEdited', listener: MessageEditedListener): void;
+    // (undocumented)
+    on(event: 'messageDeleted', listener: MessageDeletedListener): void;
     // (undocumented)
     on(event: 'messageSent', listener: MessageSentListener): void;
     // (undocumented)
@@ -812,7 +820,7 @@ export interface CallWithChatControlOptions extends CommonCallControlOptions {
 }
 
 // @public
-export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | /* @conditional-compile-remove(close-captions) */ 'isCaptionLanguageChanged' | /* @conditional-compile-remove(close-captions) */ 'isSpokenLanguageChanged' | /* @conditional-compile-remove(capabilities) */ 'capabilitiesChanged' | 'messageReceived' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
+export type CallWithChatEvent = 'callError' | 'chatError' | 'callEnded' | 'isMutedChanged' | 'callIdChanged' | 'isLocalScreenSharingActiveChanged' | 'displayNameChanged' | 'isSpeakingChanged' | 'callParticipantsJoined' | 'callParticipantsLeft' | 'selectedMicrophoneChanged' | 'selectedSpeakerChanged' | /* @conditional-compile-remove(close-captions) */ 'isCaptionsActiveChanged' | /* @conditional-compile-remove(close-captions) */ 'captionsReceived' | /* @conditional-compile-remove(close-captions) */ 'isCaptionLanguageChanged' | /* @conditional-compile-remove(close-captions) */ 'isSpokenLanguageChanged' | /* @conditional-compile-remove(capabilities) */ 'capabilitiesChanged' | 'messageReceived' | 'messageEdited' | 'messageDeleted' | 'messageSent' | 'messageRead' | 'chatParticipantsAdded' | 'chatParticipantsRemoved';
 
 // @public
 export type CapabilitiesChangedListener = (data: CapabilitiesChangeInfo) => void;
@@ -847,6 +855,8 @@ export type ChatAdapterState = ChatAdapterUiState & ChatCompositeClientState;
 // @public
 export interface ChatAdapterSubscribers {
     off(event: 'messageReceived', listener: MessageReceivedListener): void;
+    off(event: 'messageEdited', listener: MessageEditedListener): void;
+    off(event: 'messageDeleted', listener: MessageDeletedListener): void;
     off(event: 'messageSent', listener: MessageSentListener): void;
     off(event: 'messageRead', listener: MessageReadListener): void;
     off(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
@@ -854,6 +864,8 @@ export interface ChatAdapterSubscribers {
     off(event: 'topicChanged', listener: TopicChangedListener): void;
     off(event: 'error', listener: (e: AdapterError) => void): void;
     on(event: 'messageReceived', listener: MessageReceivedListener): void;
+    on(event: 'messageEdited', listener: MessageEditedListener): void;
+    on(event: 'messageDeleted', listener: MessageDeletedListener): void;
     on(event: 'messageSent', listener: MessageSentListener): void;
     on(event: 'messageRead', listener: MessageReadListener): void;
     on(event: 'participantsAdded', listener: ParticipantsAddedListener): void;
@@ -1086,7 +1098,7 @@ export const createAzureCommunicationCallWithChatAdapterFromClients: ({ callClie
 export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;
 
 // @public
-export function createAzureCommunicationChatAdapterFromClient(chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient,  options?: {
+export function createAzureCommunicationChatAdapterFromClient(chatClient: StatefulChatClient, chatThreadClient: ChatThreadClient, options?: {
     credential?: CommunicationTokenCredential;
 }): Promise<ChatAdapter>;
 
@@ -1239,6 +1251,9 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ContextMenuSpeakerIcon: React_2.JSX.Element;
 };
 
+// @public (undocumented)
+export type DeletedChatMessage = Omit<ChatMessage, 'message' | 'metadata'>;
+
 // @public
 export type DiagnosticChangedEventListner = (event: MediaDiagnosticChangedEvent | NetworkDiagnosticChangedEvent) => void;
 
@@ -1329,6 +1344,18 @@ export interface JoinCallOptions {
 export type MediaDiagnosticChangedEvent = MediaDiagnosticChangedEventArgs & {
     type: 'media';
 };
+
+// @public
+export type MessageDeletedListener = (event: {
+    message: DeletedChatMessage;
+    deletedOn: Date;
+}) => void;
+
+// @public
+export type MessageEditedListener = (event: {
+    message: ChatMessage;
+    editedOn: Date;
+}) => void;
 
 // @public
 export type MessageReadListener = (event: {

--- a/packages/react-composites/review/stable/react-composites.api.md
+++ b/packages/react-composites/review/stable/react-composites.api.md
@@ -1251,9 +1251,6 @@ export const DEFAULT_COMPOSITE_ICONS: {
     ContextMenuSpeakerIcon: React_2.JSX.Element;
 };
 
-// @public (undocumented)
-export type DeletedChatMessage = Omit<ChatMessage, 'message' | 'metadata'>;
-
 // @public
 export type DiagnosticChangedEventListner = (event: MediaDiagnosticChangedEvent | NetworkDiagnosticChangedEvent) => void;
 
@@ -1346,16 +1343,10 @@ export type MediaDiagnosticChangedEvent = MediaDiagnosticChangedEventArgs & {
 };
 
 // @public
-export type MessageDeletedListener = (event: {
-    message: DeletedChatMessage;
-    deletedOn: Date;
-}) => void;
+export type MessageDeletedListener = MessageReceivedListener;
 
 // @public
-export type MessageEditedListener = (event: {
-    message: ChatMessage;
-    editedOn: Date;
-}) => void;
+export type MessageEditedListener = MessageReceivedListener;
 
 // @public
 export type MessageReadListener = (event: {

--- a/packages/react-composites/src/composites/CallWithChatComposite/ChatButton/useUnreadMessagesTracker.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/ChatButton/useUnreadMessagesTracker.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { useEffect, useState } from 'react';
-import { ChatAdapter, DeletedChatMessage } from '../../ChatComposite/adapter/ChatAdapter';
+import { ChatAdapter } from '../../ChatComposite/adapter/ChatAdapter';
 import { ChatMessage } from '@azure/communication-chat';
 
 /**
@@ -32,7 +32,7 @@ export const useUnreadMessagesTracker = (chatAdapter: ChatAdapter, isChatPaneVis
     };
 
     // Decrement unread messages when a message is deleted and the chat pane is closed
-    const decrementUnreadChatMessagesCount = (event: { message: DeletedChatMessage }): void => {
+    const decrementUnreadChatMessagesCount = (event: { message: ChatMessage }): void => {
       if (!isChatPaneVisible) {
         setUnreadChatMessages((prevUnreadChatMessages) => {
           const newUnreadChatMessages = new Set(prevUnreadChatMessages);

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -41,7 +41,9 @@ import {
   ChatAdapter,
   ChatAdapterState,
   ParticipantsRemovedListener,
-  ParticipantsAddedListener
+  ParticipantsAddedListener,
+  MessageEditedListener,
+  MessageDeletedListener
 } from '../../ChatComposite';
 /* @conditional-compile-remove(file-sharing) */
 import { FileUploadManager } from '../../ChatComposite';
@@ -550,6 +552,8 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
   on(event: 'displayNameChanged', listener: DisplayNameChangedListener): void;
   on(event: 'isSpeakingChanged', listener: IsSpeakingChangedListener): void;
   on(event: 'messageReceived', listener: MessageReceivedListener): void;
+  on(event: 'messageEdited', listener: MessageEditedListener): void;
+  on(event: 'messageDeleted', listener: MessageDeletedListener): void;
   on(event: 'messageSent', listener: MessageReceivedListener): void;
   on(event: 'messageRead', listener: MessageReadListener): void;
   on(event: 'chatParticipantsAdded', listener: ParticipantsAddedListener): void;
@@ -620,6 +624,12 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
       case 'messageReceived':
         this.chatAdapter.on('messageReceived', listener);
         break;
+      case 'messageEdited':
+        this.chatAdapter.on('messageEdited', listener);
+        break;
+      case 'messageDeleted':
+        this.chatAdapter.on('messageDeleted', listener);
+        break;
       case 'messageSent':
         this.chatAdapter.on('messageSent', listener);
         break;
@@ -656,6 +666,8 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
   off(event: 'selectedMicrophoneChanged', listener: PropertyChangedEvent): void;
   off(event: 'selectedSpeakerChanged', listener: PropertyChangedEvent): void;
   off(event: 'messageReceived', listener: MessageReceivedListener): void;
+  off(event: 'messageEdited', listener: MessageEditedListener): void;
+  off(event: 'messageDeleted', listener: MessageDeletedListener): void;
   off(event: 'messageSent', listener: MessageReceivedListener): void;
   off(event: 'messageRead', listener: MessageReadListener): void;
   off(event: 'chatParticipantsAdded', listener: ParticipantsAddedListener): void;
@@ -723,6 +735,12 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         break;
       case 'messageReceived':
         this.chatAdapter.off('messageReceived', listener);
+        break;
+      case 'messageEdited':
+        this.chatAdapter.off('messageEdited', listener);
+        break;
+      case 'messageDeleted':
+        this.chatAdapter.off('messageDeleted', listener);
         break;
       case 'messageSent':
         this.chatAdapter.off('messageSent', listener);

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
@@ -15,6 +15,8 @@ import {
   CallEndedListener
 } from '../../CallComposite';
 import {
+  MessageDeletedListener,
+  MessageEditedListener,
   MessageReadListener,
   MessageReceivedListener,
   MessageSentListener,
@@ -522,6 +524,8 @@ export interface CallWithChatAdapterSubscriptions {
 
   // Chat subscriptions
   on(event: 'messageReceived', listener: MessageReceivedListener): void;
+  on(event: 'messageEdited', listener: MessageEditedListener): void;
+  on(event: 'messageDeleted', listener: MessageDeletedListener): void;
   on(event: 'messageSent', listener: MessageSentListener): void;
   on(event: 'messageRead', listener: MessageReadListener): void;
   on(event: 'chatParticipantsAdded', listener: ParticipantsAddedListener): void;
@@ -529,6 +533,8 @@ export interface CallWithChatAdapterSubscriptions {
   on(event: 'chatError', listener: (e: AdapterError) => void): void;
 
   off(event: 'messageReceived', listener: MessageReceivedListener): void;
+  off(event: 'messageEdited', listener: MessageEditedListener): void;
+  off(event: 'messageDeleted', listener: MessageDeletedListener): void;
   off(event: 'messageSent', listener: MessageSentListener): void;
   off(event: 'messageRead', listener: MessageReadListener): void;
   off(event: 'chatParticipantsAdded', listener: ParticipantsAddedListener): void;
@@ -571,6 +577,8 @@ export type CallWithChatEvent =
   | /* @conditional-compile-remove(close-captions) */ 'isSpokenLanguageChanged'
   | /* @conditional-compile-remove(capabilities) */ 'capabilitiesChanged'
   | 'messageReceived'
+  | 'messageEdited'
+  | 'messageDeleted'
   | 'messageSent'
   | 'messageRead'
   | 'chatParticipantsAdded'

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -517,7 +517,8 @@ const convertEventToDeletedChatMessage = (event: ChatMessageDeletedEvent): Delet
     sender: event.sender,
     senderDisplayName: event.senderDisplayName,
     sequenceId: '',
-    createdOn: new Date(event.createdOn)
+    createdOn: new Date(event.createdOn),
+    deletedOn: event.deletedOn
   };
 };
 

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -399,7 +399,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
     }
 
     const message = convertEventToChatMessage(event);
-    this.emitter.emit('messageEdited', { message, editedOn: event.editedOn });
+    this.emitter.emit('messageEdited', { message });
   }
 
   private messageDeletedListener(event: ChatMessageDeletedEvent): void {

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
@@ -225,19 +225,14 @@ export type MessageSentListener = MessageReceivedListener;
  *
  * @public
  */
-export type MessageEditedListener = (event: { message: ChatMessage; editedOn: Date }) => void;
-
-/**
- * @public
- */
-export type DeletedChatMessage = Omit<ChatMessage, 'message' | 'metadata'>;
+export type MessageEditedListener = MessageReceivedListener;
 
 /**
  * Callback for {@link ChatAdapterSubscribers} 'messageDeleted' event.
  *
  * @public
  */
-export type MessageDeletedListener = (event: { message: DeletedChatMessage; deletedOn: Date }) => void;
+export type MessageDeletedListener = MessageReceivedListener;
 
 /**
  * Callback for {@link ChatAdapterSubscribers} 'messageRead' event.

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
@@ -124,6 +124,14 @@ export interface ChatAdapterSubscribers {
    */
   on(event: 'messageReceived', listener: MessageReceivedListener): void;
   /**
+   * Subscribe function for 'messageEdited' event.
+   */
+  on(event: 'messageEdited', listener: MessageEditedListener): void;
+  /**
+   * Subscribe function for 'messageDeleted' event.
+   */
+  on(event: 'messageDeleted', listener: MessageDeletedListener): void;
+  /**
    * Subscribe function for 'messageSent' event.
    */
   on(event: 'messageSent', listener: MessageSentListener): void;
@@ -152,6 +160,14 @@ export interface ChatAdapterSubscribers {
    * Unsubscribe function for 'messageReceived' event.
    */
   off(event: 'messageReceived', listener: MessageReceivedListener): void;
+  /**
+   * Unsubscribe function for 'messageEdited' event.
+   */
+  off(event: 'messageEdited', listener: MessageEditedListener): void;
+  /**
+   * Unsubscribe function for 'messageDeleted' event.
+   */
+  off(event: 'messageDeleted', listener: MessageDeletedListener): void;
   /**
    * Unsubscribe function for 'messageSent' event.
    */
@@ -203,6 +219,25 @@ export type MessageReceivedListener = (event: { message: ChatMessage }) => void;
  * @public
  */
 export type MessageSentListener = MessageReceivedListener;
+
+/**
+ * Callback for {@link ChatAdapterSubscribers} 'messageEdited' event.
+ *
+ * @public
+ */
+export type MessageEditedListener = (event: { message: ChatMessage; editedOn: Date }) => void;
+
+/**
+ * @public
+ */
+export type DeletedChatMessage = Omit<ChatMessage, 'message' | 'metadata'>;
+
+/**
+ * Callback for {@link ChatAdapterSubscribers} 'messageDeleted' event.
+ *
+ * @public
+ */
+export type MessageDeletedListener = (event: { message: DeletedChatMessage; deletedOn: Date }) => void;
 
 /**
  * Callback for {@link ChatAdapterSubscribers} 'messageRead' event.

--- a/packages/react-composites/src/composites/ChatComposite/index.ts
+++ b/packages/react-composites/src/composites/ChatComposite/index.ts
@@ -19,9 +19,12 @@ export type {
   ChatCompositeClientState,
   ChatAdapterState,
   ChatAdapterUiState,
+  DeletedChatMessage,
   MessageReadListener,
   MessageReceivedListener,
   MessageSentListener,
+  MessageEditedListener,
+  MessageDeletedListener,
   ParticipantsAddedListener,
   ParticipantsRemovedListener,
   TopicChangedListener

--- a/packages/react-composites/src/composites/ChatComposite/index.ts
+++ b/packages/react-composites/src/composites/ChatComposite/index.ts
@@ -19,7 +19,6 @@ export type {
   ChatCompositeClientState,
   ChatAdapterState,
   ChatAdapterUiState,
-  DeletedChatMessage,
   MessageReadListener,
   MessageReceivedListener,
   MessageSentListener,


### PR DESCRIPTION
# What

- Add messageEdited and messagedDeleted events to the ChatAdapter.
- Use these events to update the unread message badge in the callwithchat composite when a message is deleted.

# Why

Unread messages badge should update when an unread chat message is deleted.

# How Tested

Verified locally deleting a chat messages decrements the unread message count to other participants in the callwithchat