### PR TITLE
Set hide attendee name option to 'False' until replaced by SDK

### DIFF
--- a/change-beta/@azure-communication-react-c5f6e075-2be5-419d-aab6-1b5fd99a9644.json
+++ b/change-beta/@azure-communication-react-c5f6e075-2be5-419d-aab6-1b5fd99a9644.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Hide Attendee Names",
+  "comment": "Set hide attendee name option to 'False' until replaced by sdk",
+  "packageName": "@azure/communication-react",
+  "email": "97124699+prabhjot-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-c5f6e075-2be5-419d-aab6-1b5fd99a9644.json
+++ b/change/@azure-communication-react-c5f6e075-2be5-419d-aab6-1b5fd99a9644.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Hide Attendee Names",
+  "comment": "Set hide attendee name option to 'False' until replaced by sdk",
+  "packageName": "@azure/communication-react",
+  "email": "97124699+prabhjot-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/src/Converter.ts
+++ b/packages/calling-stateful-client/src/Converter.ts
@@ -163,7 +163,7 @@ export function convertSdkCallToDeclarativeCall(call: CallCommon): CallState {
     },
     /* @conditional-compile-remove(hide-attendee-name) */
     // TODO: Replace this once the SDK supports hide attendee name
-    hideAttendeeNames: true
+    hideAttendeeNames: false
   };
 }
 


### PR DESCRIPTION
# What
Set hide attendee name option to 'False' until replaced by SDK

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3563552

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->