### PR TITLE
Skip compare jest coverage and compare bundle size CI steps for PRs to release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -713,7 +713,7 @@ jobs:
 
   compare_jest_tests_coverage:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.base.ref, 'release/') }}
     name: Compare unit tests coverage from pr head ref to base ref (${{ matrix.flavor }})
     needs: build_packages
     strategy:
@@ -812,7 +812,7 @@ jobs:
 
   compare_base_bundle_stats:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.base.ref, 'release/') }}
     name: Compare bundle size from pr head ref to base ref - ${{ matrix.app }}
     needs: [build_calling_sample, build_chat_sample, build_call_with_chat_sample]
     strategy:

--- a/change-beta/@azure-communication-react-d9755c98-6e78-4c86-9e89-db4864b9522b.json
+++ b/change-beta/@azure-communication-react-d9755c98-6e78-4c86-9e89-db4864b9522b.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "fix",
+  "workstream": "Release CI",
+  "comment": "Skip compare jest coverage and compare bundle stats steps when base branch is a release branch",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-d9755c98-6e78-4c86-9e89-db4864b9522b.json
+++ b/change/@azure-communication-react-d9755c98-6e78-4c86-9e89-db4864b9522b.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "fix",
+  "workstream": "Release CI",
+  "comment": "Skip compare jest coverage and compare bundle stats steps when base branch is a release branch",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# What
Skip 'compare jest coverage' and 'compare bundle size' CI steps for PRs to release

# Why
So that CI runs for cherry-pick PRs into release do not fail due to steps that do not currently work on the release branch
https://skype.visualstudio.com/SPOOL/_workitems/edit/3557820

# How Tested
Tested on a cherry-pick PR targeted for an actual release branch commit and verified that the 'compare jest coverage' and 'compare bundle size' CI steps are skipped and the CI passes
https://github.com/Azure/communication-ui-library/pull/4024

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->