### PR TITLE
[Chat] Making sourceUrl optional

### DIFF
--- a/change-beta/@azure-communication-react-04072408-0390-46c8-b8ce-1aa004cf6dae.json
+++ b/change-beta/@azure-communication-react-04072408-0390-46c8-b8ce-1aa004cf6dae.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "improvement",
+  "workstream": "InlineImages",
+  "comment": "Making sourceUrl optional",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-9ee3f1a0-b296-45d4-b15a-5ab2c0a067e2.json
+++ b/change-beta/@azure-communication-react-9ee3f1a0-b296-45d4-b15a-5ab2c0a067e2.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "improvement",
+  "workstream": "InlineImages",
+  "comment": "Making sourceUrl optional",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-04072408-0390-46c8-b8ce-1aa004cf6dae.json
+++ b/change/@azure-communication-react-04072408-0390-46c8-b8ce-1aa004cf6dae.json
@@ -1,9 +1,0 @@
-{
-  "type": "prerelease",
-  "area": "improvement",
-  "workstream": "InlineImages",
-  "comment": "Making sourceUrl optional",
-  "packageName": "@azure/communication-react",
-  "email": "9044372+JoshuaLai@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@azure-communication-react-04072408-0390-46c8-b8ce-1aa004cf6dae.json
+++ b/change/@azure-communication-react-04072408-0390-46c8-b8ce-1aa004cf6dae.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "improvement",
+  "workstream": "InlineImages",
+  "comment": "Making sourceUrl optional",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-9ee3f1a0-b296-45d4-b15a-5ab2c0a067e2.json
+++ b/change/@azure-communication-react-9ee3f1a0-b296-45d4-b15a-5ab2c0a067e2.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "improvement",
+  "workstream": "InlineImages",
+  "comment": "Making sourceUrl optional",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-component-bindings/src/messageThreadSelector.ts
+++ b/packages/chat-component-bindings/src/messageThreadSelector.ts
@@ -184,7 +184,7 @@ const generateImageAttachmentImgHtml = (message: ChatMessageWithStatus, attachme
 const getResourceSourceUrl = (result?: ResourceFetchResult): string => {
   let src = '';
   if (result) {
-    if (result.error) {
+    if (result.error || !result.sourceUrl) {
       // In case of an error we set src to some invalid value to show broken image
       src = 'blob://';
     } else {

--- a/packages/chat-stateful-client/review/beta/chat-stateful-client.api.md
+++ b/packages/chat-stateful-client/review/beta/chat-stateful-client.api.md
@@ -81,7 +81,7 @@ export const _createStatefulChatClientWithDeps: (chatClient: ChatClient, args: S
 
 // @public
 export type ResourceFetchResult = {
-    sourceUrl: string;
+    sourceUrl?: string;
     error?: Error;
 };
 

--- a/packages/chat-stateful-client/review/stable/chat-stateful-client.api.md
+++ b/packages/chat-stateful-client/review/stable/chat-stateful-client.api.md
@@ -80,7 +80,7 @@ export const _createStatefulChatClientWithDeps: (chatClient: ChatClient, args: S
 
 // @public
 export type ResourceFetchResult = {
-    sourceUrl: string;
+    sourceUrl?: string;
     error?: Error;
 };
 

--- a/packages/chat-stateful-client/src/ChatContext.ts
+++ b/packages/chat-stateful-client/src/ChatContext.ts
@@ -92,7 +92,9 @@ export class ChatContext {
           if (cache) {
             Object.keys(cache).forEach((resourceUrl) => {
               const resource = cache[resourceUrl];
-              URL.revokeObjectURL(resource.sourceUrl);
+              if (resource.sourceUrl) {
+                URL.revokeObjectURL(resource.sourceUrl);
+              }
             });
           }
           thread.chatMessages[messageId].resourceCache = undefined;
@@ -130,7 +132,10 @@ export class ChatContext {
       }
       if (message && message.resourceCache && message.resourceCache[resourceUrl]) {
         const resource = message.resourceCache[resourceUrl];
-        URL.revokeObjectURL(resource.sourceUrl);
+        if (resource.sourceUrl) {
+          URL.revokeObjectURL(resource.sourceUrl);
+        }
+
         delete message.resourceCache[resourceUrl];
       }
     });

--- a/packages/chat-stateful-client/src/types/ChatMessageWithStatus.ts
+++ b/packages/chat-stateful-client/src/types/ChatMessageWithStatus.ts
@@ -26,6 +26,6 @@ export type ChatMessageWithStatus = ChatMessage & {
  * @public
  */
 export type ResourceFetchResult = {
-  sourceUrl: string;
+  sourceUrl?: string;
   error?: Error;
 };

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -3836,7 +3836,7 @@ export type ResourceDetails = {
 
 // @public
 export type ResourceFetchResult = {
-    sourceUrl: string;
+    sourceUrl?: string;
     error?: Error;
 };
 

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -3104,7 +3104,7 @@ export type ResourceDetails = {
 
 // @public
 export type ResourceFetchResult = {
-    sourceUrl: string;
+    sourceUrl?: string;
     error?: Error;
 };
 

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -191,7 +191,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
 
   const getResourceSourceUrl = (result: ResourceFetchResult): string => {
     let src = '';
-    if (result.error) {
+    if (result.error || !result.sourceUrl) {
       src = 'blob://';
     } else {
       src = result.sourceUrl;


### PR DESCRIPTION
# What
For the new ResourceFetchResult making sourceUrl optional in the case of an error
# Why
In the case of an error `undefined` is sent back up from the stateful client instead of an ''

# How Tested
Test inline images and in the network tab turn off network while making call

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->