### PR TITLE
Cherry Pick PR 4183 into release branch

### DIFF
--- a/change/@azure-communication-react-678df3f7-61a2-47ba-8113-6d292930a836.json
+++ b/change/@azure-communication-react-678df3f7-61a2-47ba-8113-6d292930a836.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Update mention api to include isActive argument",
+  "packageName": "@azure/communication-react",
+  "email": "73612854+palatter@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/CHANGELOG.beta.md
+++ b/packages/communication-react/CHANGELOG.beta.md
@@ -18,6 +18,7 @@ Mon, 26 Feb 2024 16:19:15 GMT
 
 ### Bug Fixes
 
+- Update mention API to include `isActive` argument ([PR #4183](https://github.com/azure/communication-ui-library/pull/4183) by 73612854+palatter@users.noreply.github.com)
 - Update styling to include space for back button ([PR #4079](https://github.com/azure/communication-ui-library/pull/4079) by 94866715+dmceachernmsft@users.noreply.github.com)
 - Defect fixing the src of the inline image ([PR #4104](https://github.com/azure/communication-ui-library/pull/4104) by 9044372+JoshuaLai@users.noreply.github.com)
 - Fix for an issue when head and body tags were added to messages with html type ([PR #4106](https://github.com/azure/communication-ui-library/pull/4106) by 98852890+vhuseinova-msft@users.noreply.github.com)

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -3040,7 +3040,7 @@ export interface MentionDisplayOptions {
 // @beta
 export interface MentionLookupOptions {
     onQueryUpdated: (query: string) => Promise<Mention[]>;
-    onRenderSuggestionItem?: (suggestion: Mention, onSuggestionSelected: (suggestion: Mention) => void) => JSX.Element;
+    onRenderSuggestionItem?: (suggestion: Mention, onSuggestionSelected: (suggestion: Mention) => void, isActive: boolean) => JSX.Element;
     trigger?: string;
 }
 

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -1381,7 +1381,7 @@ export interface MentionDisplayOptions {
 // @beta
 export interface MentionLookupOptions {
     onQueryUpdated: (query: string) => Promise<Mention[]>;
-    onRenderSuggestionItem?: (suggestion: Mention, onSuggestionSelected: (suggestion: Mention) => void) => JSX.Element;
+    onRenderSuggestionItem?: (suggestion: Mention, onSuggestionSelected: (suggestion: Mention) => void, isActive: boolean) => JSX.Element;
     trigger?: string;
 }
 

--- a/packages/react-components/src/components/MentionPopover.tsx
+++ b/packages/react-components/src/components/MentionPopover.tsx
@@ -85,7 +85,11 @@ export interface MentionLookupOptions {
   /**
    * Optional callback to render an item of the mention suggestions list.
    */
-  onRenderSuggestionItem?: (suggestion: Mention, onSuggestionSelected: (suggestion: Mention) => void) => JSX.Element;
+  onRenderSuggestionItem?: (
+    suggestion: Mention,
+    onSuggestionSelected: (suggestion: Mention) => void,
+    isActive: boolean
+  ) => JSX.Element;
 }
 
 /**


### PR DESCRIPTION
Mention popover API was missing a type definition

# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->