### PR TITLE
[Chat] UpdateMessage not sending metadata

### DIFF
--- a/change-beta/@azure-communication-react-44cd578f-f084-4d4e-9c9a-8c58fde157f2.json
+++ b/change-beta/@azure-communication-react-44cd578f-f084-4d4e-9c9a-8c58fde157f2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "UpdateMessage",
+  "comment": "Bug Fix metadata was not being sent up to the handler",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-44cd578f-f084-4d4e-9c9a-8c58fde157f2.json
+++ b/change/@azure-communication-react-44cd578f-f084-4d4e-9c9a-8c58fde157f2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "UpdateMessage",
+  "comment": "Bug Fix metadata was not being sent up to the handler",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -275,7 +275,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   ): Promise<void> {
     return await this.asyncTeeErrorToEventEmitter(async () => {
       /* @conditional-compile-remove(file-sharing) */
-      const updatedOptions = options ? { attachmentMetadata: options.attachmentMetadata, metadata: metadata } : {};
+      const updatedOptions = { attachmentMetadata: options?.attachmentMetadata, metadata: metadata };
       /* @conditional-compile-remove(file-sharing) */
       return await this.handlers.onUpdateMessage(messageId, content, updatedOptions);
       return await this.handlers.onUpdateMessage(messageId, content);


### PR DESCRIPTION
# What
As per gitissue: https://github.com/Azure/communication-ui-library/issues/4209
Metadata was not being sent downstream to the handlers. 

# Why
When the options property was missing we were incorrectly dropping the metadata argument. 

# How Tested
as per git issue: https://github.com/Azure/communication-ui-library/issues/4209

# Process & policy checklist

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->