### PR TITLE
Fix calling sample joining room with room id query arg

### DIFF
--- a/change-beta/@azure-communication-react-bc13ce86-f3fc-4e7d-a8f5-529950278c3c.json
+++ b/change-beta/@azure-communication-react-bc13ce86-f3fc-4e7d-a8f5-529950278c3c.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Calling sample",
+  "comment": "Fix calling sample to be able to join room with roomId query arg",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@azure-communication-react-bc13ce86-f3fc-4e7d-a8f5-529950278c3c.json
+++ b/change/@azure-communication-react-bc13ce86-f3fc-4e7d-a8f5-529950278c3c.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "Calling sample",
+  "comment": "Fix calling sample to be able to join room with roomId query arg",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -110,7 +110,11 @@ const App = (): JSX.Element => {
             /* @conditional-compile-remove(PSTN-calls) */
             setAlternateCallerId(callDetails.alternateCallerId);
             let callLocator: CallAdapterLocator | undefined =
-              callDetails.callLocator || getTeamsLinkFromUrl() || getGroupIdFromUrl() || createGroupId();
+              callDetails.callLocator ||
+              /* @conditional-compile-remove(rooms) */ getRoomIdFromUrl() ||
+              getTeamsLinkFromUrl() ||
+              getGroupIdFromUrl() ||
+              createGroupId();
 
             /* @conditional-compile-remove(rooms) */
             if (callDetails.option === 'Rooms') {

--- a/samples/Calling/src/app/utils/AppUtils.ts
+++ b/samples/Calling/src/app/utils/AppUtils.ts
@@ -3,7 +3,9 @@
 
 import { GroupLocator, TeamsMeetingLinkLocator } from '@azure/communication-calling';
 /* @conditional-compile-remove(rooms) */
-import { RoomLocator, ParticipantRole } from '@azure/communication-calling';
+import { RoomCallLocator } from '@azure/communication-calling';
+/* @conditional-compile-remove(rooms) */
+import { ParticipantRole } from '@azure/communication-calling';
 /* @conditional-compile-remove(teams-adhoc-call) */ /* @conditional-compile-remove(PSTN-calls) */
 import { CallParticipantsLocator } from '@azure/communication-react';
 import { v1 as generateGUID } from 'uuid';
@@ -98,7 +100,7 @@ export const getIsCTE = (): boolean | undefined => {
 /**
  * Get room id from the url's query params.
  */
-export const getRoomIdFromUrl = (): RoomLocator | undefined => {
+export const getRoomIdFromUrl = (): RoomCallLocator | undefined => {
   const urlParams = new URLSearchParams(window.location.search);
   const roomId = urlParams.get('roomId');
   return roomId ? { roomId } : undefined;


### PR DESCRIPTION
# What
Fix calling sample when it is joining a room with room id query arg.

# Why
The roomId query arg was not being properly assigned to the callLocator of the CallComposite of the Calling sample app and would join a group call instead.
https://github.com/Azure/communication-ui-library/assets/79475487/1114d79f-5adc-4305-9956-38028b05ccc5

# How Tested
Local calling sample testing.
https://github.com/Azure/communication-ui-library/assets/79475487/a1f4a6e2-e14b-41b2-91fa-e0790f288837

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->