### PR TITLE
Replace html-to-react with html-react-parser

### DIFF
--- a/change-beta/@azure-communication-react-b9775229-d90b-4d3d-8453-7751d837ce3d.json
+++ b/change-beta/@azure-communication-react-b9775229-d90b-4d3d-8453-7751d837ce3d.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "Dependency updates",
+  "comment": "Replace html-to-react with html-react-parser",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-b9775229-d90b-4d3d-8453-7751d837ce3d.json
+++ b/change/@azure-communication-react-b9775229-d90b-4d3d-8453-7751d837ce3d.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "Dependency updates",
+  "comment": "Replace html-to-react with html-react-parser",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -12073,6 +12073,13 @@ packages:
       wbuf: 1.7.3
     dev: false
 
+  /html-dom-parser@5.0.6:
+    resolution: {integrity: sha512-6KSMOgxzAIZZ1Tcc6eNEfRFC/XE0+TiYaWanKNYKHSEQOtdxrR0t8ILKXNDcRea/WbIDltLUIP8mi/tw7dtFvQ==}
+    dependencies:
+      domhandler: 5.0.3
+      htmlparser2: 9.0.0
+    dev: false
+
   /html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
@@ -12114,6 +12121,18 @@ packages:
       param-case: 3.0.4
       relateurl: 0.2.7
       terser: 5.26.0
+    dev: false
+
+  /html-react-parser@5.0.11(react@18.2.0):
+    resolution: {integrity: sha512-TcLGDGMbVRbos09zwnom/QrLbd4PmNFhMEhlp2ZdHBboAuCuctRDqr8JU5aTyKzFKotdpSg8QkXVxVb5ZUU2Ag==}
+    peerDependencies:
+      react: 0.14 || 15 || 16 || 17 || 18
+    dependencies:
+      domhandler: 5.0.3
+      html-dom-parser: 5.0.6
+      react: 18.2.0
+      react-property: 2.0.2
+      style-to-js: 1.1.10
     dev: false
 
   /html-tags@3.3.1:
@@ -12181,6 +12200,15 @@ packages:
       domhandler: 4.3.1
       domutils: 2.8.0
       entities: 2.2.0
+    dev: false
+
+  /htmlparser2@9.0.0:
+    resolution: {integrity: sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
     dev: false
 
   /htmlparser2@9.1.0:
@@ -12456,6 +12484,10 @@ packages:
 
   /inline-style-parser@0.1.1:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
+    dev: false
+
+  /inline-style-parser@0.2.2:
+    resolution: {integrity: sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ==}
     dev: false
 
   /internal-slot@1.0.6:
@@ -16090,6 +16122,10 @@ packages:
       tlds: 1.248.0
     dev: false
 
+  /react-property@2.0.2:
+    resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
+    dev: false
+
   /react-refresh@0.11.0:
     resolution: {integrity: sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==}
     engines: {node: '>=0.10.0'}
@@ -17675,10 +17711,22 @@ packages:
       webpack: 5.89.0(webpack-cli@5.1.4)
     dev: false
 
+  /style-to-js@1.1.10:
+    resolution: {integrity: sha512-VC7MBJa+y0RZhpnLKDPmVRLRswsASLmixkiZ5R8xZpNT9VyjeRzwnXd2pBzAWdgSGv/pCNNH01gPCCUsB9exYg==}
+    dependencies:
+      style-to-object: 1.0.5
+    dev: false
+
   /style-to-object@0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
     dependencies:
       inline-style-parser: 0.1.1
+    dev: false
+
+  /style-to-object@1.0.5:
+    resolution: {integrity: sha512-rDRwHtoDD3UMMrmZ6BzOW0naTjMsVZLIjsGleSKS/0Oz+cgCfAPRspaqJuE8rDzpKha/nEvnM0IF4seEAZUTKQ==}
+    dependencies:
+      inline-style-parser: 0.2.2
     dev: false
 
   /styled-components@5.3.11(@babel/core@7.23.6)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
@@ -20244,7 +20292,7 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-eBabYQZQgw/C6YAMrfMWLdKFLLwDyB6pv0d7vmeaaT4XM6OwqE1jgKIG2KbhP/8rTbQNPg4i6Mh+YQrrPrPxPw==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-arP6xkRk71gqgWzdl9rFCkbCsNB1nSDNsfQFVChQN81wBHkqwysuRTVt38vMXRtPjhULFmnLnw4v/+OmRd75JQ==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
@@ -20298,6 +20346,7 @@ packages:
       eslint-plugin-react: 7.33.2(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
       events: 3.3.0
+      html-react-parser: 5.0.11(react@18.2.0)
       html-to-react: 1.7.0(react@18.2.0)
       if-env: 1.0.4
       immer: 10.0.3
@@ -20483,7 +20532,7 @@ packages:
     dev: false
 
   file:projects/react-components.tgz:
-    resolution: {integrity: sha512-xB3foPSxlBsSqVn+oOm8amD3MetD5jdJSIJIO/oPyJUyzKOY6gM75hTeSQ4ZO3DBe5MndH/DE/UrIPC21Y4pJQ==, tarball: file:projects/react-components.tgz}
+    resolution: {integrity: sha512-2qZnAdHkopzHp8WbOd7YVmR2Z6oI5EyB3WUfCUKhDwYm8ZS41E2rDCmvETfmnlDi9c6jjfw0HdrOks8BTUbmaw==, tarball: file:projects/react-components.tgz}
     name: '@rush-temp/react-components'
     version: 0.0.0
     dependencies:
@@ -20535,6 +20584,7 @@ packages:
       eslint-plugin-prettier: 3.4.1(eslint-config-prettier@6.15.0)(eslint@7.32.0)(prettier@2.3.1)
       eslint-plugin-react: 7.33.2(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
+      html-react-parser: 5.0.11(react@18.2.0)
       html-to-react: 1.7.0(react@18.2.0)
       husky: 8.0.3
       if-env: 1.0.4

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -12073,6 +12073,13 @@ packages:
       wbuf: 1.7.3
     dev: false
 
+  /html-dom-parser@5.0.6:
+    resolution: {integrity: sha512-6KSMOgxzAIZZ1Tcc6eNEfRFC/XE0+TiYaWanKNYKHSEQOtdxrR0t8ILKXNDcRea/WbIDltLUIP8mi/tw7dtFvQ==}
+    dependencies:
+      domhandler: 5.0.3
+      htmlparser2: 9.0.0
+    dev: false
+
   /html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
@@ -12114,6 +12121,18 @@ packages:
       param-case: 3.0.4
       relateurl: 0.2.7
       terser: 5.26.0
+    dev: false
+
+  /html-react-parser@5.0.11(react@18.2.0):
+    resolution: {integrity: sha512-TcLGDGMbVRbos09zwnom/QrLbd4PmNFhMEhlp2ZdHBboAuCuctRDqr8JU5aTyKzFKotdpSg8QkXVxVb5ZUU2Ag==}
+    peerDependencies:
+      react: 0.14 || 15 || 16 || 17 || 18
+    dependencies:
+      domhandler: 5.0.3
+      html-dom-parser: 5.0.6
+      react: 18.2.0
+      react-property: 2.0.2
+      style-to-js: 1.1.10
     dev: false
 
   /html-tags@3.3.1:
@@ -12181,6 +12200,15 @@ packages:
       domhandler: 4.3.1
       domutils: 2.8.0
       entities: 2.2.0
+    dev: false
+
+  /htmlparser2@9.0.0:
+    resolution: {integrity: sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
     dev: false
 
   /htmlparser2@9.1.0:
@@ -12456,6 +12484,10 @@ packages:
 
   /inline-style-parser@0.1.1:
     resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
+    dev: false
+
+  /inline-style-parser@0.2.2:
+    resolution: {integrity: sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ==}
     dev: false
 
   /internal-slot@1.0.6:
@@ -16090,6 +16122,10 @@ packages:
       tlds: 1.248.0
     dev: false
 
+  /react-property@2.0.2:
+    resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
+    dev: false
+
   /react-refresh@0.11.0:
     resolution: {integrity: sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==}
     engines: {node: '>=0.10.0'}
@@ -17675,10 +17711,22 @@ packages:
       webpack: 5.89.0(webpack-cli@5.1.4)
     dev: false
 
+  /style-to-js@1.1.10:
+    resolution: {integrity: sha512-VC7MBJa+y0RZhpnLKDPmVRLRswsASLmixkiZ5R8xZpNT9VyjeRzwnXd2pBzAWdgSGv/pCNNH01gPCCUsB9exYg==}
+    dependencies:
+      style-to-object: 1.0.5
+    dev: false
+
   /style-to-object@0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
     dependencies:
       inline-style-parser: 0.1.1
+    dev: false
+
+  /style-to-object@1.0.5:
+    resolution: {integrity: sha512-rDRwHtoDD3UMMrmZ6BzOW0naTjMsVZLIjsGleSKS/0Oz+cgCfAPRspaqJuE8rDzpKha/nEvnM0IF4seEAZUTKQ==}
+    dependencies:
+      inline-style-parser: 0.2.2
     dev: false
 
   /styled-components@5.3.11(@babel/core@7.23.6)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0):
@@ -20244,7 +20292,7 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-eBabYQZQgw/C6YAMrfMWLdKFLLwDyB6pv0d7vmeaaT4XM6OwqE1jgKIG2KbhP/8rTbQNPg4i6Mh+YQrrPrPxPw==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-arP6xkRk71gqgWzdl9rFCkbCsNB1nSDNsfQFVChQN81wBHkqwysuRTVt38vMXRtPjhULFmnLnw4v/+OmRd75JQ==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
@@ -20298,6 +20346,7 @@ packages:
       eslint-plugin-react: 7.33.2(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
       events: 3.3.0
+      html-react-parser: 5.0.11(react@18.2.0)
       html-to-react: 1.7.0(react@18.2.0)
       if-env: 1.0.4
       immer: 10.0.3
@@ -20483,7 +20532,7 @@ packages:
     dev: false
 
   file:projects/react-components.tgz:
-    resolution: {integrity: sha512-xB3foPSxlBsSqVn+oOm8amD3MetD5jdJSIJIO/oPyJUyzKOY6gM75hTeSQ4ZO3DBe5MndH/DE/UrIPC21Y4pJQ==, tarball: file:projects/react-components.tgz}
+    resolution: {integrity: sha512-2qZnAdHkopzHp8WbOd7YVmR2Z6oI5EyB3WUfCUKhDwYm8ZS41E2rDCmvETfmnlDi9c6jjfw0HdrOks8BTUbmaw==, tarball: file:projects/react-components.tgz}
     name: '@rush-temp/react-components'
     version: 0.0.0
     dependencies:
@@ -20535,6 +20584,7 @@ packages:
       eslint-plugin-prettier: 3.4.1(eslint-config-prettier@6.15.0)(eslint@7.32.0)(prettier@2.3.1)
       eslint-plugin-react: 7.33.2(eslint@7.32.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@7.32.0)
+      html-react-parser: 5.0.11(react@18.2.0)
       html-to-react: 1.7.0(react@18.2.0)
       husky: 8.0.3
       if-env: 1.0.4

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -39,7 +39,7 @@
     "copy-to-clipboard": "^3.3.1",
     "dompurify": "^3.0.3",
     "events": "^3.3.0",
-    "html-to-react": "1.7.0",
+    "html-react-parser": "^5.0.11",
     "immer": "10.0.3",
     "memoize-one": "^5.2.1",
     "nanoid": "3.3.6",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -46,7 +46,7 @@
     "@internal/acs-ui-common": "1.11.1-beta.0",
     "copy-to-clipboard": "^3.3.1",
     "dompurify": "^3.0.3",
-    "html-to-react": "1.7.0",
+    "html-react-parser": "^5.0.11",
     "react-linkify": "^1.0.0-alpha",
     "react-use-draggable-scroll": "^0.4.7",
     "textarea-caret-ts": "^4.1.1",

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { useEffect } from 'react';
 import { _formatString } from '@internal/acs-ui-common';
-import { Parser, ProcessNodeDefinitions, IsValidNodeDefinitions } from 'html-to-react';
+import parse, { HTMLReactParserOptions, Element as DOMElement, attributesToProps } from 'html-react-parser';
 
 import Linkify from 'react-linkify';
 import { ChatMessage } from '../../types/ChatMessage';
@@ -17,7 +17,7 @@ import { MentionDisplayOptions, Mention } from '../MentionPopover';
 /* @conditional-compile-remove(data-loss-prevention) */
 import { FontIcon, Stack } from '@fluentui/react';
 import { MessageThreadStrings } from '../MessageThread';
-import { AttachmentMetadata, InlineImageMetadata } from '../FileDownloadCards';
+import { AttachmentMetadata } from '../FileDownloadCards';
 import LiveMessage from '../Announcer/LiveMessage';
 /* @conditional-compile-remove(mention) */
 import { defaultOnMentionRender } from './MentionRenderer';
@@ -37,14 +37,6 @@ type ChatMessageContentProps = {
 type BlockedMessageContentProps = {
   message: BlockedMessage;
   strings: MessageThreadStrings;
-};
-
-// Missing from html-to-react.
-type ProcessingInstructionType = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  shouldProcessNode: (node: any) => boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  processNode: (node: any, children: any, index: number) => unknown;
 };
 
 type MessageContentWithLiveAriaProps = {
@@ -191,94 +183,62 @@ const messageContentAriaText = (props: ChatMessageContentProps): string | undefi
     : undefined;
 };
 
-const processNodeDefinitions = ProcessNodeDefinitions();
-const htmlToReactParser = Parser();
-
-const processInlineImage = (props: ChatMessageContentProps): ProcessingInstructionType => ({
-  // Custom <img> processing
-  shouldProcessNode: (node): boolean => {
-    function matchingImageNode(imageMetadata: InlineImageMetadata): boolean {
-      return imageMetadata.id === node.attribs.id;
-    }
-
-    // Process img node with id in attachments list
-    return (
-      node.name &&
-      node.name === 'img' &&
-      node.attribs &&
-      node.attribs.id &&
-      props.message.inlineImages?.find(matchingImageNode)
-    );
-  },
-  processNode: (node, children, index): JSX.Element => {
-    node.attribs = { ...node.attribs, 'aria-label': node.attribs.name };
-    // logic to check id in map/list
-    if (props.attachmentsMap && node.attribs.id in props.attachmentsMap) {
-      node.attribs = { ...node.attribs, src: props.attachmentsMap[node.attribs.id] };
-    }
-    const handleOnClick = (): void => {
-      props.onInlineImageClicked && props.onInlineImageClicked(node.attribs.id);
-    };
-
-    return (
-      <span
-        data-ui-id={node.attribs.id}
-        onClick={handleOnClick}
-        tabIndex={0}
-        role="button"
-        style={{
-          cursor: 'pointer'
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            handleOnClick();
-          }
-        }}
-      >
-        {processNodeDefinitions.processDefaultNode(node, children, index)}
-      </span>
-    );
-    return processNodeDefinitions.processDefaultNode(node, children, index);
-  }
-});
-
-/* @conditional-compile-remove(mention) */
-const processMention = (props: ChatMessageContentProps): ProcessingInstructionType => ({
-  shouldProcessNode: (node) => {
-    if (props.mentionDisplayOptions?.onRenderMention) {
-      // Override the handling of the <msft-mention> tag in the HTML if there's a custom renderer
-      return node.name === 'msft-mention';
-    }
-    return false;
-  },
-  processNode: (node) => {
-    if (props.mentionDisplayOptions?.onRenderMention) {
-      const { id } = node.attribs;
-      const mention: Mention = {
-        id: id,
-        displayText: node.children[0]?.data ?? ''
-      };
-      return props.mentionDisplayOptions.onRenderMention(mention, defaultOnMentionRender);
-    }
-    return processNodeDefinitions.processDefaultNode;
-  }
-});
-
 const processHtmlToReact = (props: ChatMessageContentProps): JSX.Element => {
-  const steps: ProcessingInstructionType[] = [
-    processInlineImage(props),
-    /* @conditional-compile-remove(mention) */
-    processMention(props),
-    {
-      // Process everything else in the default way
-      shouldProcessNode: IsValidNodeDefinitions.alwaysValid,
-      processNode: processNodeDefinitions.processDefaultNode
-    }
-  ];
+  const options: HTMLReactParserOptions = {
+    transform(reactNode, domNode) {
+      if (domNode instanceof DOMElement && domNode.attribs) {
+        // Transform custom rendering of mentions
+        /* @conditional-compile-remove(mention) */
+        if (props.mentionDisplayOptions?.onRenderMention && domNode.name === 'msft-mention') {
+          const { id } = domNode.attribs;
+          const mention: Mention = {
+            id: id,
+            displayText: (domNode.children[0] as unknown as Text).nodeValue ?? ''
+          };
+          return props.mentionDisplayOptions.onRenderMention(mention, defaultOnMentionRender);
+        }
 
-  return htmlToReactParser.parseWithInstructions(
-    props.message.content ?? '',
-    IsValidNodeDefinitions.alwaysValid,
-    steps
-  );
+        // Transform inline images
+        if (
+          domNode.name &&
+          domNode.name === 'img' &&
+          domNode.attribs &&
+          domNode.attribs.id &&
+          props.message.inlineImages?.find((metadata) => {
+            return metadata.id === domNode.attribs.id;
+          })
+        ) {
+          domNode.attribs['aria-label'] = domNode.attribs.name;
+          // logic to check id in map/list
+          if (props.attachmentsMap && domNode.attribs.id in props.attachmentsMap) {
+            domNode.attribs.src = props.attachmentsMap[domNode.attribs.id];
+          }
+          const handleOnClick = (): void => {
+            props.onInlineImageClicked && props.onInlineImageClicked(domNode.attribs.id);
+          };
+          const imgProps = attributesToProps(domNode.attribs);
+          return (
+            <span
+              data-ui-id={domNode.attribs.id}
+              onClick={handleOnClick}
+              tabIndex={0}
+              role="button"
+              style={{
+                cursor: 'pointer'
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  handleOnClick();
+                }
+              }}
+            >
+              <img {...imgProps} />
+            </span>
+          );
+        }
+      }
+      return <>{reactNode}</>;
+    }
+  };
+  return <>{parse(props.message.content ?? '', options)}</>;
 };

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -237,7 +237,8 @@ const processHtmlToReact = (props: ChatMessageContentProps): JSX.Element => {
           );
         }
       }
-      return <>{reactNode}</>;
+      // Pass through the original node
+      return reactNode as unknown as JSX.Element;
     }
   };
   return <>{parse(props.message.content ?? '', options)}</>;


### PR DESCRIPTION
# What
Replace non-typescript html-to-react with a the html-react-parser.

# Why
html-to-react has typings that are too loose and the html-react-parser seems to be the more widely used solution with more github stars.
https://npmtrends.com/html-react-parser-vs-html-to-react.
The html-react-parser has a clearer API and seems to reduce our bundle size considerably.

# How Tested
CI and storybook

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->