### PR TITLE
Auto run CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI
 on:
   # Postsubmit CI on main.
   push:
-    branches: [main]
+    branches:
+      - main
+      - release/**
   # Presubmit CI on PRs to all branches.
   pull_request:
   # Allows you to run this workflow manually from the Actions tab.


### PR DESCRIPTION
# What

Auto run CI on release branches

Action syntax ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches

# Why

Should be happening for the same reason main branch has it.

# How Tested
 n/a