### PR TITLE
Add options prop to composites to hide spotlight

### DIFF
--- a/change-beta/@azure-communication-react-7ca4b5ab-e195-470a-810d-f3b01b0f6439.json
+++ b/change-beta/@azure-communication-react-7ca4b5ab-e195-470a-810d-f3b01b0f6439.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "feature",
+  "workstream": "Spotlight",
+  "comment": "Add options prop to composites to hide spotlight",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-7ca4b5ab-e195-470a-810d-f3b01b0f6439.json
+++ b/change/@azure-communication-react-7ca4b5ab-e195-470a-810d-f3b01b0f6439.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "feature",
+  "workstream": "Spotlight",
+  "comment": "Add options prop to composites to hide spotlight",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -628,6 +628,9 @@ export type CallCompositeOptions = {
             url: string;
         };
     };
+    spotlight?: {
+        hideSpotlight?: boolean;
+    };
 };
 
 // @public
@@ -1308,6 +1311,9 @@ export type CallWithChatCompositeOptions = {
         backgroundImage?: {
             url: string;
         };
+    };
+    spotlight?: {
+        hideSpotlight?: boolean;
     };
 };
 

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -453,6 +453,9 @@ export type CallCompositeOptions = {
             url: string;
         };
     };
+    spotlight?: {
+        hideSpotlight?: boolean;
+    };
 };
 
 // @public
@@ -1014,6 +1017,9 @@ export type CallWithChatCompositeOptions = {
         backgroundImage?: {
             url: string;
         };
+    };
+    spotlight?: {
+        hideSpotlight?: boolean;
     };
 };
 

--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -316,6 +316,19 @@ export type CallCompositeOptions = {
       url: string;
     };
   };
+  /* @conditional-compile-remove(spotlight) */
+  /**
+   * Options for settings related to spotlight.
+   */
+  spotlight?: {
+    /**
+     * Flag to hide the menu buttons to start and stop spotlight for remote participants and menu button
+     * to start spotlight for the local participant. The menu button to stop spotlight for the local
+     * participant will not be hidden.
+     * @defaultValue false
+     */
+    hideSpotlight?: boolean;
+  };
 };
 
 type MainScreenProps = {

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -121,6 +121,8 @@ export interface CallArrangementProps {
   setIsPromptOpen?: (isOpen: boolean) => void;
   /* @conditional-compile-remove(spotlight) */
   setPromptProps?: (props: PromptProps) => void;
+  /* @conditional-compile-remove(spotlight) */
+  hideSpotlightFeature?: boolean;
 }
 
 /**
@@ -181,7 +183,7 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
   const videoGalleryProps = usePropsFor(VideoGallery);
 
   /* @conditional-compile-remove(spotlight) */
-  const { setPromptProps, setIsPromptOpen } = props;
+  const { setPromptProps, setIsPromptOpen, hideSpotlightFeature } = props;
 
   /* @conditional-compile-remove(spotlight) */
   const {
@@ -213,10 +215,16 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
   const { isPeoplePaneOpen, openPeoplePane, closePeoplePane } = usePeoplePane({
     ...peoplePaneProps,
     /* @conditional-compile-remove(spotlight) */ spotlightedParticipantUserIds: spotlightedParticipants,
-    /* @conditional-compile-remove(spotlight) */ onStartLocalSpotlight: onStartLocalSpotlightWithPrompt,
+    /* @conditional-compile-remove(spotlight) */ onStartLocalSpotlight: hideSpotlightFeature
+      ? undefined
+      : onStartLocalSpotlightWithPrompt,
     /* @conditional-compile-remove(spotlight) */ onStopLocalSpotlight: onStopLocalSpotlightWithPrompt,
-    /* @conditional-compile-remove(spotlight) */ onStartRemoteSpotlight: onStartRemoteSpotlightWithPrompt,
-    /* @conditional-compile-remove(spotlight) */ onStopRemoteSpotlight: onStopRemoteSpotlightWithPrompt,
+    /* @conditional-compile-remove(spotlight) */ onStartRemoteSpotlight: hideSpotlightFeature
+      ? undefined
+      : onStartRemoteSpotlightWithPrompt,
+    /* @conditional-compile-remove(spotlight) */ onStopRemoteSpotlight: hideSpotlightFeature
+      ? undefined
+      : onStopRemoteSpotlightWithPrompt,
     /* @conditional-compile-remove(spotlight) */ maxParticipantsToSpotlight
   });
   const togglePeoplePane = useCallback(() => {

--- a/packages/react-composites/src/composites/CallComposite/components/MediaGallery.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/MediaGallery.tsx
@@ -72,6 +72,8 @@ export interface MediaGalleryProps {
   setIsPromptOpen: (isOpen: boolean) => void;
   /* @conditional-compile-remove(spotlight) */
   setPromptProps: (props: PromptProps) => void;
+  /* @conditional-compile-remove(spotlight) */
+  hideSpotlightFeature?: boolean;
 }
 
 /**
@@ -79,7 +81,7 @@ export interface MediaGalleryProps {
  */
 export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
   /* @conditional-compile-remove(spotlight) */
-  const { setIsPromptOpen, setPromptProps } = props;
+  const { setIsPromptOpen, setPromptProps, hideSpotlightFeature } = props;
 
   const videoGalleryProps = usePropsFor(VideoGallery);
   const cameraSwitcherCameras = useSelector(localVideoCameraCycleButtonSelector);
@@ -204,13 +206,13 @@ export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
         /* @conditional-compile-remove(reaction) */
         reactionResources={reactionResources}
         /* @conditional-compile-remove(spotlight) */
-        onStartLocalSpotlight={onStartLocalSpotlightWithPrompt}
+        onStartLocalSpotlight={hideSpotlightFeature ? undefined : onStartLocalSpotlightWithPrompt}
         /* @conditional-compile-remove(spotlight) */
         onStopLocalSpotlight={onStopLocalSpotlightWithPrompt}
         /* @conditional-compile-remove(spotlight) */
-        onStartRemoteSpotlight={onStartRemoteSpotlightWithPrompt}
+        onStartRemoteSpotlight={hideSpotlightFeature ? undefined : onStartRemoteSpotlightWithPrompt}
         /* @conditional-compile-remove(spotlight) */
-        onStopRemoteSpotlight={onStopRemoteSpotlightWithPrompt}
+        onStopRemoteSpotlight={hideSpotlightFeature ? undefined : onStopRemoteSpotlightWithPrompt}
       />
     );
   }, [
@@ -241,7 +243,9 @@ export const MediaGallery = (props: MediaGalleryProps): JSX.Element => {
     /* @conditional-compile-remove(spotlight) */
     onStartRemoteSpotlightWithPrompt,
     /* @conditional-compile-remove(spotlight) */
-    onStopRemoteSpotlightWithPrompt
+    onStopRemoteSpotlightWithPrompt,
+    /* @conditional-compile-remove(spotlight) */
+    hideSpotlightFeature
   ]);
 
   return (

--- a/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/CallPage.tsx
@@ -155,6 +155,8 @@ export const CallPage = (props: CallPageProps): JSX.Element => {
           setIsPromptOpen={setIsPromptOpen}
           /* @conditional-compile-remove(spotlight) */
           setPromptProps={setPromptProps}
+          /* @conditional-compile-remove(spotlight) */
+          hideSpotlightFeature={options?.spotlight?.hideSpotlight}
         />
       );
     }
@@ -230,6 +232,8 @@ export const CallPage = (props: CallPageProps): JSX.Element => {
         setIsPromptOpen={setIsPromptOpen}
         /* @conditional-compile-remove(spotlight) */
         setPromptProps={setPromptProps}
+        /* @conditional-compile-remove(spotlight) */
+        hideSpotlightFeature={options?.spotlight?.hideSpotlight}
       />
       {
         /* @conditional-compile-remove(spotlight) */

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -265,6 +265,19 @@ export type CallWithChatCompositeOptions = {
       url: string;
     };
   };
+  /* @conditional-compile-remove(spotlight) */
+  /**
+   * Options for settings related to spotlight.
+   */
+  spotlight?: {
+    /**
+     * Flag to hide the menu buttons to start and stop spotlight for remote participants and menu button
+     * to start spotlight for the local participant. The menu button to stop spotlight for the local
+     * participant will not be hidden.
+     * @defaultValue false
+     */
+    hideSpotlight?: boolean;
+  };
 };
 
 type CallWithChatScreenProps = {
@@ -343,6 +356,10 @@ type CallWithChatScreenProps = {
   /* @conditional-compile-remove(custom-branding) */
   backgroundImage?: {
     url: string;
+  };
+  /* @conditional-compile-remove(spotlight) */
+  spotlight?: {
+    hideSpotlight?: boolean;
   };
 };
 
@@ -527,7 +544,9 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
       branding: {
         logo: props.logo,
         backgroundImage: props.backgroundImage
-      }
+      },
+      /* @conditional-compile-remove(spotlight) */
+      spotlight: props.spotlight
     }),
     [
       props.callControls,
@@ -553,7 +572,9 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
       /* @conditional-compile-remove(custom-branding) */
       props.logo,
       /* @conditional-compile-remove(custom-branding) */
-      props.backgroundImage
+      props.backgroundImage,
+      /* @conditional-compile-remove(spotlight) */
+      props.spotlight
     ]
   );
 
@@ -688,6 +709,8 @@ export const CallWithChatComposite = (props: CallWithChatCompositeProps): JSX.El
         backgroundImage={options?.branding?.backgroundImage}
         /* @conditional-compile-remove(end-of-call-survey) */
         surveyOptions={options?.surveyOptions}
+        /* @conditional-compile-remove(spotlight) */
+        spotlight={options?.spotlight}
       />
     </BaseProvider>
   );


### PR DESCRIPTION
# What
Add options prop to composites to hide spotlight

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3592932

# How Tested
Locally tested by setting option to hide spotlight in CallWithChat sample:
https://github.com/Azure/communication-ui-library/assets/79475487/9f5587d5-410b-4b8c-9201-b1c27f9a025c

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->