### PR TITLE
Enable noImplicitAny in the chat sample

### DIFF
--- a/change-beta/@azure-communication-react-6b674465-0af5-403c-8825-1461c8c69fc7.json
+++ b/change-beta/@azure-communication-react-6b674465-0af5-403c-8825-1461c8c69fc7.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "noImplicitAny fixes",
+  "comment": "Fix up Chat sample for noImplicitAny",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-6b674465-0af5-403c-8825-1461c8c69fc7.json
+++ b/change/@azure-communication-react-6b674465-0af5-403c-8825-1461c8c69fc7.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "noImplicitAny fixes",
+  "comment": "Fix up Chat sample for noImplicitAny",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/samples/Chat/src/app/utils/ShakeToSendLogs.tsx
+++ b/samples/Chat/src/app/utils/ShakeToSendLogs.tsx
@@ -35,12 +35,14 @@ const storeLog = (logType: string, log: string | undefined): void => {
   log && logs.push(`${logType} ${new Date().toISOString()} ${log}`.slice(0, logLineCharacterLimit));
 };
 
+type ConsoleLogFuncType = 'log' | 'warn' | 'error' | 'info' | 'debug';
+
 /**
  * Track console logs for pushing to a debug location.
  * This is particularly useful on mobile devices where the console is not easily accessible.
  */
 const startRecordingLogs = (): void => {
-  function hookLogType(logType: string, outputToConsole: boolean): (...args: unknown[]) => void {
+  function hookLogType(logType: ConsoleLogFuncType, outputToConsole: boolean): (...args: unknown[]) => void {
     const original = console[logType].bind(console);
     return function (...args: unknown[]) {
       storeLog(logType, safeJSONStringify(args));

--- a/samples/Chat/src/app/utils/shake.js.d.ts
+++ b/samples/Chat/src/app/utils/shake.js.d.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+declare module 'shake.js' {
+  type ShakeOptions = {
+    threshold: number;
+    timeout: number;
+  };
+  export default Shake(ShakeOptions);
+}

--- a/samples/Chat/tsconfig.json
+++ b/samples/Chat/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../common/config/tsc/tsconfig.json",
   "compilerOptions": {
-    "noImplicitAny": false,
     "outDir": "./dist/dist-esm",
     "baseUrl": "./src",
     "paths": {

--- a/samples/Chat/tsconfig.json
+++ b/samples/Chat/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../common/config/tsc/tsconfig.json",
   "compilerOptions": {
+    "noImplicitAny": false, // REMOVE THIS LINE WHEN THE UI LIBRARY SUPPORTS TRUE
     "outDir": "./dist/dist-esm",
     "baseUrl": "./src",
     "paths": {

--- a/samples/Chat/tsconfig.preprocess.json
+++ b/samples/Chat/tsconfig.preprocess.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../common/config/tsc/tsconfig.json",
   "compilerOptions": {
+    "noImplicitAny": false, // REMOVE THIS LINE WHEN THE UI LIBRARY SUPPORTS TRUE
     "outDir": "./dist/dist-esm",
     "baseUrl": "./preprocessed"
   },

--- a/samples/Chat/tsconfig.preprocess.json
+++ b/samples/Chat/tsconfig.preprocess.json
@@ -2,7 +2,6 @@
   "extends": "../../common/config/tsc/tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/dist-esm",
-    "noImplicitAny": false,
     "baseUrl": "./preprocessed"
   },
   "typeRoots": ["./node_modules/@types"],


### PR DESCRIPTION
# What
Ensure types are available and allow `noImplicitAny` to be true.

NOTE: it can only be truly enabled once the entire UI library is enabled, as the code is referenced directly from the sample apps.

# Why
Stricter TS

# How Tested
CI

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->