### PR TITLE
[OCE] Remove beta banner for features that are stable

### DIFF
--- a/change-beta/@azure-communication-react-08c687d3-39ac-414b-adff-8a43ba554b1f.json
+++ b/change-beta/@azure-communication-react-08c687d3-39ac-414b-adff-8a43ba554b1f.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "feature",
+  "workstream": "Calling sounds",
+  "comment": "remove sounds beta banner from storybook",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-08c687d3-39ac-414b-adff-8a43ba554b1f.json
+++ b/change/@azure-communication-react-08c687d3-39ac-414b-adff-8a43ba554b1f.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "feature",
+  "workstream": "Calling sounds",
+  "comment": "remove sounds beta banner from storybook",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/AddingSounds.stories.mdx
+++ b/packages/storybook/stories/AddingSounds.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Source } from '@storybook/addon-docs';
-import { DetailedBetaBanner } from './BetaBanners/DetailedBetaBanner';
 
 <Meta
   id="addingSounds"
@@ -14,8 +13,6 @@ import CallingSoundsOptionSnippetText from '!!raw-loader!./snippets/CallingSound
 The web is a quiet place and communication experiences are not. This concept is about creating a more rich communication experience by providing event driven sounds to your communication experiences.
 
 ## Calling sounds
-
-<DetailedBetaBanner />
 
 This feature is designed to empower developers by enabling them to integrate sounds into their calling experiences.
 While the web environment is generally quiet, calling experiences tend to be more dynamic. There are various scenarios in which we aim to incorporate sound


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Remove beta banner for features that are stable
# Why
<!--- What problem does this change solve? -->
Properly represents the features in storybook that are no longer in public preview
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated storybook locally, will go with next beta