### PR TITLE
[Chat] Include inline image into live message ally announcement

### DIFF
--- a/change-beta/@azure-communication-react-e86034e6-98d2-498e-a5fb-9394d509453c.json
+++ b/change-beta/@azure-communication-react-e86034e6-98d2-498e-a5fb-9394d509453c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "InlineImage",
+  "comment": "Fix inline image live message content for ally",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-e86034e6-98d2-498e-a5fb-9394d509453c.json
+++ b/change/@azure-communication-react-e86034e6-98d2-498e-a5fb-9394d509453c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "InlineImage",
+  "comment": "Fix inline image live message content for ally",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -167,22 +167,7 @@ export const BlockedMessageContent = (props: BlockedMessageContentProps): JSX.El
   );
 };
 
-// https://stackoverflow.com/questions/28899298/extract-the-text-out-of-html-string-using-javascript
-const extractContent = (s: string): string => {
-  const span = document.createElement('span');
-  span.innerHTML = s;
-  return span.textContent || span.innerText;
-};
-
-const generateLiveMessage = (props: ChatMessageContentProps): string => {
-  const liveAuthor = _formatString(props.strings.liveAuthorIntro, { author: `${props.message.senderDisplayName}` });
-
-  return `${props.message.editedOn ? props.strings.editedTag : ''} ${
-    props.message.mine ? '' : liveAuthor
-  } ${extractContent(props.message.content || '')} `;
-};
-
-const messageContentAriaText = (props: ChatMessageContentProps): string | undefined => {
+const extractContentForAllyMessage = (props: ChatMessageContentProps): string => {
   if (props.message.content) {
     // Replace all <img> tags with 'image' for aria.
     const parsedContent = DOMPurify.sanitize(props.message.content, {
@@ -201,17 +186,29 @@ const messageContentAriaText = (props: ChatMessageContentProps): string | undefi
 
     // Strip all html tags from the content for aria.
     const message = DOMPurify.sanitize(parsedContent, { ALLOWED_TAGS: [] });
-
-    return props.message.mine
-      ? _formatString(props.strings.messageContentMineAriaText, {
-          message: message
-        })
-      : _formatString(props.strings.messageContentAriaText, {
-          author: `${props.message.senderDisplayName}`,
-          message: message
-        });
+    return message;
   }
-  return undefined;
+  return '';
+};
+
+const generateLiveMessage = (props: ChatMessageContentProps): string => {
+  const liveAuthor = _formatString(props.strings.liveAuthorIntro, { author: `${props.message.senderDisplayName}` });
+
+  return `${props.message.editedOn ? props.strings.editedTag : ''} ${
+    props.message.mine ? '' : liveAuthor
+  } ${extractContentForAllyMessage(props)} `;
+};
+
+const messageContentAriaText = (props: ChatMessageContentProps): string | undefined => {
+  const message = extractContentForAllyMessage(props);
+  return props.message.mine
+    ? _formatString(props.strings.messageContentMineAriaText, {
+        message: message
+      })
+    : _formatString(props.strings.messageContentAriaText, {
+        author: `${props.message.senderDisplayName}`,
+        message: message
+      });
 };
 
 /* @conditional-compile-remove(image-overlay) */


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Currently, for message ally announcement, we have both `ariaLabel` and `liveMessage` and they are using different logics to generate the ally content.
`ariaLabel` will be announced when user navigates to the message bubble component, and we've fixed the `ariaLabel` one to include the inline image into the announcement in this PR: https://github.com/Azure/communication-ui-library/pull/4128/files
`liveMessage` will be auto announced when the focus is chat composite and a new message comes in. This PR is to include the inline image into the content.

This PR will not fix the file sharing content for `liveMessage`. Another bug ticket will be created separately.


https://github.com/Azure/communication-ui-library/assets/107075081/c917a362-be2e-4a6c-8765-00fe84a5261a




# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->