### PR TITLE
Alkwa/fix rejoin freeze

### DIFF
--- a/change-beta/@azure-communication-react-19dfb179-e943-4922-b916-67f5fa4664e5.json
+++ b/change-beta/@azure-communication-react-19dfb179-e943-4922-b916-67f5fa4664e5.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Frozen streams when quickly rejoining the call with the same identity",
+  "comment": "prioritize the last stream of each type that is available",
+  "packageName": "@azure/communication-react",
+  "email": "alkwa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-19dfb179-e943-4922-b916-67f5fa4664e5.json
+++ b/change/@azure-communication-react-19dfb179-e943-4922-b916-67f5fa4664e5.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Frozen streams when quickly rejoining the call with the same identity",
+  "comment": "prioritize the last stream of each type that is available",
+  "packageName": "@azure/communication-react",
+  "email": "alkwa@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/src/handlers/createCommonHandlers.ts
+++ b/packages/calling-component-bindings/src/handlers/createCommonHandlers.ts
@@ -404,6 +404,13 @@ export const createDefaultCommonCallingHandlers = memoizeOne(
         return;
       }
 
+      /**
+       * There is a bug from the calling sdk where if a user leaves and rejoins immediately
+       * it adds 2 more potential streams this remote participant can use. The old 2 streams
+       * still show as available and that is how we got a frozen stream in this case. The stopgap
+       * until streams accurately reflect their availability is to always prioritize the latest streams of a certain type
+       * e.g findLast instead of find
+       */
       // Find the first available stream, if there is none, then get the first stream
       const remoteVideoStream =
         Object.values(participant.videoStreams).findLast((i) => i.mediaStreamType === 'Video' && i.isAvailable) ||

--- a/packages/calling-component-bindings/src/handlers/createCommonHandlers.ts
+++ b/packages/calling-component-bindings/src/handlers/createCommonHandlers.ts
@@ -406,12 +406,13 @@ export const createDefaultCommonCallingHandlers = memoizeOne(
 
       // Find the first available stream, if there is none, then get the first stream
       const remoteVideoStream =
-        Object.values(participant.videoStreams).find((i) => i.mediaStreamType === 'Video' && i.isAvailable) ||
-        Object.values(participant.videoStreams).find((i) => i.mediaStreamType === 'Video');
+        Object.values(participant.videoStreams).findLast((i) => i.mediaStreamType === 'Video' && i.isAvailable) ||
+        Object.values(participant.videoStreams).findLast((i) => i.mediaStreamType === 'Video');
 
       const screenShareStream =
-        Object.values(participant.videoStreams).find((i) => i.mediaStreamType === 'ScreenSharing' && i.isAvailable) ||
-        Object.values(participant.videoStreams).find((i) => i.mediaStreamType === 'ScreenSharing');
+        Object.values(participant.videoStreams).findLast(
+          (i) => i.mediaStreamType === 'ScreenSharing' && i.isAvailable
+        ) || Object.values(participant.videoStreams).findLast((i) => i.mediaStreamType === 'ScreenSharing');
 
       let createViewResult: CreateViewResult | undefined = undefined;
       if (remoteVideoStream && remoteVideoStream.isAvailable && !remoteVideoStream.view) {

--- a/packages/calling-component-bindings/src/utils/videoGalleryUtils.ts
+++ b/packages/calling-component-bindings/src/utils/videoGalleryUtils.ts
@@ -150,12 +150,12 @@ export const convertRemoteParticipantToVideoGalleryRemoteParticipant = (
   let screenShareStream: VideoGalleryStream | undefined = undefined;
 
   const sdkRemoteVideoStream =
-    Object.values(rawVideoStreamsArray).find((i) => i.mediaStreamType === 'Video' && i.isAvailable) ||
-    Object.values(rawVideoStreamsArray).find((i) => i.mediaStreamType === 'Video');
+    Object.values(rawVideoStreamsArray).findLast((i) => i.mediaStreamType === 'Video' && i.isAvailable) ||
+    Object.values(rawVideoStreamsArray).findLast((i) => i.mediaStreamType === 'Video');
 
   const sdkScreenShareStream =
-    Object.values(rawVideoStreamsArray).find((i) => i.mediaStreamType === 'ScreenSharing' && i.isAvailable) ||
-    Object.values(rawVideoStreamsArray).find((i) => i.mediaStreamType === 'ScreenSharing');
+    Object.values(rawVideoStreamsArray).findLast((i) => i.mediaStreamType === 'ScreenSharing' && i.isAvailable) ||
+    Object.values(rawVideoStreamsArray).findLast((i) => i.mediaStreamType === 'ScreenSharing');
 
   if (sdkRemoteVideoStream) {
     videoStream = convertRemoteVideoStreamToVideoGalleryStream(sdkRemoteVideoStream);

--- a/packages/calling-component-bindings/src/utils/videoGalleryUtils.ts
+++ b/packages/calling-component-bindings/src/utils/videoGalleryUtils.ts
@@ -149,6 +149,13 @@ export const convertRemoteParticipantToVideoGalleryRemoteParticipant = (
   let videoStream: VideoGalleryStream | undefined = undefined;
   let screenShareStream: VideoGalleryStream | undefined = undefined;
 
+  /**
+   * There is a bug from the calling sdk where if a user leaves and rejoins immediately
+   * it adds 2 more potential streams this remote participant can use. The old 2 streams
+   * still show as available and that is how we got a frozen stream in this case. The stopgap
+   * until streams accurately reflect their availability is to always prioritize the latest streams of a certain type
+   * e.g findLast instead of find
+   */
   const sdkRemoteVideoStream =
     Object.values(rawVideoStreamsArray).findLast((i) => i.mediaStreamType === 'Video' && i.isAvailable) ||
     Object.values(rawVideoStreamsArray).findLast((i) => i.mediaStreamType === 'Video');


### PR DESCRIPTION
# What
In a call, if a user with a stream on leaves and rejoins again quickly (with the same identity), we see a frozen stream.

# Why
In the code we are seeing 2 additional streams being added to the user (in total 4). The old stream is still showing availability = true however its not true, so it looks frozen if the client chooses to prioritize the first available stream of the specific type (e.g video). A few min later the old streams will be removed and then the client code will re-render with the correct available stream.
Since it could take some time for the SDK to figure out the correct logic, it would be better for UI Library to always prefer the latest stream of a specific type that is available. This is under the assumption at this time that there will only be one video and one screensharing stream per use.

# How Tested
ran one instance via localhost:3000 and then joined with another use from aka.ms/acsstorybook.
Have the storybook user turn their camera on, then refresh the page.
The localhost user should see a frozen stream.
(w/o the fix) the stream will be frozen for a few min after the storybook user joins the call
(w/ fix) the stream will go away just showing the tile and then it will render the correct stream.
eak.
