### PR TITLE
Groom changelog /1.14.0

### DIFF
--- a/GROOMME.md
+++ b/GROOMME.md
@@ -1,1 +1,0 @@
-Please groom the changelog and then delete me.

--- a/GROOMME.md
+++ b/GROOMME.md
@@ -1,0 +1,1 @@
+Please groom the changelog and then delete me.

--- a/packages/communication-react/CHANGELOG.stable.md
+++ b/packages/communication-react/CHANGELOG.stable.md
@@ -4,7 +4,7 @@ This log was last generated on Thu, 14 Mar 2024 03:50:48 GMT and should not be m
 
 <!-- Start content -->
 
-## [1.14.0](https://github.com/azure/communication-ui-library/tree/@azure/communication-react_v1.14.0)
+## [1.14.0](https://github.com/azure/communication-ui-library/tree/1.14.0)
 
 Thu, 14 Mar 2024 03:50:48 GMT 
 [Compare changes](https://github.com/azure/communication-ui-library/compare/1.13.0...1.14.0)
@@ -47,7 +47,7 @@ The CallComposite and CallWithChatComposite now support applying a background im
 - Update Calling sounds to not play end call sound when transfer happens ([PR #4163](https://github.com/azure/communication-ui-library/pull/4163) by dmceachern@microsoft.com)
 - Fix hanging express.close if have unclosed connection ([PR #4138](https://github.com/azure/communication-ui-library/pull/4138) by 77021369+jimchou-dev@users.noreply.github.com)
 
-## [1.13.0](https://github.com/azure/communication-ui-library/tree/@azure/communication-react_v1.13.0)
+## [1.13.0](https://github.com/azure/communication-ui-library/tree/1.13.0)
 
 Mon, 12 Feb 2024 18:52:29 GMT 
 [Compare changes](https://github.com/azure/communication-ui-library/compare/1.12.0...1.13.0)

--- a/packages/communication-react/CHANGELOG.stable.md
+++ b/packages/communication-react/CHANGELOG.stable.md
@@ -7,104 +7,45 @@ This log was last generated on Thu, 14 Mar 2024 03:50:48 GMT and should not be m
 ## [1.14.0](https://github.com/azure/communication-ui-library/tree/@azure/communication-react_v1.14.0)
 
 Thu, 14 Mar 2024 03:50:48 GMT 
-[Compare changes](https://github.com/azure/communication-ui-library/compare/@azure/communication-react_v1.14.0-beta.2...@azure/communication-react_v1.14.0)
+[Compare changes](https://github.com/azure/communication-ui-library/compare/1.13.0...1.14.0)
+
+### PowerPoint Live (Viewing) Support - General Availability
+
+Today the Azure Communication Services Web UI Library now can view PowerPoint Live sessions initiated by a Teams client. Users can follow along with the current slide the presenter is sharing and view presenter annotations. Developers can use this functionality today through our composites (e.g CallComposite, CallWithChatComposite) as well as through components (e.g VideoGallery).
+
+### Teams Interop Chat Inline Images - General Availability
+
+We are excited to announce that the Azure Communication Services Web UI Library now has the ability to receive Teams interop images inline. Additionally, we have enabled users to click on an individual image to view it in a new ImageOverlay component. This component displays the selected image in full screen and allows users to download the image.
+
+### CallComposite and CallWithChatComposite Custom Branding - General Availability
+
+The CallComposite and CallWithChatComposite now support applying a background image and logo to the Configuration Page. This allows developers to unify their customers' joining experiences if they have a Teams Premium feature enabled called Teams Meeting Themes.
 
 ### Features
-- Introduce new ability in the queue to cancel inflight request ([PR #4237](https://github.com/azure/communication-ui-library/pull/4237) by 9044372+JoshuaLai@users.noreply.github.com)
-- Storybook page for survey ([PR #4123](https://github.com/azure/communication-ui-library/pull/4123) by 96077406+carocao-msft@users.noreply.github.com)
-- pptlive component ([PR #4189](https://github.com/azure/communication-ui-library/pull/4189) by 93549644+ShaunaSong@users.noreply.github.com)
-- Add menu to local video tile to start and stop spotlight ([PR #4129](https://github.com/azure/communication-ui-library/pull/4129) by 79475487+mgamis-msft@users.noreply.github.com)
-- Release 1.14.0-beta.1 merge back of pre-release branch ([PR #4191](https://github.com/azure/communication-ui-library/pull/4191) by 3941071+emlynmac@users.noreply.github.com)
-- Add options prop to composites to hide spotlight ([PR #4162](https://github.com/azure/communication-ui-library/pull/4162) by 79475487+mgamis-msft@users.noreply.github.com)
-- Update Transfer API to use new SDK 'transferAccepted' event ([PR #4114](https://github.com/azure/communication-ui-library/pull/4114) by dmceachern@microsoft.com)
-- Add exit spotlight button to call control bar and add composite option to remove it ([PR #4159](https://github.com/azure/communication-ui-library/pull/4159) by 79475487+mgamis-msft@users.noreply.github.com)
-- pptlive component ([PR #4222](https://github.com/azure/communication-ui-library/pull/4222) by 93549644+ShaunaSong@users.noreply.github.com)
-- Move survey a bit up to allow more room for tag survey, fix survey in the same place in the page and not move around based on height ([PR #4127](https://github.com/azure/communication-ui-library/pull/4127) by 96077406+carocao-msft@users.noreply.github.com)
-- Add adapter function to stop all spotligh t. Add people pane menu button to stop all spotlight. ([PR #4202](https://github.com/azure/communication-ui-library/pull/4202) by 79475487+mgamis-msft@users.noreply.github.com)
+
 - Stabilize Custom Branding ([PR #4211](https://github.com/azure/communication-ui-library/pull/4211) by 2684369+JamesBurnside@users.noreply.github.com)
-- We are excited to announce that the Azure Communication Services Web UI Library now can view PowerPoint Live sessions initiated by a Teams client. Users can follow along with the current slide the presenter is sharing and view presenter annotations. Developers can use this functionality today through our composites (e.g CallComposite, CallWithChatComposite) as well as through components (e.g VideoGallery). ([PR #4264](https://github.com/azure/communication-ui-library/pull/4264) by 93549644+ShaunaSong@users.noreply.github.com)
-- Introduce new concept of ResourceResult ([PR #4223](https://github.com/azure/communication-ui-library/pull/4223) by 9044372+JoshuaLai@users.noreply.github.com)
-- Stabilize Call Transfer in UI lib ([PR #4143](https://github.com/azure/communication-ui-library/pull/4143) by dmceachern@microsoft.com)
-- Update to match updates made to Cherry pick in 1.13.0 ([PR #4146](https://github.com/azure/communication-ui-library/pull/4146) by dmceachern@microsoft.com)
-- Introduce improvments for making outbound calls ([PR #4108](https://github.com/azure/communication-ui-library/pull/4108) by dmceachern@microsoft.com)
-- Remove the InlineImageMetadata type ([PR #4212](https://github.com/azure/communication-ui-library/pull/4212) by 9044372+JoshuaLai@users.noreply.github.com)
-- Introduce the new dispose and download apis in the ChatAdapter ([PR #4126](https://github.com/azure/communication-ui-library/pull/4126) by 9044372+JoshuaLai@users.noreply.github.com)
-- Chat Stateful Client now returns and empty string in cases of errors ([PR #4230](https://github.com/azure/communication-ui-library/pull/4230) by 9044372+JoshuaLai@users.noreply.github.com)
-- Add styling for send and message edit boxes ([PR #4224](https://github.com/azure/communication-ui-library/pull/4224) by 98852890+vhuseinova-msft@users.noreply.github.com)
-- Storybook removing beta banner ([PR #4245](https://github.com/azure/communication-ui-library/pull/4245) by 9044372+JoshuaLai@users.noreply.github.com)
-- Add Ribbon toolbar for rich text editor ([PR #4160](https://github.com/azure/communication-ui-library/pull/4160) by 98852890+vhuseinova-msft@users.noreply.github.com)
-- Update storybook to include snippets for up to date Call-transfer ([PR #4122](https://github.com/azure/communication-ui-library/pull/4122) by 94866715+dmceachernmsft@users.noreply.github.com)
-- Add basic API and Lazy Loading  ([PR #4186](https://github.com/azure/communication-ui-library/pull/4186) by 73612854+palatter@users.noreply.github.com)
+- Stabilize Teams Interop Inline Images([PR #4262](https://github.com/Azure/communication-ui-library/pull/4262) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
+- Stabilize PowerPoint Live rendering when shared by a Teams client([PR #4264](https://github.com/azure/communication-ui-library/pull/4264) by 93549644+ShaunaSong@users.noreply.github.com)
+
 ### Improvements
-- Hide participant information ([PR #4254](https://github.com/azure/communication-ui-library/pull/4254) by 93549644+ShaunaSong@users.noreply.github.com)
-- Update localized strings ([PR #4179](https://github.com/azure/communication-ui-library/pull/4179) by 3941071+emlynmac@users.noreply.github.com)
-- update sdk version ([PR #4221](https://github.com/azure/communication-ui-library/pull/4221) by 93549644+ShaunaSong@users.noreply.github.com)
-- TDBuild - updating localized resource files. ([PR #4263](https://github.com/azure/communication-ui-library/pull/4263) by alkwa@microsoft.com)
-- Validate that the src you are fetching from and endpoint match ([PR #4251](https://github.com/azure/communication-ui-library/pull/4251) by 9044372+JoshuaLai@users.noreply.github.com)
-- API naming update from ARB feedback ([PR #4165](https://github.com/azure/communication-ui-library/pull/4165) by mbellah@microsoft.com)
-- In the chat composite, if the message contains image that's not an ACS image, we will render the image but it will not be clickable to view and download in the ImageOverlay ([PR #4214](https://github.com/azure/communication-ui-library/pull/4214) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Update mention api to include isActive argument ([PR #4183](https://github.com/azure/communication-ui-library/pull/4183) by 73612854+palatter@users.noreply.github.com)
-- Rerender ImageOverlay when selected image is fetched in the queue ([PR #4154](https://github.com/azure/communication-ui-library/pull/4154) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Change screenShareParicipant to be optional ([PR #4204](https://github.com/azure/communication-ui-library/pull/4204) by 93549644+ShaunaSong@users.noreply.github.com)
-- Remove AttachmentMetadata ([PR #4217](https://github.com/azure/communication-ui-library/pull/4217) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Rename imgAttrs to imageAttributes ([PR #4242](https://github.com/azure/communication-ui-library/pull/4242) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- In Composite, use adapter state to get the full size cached image src ([PR #4207](https://github.com/azure/communication-ui-library/pull/4207) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Add more CCs for inline image ([PR #4187](https://github.com/azure/communication-ui-library/pull/4187) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Turning off reaction feature usage in sample ([PR #4171](https://github.com/azure/communication-ui-library/pull/4171) by mbellah@microsoft.com)
-- Update release process instructions ([PR #4069](https://github.com/azure/communication-ui-library/pull/4069) by 73612854+palatter@users.noreply.github.com)
-- patch updates ([PR #4235](https://github.com/azure/communication-ui-library/pull/4235) by dmceachern@microsoft.com)
-- Update minor version of microsoft/api-extractor version to 7.40.6 ([PR #4140](https://github.com/azure/communication-ui-library/pull/4140) by 79475487+mgamis-msft@users.noreply.github.com)
-- Add support for enter key when formatting options are not shown. ([PR #4239](https://github.com/azure/communication-ui-library/pull/4239) by 73612854+palatter@users.noreply.github.com)
-- Updates for the Rich Text Editor styling ([PR #4195](https://github.com/azure/communication-ui-library/pull/4195) by 98852890+vhuseinova-msft@users.noreply.github.com)
-- Update samples with noImplicitAny ([PR #4199](https://github.com/azure/communication-ui-library/pull/4199) by edwardlee@microsoft.com)
-- Move inline image and image overlay to stabilizedFeatures ([PR #4196](https://github.com/azure/communication-ui-library/pull/4196) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Remove conditional compile statements from codebase for DTMF dialer ([PR #4226](https://github.com/azure/communication-ui-library/pull/4226) by dmceachern@microsoft.com)
-- patch updates ([PR #4235](https://github.com/azure/communication-ui-library/pull/4235) by dmceachern@microsoft.com)
-- Add UI and unit tests for rich text editor components ([PR #4244](https://github.com/azure/communication-ui-library/pull/4244) by 98852890+vhuseinova-msft@users.noreply.github.com)
-- Improved storybook wording and make sure code snippets do not include return statements, and move survey story to internal folder  ([PR #4153](https://github.com/azure/communication-ui-library/pull/4153) by 96077406+carocao-msft@users.noreply.github.com)
-- groom changelog ([PR #4180](https://github.com/azure/communication-ui-library/pull/4180) by 2684369+JamesBurnside@users.noreply.github.com)
-- Update react-composite and communication-react to flag noImplicitAny ([PR #4166](https://github.com/azure/communication-ui-library/pull/4166) by edwardlee@microsoft.com)
-- Use appSettings.json.sample ([PR #4152](https://github.com/azure/communication-ui-library/pull/4152) by 73612854+palatter@users.noreply.github.com)
-- Add reference to the stateful client storybook page ([PR #4257](https://github.com/azure/communication-ui-library/pull/4257) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Update the Storybook for the adapter changes for inline image ([PR #4156](https://github.com/azure/communication-ui-library/pull/4156) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Update storybook docs on adapter disposal ([PR #4142](https://github.com/azure/communication-ui-library/pull/4142) by 3941071+emlynmac@users.noreply.github.com)
-- Remove conditional-compilation flags for Gallery-layouts ([PR #4205](https://github.com/azure/communication-ui-library/pull/4205) by dmceachern@microsoft.com)
-- Add documentation for unit tests coverage ([PR #4253](https://github.com/azure/communication-ui-library/pull/4253) by 98852890+vhuseinova-msft@users.noreply.github.com)
-- Only generate one change file if change type is none or prerelease ([PR #4234](https://github.com/azure/communication-ui-library/pull/4234) by 2684369+JamesBurnside@users.noreply.github.com)
-- Update stable calling dependency to latest ([PR #4238](https://github.com/azure/communication-ui-library/pull/4238) by dmceachern@microsoft.com)
-- run CI on release branches ([PR #4181](https://github.com/azure/communication-ui-library/pull/4181) by 2684369+JamesBurnside@users.noreply.github.com)
-- Remove inline image CCs that's combined with other flags ([PR #4227](https://github.com/azure/communication-ui-library/pull/4227) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Improve generate-api-diff output to more easily see errors ([PR #4192](https://github.com/azure/communication-ui-library/pull/4192) by 2684369+JamesBurnside@users.noreply.github.com)
-- Perform patch updates for dependencies ([PR #4140](https://github.com/azure/communication-ui-library/pull/4140) by 79475487+mgamis-msft@users.noreply.github.com)
-- NoImplicitAny for React Components Package ([PR #4168](https://github.com/azure/communication-ui-library/pull/4168) by edwardlee@microsoft.com)
-- Updated capabilites storybook doc ([PR #4145](https://github.com/azure/communication-ui-library/pull/4145) by 79475487+mgamis-msft@users.noreply.github.com)
-- Storybook snippets noImplicitAny ([PR #4206](https://github.com/azure/communication-ui-library/pull/4206) by edwardlee@microsoft.com)
+
+- Update Transfer API to use new SDK 'transferAccepted' event ([PR #4114](https://github.com/azure/communication-ui-library/pull/4114) by dmceachern@microsoft.com)
+- Add noImplicitAny support in samples ([PR #4199](https://github.com/azure/communication-ui-library/pull/4199) by edwardlee@microsoft.com)
+- Add noImplicitAny support in react-composites and communication-react ([PR #4166](https://github.com/azure/communication-ui-library/pull/4166) by edwardlee@microsoft.com)
+- Add NoImplicitAny support for react-components ([PR #4168](https://github.com/azure/communication-ui-library/pull/4168) by edwardlee@microsoft.com)
+- Add noImplicitAny support in Storybook ([PR #4206](https://github.com/azure/communication-ui-library/pull/4206) by edwardlee@microsoft.com)
+ 
 ### Bug Fixes
-- update gallery logic to not include local participant in grid calculations. ([PR #4136](https://github.com/azure/communication-ui-library/pull/4136) by dmceachern@microsoft.com)
-- Change inline image cursor to pointer ([PR #4164](https://github.com/azure/communication-ui-library/pull/4164) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
+
+- Update gallery logic to not include local participant in grid calculations ([PR #4136](https://github.com/azure/communication-ui-library/pull/4136) by dmceachern@microsoft.com)
 - Hangup Call to transfer target when leaving in mid-transfer ([PR #4155](https://github.com/azure/communication-ui-library/pull/4155) by dmceachern@microsoft.com)
-- Disable clicking before inline image is loaded ([PR #4248](https://github.com/azure/communication-ui-library/pull/4248) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- use default microphone aria labels in composite ([PR #4247](https://github.com/azure/communication-ui-library/pull/4247) by alkwa@microsoft.com)
+- Set correct microphone aria label in Lobby scenarios ([PR #4247](https://github.com/azure/communication-ui-library/pull/4247) by alkwa@microsoft.com)
 - Fix for a deleted message accessibility announcement ([PR #4169](https://github.com/azure/communication-ui-library/pull/4169) by 98852890+vhuseinova-msft@users.noreply.github.com)
-- fix missing alternate Caller id ([PR #4216](https://github.com/azure/communication-ui-library/pull/4216) by dmceachern@microsoft.com)
-- Replace Inline Image tag with image text for aria text ([PR #4128](https://github.com/azure/communication-ui-library/pull/4128) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Reaction button ally bug for announcement ([PR #4233](https://github.com/azure/communication-ui-library/pull/4233) by mbellah@microsoft.com)
+- Fix missing alternate Caller id ([PR #4216](https://github.com/azure/communication-ui-library/pull/4216) by dmceachern@microsoft.com)
 - Resolved issue where edited label is missing from received messages ([PR #4150](https://github.com/azure/communication-ui-library/pull/4150) by 73612854+palatter@users.noreply.github.com)
-- Fix the local screen share ([PR #4255](https://github.com/azure/communication-ui-library/pull/4255) by 93549644+ShaunaSong@users.noreply.github.com)
-- Fix inline image live message content for accessibility ([PR #4236](https://github.com/azure/communication-ui-library/pull/4236) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
 - Fixed error when spoken language and caption language show up empty on initiation  ([PR #4228](https://github.com/azure/communication-ui-library/pull/4228) by 96077406+carocao-msft@users.noreply.github.com)
 - Update Calling sounds to not play end call sound when transfer happens ([PR #4163](https://github.com/azure/communication-ui-library/pull/4163) by dmceachern@microsoft.com)
-- Resolve issue where images previews would not sure in a message if the message also had a file attachment. ([PR #4167](https://github.com/azure/communication-ui-library/pull/4167) by 73612854+palatter@users.noreply.github.com)
-- Bug Fix metadata was not being sent up to the handler ([PR #4213](https://github.com/azure/communication-ui-library/pull/4213) by 9044372+JoshuaLai@users.noreply.github.com)
-- Fixed the issue where image placeholder being shown when fetching failed ([PR #4172](https://github.com/azure/communication-ui-library/pull/4172) by 109105353+jpeng-ms@users.noreply.github.com)
-- Add key to MsftMention tag ([PR #4188](https://github.com/azure/communication-ui-library/pull/4188) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- BugFix on showing broken img icon into the image gallery on error ([PR #4249](https://github.com/azure/communication-ui-library/pull/4249) by 9044372+JoshuaLai@users.noreply.github.com)
-- Resolve issue where envHelper would return early on error throw when appsettings.json doesn't exist ([PR #4161](https://github.com/azure/communication-ui-library/pull/4161) by 73612854+palatter@users.noreply.github.com)
-- Revert "[Chat] Wrap ImageOverlay with theme provider and change some of the APIs (#4117)" ([PR #4131](https://github.com/azure/communication-ui-library/pull/4131) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
 - Fix hanging express.close if have unclosed connection ([PR #4138](https://github.com/azure/communication-ui-library/pull/4138) by 77021369+jimchou-dev@users.noreply.github.com)
-- Remove CC in Storybook ([PR #4200](https://github.com/azure/communication-ui-library/pull/4200) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-- Fix crush when inline image is deleted from another client ([PR #4261](https://github.com/azure/communication-ui-library/pull/4261) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
-
 
 ## [1.13.0](https://github.com/azure/communication-ui-library/tree/@azure/communication-react_v1.13.0)
 

--- a/packages/communication-react/CHANGELOG.stable.md
+++ b/packages/communication-react/CHANGELOG.stable.md
@@ -13,7 +13,7 @@ Thu, 14 Mar 2024 03:50:48 GMT
 
 Today the Azure Communication Services Web UI Library now can view PowerPoint Live sessions initiated by a Teams client. Users can follow along with the current slide the presenter is sharing and view presenter annotations. Developers can use this functionality today through our composites (e.g CallComposite, CallWithChatComposite) as well as through components (e.g VideoGallery).
 
-### Teams Interop Chat Inline Images - General Availability
+### Teams Interop Chat Image Sharing - General Availability
 
 We are excited to announce that the Azure Communication Services Web UI Library now has the ability to receive Teams interop images inline. Additionally, we have enabled users to click on an individual image to view it in a new ImageOverlay component. This component displays the selected image in full screen and allows users to download the image.
 
@@ -24,7 +24,7 @@ The CallComposite and CallWithChatComposite now support applying a background im
 ### Features
 
 - Stabilize Custom Branding ([PR #4211](https://github.com/azure/communication-ui-library/pull/4211) by 2684369+JamesBurnside@users.noreply.github.com)
-- Stabilize Teams Interop Inline Images([PR #4262](https://github.com/Azure/communication-ui-library/pull/4262) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
+- Stabilize Teams Interop Inline Images([PR #4196](https://github.com/Azure/communication-ui-library/pull/4196) by 107075081+Leah-Xia-Microsoft@users.noreply.github.com)
 - Stabilize PowerPoint Live rendering when shared by a Teams client([PR #4264](https://github.com/azure/communication-ui-library/pull/4264) by 93549644+ShaunaSong@users.noreply.github.com)
 
 ### Improvements
@@ -42,8 +42,8 @@ The CallComposite and CallWithChatComposite now support applying a background im
 - Set correct microphone aria label in Lobby scenarios ([PR #4247](https://github.com/azure/communication-ui-library/pull/4247) by alkwa@microsoft.com)
 - Fix for a deleted message accessibility announcement ([PR #4169](https://github.com/azure/communication-ui-library/pull/4169) by 98852890+vhuseinova-msft@users.noreply.github.com)
 - Fix missing alternate Caller id ([PR #4216](https://github.com/azure/communication-ui-library/pull/4216) by dmceachern@microsoft.com)
-- Resolved issue where edited label is missing from received messages ([PR #4150](https://github.com/azure/communication-ui-library/pull/4150) by 73612854+palatter@users.noreply.github.com)
-- Fixed error when spoken language and caption language show up empty on initiation  ([PR #4228](https://github.com/azure/communication-ui-library/pull/4228) by 96077406+carocao-msft@users.noreply.github.com)
+- Resolve issue where edited label is missing from received messages ([PR #4150](https://github.com/azure/communication-ui-library/pull/4150) by 73612854+palatter@users.noreply.github.com)
+- Fix error when spoken language and caption language show up empty on initiation  ([PR #4228](https://github.com/azure/communication-ui-library/pull/4228) by 96077406+carocao-msft@users.noreply.github.com)
 - Update Calling sounds to not play end call sound when transfer happens ([PR #4163](https://github.com/azure/communication-ui-library/pull/4163) by dmceachern@microsoft.com)
 - Fix hanging express.close if have unclosed connection ([PR #4138](https://github.com/azure/communication-ui-library/pull/4138) by 77021369+jimchou-dev@users.noreply.github.com)
 


### PR DESCRIPTION
# What
Changelog refinement for our stable release

# Why
We want to prune the changelog so developers can understand what bug fixes, features, and improvements they will have access to with 1.14.0

It would be helpful for people to mainly review the stable changelog in communication-react packlet
packages/communication-react/CHANGELOG.stable.md