### PR TITLE
[Chat] Inline image displayed DLP

### DIFF
--- a/change-beta/@azure-communication-react-74550d0c-51e2-4584-8fb7-77fbe2539615.json
+++ b/change-beta/@azure-communication-react-74550d0c-51e2-4584-8fb7-77fbe2539615.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "InlineImage",
+  "comment": "Update the policy violation check",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-74550d0c-51e2-4584-8fb7-77fbe2539615.json
+++ b/change/@azure-communication-react-74550d0c-51e2-4584-8fb7-77fbe2539615.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "InlineImage",
+  "comment": "Update the policy violation check",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-stateful-client/src/convertChatMessage.ts
+++ b/packages/chat-stateful-client/src/convertChatMessage.ts
@@ -21,7 +21,8 @@ export const convertChatMessage = (
     policyViolation: !!(
       message.sender?.kind === 'microsoftTeamsUser' &&
       !!message.editedOn &&
-      message.content?.message === ''
+      message.content?.message === '' &&
+      message.content.attachments?.length === 0
     )
   };
 };


### PR DESCRIPTION
# What
In the case of an edited message with no message content, but a few attachments via file sharing, triggers DLP. 
# Why
The policy violation check did not validate against the existence of attachments 
# How Tested
Teams side: 
Send a message with message content and drag and drop an image.
Edit the message to delete the message content. 

CallWithChatComposite:
Message should display as expected

# Process & policy checklist
- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->