### PR TITLE
Fix dominant speakers to be placed in first page of overflow gallery

### DIFF
--- a/change-beta/@azure-communication-react-1606ed6b-b308-4259-85d6-4e742ed2e4ae.json
+++ b/change-beta/@azure-communication-react-1606ed6b-b308-4259-85d6-4e742ed2e4ae.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Dominant speakers",
+  "comment": "Fix order of dominant speakers in overflow gallery",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-1606ed6b-b308-4259-85d6-4e742ed2e4ae.json
+++ b/change/@azure-communication-react-1606ed6b-b308-4259-85d6-4e742ed2e4ae.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Dominant speakers",
+  "comment": "Fix order of dominant speakers in overflow gallery",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/VideoGallery/utils/videoGalleryLayoutUtils.ts
+++ b/packages/react-components/src/components/VideoGallery/utils/videoGalleryLayoutUtils.ts
@@ -194,9 +194,9 @@ const _useOrganizedParticipantsWithFocusedParticipants = (
   // get focused participants from map of remote participants in the order of the user ids
   const focusedParticipants: VideoGalleryRemoteParticipant[] = [];
   focusedParticipantUserIds.forEach((id) => {
-    const pinnedParticipant = remoteParticipantMap[id];
-    if (pinnedParticipant) {
-      focusedParticipants.push(pinnedParticipant);
+    const focusedParticipant = remoteParticipantMap[id];
+    if (focusedParticipant) {
+      focusedParticipants.push(focusedParticipant);
     }
   });
 
@@ -212,6 +212,17 @@ const _useOrganizedParticipantsWithFocusedParticipants = (
 
   const useOrganizedParticipantsResult = _useOrganizedParticipants(useOrganizedParticipantsProps);
 
+  const useOrganizedParticipantsWithFocusedParticipantsProps = {
+    ...props,
+    maxRemoteVideoStreams: 0,
+    // if there are pinned participants then we should only consider unpinned participants
+    remoteParticipants: unfocusedParticipants
+  };
+
+  const useOrganizedParticipantsWithFocusedParticipantsResult = _useOrganizedParticipants(
+    useOrganizedParticipantsWithFocusedParticipantsProps
+  );
+
   if (focusedParticipants.length === 0) {
     return useOrganizedParticipantsResult;
   }
@@ -219,10 +230,8 @@ const _useOrganizedParticipantsWithFocusedParticipants = (
   return {
     gridParticipants: props.isScreenShareActive ? [] : focusedParticipants,
     overflowGalleryParticipants: props.isScreenShareActive
-      ? focusedParticipants.concat(useOrganizedParticipantsResult.overflowGalleryParticipants)
-      : useOrganizedParticipantsResult.gridParticipants.concat(
-          useOrganizedParticipantsResult.overflowGalleryParticipants
-        )
+      ? focusedParticipants.concat(useOrganizedParticipantsWithFocusedParticipantsResult.overflowGalleryParticipants)
+      : useOrganizedParticipantsWithFocusedParticipantsResult.overflowGalleryParticipants
   };
 };
 

--- a/packages/react-components/src/components/VideoGallery/utils/videoGalleryLayoutUtils.ts
+++ b/packages/react-components/src/components/VideoGallery/utils/videoGalleryLayoutUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { useCallback, useRef } from 'react';
+import { useRef } from 'react';
 import { smartDominantSpeakerParticipants } from '../../../gallery';
 import { VideoGalleryParticipant, VideoGalleryRemoteParticipant } from '../../../types';
 /* @conditional-compile-remove(reaction) */
@@ -22,6 +22,8 @@ export interface OrganizedParticipantsArgs {
   pinnedParticipantUserIds?: string[];
   layout?: VideoGalleryLayout;
   spotlightedParticipantUserIds?: string[];
+  previousGridParticipants?: VideoGalleryRemoteParticipant[];
+  previousOverflowParticipants?: VideoGalleryRemoteParticipant[];
 }
 
 /**
@@ -37,148 +39,94 @@ const DEFAULT_MAX_OVERFLOW_GALLERY_DOMINANT_SPEAKERS = 6;
 const DEFAULT_MAX_VIDEO_SREAMS = 4;
 const MAX_GRID_PARTICIPANTS_NOT_LARGE_GALLERY = 9;
 
-const _useOrganizedParticipants = (props: OrganizedParticipantsArgs): OrganizedParticipantsResult => {
-  const visibleGridParticipants = useRef<VideoGalleryRemoteParticipant[]>([]);
-  const visibleOverflowGalleryParticipants = useRef<VideoGalleryRemoteParticipant[]>([]);
-
+const getOrganizedParticipants = (props: OrganizedParticipantsArgs): OrganizedParticipantsResult => {
   const {
     remoteParticipants = [],
     dominantSpeakers = [],
     maxRemoteVideoStreams = DEFAULT_MAX_VIDEO_SREAMS,
     maxOverflowGalleryDominantSpeakers = DEFAULT_MAX_OVERFLOW_GALLERY_DOMINANT_SPEAKERS,
     isScreenShareActive = false,
-    pinnedParticipantUserIds = [],
-    layout
+    layout,
+    previousGridParticipants = [],
+    previousOverflowParticipants = []
   } = props;
 
-  const calculateMaxRemoteVideoStreams = (): number => {
-    if (maxRemoteVideoStreams > MAX_GRID_PARTICIPANTS_NOT_LARGE_GALLERY) {
-      return MAX_GRID_PARTICIPANTS_NOT_LARGE_GALLERY;
-    } else {
-      return maxRemoteVideoStreams;
-    }
-    return maxRemoteVideoStreams;
-  };
+  const maxRemoteVideoStreamsToUse =
+    maxRemoteVideoStreams > MAX_GRID_PARTICIPANTS_NOT_LARGE_GALLERY
+      ? MAX_GRID_PARTICIPANTS_NOT_LARGE_GALLERY
+      : maxRemoteVideoStreams;
 
-  const maxRemoteVideoStreamsToUse = calculateMaxRemoteVideoStreams();
-
+  const remoteParticipantsOrdered = putVideoParticipantsFirst(remoteParticipants);
   const videoParticipants = remoteParticipants.filter((p) => p.videoStream?.isAvailable);
+  const participants =
+    layout === 'floatingLocalVideo' && videoParticipants.length > 0 ? videoParticipants : remoteParticipantsOrdered;
 
-  const participantsToSortTrampoline = (): VideoGalleryRemoteParticipant[] => {
-    return layout !== 'floatingLocalVideo' ? putVideoParticipantsFirst(remoteParticipants) : videoParticipants;
-    return videoParticipants;
-  };
-
-  visibleGridParticipants.current =
-    pinnedParticipantUserIds.length > 0 || isScreenShareActive
-      ? []
-      : smartDominantSpeakerParticipants({
-          participants: participantsToSortTrampoline(),
-          dominantSpeakers,
-          lastVisibleParticipants: visibleGridParticipants.current,
-          maxDominantSpeakers: maxRemoteVideoStreamsToUse
-        }).slice(0, maxRemoteVideoStreamsToUse);
+  let newGridParticipants = smartDominantSpeakerParticipants({
+    participants: participants,
+    dominantSpeakers,
+    currentParticipants: previousGridParticipants,
+    maxDominantSpeakers: maxRemoteVideoStreamsToUse
+  }).slice(0, maxRemoteVideoStreamsToUse);
 
   const dominantSpeakerToGrid =
     layout === 'speaker'
       ? dominantSpeakers && dominantSpeakers[0]
-        ? visibleGridParticipants.current.filter((p) => p.userId === dominantSpeakers[0])
-        : [visibleGridParticipants.current[0]]
+        ? newGridParticipants.filter((p) => p.userId === dominantSpeakers[0])
+        : [newGridParticipants[0]]
       : [];
+
   if (dominantSpeakerToGrid[0]) {
-    visibleGridParticipants.current = dominantSpeakerToGrid;
+    newGridParticipants = dominantSpeakerToGrid;
   }
 
-  const visibleGridParticipantsSet = new Set(visibleGridParticipants.current.map((p) => p.userId));
-
-  const remoteParticipantsOrdered = putVideoParticipantsFirst(remoteParticipants);
+  const gridParticipantSet = new Set(newGridParticipants.map((p) => p.userId));
 
   /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
   const callingParticipants = remoteParticipantsOrdered.filter((p) => p.state === ('Connecting' || 'Ringing'));
   /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
   const callingParticipantsSet = new Set(callingParticipants.map((p) => p.userId));
 
-  visibleOverflowGalleryParticipants.current = smartDominantSpeakerParticipants({
+  const newOverflowGalleryParticipants = smartDominantSpeakerParticipants({
     participants: remoteParticipantsOrdered.filter(
       (p) =>
-        !visibleGridParticipantsSet.has(p.userId) &&
+        !gridParticipantSet.has(p.userId) &&
         /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */ !callingParticipantsSet.has(
           p.userId
         )
     ),
     dominantSpeakers: dominantSpeakers,
-    lastVisibleParticipants: visibleOverflowGalleryParticipants.current,
+    currentParticipants: previousOverflowParticipants,
     maxDominantSpeakers: maxOverflowGalleryDominantSpeakers
   });
 
-  const getGridParticipants = useCallback((): VideoGalleryRemoteParticipant[] => {
-    if (isScreenShareActive) {
-      return [];
-    }
-    // if we have no grid participants we need to cap the max number of overflowGallery participants in the grid
-    // we will use the max streams provided to the function to find the max participants that can go in the grid
-    // if there are less participants than max streams then we will use all participants including joining in the grid
-    /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
-    return visibleGridParticipants.current.length > 0
-      ? visibleGridParticipants.current
-      : visibleOverflowGalleryParticipants.current.length > maxRemoteVideoStreamsToUse
-      ? visibleOverflowGalleryParticipants.current.slice(0, maxRemoteVideoStreamsToUse)
-      : visibleOverflowGalleryParticipants.current.slice(0, maxRemoteVideoStreamsToUse).concat(callingParticipants);
-    return visibleGridParticipants.current.length > 0
-      ? visibleGridParticipants.current
-      : visibleOverflowGalleryParticipants.current.slice(0, maxRemoteVideoStreamsToUse);
-  }, [
-    /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */ callingParticipants,
+  const gridParticipants = getGridParticipants({
     isScreenShareActive,
-    maxRemoteVideoStreamsToUse
-  ]);
+    gridParticipants: newGridParticipants,
+    overflowGalleryParticipants: newOverflowGalleryParticipants,
+    maxRemoteVideoStreams: maxRemoteVideoStreamsToUse,
+    /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */ callingParticipants
+  });
 
-  const gridParticipants = getGridParticipants();
-
-  const getOverflowGalleryRemoteParticipants = useCallback((): (
-    | VideoGalleryParticipant
-    | VideoGalleryRemoteParticipant
-  )[] => {
-    if (isScreenShareActive) {
-      // If screen sharing is active, assign video and audio participants as overflow gallery participants
-      /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
-      return visibleGridParticipants.current.concat(
-        visibleOverflowGalleryParticipants.current.concat(callingParticipants)
-      );
-      return visibleGridParticipants.current.concat(visibleOverflowGalleryParticipants.current);
-    } else {
-      // If screen sharing is not active, then assign all video tiles as grid tiles.
-      // If there are no video tiles, then assign audio tiles as grid tiles.
-      // if there are more overflow tiles than max streams then find the tiles that don't fit in the grid and put them in overflow
-      // overflow should be empty if total participants including calling participants is less than max streams
-      /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
-      return visibleGridParticipants.current.length > 0
-        ? visibleOverflowGalleryParticipants.current.concat(callingParticipants)
-        : visibleOverflowGalleryParticipants.current.length > maxRemoteVideoStreamsToUse
-        ? visibleOverflowGalleryParticipants.current.slice(maxRemoteVideoStreamsToUse).concat(callingParticipants)
-        : [];
-      return visibleGridParticipants.current.length > 0
-        ? visibleOverflowGalleryParticipants.current
-        : visibleOverflowGalleryParticipants.current.slice(maxRemoteVideoStreamsToUse);
-    }
-  }, [
-    /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */ callingParticipants,
+  const overflowGalleryParticipants = getOverflowGalleryRemoteParticipants({
     isScreenShareActive,
-    maxRemoteVideoStreamsToUse
-  ]);
+    gridParticipants: newGridParticipants,
+    overflowGalleryParticipants: newOverflowGalleryParticipants,
+    maxRemoteVideoStreams: maxRemoteVideoStreamsToUse,
+    /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */ callingParticipants
+  });
 
-  const overflowGalleryParticipants = getOverflowGalleryRemoteParticipants();
-
-  return { gridParticipants, overflowGalleryParticipants: overflowGalleryParticipants };
+  return { gridParticipants, overflowGalleryParticipants };
 };
 
 interface SortedRemoteParticipants {
   [key: string]: VideoGalleryRemoteParticipant;
 }
 
-const _useOrganizedParticipantsWithFocusedParticipants = (
-  props: OrganizedParticipantsArgs
-): OrganizedParticipantsResult => {
+/**
+ * Hook to determine which participants should be in grid and overflow gallery and their order respectively
+ * @private
+ */
+export const useOrganizedParticipants = (props: OrganizedParticipantsArgs): OrganizedParticipantsResult => {
   // map remote participants by userId
   const remoteParticipantMap = props.remoteParticipants.reduce((map, remoteParticipant) => {
     map[remoteParticipant.userId] = remoteParticipant;
@@ -186,53 +134,98 @@ const _useOrganizedParticipantsWithFocusedParticipants = (
   }, {} as SortedRemoteParticipants);
 
   const spotlightedParticipantUserIds = props.spotlightedParticipantUserIds ?? [];
-  // declare focused participant user ids as spotlighted participants user ids followed by
-  // pinned participants user ids
-  const focusedParticipantUserIds = [
-    ...new Set(spotlightedParticipantUserIds.concat(props.pinnedParticipantUserIds ?? []))
-  ];
+  const pinnedParticipantUserIds = props.pinnedParticipantUserIds ?? [];
+  // declare set of focused participant user ids as spotlighted participants user ids followed by
+  // pinned participants user ids which is deduplicated while maintaining order
+  const focusedParticipantUserIdSet = new Set(
+    spotlightedParticipantUserIds.concat(pinnedParticipantUserIds).filter((p) => remoteParticipantMap[p])
+  );
   // get focused participants from map of remote participants in the order of the user ids
-  const focusedParticipants: VideoGalleryRemoteParticipant[] = [];
-  focusedParticipantUserIds.forEach((id) => {
-    const focusedParticipant = remoteParticipantMap[id];
-    if (focusedParticipant) {
-      focusedParticipants.push(focusedParticipant);
-    }
-  });
-
-  // get unfocused participants by filtering out set of focused participant user ids from all remote participants
-  const focusedParticipantUserIdSet = new Set(focusedParticipantUserIds);
-  const unfocusedParticipants = props.remoteParticipants.filter((p) => !focusedParticipantUserIdSet.has(p.userId));
-
-  const useOrganizedParticipantsProps = {
-    ...props,
-    // if there are pinned participants then we should only consider unpinned participants
-    remoteParticipants: unfocusedParticipants
-  };
-
-  const useOrganizedParticipantsResult = _useOrganizedParticipants(useOrganizedParticipantsProps);
-
-  const useOrganizedParticipantsWithFocusedParticipantsProps = {
-    ...props,
-    maxRemoteVideoStreams: 0,
-    // if there are pinned participants then we should only consider unpinned participants
-    remoteParticipants: unfocusedParticipants
-  };
-
-  const useOrganizedParticipantsWithFocusedParticipantsResult = _useOrganizedParticipants(
-    useOrganizedParticipantsWithFocusedParticipantsProps
+  const focusedParticipants: VideoGalleryRemoteParticipant[] = [...focusedParticipantUserIdSet].map(
+    (p) => remoteParticipantMap[p]
   );
 
-  if (focusedParticipants.length === 0) {
-    return useOrganizedParticipantsResult;
-  }
+  const currentGridParticipants = useRef<VideoGalleryRemoteParticipant[]>([]);
+  const currentOverflowGalleryParticipants = useRef<VideoGalleryRemoteParticipant[]>([]);
 
-  return {
-    gridParticipants: props.isScreenShareActive ? [] : focusedParticipants,
-    overflowGalleryParticipants: props.isScreenShareActive
-      ? focusedParticipants.concat(useOrganizedParticipantsWithFocusedParticipantsResult.overflowGalleryParticipants)
-      : useOrganizedParticipantsWithFocusedParticipantsResult.overflowGalleryParticipants
+  const unfocusedParticipants = props.remoteParticipants.filter((p) => !focusedParticipantUserIdSet.has(p.userId));
+
+  const useOrganizedParticipantsProps: OrganizedParticipantsArgs = {
+    ...props,
+    // if there are focused participants then leave no room in the grid by setting maxGridParticipants to 0
+    maxRemoteVideoStreams:
+      focusedParticipants.length > 0 || props.isScreenShareActive ? 0 : props.maxRemoteVideoStreams,
+    remoteParticipants: unfocusedParticipants,
+    previousGridParticipants: currentGridParticipants.current,
+    previousOverflowParticipants: currentOverflowGalleryParticipants.current
   };
+
+  const useOrganizedParticipantsResult = getOrganizedParticipants(useOrganizedParticipantsProps);
+
+  currentGridParticipants.current = useOrganizedParticipantsResult.gridParticipants;
+  currentOverflowGalleryParticipants.current = useOrganizedParticipantsResult.overflowGalleryParticipants;
+
+  return focusedParticipants.length > 0
+    ? {
+        gridParticipants: props.isScreenShareActive ? [] : focusedParticipants,
+        overflowGalleryParticipants: props.isScreenShareActive
+          ? focusedParticipants.concat(useOrganizedParticipantsResult.overflowGalleryParticipants)
+          : useOrganizedParticipantsResult.overflowGalleryParticipants
+      }
+    : useOrganizedParticipantsResult;
+};
+
+const getGridParticipants = (args: {
+  isScreenShareActive: boolean;
+  gridParticipants: VideoGalleryParticipant[];
+  overflowGalleryParticipants: VideoGalleryParticipant[];
+  maxRemoteVideoStreams: number;
+  /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */ callingParticipants: VideoGalleryParticipant[];
+}): VideoGalleryRemoteParticipant[] => {
+  if (args.isScreenShareActive) {
+    return [];
+  }
+  // if we have no grid participants we need to cap the max number of overflowGallery participants in the grid
+  // we will use the max streams provided to the function to find the max participants that can go in the grid
+  // if there are less participants than max streams then we will use all participants including joining in the grid
+  /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
+  return args.gridParticipants.length > 0
+    ? args.gridParticipants
+    : args.overflowGalleryParticipants.length > args.maxRemoteVideoStreams
+    ? args.overflowGalleryParticipants.slice(0, args.maxRemoteVideoStreams)
+    : args.overflowGalleryParticipants.slice(0, args.maxRemoteVideoStreams).concat(args.callingParticipants);
+  return args.gridParticipants.length > 0
+    ? args.gridParticipants
+    : args.overflowGalleryParticipants.slice(0, args.maxRemoteVideoStreams);
+};
+
+const getOverflowGalleryRemoteParticipants = (args: {
+  isScreenShareActive: boolean;
+  gridParticipants: VideoGalleryParticipant[];
+  overflowGalleryParticipants: VideoGalleryParticipant[];
+  maxRemoteVideoStreams: number;
+  /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */ callingParticipants: VideoGalleryParticipant[];
+}): VideoGalleryRemoteParticipant[] => {
+  if (args.isScreenShareActive) {
+    // If screen sharing is active, assign video and audio participants as overflow gallery participants
+    /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
+    return args.gridParticipants.concat(args.overflowGalleryParticipants.concat(args.callingParticipants));
+    return args.gridParticipants.concat(args.overflowGalleryParticipants);
+  } else {
+    // If screen sharing is not active, then assign all video tiles as grid tiles.
+    // If there are no video tiles, then assign audio tiles as grid tiles.
+    // if there are more overflow tiles than max streams then find the tiles that don't fit in the grid and put them in overflow
+    // overflow should be empty if total participants including calling participants is less than max streams
+    /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
+    return args.gridParticipants.length > 0
+      ? args.overflowGalleryParticipants.concat(args.callingParticipants)
+      : args.overflowGalleryParticipants.length > args.maxRemoteVideoStreams
+      ? args.overflowGalleryParticipants.slice(args.maxRemoteVideoStreams).concat(args.callingParticipants)
+      : [];
+    return args.gridParticipants.length > 0
+      ? args.overflowGalleryParticipants
+      : args.overflowGalleryParticipants.slice(args.maxRemoteVideoStreams);
+  }
 };
 
 const putVideoParticipantsFirst = (
@@ -249,14 +242,6 @@ const putVideoParticipantsFirst = (
   });
   const remoteParticipantSortedByVideo = videoParticipants.concat(audioParticipants);
   return remoteParticipantSortedByVideo;
-};
-
-/**
- * Hook to determine which participants should be in grid and overflow gallery and their order respectively
- * @private
- */
-export const useOrganizedParticipants = (args: OrganizedParticipantsArgs): OrganizedParticipantsResult => {
-  return _useOrganizedParticipantsWithFocusedParticipants(args);
 };
 
 /* @conditional-compile-remove(reaction) */

--- a/packages/react-components/src/gallery/dominantSpeaker.test.ts
+++ b/packages/react-components/src/gallery/dominantSpeaker.test.ts
@@ -43,7 +43,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     result = smartDominantSpeakerParticipants({
       participants: participants,
       dominantSpeakers: ['2', '1'],
-      lastVisibleParticipants: result,
+      currentParticipants: result,
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['1', '3', '2', '4', '5', '6', '7', '8']);
@@ -62,7 +62,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     const result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['1', '3', '5', '7'],
-      lastVisibleParticipants: [{ userId: '1' }, { userId: '2' }, { userId: '3' }, { userId: '4' }],
+      currentParticipants: [{ userId: '1' }, { userId: '2' }, { userId: '3' }, { userId: '4' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['1', '5', '3', '7', '2', '4', '6', '8']);
@@ -72,7 +72,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     let result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['1', '2', '3', '4'],
-      lastVisibleParticipants: [{ userId: '3' }, { userId: '4' }],
+      currentParticipants: [{ userId: '3' }, { userId: '4' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['3', '4', '1', '2', '5', '6', '7', '8']);
@@ -80,7 +80,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['1', '2', '3', '4'],
-      lastVisibleParticipants: [{ userId: '2' }, { userId: '1' }],
+      currentParticipants: [{ userId: '2' }, { userId: '1' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['2', '1', '3', '4', '5', '6', '7', '8']);
@@ -90,7 +90,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     let result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['1', '2', '3', '4'],
-      lastVisibleParticipants: [{ userId: '1' }, { userId: '2' }],
+      currentParticipants: [{ userId: '1' }, { userId: '2' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['1', '2', '3', '4', '5', '6', '7', '8']);
@@ -98,7 +98,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['5', '2', '3', '4'],
-      lastVisibleParticipants: [{ userId: '11' }, { userId: '10' }],
+      currentParticipants: [{ userId: '11' }, { userId: '10' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['5', '2', '3', '4', '1', '6', '7', '8']);
@@ -108,7 +108,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     const result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['3', '4', '5', '2'],
-      lastVisibleParticipants: [{ userId: '11' }, { userId: '10' }, { userId: '3' }, { userId: '4' }],
+      currentParticipants: [{ userId: '11' }, { userId: '10' }, { userId: '3' }, { userId: '4' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['5', '2', '3', '4', '1', '6', '7', '8']);
@@ -118,7 +118,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     const result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['5', '6', '7', '8'],
-      lastVisibleParticipants: [{ userId: '1' }, { userId: '2' }, { userId: '3' }, { userId: '4' }],
+      currentParticipants: [{ userId: '1' }, { userId: '2' }, { userId: '3' }, { userId: '4' }],
       maxDominantSpeakers: 3
     });
     expect(result.map((p) => p.userId)).toEqual(['5', '6', '7', '1', '2', '3', '4', '8']);
@@ -128,7 +128,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     const result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['5', '6', '7', '8'],
-      lastVisibleParticipants: [{ userId: '1' }, { userId: '2' }, { userId: '3' }, { userId: '4' }],
+      currentParticipants: [{ userId: '1' }, { userId: '2' }, { userId: '3' }, { userId: '4' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['5', '6', '7', '8', '1', '2', '3', '4']);
@@ -138,7 +138,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     let result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['1', '2', '3', '4'],
-      lastVisibleParticipants: [{ userId: '1' }, { userId: '2' }, { userId: '3' }, { userId: '4' }],
+      currentParticipants: [{ userId: '1' }, { userId: '2' }, { userId: '3' }, { userId: '4' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['1', '2', '3', '4', '5', '6', '7', '8']);
@@ -147,7 +147,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
       participants,
       // Dominant speakers rearranged, other arguments unchanged.
       dominantSpeakers: ['3', '2', '1', '4'],
-      lastVisibleParticipants: result.slice(0, 4),
+      currentParticipants: result.slice(0, 4),
       maxDominantSpeakers: 4
     });
     // No rearrangement in result.
@@ -158,7 +158,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     const result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['1', '1', '3', '7'],
-      lastVisibleParticipants: [{ userId: '1' }, { userId: '2' }, { userId: '3' }, { userId: '4' }],
+      currentParticipants: [{ userId: '1' }, { userId: '2' }, { userId: '3' }, { userId: '4' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['1', '7', '3', '4', '2', '5', '6', '8']);
@@ -168,7 +168,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     let result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['5', '7', '8'],
-      lastVisibleParticipants: [{ userId: '3' }, { userId: '5' }, { userId: '8' }, { userId: '4' }, { userId: '1' }],
+      currentParticipants: [{ userId: '3' }, { userId: '5' }, { userId: '8' }, { userId: '4' }, { userId: '1' }],
       maxDominantSpeakers: 3
     });
     expect(result.map((p) => p.userId)).toEqual(['7', '5', '8', '1', '2', '3', '4', '6']);
@@ -176,7 +176,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['5', '7', '8'],
-      lastVisibleParticipants: result,
+      currentParticipants: result,
       maxDominantSpeakers: 3
     });
     expect(result.map((p) => p.userId)).toEqual(['7', '5', '8', '1', '2', '3', '4', '6']);
@@ -186,7 +186,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     const result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['12', '3', '4', '5'],
-      lastVisibleParticipants: [{ userId: '11' }, { userId: '10' }, { userId: '3' }, { userId: '4' }],
+      currentParticipants: [{ userId: '11' }, { userId: '10' }, { userId: '3' }, { userId: '4' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['5', '3', '4', '1', '2', '6', '7', '8']);
@@ -196,7 +196,7 @@ describe('Test smartDominantSpeakerParticipants function', () => {
     const result = smartDominantSpeakerParticipants({
       participants,
       dominantSpeakers: ['12', '3', '4', '5', '6'],
-      lastVisibleParticipants: [{ userId: '11' }, { userId: '10' }, { userId: '3' }, { userId: '4' }],
+      currentParticipants: [{ userId: '11' }, { userId: '10' }, { userId: '3' }, { userId: '4' }],
       maxDominantSpeakers: 4
     });
     expect(result.map((p) => p.userId)).toEqual(['5', '6', '3', '4', '1', '2', '7', '8']);

--- a/packages/react-components/src/gallery/dominantSpeaker.ts
+++ b/packages/react-components/src/gallery/dominantSpeaker.ts
@@ -14,10 +14,9 @@ type SmartDominantSpeakerParticipantsArgs = {
    */
   dominantSpeakers?: string[];
   /**
-   * Array containing currently rendered (visible)
-   * participants in the call. {@link @azure/communication-react#VideoGalleryRemoteParticipant}
+   * Array containing the current participants in the call. {@link @azure/communication-react#VideoGalleryRemoteParticipant}
    */
-  lastVisibleParticipants?: VideoGalleryRemoteParticipant[];
+  currentParticipants?: VideoGalleryRemoteParticipant[];
   /**
    * Maximum number of dominant speaker positions to move participants in.
    */
@@ -33,7 +32,7 @@ type SmartDominantSpeakerParticipantsArgs = {
 export const smartDominantSpeakerParticipants = (
   args: SmartDominantSpeakerParticipantsArgs
 ): VideoGalleryRemoteParticipant[] => {
-  const { participants, dominantSpeakers = [], lastVisibleParticipants = [], maxDominantSpeakers } = args;
+  const { participants, dominantSpeakers = [], currentParticipants = [], maxDominantSpeakers } = args;
 
   // Don't apply any logic if total number of video streams is less than max dominant speakers.
   if (participants.length <= maxDominantSpeakers) {
@@ -45,7 +44,7 @@ export const smartDominantSpeakerParticipants = (
   // Only use the Max allowed dominant speakers that exist in participants
   const dominantSpeakerIds = dominantSpeakers.filter((id) => !!participantsMap[id]).slice(0, maxDominantSpeakers);
 
-  const newVisibleParticipantIds = lastVisibleParticipants.map((p) => p.userId).slice(0, maxDominantSpeakers);
+  const newVisibleParticipantIds = currentParticipants.map((p) => p.userId).slice(0, maxDominantSpeakers);
   const newDominantSpeakerIds = dominantSpeakerIds.filter((id) => !newVisibleParticipantIds.includes(id));
 
   // Remove participants that are no longer dominant and replace them with new dominant speakers.


### PR DESCRIPTION
# What
- Fix dominant speakers to be placed in first page of overflow gallery (commit: https://github.com/Azure/communication-ui-library/pull/4276/commits/e70dc8941f2f6bf2b469bc8239d1620343b0a36f)
- Clean up useOrganizedParticipants hook (commit: https://github.com/Azure/communication-ui-library/pull/4276/commits/9d3840145e34510268c55fa636e13fafe04762ad)

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3575666

# How Tested
Local calling sample testing:
https://github.com/Azure/communication-ui-library/assets/79475487/596de893-d783-4943-beb9-ca90d6136dc4

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->