### PR TITLE
[Chat] Bug fix Img via file share with no message content

### DIFF
--- a/change-beta/@azure-communication-react-1466d23d-73bc-4aa9-8a92-4537c310db9c.json
+++ b/change-beta/@azure-communication-react-1466d23d-73bc-4aa9-8a92-4537c310db9c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "InlineImages",
+  "comment": "Fixing defect when a img is shared via drag and drop and there is no message content",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-1466d23d-73bc-4aa9-8a92-4537c310db9c.json
+++ b/change/@azure-communication-react-1466d23d-73bc-4aa9-8a92-4537c310db9c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "InlineImages",
+  "comment": "Fixing defect when a img is shared via drag and drop and there is no message content",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-component-bindings/src/messageThreadSelector.ts
+++ b/packages/chat-component-bindings/src/messageThreadSelector.ts
@@ -151,19 +151,23 @@ const extractAttachmentUrl = (attachment: ChatAttachment): string => {
 const processChatMessageContent = (message: ChatMessageWithStatus): string | undefined => {
   let content = message.content?.message;
   /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
-  if (content && message.content?.attachments && sanitizedMessageContentType(message.type).includes('html')) {
+
+  if (message.content?.attachments && sanitizedMessageContentType(message.type).includes('html')) {
     const attachments: ChatAttachment[] = message.content?.attachments;
     // Fill in the src here
-    const document = new DOMParser().parseFromString(content, 'text/html');
-    document.querySelectorAll('img').forEach((img) => {
-      const attachmentPreviewUrl = attachments.find((attachment) => attachment.id === img.id)?.previewUrl;
-      if (attachmentPreviewUrl) {
-        const src = message.resourceCache?.[attachmentPreviewUrl] ?? '';
-        img.src = src;
-      }
-    });
     /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
-    content = document.documentElement.innerHTML;
+    if (content) {
+      const document = new DOMParser().parseFromString(content ?? '', 'text/html');
+      document.querySelectorAll('img').forEach((img) => {
+        const attachmentPreviewUrl = attachments.find((attachment) => attachment.id === img.id)?.previewUrl;
+        if (attachmentPreviewUrl) {
+          const src = message.resourceCache?.[attachmentPreviewUrl] ?? '';
+          img.src = src;
+        }
+      });
+      content = document.documentElement.innerHTML;
+    }
+
     const teamsImageHtmlContent = attachments
       .filter(
         (attachment) =>

--- a/packages/chat-stateful-client/src/ChatContext.ts
+++ b/packages/chat-stateful-client/src/ChatContext.ts
@@ -319,7 +319,7 @@ export class ChatContext {
   /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
   private parseAttachments(threadId: string, message: ChatMessageWithStatus): void {
     const attachments = message.content?.attachments;
-    if (message.type === 'html' && message.content?.message && attachments && attachments.length > 0) {
+    if (message.type === 'html' && attachments && attachments.length > 0) {
       if (
         this._messageQueue &&
         !this._messageQueue.containsMessageWithSameAttachments(message) &&


### PR DESCRIPTION
# What
Images being shared via file share (drag and drop) with no message content was not being displayed in the message bubbles

# Why
Bug where we were check for valid content before making a request to download inline images. 

# How Tested
Teams side:
- Drag and drop an file img into the chat box without a message content
CallWithChatComposite
- Notice message bubble loads inline image

# Process & policy checklist
- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->