### PR TITLE
[Chat] Add key attr to MsftMention tag for Contosos who uses the defaultOnMentionRender

### DIFF
--- a/change-beta/@azure-communication-react-45c5859b-a0f7-4174-861c-0ba461ebf681.json
+++ b/change-beta/@azure-communication-react-45c5859b-a0f7-4174-861c-0ba461ebf681.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Mention",
+  "comment": "Add key to MsftMention tag",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-45c5859b-a0f7-4174-861c-0ba461ebf681.json
+++ b/change/@azure-communication-react-45c5859b-a0f7-4174-861c-0ba461ebf681.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Mention",
+  "comment": "Add key to MsftMention tag",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -227,13 +227,16 @@ const processHtmlToReact = (props: ChatMessageContentProps): JSX.Element => {
       if (domNode instanceof DOMElement && domNode.attribs) {
         // Transform custom rendering of mentions
         /* @conditional-compile-remove(mention) */
-        if (props.mentionDisplayOptions?.onRenderMention && domNode.name === 'msft-mention') {
+        if (domNode.name === 'msft-mention') {
           const { id } = domNode.attribs;
           const mention: Mention = {
             id: id,
             displayText: (domNode.children[0] as unknown as Text).nodeValue ?? ''
           };
-          return props.mentionDisplayOptions.onRenderMention(mention, defaultOnMentionRender);
+          if (props.mentionDisplayOptions?.onRenderMention) {
+            return props.mentionDisplayOptions.onRenderMention(mention, defaultOnMentionRender);
+          }
+          return defaultOnMentionRender(mention);
         }
 
         // Transform inline images

--- a/packages/react-components/src/components/ChatMessage/MentionRenderer.tsx
+++ b/packages/react-components/src/components/ChatMessage/MentionRenderer.tsx
@@ -12,5 +12,9 @@ import { Mention } from '../MentionPopover';
 export const defaultOnMentionRender = (mention: Mention): JSX.Element => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const MsftMention = 'msft-mention' as any;
-  return <MsftMention id={mention.id}>{mention.displayText}</MsftMention>;
+  return (
+    <MsftMention id={mention.id} key={Math.random().toString()}>
+      {mention.displayText}
+    </MsftMention>
+  );
 };

--- a/packages/storybook/stories/MessageThread/snippets/MessageWithCustomMentionRenderer.snippet.tsx
+++ b/packages/storybook/stories/MessageThread/snippets/MessageWithCustomMentionRenderer.snippet.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 export const MessageWithCustomMentionRenderer: () => JSX.Element = () => {
   const user1Id = 'user1';
   const user2Id = 'user2';
+  const user3Id = 'user3';
 
   const messages: ChatMessage[] = [
     {
@@ -11,7 +12,7 @@ export const MessageWithCustomMentionRenderer: () => JSX.Element = () => {
       senderId: user1Id,
       senderDisplayName: 'Kat Larsson',
       messageId: Math.random().toString(),
-      content: `Hey <msft-mention id="${user2Id}">Robert Tolbert</msft-mention>, can you help me with my internet connection?`,
+      content: `Hey <msft-mention id="${user2Id}">Robert Tolbert</msft-mention> and <msft-mention id="${user3Id}">Milton Dyer</msft-mention>, can you help me with my internet connection?`,
       createdOn: new Date('2019-04-13T00:00:00.000+08:10'),
       mine: false,
       attached: false,


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
This fix is only for Contosos who're not using the onRenderMention callback, or in the onRenderMention callback, directly returns the defaultOnMentionRender.
For Contosos who wraps the defaultOnMentionRender in another element, they also need to set the key to the wrapper component as shown in our Storybook page:
```
displayOptions: {
  onRenderMention: (mention, defaultOnMentionRender) => {
    return <button key={Math.random().toString()}>{defaultOnMentionRender(mention)}</button>;
  }
},
```

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->