### PR TITLE
[DTMF Dialer] Dialpad back button overlap fix

### DIFF
--- a/change-beta/@azure-communication-react-050d4869-a611-4569-b4e3-379a73dddeff.json
+++ b/change-beta/@azure-communication-react-050d4869-a611-4569-b4e3-379a73dddeff.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "fix",
+  "workstream": "DTMF Dialer",
+  "comment": "update styling to include space for back button",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-050d4869-a611-4569-b4e3-379a73dddeff.json
+++ b/change/@azure-communication-react-050d4869-a611-4569-b4e3-379a73dddeff.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "fix",
+  "workstream": "DTMF Dialer",
+  "comment": "update styling to include space for back button",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/Dialpad/Dialpad.tsx
+++ b/packages/react-components/src/components/Dialpad/Dialpad.tsx
@@ -370,7 +370,7 @@ const DialpadContainer = (props: {
     >
       {dialpadMode === 'dialer' && (
         <TextField
-          styles={concatStyleSets(textFieldStyles(theme), props.styles?.textField)}
+          styles={concatStyleSets(textFieldStyles(theme, plainTextValue !== ''), props.styles?.textField)}
           value={textFieldValue ? textFieldValue : formatPhoneNumber(plainTextValue)}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           onChange={(e: any) => {

--- a/packages/react-components/src/components/styles/Dialpad.styles.ts
+++ b/packages/react-components/src/components/styles/Dialpad.styles.ts
@@ -57,11 +57,12 @@ export const textFieldStyles = (theme: Theme, buttonPresent: boolean): Partial<I
     textAlign: 'center',
     fontSize: `${_pxToRem(18)}`,
     fontWeight: 400,
-    width: `${!buttonPresent ? '12rem' : '10rem'}`,
+    width: `${buttonPresent ? '10rem' : '12rem'}`,
     height: '3rem',
     borderRadius: '0.5rem',
     position: 'relative',
-    overflowX: 'auto'
+    overflowX: 'hidden',
+    textOverflow: 'clip'
   },
   root: {
     backgroundColor: `${theme.palette.neutralLighter}`,

--- a/packages/react-components/src/components/styles/Dialpad.styles.ts
+++ b/packages/react-components/src/components/styles/Dialpad.styles.ts
@@ -51,13 +51,13 @@ export const digitStyles = (theme: Theme): IStyle => {
 /**
  * @private
  */
-export const textFieldStyles = (theme: Theme): Partial<ITextFieldStyles> => ({
+export const textFieldStyles = (theme: Theme, buttonPresent: boolean): Partial<ITextFieldStyles> => ({
   field: {
     padding: 0,
     textAlign: 'center',
     fontSize: `${_pxToRem(18)}`,
     fontWeight: 400,
-    width: `${_pxToRem(192)}`,
+    width: `${!buttonPresent ? '12rem' : '10rem'}`,
     height: '3rem',
     borderRadius: '0.5rem',
     position: 'relative',
@@ -72,6 +72,7 @@ export const textFieldStyles = (theme: Theme): Partial<ITextFieldStyles> => ({
   fieldGroup: {
     border: 'none',
     borderRadius: '0.5rem',
+    width: '12rem',
     height: '3rem',
     backgroundColor: `${theme.palette.neutralLighter}`,
     ':after': {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fix issue where back button over laps dialed number
# Why
<!--- What problem does this change solve? -->
allows for even spacing between button and phone number entered
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3588391
# How Tested
<!--- How did you test your change. What tests have you added. -->
![image](https://github.com/Azure/communication-ui-library/assets/94866715/3be40896-3fe0-4b65-b6d9-31b114da2902)
Validated locally