### PR TITLE
Stabilize video gallery UI test

### DIFF
--- a/change/@azure-communication-react-0fff92fd-8d3f-4441-a5d5-d1e83a03fe3a.json
+++ b/change/@azure-communication-react-0fff92fd-8d3f-4441-a5d5-d1e83a03fe3a.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "Playwright test",
+  "comment": "Stabilize flaky video gallery UI test",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-composites/tests/browser/call/hermetic/VideoGallery.test.ts
+++ b/packages/react-composites/tests/browser/call/hermetic/VideoGallery.test.ts
@@ -255,6 +255,7 @@ test.describe('VideoGallery tests', async () => {
     await pageClick(page, dataUiId(IDS.moreButton));
     await page.locator('span:has-text("View")');
     await page.locator('span:has-text("View")').click();
+    await page.locator('div[role=menuitem]').first().focus();
     expect(await stableScreenshot(page)).toMatchSnapshot('gallery-options-mobile.png');
   });
 });


### PR DESCRIPTION
# What
Ensure first menu item is focused so that VideoGallery UI test is stable

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3607280

# How Tested
Tested by focusing on second menu item and it worked

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->