### PR TITLE
Fixed bug where spoken and caption language show up empty on initiation 

### DIFF
--- a/change-beta/@azure-communication-react-2d4cbac7-aa49-4ce4-a5ea-8bcc25602f9c.json
+++ b/change-beta/@azure-communication-react-2d4cbac7-aa49-4ce4-a5ea-8bcc25602f9c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Captions",
+  "comment": "Fixed error when spoken language and caption language show up empty on initiation ",
+  "packageName": "@azure/communication-react",
+  "email": "96077406+carocao-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-2d4cbac7-aa49-4ce4-a5ea-8bcc25602f9c.json
+++ b/change/@azure-communication-react-2d4cbac7-aa49-4ce4-a5ea-8bcc25602f9c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Captions",
+  "comment": "Fixed error when spoken language and caption language show up empty on initiation ",
+  "packageName": "@azure/communication-react",
+  "email": "96077406+carocao-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/CaptionsSettingsModal.tsx
+++ b/packages/react-components/src/components/CaptionsSettingsModal.tsx
@@ -103,13 +103,13 @@ export const _CaptionsSettingsModal = (props: _CaptionsSettingsModalProps): JSX.
   const [hasSetSpokenLanguage, setHasSetSpokenLanguage] = useState(false);
 
   const [selectedSpokenLanguage, setSelectedSpokenLanguage] = useState<SpokenLanguageDropdownOptions>({
-    key: currentSpokenLanguage ?? defaultSpokenLanguage,
-    text: currentSpokenLanguage ?? defaultSpokenLanguage
+    key: currentSpokenLanguage || defaultSpokenLanguage,
+    text: currentSpokenLanguage || defaultSpokenLanguage
   });
 
   const [selectedCaptionLanguage, setSelectedCaptionLanguage] = useState<CaptionLanguageDropdownOptions>({
-    key: currentCaptionLanguage ?? _spokenLanguageToCaptionLanguage[selectedSpokenLanguage.key],
-    text: currentCaptionLanguage ?? _spokenLanguageToCaptionLanguage[selectedSpokenLanguage.key]
+    key: currentCaptionLanguage || _spokenLanguageToCaptionLanguage[selectedSpokenLanguage.key],
+    text: currentCaptionLanguage || _spokenLanguageToCaptionLanguage[selectedSpokenLanguage.key]
   });
 
   useEffect(() => {


### PR DESCRIPTION
# What
Fixed bug where spoken and caption language show up empty on initiation 

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->