### PR TITLE
[Chat] Remove AttachmentMetadata

### DIFF
--- a/change-beta/@azure-communication-react-e4833c07-1bee-49be-ace6-f059887ff1d6.json
+++ b/change-beta/@azure-communication-react-e4833c07-1bee-49be-ace6-f059887ff1d6.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "improvement",
+  "workstream": "InlineImage",
+  "comment": "Remove AttachmentMetadata",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-e4833c07-1bee-49be-ace6-f059887ff1d6.json
+++ b/change/@azure-communication-react-e4833c07-1bee-49be-ace6-f059887ff1d6.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "improvement",
+  "workstream": "InlineImage",
+  "comment": "Remove AttachmentMetadata",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-component-bindings/review/beta/chat-component-bindings.api.md
+++ b/packages/chat-component-bindings/review/beta/chat-component-bindings.api.md
@@ -8,12 +8,12 @@
 
 import { ActiveErrorMessage } from '@internal/react-components';
 import { AreEqual } from '@internal/acs-ui-common';
-import { AttachmentMetadata } from '@internal/react-components';
 import { ChatClientState } from '@internal/chat-stateful-client';
 import { ChatThreadClient } from '@azure/communication-chat';
 import { Common } from '@internal/acs-ui-common';
 import { CommunicationParticipant } from '@internal/react-components';
 import { ErrorBar } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 import { Message } from '@internal/react-components';
 import { MessageThread } from '@internal/react-components';
 import { ParticipantList } from '@internal/react-components';
@@ -49,7 +49,7 @@ export type ChatHandlers = {
     onLoadPreviousChatMessages: (messagesToLoad: number) => Promise<boolean>;
     onUpdateMessage: (messageId: string, content: string, options?: {
         metadata?: Record<string, string>;
-        attachmentMetadata?: AttachmentMetadata[];
+        attachmentMetadata?: FileMetadata[];
     }) => Promise<void>;
     onDeleteMessage: (messageId: string) => Promise<void>;
 };

--- a/packages/chat-component-bindings/src/handlers/createHandlers.ts
+++ b/packages/chat-component-bindings/src/handlers/createHandlers.ts
@@ -7,7 +7,7 @@ import { Common, fromFlatCommunicationIdentifier } from '@internal/acs-ui-common
 import { StatefulChatClient } from '@internal/chat-stateful-client';
 import { ChatMessage, ChatMessageReadReceipt, ChatThreadClient, SendMessageOptions } from '@azure/communication-chat';
 import memoizeOne from 'memoize-one';
-import { AttachmentMetadata } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 
 /**
  * Object containing all the handlers required for chat components.
@@ -31,7 +31,7 @@ export type ChatHandlers = {
     options?: {
       /* @conditional-compile-remove(file-sharing) */
       metadata?: Record<string, string>;
-      attachmentMetadata?: AttachmentMetadata[];
+      attachmentMetadata?: FileMetadata[];
     }
   ) => Promise<void>;
   onDeleteMessage: (messageId: string) => Promise<void>;
@@ -64,7 +64,7 @@ export const createDefaultChatHandlers = memoizeOne(
         content: string,
         options?: {
           metadata?: Record<string, string>;
-          attachmentMetadata?: AttachmentMetadata[];
+          attachmentMetadata?: FileMetadata[];
         }
       ) => {
         const updatedMetadata = options?.metadata ? { ...options.metadata } : {};

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -148,9 +148,6 @@ export type AreParamEqual<A extends (props: any) => JSX.Element | undefined, B e
 // @public
 export type AreTypeEqual<A, B> = A extends B ? (B extends A ? true : false) : false;
 
-// @beta
-export type AttachmentMetadata = FileMetadata;
-
 // @public
 export type AvatarPersonaData = {
     text?: string;
@@ -1029,7 +1026,7 @@ export interface CallWithChatAdapterManagement {
     // @beta (undocumented)
     registerActiveFileUploads: (files: File[]) => FileUploadManager[];
     // @beta (undocumented)
-    registerCompletedFileUploads: (metadata: AttachmentMetadata[]) => FileUploadManager[];
+    registerCompletedFileUploads: (metadata: FileMetadata[]) => FileUploadManager[];
     removeParticipant(userId: string): Promise<void>;
     // @beta
     removeParticipant(participant: CommunicationIdentifier): Promise<void>;
@@ -1066,7 +1063,7 @@ export interface CallWithChatAdapterManagement {
     // @beta (undocumented)
     updateFileUploadErrorMessage: (id: string, errorMessage: string) => void;
     // @beta (undocumented)
-    updateFileUploadMetadata: (id: string, metadata: AttachmentMetadata) => void;
+    updateFileUploadMetadata: (id: string, metadata: FileMetadata) => void;
     // @beta (undocumented)
     updateFileUploadProgress: (id: string, progress: number) => void;
     updateMessage(messageId: string, content: string, metadata?: Record<string, string>): Promise<void>;
@@ -1639,7 +1636,7 @@ export interface ChatAdapterThreadManagement {
     sendTypingIndicator(): Promise<void>;
     setTopic(topicName: string): Promise<void>;
     updateMessage(messageId: string, content: string, metadata?: Record<string, string>, options?: {
-        attachmentMetadata?: AttachmentMetadata[];
+        attachmentMetadata?: FileMetadata[];
     }): Promise<void>;
 }
 
@@ -1759,7 +1756,7 @@ export type ChatHandlers = {
     onLoadPreviousChatMessages: (messagesToLoad: number) => Promise<boolean>;
     onUpdateMessage: (messageId: string, content: string, options?: {
         metadata?: Record<string, string>;
-        attachmentMetadata?: AttachmentMetadata[];
+        attachmentMetadata?: FileMetadata[];
     }) => Promise<void>;
     onDeleteMessage: (messageId: string) => Promise<void>;
 };
@@ -2862,7 +2859,7 @@ export interface FileDownloadError {
 }
 
 // @beta
-export type FileDownloadHandler = (userId: string, fileMetadata: AttachmentMetadata) => Promise<URL | FileDownloadError>;
+export type FileDownloadHandler = (userId: string, fileMetadata: FileMetadata) => Promise<URL | FileDownloadError>;
 
 // @beta
 export interface FileMetadata {
@@ -2893,11 +2890,11 @@ export interface FileUploadAdapter {
     // (undocumented)
     registerActiveFileUploads: (files: File[]) => FileUploadManager[];
     // (undocumented)
-    registerCompletedFileUploads: (metadata: AttachmentMetadata[]) => FileUploadManager[];
+    registerCompletedFileUploads: (metadata: FileMetadata[]) => FileUploadManager[];
     // (undocumented)
     updateFileUploadErrorMessage: (id: string, errorMessage: string) => void;
     // (undocumented)
-    updateFileUploadMetadata: (id: string, metadata: AttachmentMetadata) => void;
+    updateFileUploadMetadata: (id: string, metadata: FileMetadata) => void;
     // (undocumented)
     updateFileUploadProgress: (id: string, progress: number) => void;
 }
@@ -2915,7 +2912,7 @@ export type FileUploadHandler = (userId: string, fileUploads: FileUploadManager[
 export interface FileUploadManager {
     file?: File;
     id: string;
-    notifyUploadCompleted: (metadata: AttachmentMetadata) => void;
+    notifyUploadCompleted: (metadata: FileMetadata) => void;
     notifyUploadFailed: (message: string) => void;
     notifyUploadProgressChanged: (value: number) => void;
 }
@@ -2925,7 +2922,7 @@ export interface FileUploadState {
     error?: FileUploadError;
     filename: string;
     id: string;
-    metadata?: AttachmentMetadata;
+    metadata?: FileMetadata;
     progress: number;
 }
 
@@ -4353,7 +4350,7 @@ export interface UnsupportedOperatingSystemStrings {
 // @public
 export type UpdateMessageCallback = (messageId: string, content: string, options?: {
     metadata?: Record<string, string>;
-    attachmentMetadata?: AttachmentMetadata[];
+    attachmentMetadata?: FileMetadata[];
 }) => Promise<void>;
 
 // @public

--- a/packages/communication-react/src/index.ts
+++ b/packages/communication-react/src/index.ts
@@ -332,8 +332,6 @@ export type {
   FileDownloadError
 } from '../../react-components/src';
 /* @conditional-compile-remove(file-sharing) */
-export type { AttachmentMetadata } from '../../react-components/src';
-/* @conditional-compile-remove(file-sharing) */
 export type { FileMetadata } from '../../react-components/src';
 /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
 export type { ChatAttachmentType } from '../../react-components/src';

--- a/packages/react-components/review/beta/react-components.api.md
+++ b/packages/react-components/review/beta/react-components.api.md
@@ -65,9 +65,6 @@ export type AnnouncerProps = {
     ariaLive: 'off' | 'polite' | 'assertive' | undefined;
 };
 
-// @beta
-export type AttachmentMetadata = FileMetadata;
-
 // @internal
 export type _AudioIssue = 'NoLocalAudio' | 'NoRemoteAudio' | 'Echo' | 'AudioNoise' | 'LowVolume' | 'AudioStoppedUnexpectedly' | 'DistortedSpeech' | 'AudioInterruption' | 'OtherIssues';
 
@@ -1162,7 +1159,7 @@ export const _FileDownloadCards: (props: _FileDownloadCardsProps) => JSX.Element
 // @internal (undocumented)
 export interface _FileDownloadCardsProps {
     downloadHandler?: FileDownloadHandler;
-    fileMetadata?: AttachmentMetadata[];
+    fileMetadata?: FileMetadata[];
     onDownloadErrorMessage?: (errMsg: string) => void;
     strings?: _FileDownloadCardsStrings;
     userId: string;
@@ -1181,7 +1178,7 @@ export interface FileDownloadError {
 }
 
 // @beta
-export type FileDownloadHandler = (userId: string, fileMetadata: AttachmentMetadata) => Promise<URL | FileDownloadError>;
+export type FileDownloadHandler = (userId: string, fileMetadata: FileMetadata) => Promise<URL | FileDownloadError>;
 
 // @beta
 export interface FileMetadata {
@@ -2501,7 +2498,7 @@ export interface UnsupportedOperatingSystemStrings {
 // @public
 export type UpdateMessageCallback = (messageId: string, content: string, options?: {
     metadata?: Record<string, string>;
-    attachmentMetadata?: AttachmentMetadata[];
+    attachmentMetadata?: FileMetadata[];
 }) => Promise<void>;
 
 // @internal

--- a/packages/react-components/review/stable/react-components.api.md
+++ b/packages/react-components/review/stable/react-components.api.md
@@ -55,9 +55,6 @@ export type AnnouncerProps = {
     ariaLive: 'off' | 'polite' | 'assertive' | undefined;
 };
 
-// @beta
-export type AttachmentMetadata = FileMetadata;
-
 // @public
 export interface BaseCustomStyles {
     root?: IStyle;
@@ -949,7 +946,7 @@ export const _FileDownloadCards: (props: _FileDownloadCardsProps) => JSX.Element
 // @internal (undocumented)
 export interface _FileDownloadCardsProps {
     downloadHandler?: FileDownloadHandler;
-    fileMetadata?: AttachmentMetadata[];
+    fileMetadata?: FileMetadata[];
     onDownloadErrorMessage?: (errMsg: string) => void;
     strings?: _FileDownloadCardsStrings;
     userId: string;
@@ -968,7 +965,7 @@ export interface FileDownloadError {
 }
 
 // @beta
-export type FileDownloadHandler = (userId: string, fileMetadata: AttachmentMetadata) => Promise<URL | FileDownloadError>;
+export type FileDownloadHandler = (userId: string, fileMetadata: FileMetadata) => Promise<URL | FileDownloadError>;
 
 // @beta
 export interface FileMetadata {

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponent.tsx
@@ -9,7 +9,7 @@ import { ChatMessage, ComponentSlotStyle, OnRenderAvatarCallback } from '../../t
 /* @conditional-compile-remove(data-loss-prevention) */
 import { BlockedMessage } from '../../types';
 import { ChatMessageComponentAsMessageBubble } from './ChatMessageComponentAsMessageBubble';
-import { FileDownloadHandler, AttachmentMetadata } from '../FileDownloadCards';
+import { FileDownloadHandler, FileMetadata } from '../FileDownloadCards';
 /* @conditional-compile-remove(mention) */
 import { MentionOptions } from '../MentionPopover';
 /* @conditional-compile-remove(image-overlay) */
@@ -26,7 +26,7 @@ type ChatMessageComponentProps = {
     content: string,
     metadata?: Record<string, string>,
     options?: {
-      attachmentMetadata?: AttachmentMetadata[];
+      attachmentMetadata?: FileMetadata[];
     }
   ) => Promise<void>;
   onCancelEditMessage?: (messageId: string) => void;

--- a/packages/react-components/src/components/FileDownloadCards.test.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.test.tsx
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 
 import React from 'react';
-import { AttachmentMetadata, _FileDownloadCards } from './FileDownloadCards';
-import { FileMetadata } from './FileDownloadCards';
+import { FileMetadata, _FileDownloadCards } from './FileDownloadCards';
 import { render, screen } from '@testing-library/react';
 import { registerIcons } from '@fluentui/react';
 
@@ -43,5 +42,5 @@ const renderFileDownloadCardsWithDefaults = (props: MockDownloadCardProps): void
 
 interface MockDownloadCardProps {
   userId: string;
-  fileMetadata: AttachmentMetadata[];
+  fileMetadata: FileMetadata[];
 }

--- a/packages/react-components/src/components/FileDownloadCards.tsx
+++ b/packages/react-components/src/components/FileDownloadCards.tsx
@@ -56,12 +56,6 @@ export interface FileMetadata {
 }
 
 /**
- * Metadata containing information about the uploaded file.
- * @beta
- */
-export type AttachmentMetadata = FileMetadata;
-
-/**
  * Strings of _FileDownloadCards that can be overridden.
  *
  * @internal
@@ -110,12 +104,9 @@ export interface FileDownloadError {
  *
  * ```
  * @param userId - The user ID of the user downloading the file.
- * @param fileMetadata - The {@link AttachmentMetadata} containing file `url`, `extension` and `name`.
+ * @param fileMetadata - The {@link FileMetadata} containing file `url`, `extension` and `name`.
  */
-export type FileDownloadHandler = (
-  userId: string,
-  fileMetadata: AttachmentMetadata
-) => Promise<URL | FileDownloadError>;
+export type FileDownloadHandler = (userId: string, fileMetadata: FileMetadata) => Promise<URL | FileDownloadError>;
 
 /**
  * @internal
@@ -128,7 +119,7 @@ export interface _FileDownloadCardsProps {
   /**
    * A chat message metadata that includes file metadata
    */
-  fileMetadata?: AttachmentMetadata[];
+  fileMetadata?: FileMetadata[];
   /**
    * A function of type {@link FileDownloadHandler} for handling file downloads.
    * If the function is not specified, the file's `url` will be opened in a new tab to
@@ -166,14 +157,14 @@ export const _FileDownloadCards = (props: _FileDownloadCardsProps): JSX.Element 
     [props.strings?.downloadFile, localeStrings.downloadFile]
   );
 
-  const isFileSharingAttachment = useCallback((attachment: AttachmentMetadata): boolean => {
+  const isFileSharingAttachment = useCallback((attachment: FileMetadata): boolean => {
     /* @conditional-compile-remove(file-sharing) */
     return attachment.attachmentType === 'file';
     return false;
   }, []);
 
   /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
-  const isShowDownloadIcon = useCallback((attachment: AttachmentMetadata): boolean => {
+  const isShowDownloadIcon = useCallback((attachment: FileMetadata): boolean => {
     /* @conditional-compile-remove(file-sharing) */
     return attachment.attachmentType === 'file' && attachment.payload?.teamsFileAttachment !== 'true';
     return true;
@@ -194,7 +185,7 @@ export const _FileDownloadCards = (props: _FileDownloadCardsProps): JSX.Element 
   );
 
   const fileDownloadHandler = useCallback(
-    async (userId: string, file: AttachmentMetadata) => {
+    async (userId: string, file: FileMetadata) => {
       if (!props.downloadHandler) {
         window.open(file.url, '_blank', 'noopener,noreferrer');
       } else {
@@ -244,14 +235,14 @@ export const _FileDownloadCards = (props: _FileDownloadCardsProps): JSX.Element 
                       <Spinner size={SpinnerSize.medium} aria-live={'polite'} role={'status'} />
                     ) : true &&
                       /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */ isShowDownloadIcon(
-                        file as unknown as AttachmentMetadata
+                        file
                       ) ? (
                       <IconButton className={iconButtonClassName} ariaLabel={downloadFileButtonString()}>
                         <DownloadIconTrampoline />
                       </IconButton>
                     ) : undefined
                   }
-                  actionHandler={() => fileDownloadHandler(userId, file as unknown as AttachmentMetadata)}
+                  actionHandler={() => fileDownloadHandler(userId, file)}
                 />
               </TooltipHost>
             ))}

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -35,7 +35,7 @@ import getParticipantsWhoHaveReadMessage from './utils/getParticipantsWhoHaveRea
 /* @conditional-compile-remove(file-sharing) */
 import { FileDownloadHandler } from './FileDownloadCards';
 /* @conditional-compile-remove(file-sharing) */
-import { AttachmentMetadata } from './FileDownloadCards';
+import { FileMetadata } from './FileDownloadCards';
 import { useTheme } from '../theming';
 import { FluentV9ThemeProvider } from './../theming/FluentV9ThemeProvider';
 import LiveAnnouncer from './Announcer/LiveAnnouncer';
@@ -352,7 +352,7 @@ export type UpdateMessageCallback = (
   options?: {
     /* @conditional-compile-remove(file-sharing) */
     metadata?: Record<string, string>;
-    attachmentMetadata?: AttachmentMetadata[];
+    attachmentMetadata?: FileMetadata[];
   }
 ) => Promise<void>;
 /**

--- a/packages/react-composites/review/beta/react-composites.api.md
+++ b/packages/react-composites/review/beta/react-composites.api.md
@@ -7,7 +7,6 @@
 /// <reference types="react" />
 
 import { AddPhoneNumberOptions } from '@azure/communication-calling';
-import { AttachmentMetadata } from '@internal/react-components';
 import { AudioDeviceInfo } from '@azure/communication-calling';
 import type { BackgroundBlurConfig } from '@azure/communication-calling';
 import type { BackgroundReplacementConfig } from '@azure/communication-calling';
@@ -36,7 +35,7 @@ import { DeviceManagerState } from '@internal/calling-stateful-client';
 import { DtmfTone } from '@azure/communication-calling';
 import { EnvironmentInfo } from '@azure/communication-calling';
 import { FileDownloadHandler } from '@internal/react-components';
-import type { FileMetadata } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 import { GroupCallLocator } from '@azure/communication-calling';
 import type { MediaDiagnosticChangedEventArgs } from '@azure/communication-calling';
 import { MessageProps } from '@internal/react-components';
@@ -731,7 +730,7 @@ export interface CallWithChatAdapterManagement {
     // @beta (undocumented)
     registerActiveFileUploads: (files: File[]) => FileUploadManager[];
     // @beta (undocumented)
-    registerCompletedFileUploads: (metadata: AttachmentMetadata[]) => FileUploadManager[];
+    registerCompletedFileUploads: (metadata: FileMetadata[]) => FileUploadManager[];
     removeParticipant(userId: string): Promise<void>;
     // @beta
     removeParticipant(participant: CommunicationIdentifier): Promise<void>;
@@ -768,7 +767,7 @@ export interface CallWithChatAdapterManagement {
     // @beta (undocumented)
     updateFileUploadErrorMessage: (id: string, errorMessage: string) => void;
     // @beta (undocumented)
-    updateFileUploadMetadata: (id: string, metadata: AttachmentMetadata) => void;
+    updateFileUploadMetadata: (id: string, metadata: FileMetadata) => void;
     // @beta (undocumented)
     updateFileUploadProgress: (id: string, progress: number) => void;
     updateMessage(messageId: string, content: string, metadata?: Record<string, string>): Promise<void>;
@@ -1156,7 +1155,7 @@ export interface ChatAdapterThreadManagement {
     sendTypingIndicator(): Promise<void>;
     setTopic(topicName: string): Promise<void>;
     updateMessage(messageId: string, content: string, metadata?: Record<string, string>, options?: {
-        attachmentMetadata?: AttachmentMetadata[];
+        attachmentMetadata?: FileMetadata[];
     }): Promise<void>;
 }
 
@@ -1670,11 +1669,11 @@ export interface FileUploadAdapter {
     // (undocumented)
     registerActiveFileUploads: (files: File[]) => FileUploadManager[];
     // (undocumented)
-    registerCompletedFileUploads: (metadata: AttachmentMetadata[]) => FileUploadManager[];
+    registerCompletedFileUploads: (metadata: FileMetadata[]) => FileUploadManager[];
     // (undocumented)
     updateFileUploadErrorMessage: (id: string, errorMessage: string) => void;
     // (undocumented)
-    updateFileUploadMetadata: (id: string, metadata: AttachmentMetadata) => void;
+    updateFileUploadMetadata: (id: string, metadata: FileMetadata) => void;
     // (undocumented)
     updateFileUploadProgress: (id: string, progress: number) => void;
 }
@@ -1692,7 +1691,7 @@ export type FileUploadHandler = (userId: string, fileUploads: FileUploadManager[
 export interface FileUploadManager {
     file?: File;
     id: string;
-    notifyUploadCompleted: (metadata: AttachmentMetadata) => void;
+    notifyUploadCompleted: (metadata: FileMetadata) => void;
     notifyUploadFailed: (message: string) => void;
     notifyUploadProgressChanged: (value: number) => void;
 }
@@ -1702,7 +1701,7 @@ export interface FileUploadState {
     error?: FileUploadError;
     filename: string;
     id: string;
-    metadata?: AttachmentMetadata;
+    metadata?: FileMetadata;
     progress: number;
 }
 

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -25,7 +25,7 @@ import { AddPhoneNumberOptions } from '@azure/communication-calling';
 import { DtmfTone } from '@azure/communication-calling';
 import { CreateVideoStreamViewResult, VideoStreamOptions } from '@internal/react-components';
 /* @conditional-compile-remove(file-sharing) */
-import { AttachmentMetadata } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 import {
   ParticipantsJoinedListener,
   ParticipantsLeftListener,
@@ -439,7 +439,7 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
     metadata?: Record<string, string>,
     options?: {
       /* @conditional-compile-remove(file-sharing) */
-      attachmentMetadata?: AttachmentMetadata[];
+      attachmentMetadata?: FileMetadata[];
     }
   ): Promise<void> {
     return await this.chatAdapter.updateMessage(
@@ -458,7 +458,7 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
     return this.chatAdapter.registerActiveFileUploads(files);
   };
   /* @conditional-compile-remove(file-sharing) */
-  public registerCompletedFileUploads = (metadata: AttachmentMetadata[]): FileUploadManager[] => {
+  public registerCompletedFileUploads = (metadata: FileMetadata[]): FileUploadManager[] => {
     return this.chatAdapter.registerCompletedFileUploads(metadata);
   };
   /* @conditional-compile-remove(file-sharing) */
@@ -478,7 +478,7 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
     this.chatAdapter.updateFileUploadErrorMessage(id, errorMessage);
   };
   /* @conditional-compile-remove(file-sharing) */
-  public updateFileUploadMetadata = (id: string, metadata: AttachmentMetadata): void => {
+  public updateFileUploadMetadata = (id: string, metadata: FileMetadata): void => {
     this.chatAdapter.updateFileUploadMetadata(id, metadata);
   };
   /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
@@ -47,7 +47,7 @@ import { CreateVideoStreamViewResult, VideoStreamOptions } from '@internal/react
 import { SendMessageOptions } from '@azure/communication-chat';
 import { JoinCallOptions } from '../../CallComposite/adapter/CallAdapter';
 /* @conditional-compile-remove(file-sharing) */
-import { AttachmentMetadata } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 /* @conditional-compile-remove(file-sharing) */
 import { FileUploadManager } from '../../ChatComposite';
 /* @conditional-compile-remove(PSTN-calls) */
@@ -385,7 +385,7 @@ export interface CallWithChatAdapterManagement {
   registerActiveFileUploads: (files: File[]) => FileUploadManager[];
   /* @conditional-compile-remove(file-sharing) */
   /** @beta */
-  registerCompletedFileUploads: (metadata: AttachmentMetadata[]) => FileUploadManager[];
+  registerCompletedFileUploads: (metadata: FileMetadata[]) => FileUploadManager[];
   /* @conditional-compile-remove(file-sharing) */
   /** @beta */
   clearFileUploads: () => void;
@@ -400,7 +400,7 @@ export interface CallWithChatAdapterManagement {
   updateFileUploadErrorMessage: (id: string, errorMessage: string) => void;
   /* @conditional-compile-remove(file-sharing) */
   /** @beta */
-  updateFileUploadMetadata: (id: string, metadata: AttachmentMetadata) => void;
+  updateFileUploadMetadata: (id: string, metadata: FileMetadata) => void;
   /* @conditional-compile-remove(teams-inline-images-and-file-sharing) */
   /** @beta */
   downloadResourceToCache(resourceDetails: ResourceDetails): Promise<void>;

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedChatAdapter.ts
@@ -8,7 +8,7 @@ import { ResourceDetails } from '../../ChatComposite';
 /* @conditional-compile-remove(file-sharing) */
 import { FileUploadManager } from '../../ChatComposite';
 /* @conditional-compile-remove(file-sharing) */
-import { AttachmentMetadata } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 import { ErrorBarStrings } from '@internal/react-components';
 import { CallWithChatAdapterState } from '../state/CallWithChatAdapterState';
 
@@ -100,7 +100,7 @@ export class CallWithChatBackedChatAdapter implements ChatAdapter {
   };
 
   /* @conditional-compile-remove(file-sharing) */
-  public registerCompletedFileUploads = (metadata: AttachmentMetadata[]): FileUploadManager[] => {
+  public registerCompletedFileUploads = (metadata: FileMetadata[]): FileUploadManager[] => {
     return this.callWithChatAdapter.registerCompletedFileUploads(metadata);
   };
 
@@ -125,7 +125,7 @@ export class CallWithChatBackedChatAdapter implements ChatAdapter {
   };
 
   /* @conditional-compile-remove(file-sharing) */
-  public updateFileUploadMetadata = (id: string, metadata: AttachmentMetadata): void => {
+  public updateFileUploadMetadata = (id: string, metadata: FileMetadata): void => {
     this.callWithChatAdapter.updateFileUploadMetadata(id, metadata);
   };
 

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -42,7 +42,7 @@ import { AzureCommunicationFileUploadAdapter } from './AzureCommunicationFileUpl
 import { useEffect, useRef, useState } from 'react';
 import { _isValidIdentifier } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(file-sharing) */
-import { AttachmentMetadata } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 /* @conditional-compile-remove(file-sharing) */
 import { FileUploadManager } from '../file-sharing';
 
@@ -270,7 +270,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
     metadata?: Record<string, string>,
     options?: {
       /* @conditional-compile-remove(file-sharing) */
-      attachmentMetadata?: AttachmentMetadata[];
+      attachmentMetadata?: FileMetadata[];
     }
   ): Promise<void> {
     return await this.asyncTeeErrorToEventEmitter(async () => {
@@ -294,7 +294,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   }
 
   /* @conditional-compile-remove(file-sharing) */
-  registerCompletedFileUploads(metadata: AttachmentMetadata[]): FileUploadManager[] {
+  registerCompletedFileUploads(metadata: FileMetadata[]): FileUploadManager[] {
     return this.fileUploadAdapter.registerCompletedFileUploads(metadata);
   }
 
@@ -319,7 +319,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   }
 
   /* @conditional-compile-remove(file-sharing) */
-  updateFileUploadMetadata(id: string, metadata: AttachmentMetadata): void {
+  updateFileUploadMetadata(id: string, metadata: FileMetadata): void {
     this.fileUploadAdapter.updateFileUploadMetadata(id, metadata);
   }
 

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationFileUploadAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationFileUploadAdapter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AttachmentMetadata } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 import { FileUploadManager, FileUploadState } from '../file-sharing';
 /* @conditional-compile-remove(file-sharing) */
 import { produce } from 'immer';
@@ -23,12 +23,12 @@ export type FileUploadsUiState = Record<string, FileUploadState>;
  */
 export interface FileUploadAdapter {
   registerActiveFileUploads: (files: File[]) => FileUploadManager[];
-  registerCompletedFileUploads: (metadata: AttachmentMetadata[]) => FileUploadManager[];
+  registerCompletedFileUploads: (metadata: FileMetadata[]) => FileUploadManager[];
   clearFileUploads: () => void;
   cancelFileUpload: (id: string) => void;
   updateFileUploadProgress: (id: string, progress: number) => void;
   updateFileUploadErrorMessage: (id: string, errorMessage: string) => void;
-  updateFileUploadMetadata: (id: string, metadata: AttachmentMetadata) => void;
+  updateFileUploadMetadata: (id: string, metadata: FileMetadata) => void;
 }
 
 /* @conditional-compile-remove(file-sharing) */
@@ -123,7 +123,7 @@ export class AzureCommunicationFileUploadAdapter implements FileUploadAdapter {
     this.deleteFileUploads(ids);
   }
 
-  private registerFileUploads(files: File[] | AttachmentMetadata[]): FileUploadManager[] {
+  private registerFileUploads(files: File[] | FileMetadata[]): FileUploadManager[] {
     this.deleteErroneousFileUploads();
     const fileUploads: FileUpload[] = [];
     files.forEach((file) => fileUploads.push(new FileUpload(file)));
@@ -137,7 +137,7 @@ export class AzureCommunicationFileUploadAdapter implements FileUploadAdapter {
     return this.registerFileUploads(files);
   }
 
-  registerCompletedFileUploads(metadata: AttachmentMetadata[]): FileUploadManager[] {
+  registerCompletedFileUploads(metadata: FileMetadata[]): FileUploadManager[] {
     return this.registerFileUploads(metadata);
   }
 
@@ -167,7 +167,7 @@ export class AzureCommunicationFileUploadAdapter implements FileUploadAdapter {
     });
   }
 
-  updateFileUploadMetadata(id: string, metadata: AttachmentMetadata): void {
+  updateFileUploadMetadata(id: string, metadata: FileMetadata): void {
     this.context.updateFileUpload(id, { progress: 1, metadata });
   }
 
@@ -190,7 +190,7 @@ export class AzureCommunicationFileUploadAdapter implements FileUploadAdapter {
  * @private
  */
 export const convertFileUploadsUiStateToMessageMetadata = (fileUploads?: FileUploadsUiState): FileSharingMetadata => {
-  const fileMetadata: AttachmentMetadata[] = [];
+  const fileMetadata: FileMetadata[] = [];
   if (fileUploads) {
     Object.keys(fileUploads).forEach((key) => {
       const file = fileUploads[key];

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
@@ -8,7 +8,7 @@ import type { AdapterError, AdapterErrors, AdapterState, Disposable } from '../.
 /* @conditional-compile-remove(file-sharing) */
 import { FileUploadAdapter, FileUploadsUiState } from './AzureCommunicationFileUploadAdapter';
 /* @conditional-compile-remove(file-sharing) */
-import { AttachmentMetadata } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 
 /**
  * {@link ChatAdapter} state for pure UI purposes.
@@ -92,7 +92,7 @@ export interface ChatAdapterThreadManagement {
     metadata?: Record<string, string>,
     /* @conditional-compile-remove(file-sharing) */
     options?: {
-      attachmentMetadata?: AttachmentMetadata[];
+      attachmentMetadata?: FileMetadata[];
     }
   ): Promise<void>;
   /**

--- a/packages/react-composites/src/composites/ChatComposite/file-sharing/FileUpload.ts
+++ b/packages/react-composites/src/composites/ChatComposite/file-sharing/FileUpload.ts
@@ -4,7 +4,7 @@
 import { EventEmitter } from 'events';
 import { nanoid } from 'nanoid';
 import { _MAX_EVENT_LISTENERS } from '@internal/acs-ui-common';
-import { AttachmentMetadata, FileMetadata } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 
 /**
  * Contains the state attributes of a file upload like name, progress etc.
@@ -28,9 +28,9 @@ export interface FileUploadState {
   progress: number;
 
   /**
-   * Metadata {@link AttachmentMetadata} containing information about the uploaded file.
+   * Metadata {@link FileMetadata} containing information about the uploaded file.
    */
-  metadata?: AttachmentMetadata;
+  metadata?: FileMetadata;
 
   /**
    * Error message to be displayed to the user if the upload fails.
@@ -70,9 +70,9 @@ export interface FileUploadManager {
   /**
    * Mark the upload as complete.
    * Requires the `metadata` param containing uploaded file information.
-   * @param metadata - {@link AttachmentMetadata}
+   * @param metadata - {@link FileMetadata}
    */
-  notifyUploadCompleted: (metadata: AttachmentMetadata) => void;
+  notifyUploadCompleted: (metadata: FileMetadata) => void;
   /**
    * Mark the upload as failed.
    * @param message - An error message that can be displayed to the user.
@@ -94,11 +94,11 @@ export class FileUpload implements FileUploadManager, FileUploadEventEmitter {
    */
   public readonly fileName: string;
   /**
-   * Optional object of type {@link AttachmentMetadata}
+   * Optional object of type {@link FileMetadata}
    */
-  public metadata?: AttachmentMetadata;
+  public metadata?: FileMetadata;
 
-  constructor(data: File | AttachmentMetadata) {
+  constructor(data: File | FileMetadata) {
     this._emitter = new EventEmitter();
     this._emitter.setMaxListeners(_MAX_EVENT_LISTENERS);
     this.id = nanoid();
@@ -115,7 +115,7 @@ export class FileUpload implements FileUploadManager, FileUploadEventEmitter {
     this._emitter.emit('uploadProgressChange', this.id, value);
   }
 
-  notifyUploadCompleted(metadata: AttachmentMetadata): void {
+  notifyUploadCompleted(metadata: FileMetadata): void {
     this._emitter.emit('uploadComplete', this.id, metadata);
   }
 
@@ -169,7 +169,7 @@ type UploadProgressListener = (id: string, value: number) => void;
  * Listener for `uploadComplete` event.
  * @beta
  */
-type UploadCompleteListener = (id: string, metadata: AttachmentMetadata) => void;
+type UploadCompleteListener = (id: string, metadata: FileMetadata) => void;
 /**
  * Listener for `uploadFailed` event.
  * @beta

--- a/packages/react-composites/src/composites/ChatComposite/hooks/useHandlers.ts
+++ b/packages/react-composites/src/composites/ChatComposite/hooks/useHandlers.ts
@@ -9,7 +9,7 @@ import memoizeOne from 'memoize-one';
 import { ChatAdapter } from '../adapter/ChatAdapter';
 import { useAdapter } from '../adapter/ChatAdapterProvider';
 /* @conditional-compile-remove(file-sharing) */
-import { AttachmentMetadata } from '@internal/react-components';
+import { FileMetadata } from '@internal/react-components';
 
 /**
  * @private
@@ -37,7 +37,7 @@ const createCompositeHandlers = memoizeOne(
       options?: {
         metadata?: Record<string, string>;
         /* @conditional-compile-remove(file-sharing) */
-        attachmentMetadata?: AttachmentMetadata[];
+        attachmentMetadata?: FileMetadata[];
       }
     ) => {
       const metadata = options?.metadata;


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Remove AttachmentMetadata and directly use FileMetadata instead.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->