### PR TITLE
[Chat] Bug fix for the image gallery not displaying the broken img

### DIFF
--- a/change/@azure-communication-react-d20fa102-7159-4cd6-aecf-1493fcad9972.json
+++ b/change/@azure-communication-react-d20fa102-7159-4cd6-aecf-1493fcad9972.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "InlineImages",
+  "comment": "BugFix on showing broken img icon into the image gallery on error",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -54,6 +54,7 @@ import { ImageOverlay } from '@internal/react-components';
 /* @conditional-compile-remove(image-overlay) */
 import { InlineImage } from '@internal/react-components';
 import { SendBox } from '../common/SendBox';
+import { ResourceFetchResult } from '@internal/chat-stateful-client';
 
 /**
  * @private
@@ -172,7 +173,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
     const message = adapter.getState().thread.chatMessages[overlayImageItem?.messageId];
     const resourceCache = message.resourceCache;
     if (overlayImageItem.imageSrc === '' && resourceCache) {
-      const fullSizeImageSrc = resourceCache[overlayImageItem.imageUrl].sourceUrl;
+      const fullSizeImageSrc = getResourceSourceUrl(resourceCache[overlayImageItem.imageUrl]);
       if (fullSizeImageSrc === undefined || fullSizeImageSrc === '' || overlayImageItem.imageSrc === fullSizeImageSrc) {
         return;
       }
@@ -184,6 +185,17 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
     // Disable eslint because we are using the overlayImageItem in this effect but don't want to have it as a dependency, as it will cause an infinite loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messageThreadProps.messages]);
+
+  const getResourceSourceUrl = (result: ResourceFetchResult): string => {
+    let src = '';
+    if (result.error) {
+      src = 'blob://';
+    } else {
+      src = result.sourceUrl;
+    }
+
+    return src;
+  };
 
   const onRenderAvatarCallback = useCallback(
     (userId?: string, defaultOptions?: AvatarPersonaProps) => {
@@ -261,7 +273,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
 
       if (attachment.url) {
         if (resourceCache && resourceCache[attachment.url]) {
-          imageSrc = resourceCache[attachment.url].sourceUrl;
+          imageSrc = getResourceSourceUrl(resourceCache[attachment.url]);
         } else {
           adapter.downloadResourceToCache({
             threadId: adapter.getState().thread.threadId,


### PR DESCRIPTION
# What
In the case of errors the image gallery should display a broken img icon
# Why
Regression when introducing the new error scenarios 

# How Tested
When launching the img gallery, mock no network connection in the network tab. 

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->