### PR TITLE
Only generate one change file if change type is none or prerelease

### DIFF
--- a/change/@azure-communication-react-d2ee527f-6fd5-45c6-9081-7ad8c09d2e40.json
+++ b/change/@azure-communication-react-d2ee527f-6fd5-45c6-9081-7ad8c09d2e40.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Only generate one change file if change type is none or prerelease",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/scripts/changelog/check.mjs
+++ b/common/scripts/changelog/check.mjs
@@ -17,13 +17,18 @@ import { parseNewChangeFiles } from "./utils.mjs";
 
 async function main() {
   const [base, head] = parseArgs(process.argv);
-  const gitLogStdout = await exec_output(`git log --name-status ${base}..${head} -- ${path.join(REPO_ROOT, 'change/')}`);
-  const newChangeFiles = parseNewChangeFiles(gitLogStdout);
-  if (!newChangeFiles?.length) {
+  const gitLogStdoutStableChangeFiles = await exec_output(`git log --name-status ${base}..${head} -- ${path.join(REPO_ROOT, 'change/')}`);
+  const gitLogStdoutBetaChangeFiles = await exec_output(`git log --name-status ${base}..${head} -- ${path.join(REPO_ROOT, 'change-beta/')}`);
+
+  const newStableChangeFiles = parseNewChangeFiles(gitLogStdoutStableChangeFiles);
+  const newBetaChangeFiles = parseNewChangeFiles(gitLogStdoutBetaChangeFiles);
+  const newChangeFilesCount = (newStableChangeFiles?.length ?? 0) + (newBetaChangeFiles?.length ?? 0);
+
+  if (newChangeFilesCount === 0) {
     console.error('No changefile detected! Please run `rush changelog` to document your change.');
     process.exit(1);
   }
-  console.log(`Found ${newChangeFiles.length} changefiles. All is good!`)
+  console.log(`Found ${newChangeFilesCount} changefiles. All is good!`)
 }
 
 function parseArgs(args) {


### PR DESCRIPTION
# What

- If change log type is none - do not duplicate the change file - one is sufficient.
- If change log type is prerelease - delete the stable changelog - it is not relevant to stable release.

# Why

- Reduce PR noise.
- Improve stable changelog generation.

# How Tested
- Tested `rush changelog` with all 4 change types.
- Have **not** tested CI action as it v. difficult locally - please scrutinize changes here in this review. This CI run will at least test the none passes the CI successfully.

Adding two chat and two calling devs for review