### PR TITLE
[Calling][Bug] Fix the local screen share and PPTLive Conflict

### DIFF
--- a/change-beta/@azure-communication-react-db28d87d-f40a-4ef9-904f-c1f1c5429adb.json
+++ b/change-beta/@azure-communication-react-db28d87d-f40a-4ef9-904f-c1f1c5429adb.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Fix the local screen sharing and pptlive conflict",
+  "comment": "Fix the local screen share",
+  "packageName": "@azure/communication-react",
+  "email": "93549644+ShaunaSong@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-db28d87d-f40a-4ef9-904f-c1f1c5429adb.json
+++ b/change/@azure-communication-react-db28d87d-f40a-4ef9-904f-c1f1c5429adb.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Fix the local screen sharing and pptlive conflict",
+  "comment": "Fix the local screen share",
+  "packageName": "@azure/communication-react",
+  "email": "93549644+ShaunaSong@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -267,6 +267,11 @@ export class CallContext {
         addRemoteParticipant.forEach((participant: RemoteParticipantState) => {
           call.remoteParticipants[toFlatCommunicationIdentifier(participant.identifier)] = participant;
         });
+        // TODO: need to remove after contentSharingRole avaible in WebCalling SDK.
+        /* @conditional-compile-remove(ppt-live) */
+        if (!call.contentSharingRemoteParticipant) {
+          call.contentSharingRemoteParticipant = toFlatCommunicationIdentifier(addRemoteParticipant[0].identifier);
+        }
       }
     });
   }

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -267,11 +267,6 @@ export class CallContext {
         addRemoteParticipant.forEach((participant: RemoteParticipantState) => {
           call.remoteParticipants[toFlatCommunicationIdentifier(participant.identifier)] = participant;
         });
-        // TODO: need to remove after contentSharingRole avaible in WebCalling SDK.
-        /* @conditional-compile-remove(ppt-live) */
-        if (!call.contentSharingRemoteParticipant) {
-          call.contentSharingRemoteParticipant = toFlatCommunicationIdentifier(addRemoteParticipant[0].identifier);
-        }
       }
     });
   }

--- a/packages/calling-stateful-client/src/CallSubscriber.ts
+++ b/packages/calling-stateful-client/src/CallSubscriber.ts
@@ -85,11 +85,7 @@ export class CallSubscriber {
       this._call.feature(Features.Recording)
     );
     /* @conditional-compile-remove(ppt-live) */
-    this._pptLiveSubscriber = new PPTLiveSubscriber(
-      this._callIdRef,
-      this._context,
-      this._call.feature(Features.PPTLive)
-    );
+    this._pptLiveSubscriber = new PPTLiveSubscriber(this._callIdRef, this._context, this._call);
     this._transcriptionSubscriber = new TranscriptionSubscriber(
       this._callIdRef,
       this._context,

--- a/packages/calling-stateful-client/src/PPTLiveSubscriber.ts
+++ b/packages/calling-stateful-client/src/PPTLiveSubscriber.ts
@@ -8,6 +8,7 @@ import { Features, PPTLiveCallFeature } from '@azure/communication-calling';
 import { CallContext } from './CallContext';
 /* @conditional-compile-remove(ppt-live) */
 import { CallIdRef } from './CallIdRef';
+/* @conditional-compile-remove(ppt-live) */
 import { CallCommon } from './BetaToStableTypes';
 
 /* @conditional-compile-remove(ppt-live) */

--- a/packages/calling-stateful-client/src/PPTLiveSubscriber.ts
+++ b/packages/calling-stateful-client/src/PPTLiveSubscriber.ts
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 /* @conditional-compile-remove(ppt-live) */
-import { PPTLiveCallFeature } from '@azure/communication-calling';
+import { Features, PPTLiveCallFeature } from '@azure/communication-calling';
 
 /* @conditional-compile-remove(ppt-live) */
 import { CallContext } from './CallContext';
 /* @conditional-compile-remove(ppt-live) */
 import { CallIdRef } from './CallIdRef';
+import { CallCommon } from './BetaToStableTypes';
 
 /* @conditional-compile-remove(ppt-live) */
 /**
@@ -17,11 +18,13 @@ export class PPTLiveSubscriber {
   private _callIdRef: CallIdRef;
   private _context: CallContext;
   private _pptLive: PPTLiveCallFeature;
+  private _call: CallCommon;
 
-  constructor(callIdRef: CallIdRef, context: CallContext, pptLive: PPTLiveCallFeature) {
+  constructor(callIdRef: CallIdRef, context: CallContext, call: CallCommon) {
     this._callIdRef = callIdRef;
     this._context = context;
-    this._pptLive = pptLive;
+    this._pptLive = call.feature(Features.PPTLive);
+    this._call = call;
 
     this.subscribe();
   }
@@ -41,6 +44,10 @@ export class PPTLiveSubscriber {
 
   private checkAndUpdatePPTLiveParticipant = async (): Promise<void> => {
     if (this._pptLive.isActive) {
+      // TODO： need to refactor if Web Calling SDK has this logic ready
+      if (this._call.isScreenSharingOn) {
+        await this._call.stopScreenSharing();
+      }
       this._context.setCallParticipantPPTLive(this._callIdRef.callId, this._pptLive.target);
     } else {
       this._context.setCallParticipantPPTLive(this._callIdRef.callId, undefined);


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Need to stop the local screen share when remote pptlive is active 
Web calling SDK is missing this logic which will include in the next release as well 
TODO: Need to refactor after the next release is ready. 
# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->