### PR TITLE
[cherry pick from pre-release branch] Alkwa/remove pptlive note (#4290)

### DIFF
--- a/change/@azure-communication-react-be0c076c-19e1-4d01-b0d1-ee6078454003.json
+++ b/change/@azure-communication-react-be0c076c-19e1-4d01-b0d1-ee6078454003.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "1.14.0 stable release",
+  "comment": "updated changelog",
+  "packageName": "@azure/communication-react",
+  "email": "alkwa@microsoft.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
* updated changelog

* Change files

# What
Removed the PPTLive release note in the changelog

# Why
We are not shipping PPTLive with 1.14.0
