### PR TITLE
[Chat][FileSharing] Split file-sharing conditional compile to attachment flags

### DIFF
--- a/change/@azure-communication-react-15d34ebc-a688-486e-be44-a582e268fb20.json
+++ b/change/@azure-communication-react-15d34ebc-a688-486e-be44-a582e268fb20.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "Conditional Compile flag",
+  "comment": "Rename file-sharing cc flag to attachment",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/common/config/babel/features.js
+++ b/common/config/babel/features.js
@@ -26,8 +26,10 @@ module.exports = {
     "dialpad",
     // Data loss prevention feature
     "data-loss-prevention",
-    // Ability to upload/download files in message thread.
-    "file-sharing",
+    // Ability to download files attachments in message thread.
+    "attachment-download",
+    // Ability to upload files attachments in message thread.
+    "attachment-upload",
     // Mention feature
     "mention",
     // 1 to N Calling feature.

--- a/packages/chat-component-bindings/src/handlers/createHandlers.ts
+++ b/packages/chat-component-bindings/src/handlers/createHandlers.ts
@@ -27,9 +27,9 @@ export type ChatHandlers = {
   onUpdateMessage: (
     messageId: string,
     content: string,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     options?: {
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       metadata?: Record<string, string>;
       attachmentMetadata?: AttachmentMetadata[];
     }

--- a/packages/chat-component-bindings/src/messageThreadSelector.ts
+++ b/packages/chat-component-bindings/src/messageThreadSelector.ts
@@ -28,11 +28,11 @@ import { createSelector } from 'reselect';
 import { DEFAULT_DATA_LOSS_PREVENTION_POLICY_URL } from './utils/constants';
 import { ACSKnownMessageType } from './utils/constants';
 import { updateMessagesWithAttached } from './utils/updateMessagesWithAttached';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata } from '@internal/react-components';
 import { ChatAttachment } from '@azure/communication-chat';
 import type { ChatParticipant } from '@azure/communication-chat';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ChatAttachmentType } from '@internal/react-components';
 
 const memoizedAllConvertChatMessage = memoizeFnAll(
@@ -60,7 +60,7 @@ const memoizedAllConvertChatMessage = memoizeFnAll(
   }
 );
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 const extractAttachedFilesMetadata = (metadata: Record<string, string>): AttachmentMetadata[] => {
   const fileMetadata = metadata.fileSharingMetadata;
   if (!fileMetadata) {
@@ -73,7 +73,7 @@ const extractAttachedFilesMetadata = (metadata: Record<string, string>): Attachm
     return [];
   }
 };
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 const extractTeamsAttachmentsMetadata = (
   attachments: ChatAttachment[]
 ): {
@@ -120,7 +120,7 @@ const convertToUiBlockedMessage = (
   };
 };
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 const extractAttachmentUrl = (attachment: ChatAttachment): string => {
   return attachment.previewUrl ? attachment.previewUrl : attachment.url || '';
 };
@@ -198,7 +198,7 @@ const extractAttachmentContentTypeFromName = (name?: string): string => {
   return contentType;
 };
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 const extractAttachmentsMetadata = (message: ChatMessageWithStatus): { files?: AttachmentMetadata[] } => {
   let files: AttachmentMetadata[] = [];
   if (message.metadata) {
@@ -217,7 +217,7 @@ const convertToUiChatMessage = (
   isLargeGroup: boolean
 ): ChatMessage => {
   const messageSenderId = message.sender !== undefined ? toFlatCommunicationIdentifier(message.sender) : userId;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const { files } = extractAttachmentsMetadata(message);
   return {
     messageType: 'chat',
@@ -233,7 +233,7 @@ const convertToUiChatMessage = (
     deletedOn: message.deletedOn,
     mine: messageSenderId === userId,
     metadata: message.metadata,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     files
   };
 };

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1658,7 +1658,7 @@ export type ChatAdapterUiState = {
 };
 
 // @public
-export type ChatAttachmentType = 'unknown' | 'image' | /* @conditional-compile-remove(file-sharing) */ 'file';
+export type ChatAttachmentType = 'unknown' | 'image' | /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ 'file';
 
 // @public
 export type ChatBaseSelectorProps = {

--- a/packages/communication-react/src/index.ts
+++ b/packages/communication-react/src/index.ts
@@ -319,14 +319,14 @@ export type {
   DtmfTone,
   LongPressTrigger
 } from '../../react-components/src';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 export type {
   ActiveFileUpload,
   SendBoxErrorBarError,
   FileDownloadHandler,
   FileDownloadError
 } from '../../react-components/src';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 export type { AttachmentMetadata } from '../../react-components/src';
 export type { ChatAttachmentType } from '../../react-components/src';
 export type { InlineImageOptions, InlineImage } from '../../react-components/src';

--- a/packages/react-components/src/components/AttachmentCard.tsx
+++ b/packages/react-components/src/components/AttachmentCard.tsx
@@ -90,7 +90,7 @@ export const _AttachmentCard = (props: _AttachmentCardProps): JSX.Element => {
   // placeholder before refactoring the props
   const attachment = useMemo(() => {
     return {
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       id: 'attachmentId',
       extension: attachmentExtension,
       name: attachmentName,

--- a/packages/react-components/src/components/AttachmentDownloadCards.test.tsx
+++ b/packages/react-components/src/components/AttachmentDownloadCards.test.tsx
@@ -23,7 +23,7 @@ describe('FileDownloadCards should be rendered properly', () => {
       name: 'MockAttachmentCard',
       extension: 'docx',
       url: 'mockUrl',
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       id: 'mockId'
     };
 

--- a/packages/react-components/src/components/AttachmentDownloadCards.tsx
+++ b/packages/react-components/src/components/AttachmentDownloadCards.tsx
@@ -4,21 +4,24 @@
 import { Icon, Spinner, SpinnerSize, TooltipHost } from '@fluentui/react';
 import React, { useCallback, useState } from 'react';
 import { useMemo } from 'react';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { useLocale } from '../localization';
 import { _AttachmentCard } from './AttachmentCard';
 import { _AttachmentCardGroup } from './AttachmentCardGroup';
 import { _formatString } from '@internal/acs-ui-common';
 import { AttachmentMetadata, FileDownloadHandler } from '../types/Attachment';
 import { Open20Regular } from '@fluentui/react-icons';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ArrowDownload20Regular } from '@fluentui/react-icons';
 
 /**
  * Represents the type of attachment
  * @public
  */
-export type ChatAttachmentType = 'unknown' | 'image' | /* @conditional-compile-remove(file-sharing) */ 'file';
+export type ChatAttachmentType =
+  | 'unknown'
+  | 'image'
+  | /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ 'file';
 
 /**
  * Strings of _AttachmentDownloadCards that can be overridden.
@@ -81,7 +84,7 @@ export const _AttachmentDownloadCards = (props: _AttachmentDownloadCardsProps): 
   );
 
   const isShowDownloadIcon = useCallback((attachment: AttachmentMetadata): boolean => {
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     return attachment.payload?.teamsFileAttachment !== 'true';
     return true;
   }, []);
@@ -90,7 +93,7 @@ export const _AttachmentDownloadCards = (props: _AttachmentDownloadCardsProps): 
     () => () => {
       const fileGroupLocaleString =
         props.strings?.attachmentCardGroupMessage ?? localeStrings.attachmentCardGroupMessage;
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       return _formatString(fileGroupLocaleString, {
         attachmentCount: `${fileMetadata?.length ?? 0}`
       });
@@ -158,14 +161,14 @@ export const _AttachmentDownloadCards = (props: _AttachmentDownloadCardsProps): 
  * @private
  */
 const DownloadIconTrampoline = (): JSX.Element => {
-  // @conditional-compile-remove(file-sharing)
+  // @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload)
   return <ArrowDownload20Regular data-ui-id={'file-download-card-download-icon'} />;
   // Return _some_ available icon, as the real icon is beta-only.
   return <Icon iconName="EditBoxCancel" style={actionIconStyle} />;
 };
 
 const useLocaleStringsTrampoline = (): _AttachmentDownloadCardsStrings => {
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   return useLocale().strings.messageThread;
   return { downloadAttachment: '', attachmentCardGroupMessage: '' };
 };

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsEditBox.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsEditBox.tsx
@@ -14,7 +14,7 @@ import { MessageThreadStrings } from '../MessageThread';
 import { useChatMyMessageStyles } from '../styles/MessageThread.styles';
 import { ChatMessage } from '../../types';
 import { _AttachmentUploadCards } from '../AttachmentUploadCards';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata } from '../../types/Attachment';
 import {
   chatMessageFailedTagStyle,
@@ -27,7 +27,7 @@ import {
 import { MentionLookupOptions } from '../MentionPopover';
 import { MAXIMUM_LENGTH_OF_MESSAGE } from '../utils/SendBoxUtils';
 import { getMessageState, onRenderCancelIcon, onRenderSubmitIcon } from '../utils/ChatMessageComponentAsEditBoxUtils';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { getMessageAttachedFilesMetadata } from '../utils/ChatMessageComponentAsEditBoxUtils';
 
 /** @private */
@@ -37,7 +37,7 @@ export type ChatMessageComponentAsEditBoxProps = {
     text: string,
     metadata?: Record<string, string>,
     options?: {
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       attachmentMetadata?: AttachmentMetadata[];
     }
   ) => void;
@@ -56,13 +56,14 @@ export const ChatMessageComponentAsEditBox = (props: ChatMessageComponentAsEditB
   const { mentionLookupOptions } = props;
 
   const [textValue, setTextValue] = useState<string>(message.content || '');
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const [attachmentMetadata, setAttachedFilesMetadata] = React.useState(getMessageAttachedFilesMetadata(message));
   const editTextFieldRef = React.useRef<ITextField>(null);
   const theme = useTheme();
   const messageState = getMessageState(
     textValue,
-    /* @conditional-compile-remove(file-sharing) */ attachmentMetadata ?? []
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ attachmentMetadata ??
+      []
   );
   const submitEnabled = messageState === 'OK';
 
@@ -108,7 +109,7 @@ export const ChatMessageComponentAsEditBox = (props: ChatMessageComponentAsEditB
     return concatStyleSets(editBoxStyleSet, { textField: { borderColor: theme.palette.themePrimary } });
   }, [theme.palette.themePrimary]);
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const onRenderFileUploads = useCallback(() => {
     return (
       !!attachmentMetadata &&
@@ -149,7 +150,7 @@ export const ChatMessageComponentAsEditBox = (props: ChatMessageComponentAsEditB
               onSubmit(
                 textValue,
                 message.metadata,
-                /* @conditional-compile-remove(file-sharing) */ {
+                /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ {
                   attachmentMetadata
                 }
               );
@@ -197,7 +198,7 @@ export const ChatMessageComponentAsEditBox = (props: ChatMessageComponentAsEditB
                   onSubmit(
                     textValue,
                     message.metadata,
-                    /* @conditional-compile-remove(file-sharing) */ {
+                    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ {
                       attachmentMetadata
                     }
                   );
@@ -207,7 +208,9 @@ export const ChatMessageComponentAsEditBox = (props: ChatMessageComponentAsEditB
             />
           </Stack.Item>
         </Stack>
-        {/* @conditional-compile-remove(file-sharing) */ onRenderFileUploads()}
+        {
+          /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ onRenderFileUploads()
+        }
       </>
     );
   };

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsRichTextEditBox.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentAsRichTextEditBox.tsx
@@ -13,12 +13,12 @@ import { MessageThreadStrings } from '../MessageThread';
 import { useChatMyMessageStyles } from '../styles/MessageThread.styles';
 import { ChatMessage } from '../../types';
 import { _AttachmentUploadCards } from '../AttachmentUploadCards';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata } from '../../types/Attachment';
 import { useChatMessageRichTextEditContainerStyles } from '../styles/ChatMessageComponent.styles';
 import { MAXIMUM_LENGTH_OF_MESSAGE } from '../utils/SendBoxUtils';
 import { getMessageState, onRenderCancelIcon, onRenderSubmitIcon } from '../utils/ChatMessageComponentAsEditBoxUtils';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { getMessageAttachedFilesMetadata } from '../utils/ChatMessageComponentAsEditBoxUtils';
 import { RichTextEditorComponentRef } from '../RichTextEditor/RichTextEditor';
 import { RichTextInputBoxComponent } from '../RichTextEditor/RichTextInputBoxComponent';
@@ -33,7 +33,7 @@ export type ChatMessageComponentAsRichTextEditBoxProps = {
     text: string,
     metadata?: Record<string, string>,
     options?: {
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       attachmentMetadata?: AttachmentMetadata[];
     }
   ) => void;
@@ -50,13 +50,14 @@ export const ChatMessageComponentAsRichTextEditBox = (
   const { onCancel, onSubmit, strings, message } = props;
 
   const [textValue, setTextValue] = useState<string>(message.content || '');
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const [attachmentMetadata, _] = React.useState(getMessageAttachedFilesMetadata(message));
   const editTextFieldRef = React.useRef<RichTextEditorComponentRef>(null);
   const theme = useTheme();
   const messageState = getMessageState(
     textValue,
-    /* @conditional-compile-remove(file-sharing) */ attachmentMetadata ?? []
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ attachmentMetadata ??
+      []
   );
   const submitEnabled = messageState === 'OK';
 
@@ -124,7 +125,7 @@ export const ChatMessageComponentAsRichTextEditBox = (
               onSubmit(
                 textValue,
                 message.metadata,
-                /* @conditional-compile-remove(file-sharing) */ {
+                /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ {
                   attachmentMetadata
                 }
               );
@@ -135,7 +136,7 @@ export const ChatMessageComponentAsRichTextEditBox = (
       </Stack>
     );
   }, [
-    /* @conditional-compile-remove(file-sharing) */ attachmentMetadata,
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ attachmentMetadata,
     message.messageId,
     message.metadata,
     onCancel,

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentWrapper.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentWrapper.tsx
@@ -7,7 +7,7 @@ import { MessageProps, MessageRenderer, MessageThreadStyles, _ChatMessageProps }
 import { ChatMessage, OnRenderAvatarCallback } from '../../types';
 /* @conditional-compile-remove(data-loss-prevention) */
 import { BlockedMessage } from '../../types';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileDownloadHandler } from '../../types/Attachment';
 /* @conditional-compile-remove(mention) */
 import { MentionOptions } from '../MentionPopover';
@@ -42,7 +42,7 @@ export type ChatMessageComponentWrapperProps = _ChatMessageProps & {
   showMessageStatus?: boolean;
   participantCount?: number;
   readCount?: number;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   onRenderFileDownloads?: (userId: string, message: ChatMessage) => JSX.Element;
   onActionButtonClick: (
     message: ChatMessage,
@@ -53,7 +53,7 @@ export type ChatMessageComponentWrapperProps = _ChatMessageProps & {
       }[]
     ) => void
   ) => void;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   fileDownloadHandler?: FileDownloadHandler;
   /* @conditional-compile-remove(date-time-customization) */
   onDisplayDateTimeString?: (messageDate: Date) => string;

--- a/packages/react-components/src/components/ChatMessage/MessageComponents/ChatMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/MessageComponents/ChatMessageComponentAsMessageBubble.tsx
@@ -14,7 +14,7 @@ import { ChatMessage } from '../../../types/ChatMessage';
 import { BlockedMessage } from '../../../types/ChatMessage';
 import { MessageThreadStrings } from '../../MessageThread';
 import { ComponentSlotStyle } from '../../../types';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileDownloadHandler } from '../../../types/Attachment';
 import { _AttachmentDownloadCards } from '../../AttachmentDownloadCards';
 import { useLocale } from '../../../localization';
@@ -40,12 +40,12 @@ type ChatMessageComponentAsMessageBubbleProps = {
    * Whether to overlap avatar and message when the view is width constrained.
    */
   shouldOverlapAvatarAndMessage: boolean;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optional callback to render uploaded files in the message component.
    */
   onRenderFileDownloads?: (userId: string, message: ChatMessage) => JSX.Element;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optional function called when someone clicks on the file download icon.
    */
@@ -80,11 +80,11 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
     showDate,
     messageContainerStyle,
     strings,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     fileDownloadHandler,
     inlineImageOptions,
     shouldOverlapAvatarAndMessage,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     onRenderFileDownloads,
     /* @conditional-compile-remove(mention) */
     mentionDisplayOptions,
@@ -113,19 +113,19 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
       strings,
       userId,
       inlineImageOptions,
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       onRenderFileDownloads,
       /* @conditional-compile-remove(mention) */
       mentionDisplayOptions,
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       fileDownloadHandler
     );
   }, [
-    /* @conditional-compile-remove(file-sharing) */ fileDownloadHandler,
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ fileDownloadHandler,
     inlineImageOptions,
     /* @conditional-compile-remove(mention) */ mentionDisplayOptions,
     message,
-    /* @conditional-compile-remove(file-sharing) */ onRenderFileDownloads,
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ onRenderFileDownloads,
     strings,
     userId
   ]);

--- a/packages/react-components/src/components/ChatMessage/MessageComponents/FluentChatMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/MessageComponents/FluentChatMessageComponent.tsx
@@ -47,10 +47,10 @@ export const FluentChatMessageComponent = (props: FluentChatMessageComponentWrap
     /* @conditional-compile-remove(date-time-customization) */
     onDisplayDateTimeString,
     inlineImageOptions,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     fileDownloadHandler,
     userId,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     onRenderFileDownloads,
     /* @conditional-compile-remove(mention) */
     mentionOptions
@@ -58,10 +58,12 @@ export const FluentChatMessageComponent = (props: FluentChatMessageComponentWrap
   const chatMessageRenderStyles = useChatMessageRenderStyles();
 
   const onRenderFileDownloadsMemo = useMemo(() => {
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     return onRenderFileDownloads;
     return undefined;
-  }, [/* @conditional-compile-remove(file-sharing) */ onRenderFileDownloads]);
+  }, [
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ onRenderFileDownloads
+  ]);
 
   // To rerender the defaultChatMessageRenderer if app running across days(every new day chat time stamp
   // needs to be regenerated), the dependency on "new Date().toDateString()"" is added.
@@ -74,9 +76,9 @@ export const FluentChatMessageComponent = (props: FluentChatMessageComponentWrap
         return (
           <ChatMessageComponentAsMessageBubble
             {...messageProps}
-            /* @conditional-compile-remove(file-sharing) */
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
             onRenderFileDownloads={onRenderFileDownloadsMemo}
-            /* @conditional-compile-remove(file-sharing) */
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
             strings={messageProps.strings}
             message={messageProps.message}
             userId={userId}
@@ -84,7 +86,7 @@ export const FluentChatMessageComponent = (props: FluentChatMessageComponentWrap
             /* @conditional-compile-remove(date-time-customization) */
             onDisplayDateTimeString={onDisplayDateTimeString}
             inlineImageOptions={inlineImageOptions}
-            /* @conditional-compile-remove(file-sharing) */
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
             fileDownloadHandler={fileDownloadHandler}
             /* @conditional-compile-remove(mention) */
             mentionDisplayOptions={mentionOptions?.displayOptions}
@@ -100,7 +102,7 @@ export const FluentChatMessageComponent = (props: FluentChatMessageComponentWrap
       /* @conditional-compile-remove(date-time-customization) */
       onDisplayDateTimeString,
       inlineImageOptions,
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       fileDownloadHandler,
       /* @conditional-compile-remove(mention) */
       mentionOptions,

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMyMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMyMessageComponentAsMessageBubble.tsx
@@ -16,7 +16,7 @@ import { BlockedMessage } from '../../../types/ChatMessage';
 import { MessageThreadStrings } from '../../MessageThread';
 import { chatMessageActionMenuProps } from '../ChatMessageActionMenu';
 import { ComponentSlotStyle, OnRenderAvatarCallback } from '../../../types';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileDownloadHandler } from '../../../types/Attachment';
 import { _AttachmentDownloadCards } from '../../AttachmentDownloadCards';
 import { useLocale } from '../../../localization';
@@ -47,12 +47,12 @@ type ChatMyMessageComponentAsMessageBubbleProps = {
    * Whether the status indicator for each message is displayed or not.
    */
   showMessageStatus?: boolean;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optional callback to render uploaded files in the message component.
    */
   onRenderFileDownloads?: (userId: string, message: ChatMessage) => JSX.Element;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optional function called when someone clicks on the file download icon.
    */
@@ -107,10 +107,10 @@ const MessageBubble = (props: ChatMyMessageComponentAsMessageBubbleProps): JSX.E
     onRenderAvatar,
     showMessageStatus,
     messageStatus,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     fileDownloadHandler,
     inlineImageOptions,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     onRenderFileDownloads,
     /* @conditional-compile-remove(mention) */
     mentionDisplayOptions,
@@ -184,19 +184,19 @@ const MessageBubble = (props: ChatMyMessageComponentAsMessageBubbleProps): JSX.E
       strings,
       userId,
       inlineImageOptions,
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       onRenderFileDownloads,
       /* @conditional-compile-remove(mention) */
       mentionDisplayOptions,
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       fileDownloadHandler
     );
   }, [
-    /* @conditional-compile-remove(file-sharing) */ fileDownloadHandler,
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ fileDownloadHandler,
     inlineImageOptions,
     /* @conditional-compile-remove(mention) */ mentionDisplayOptions,
     message,
-    /* @conditional-compile-remove(file-sharing) */ onRenderFileDownloads,
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ onRenderFileDownloads,
     strings,
     userId
   ]);

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/FluentChatMyMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/FluentChatMyMessageComponent.tsx
@@ -42,10 +42,10 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
     inlineImageOptions,
     /* @conditional-compile-remove(mention) */
     mentionOptions,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     fileDownloadHandler,
     userId,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     onRenderFileDownloads,
     defaultStatusRenderer,
     statusToRender
@@ -53,10 +53,12 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
   const chatMessageRenderStyles = useChatMessageRenderStyles();
 
   const onRenderFileDownloadsMemo = useMemo(() => {
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     return onRenderFileDownloads;
     return undefined;
-  }, [/* @conditional-compile-remove(file-sharing) */ onRenderFileDownloads]);
+  }, [
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ onRenderFileDownloads
+  ]);
 
   // To rerender the defaultChatMessageRenderer if app running across days(every new day chat time stamp
   // needs to be regenerated), the dependency on "new Date().toDateString()"" is added.
@@ -69,9 +71,9 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
         return (
           <ChatMyMessageComponent
             {...messageProps}
-            /* @conditional-compile-remove(file-sharing) */
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
             onRenderFileDownloads={onRenderFileDownloadsMemo}
-            /* @conditional-compile-remove(file-sharing) */
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
             strings={messageProps.strings}
             message={messageProps.message}
             userId={userId}
@@ -86,7 +88,7 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
             inlineImageOptions={inlineImageOptions}
             /* @conditional-compile-remove(mention) */
             mentionOptions={mentionOptions}
-            /* @conditional-compile-remove(file-sharing) */
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
             fileDownloadHandler={fileDownloadHandler}
           />
         );
@@ -106,7 +108,7 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
       inlineImageOptions,
       /* @conditional-compile-remove(mention) */
       mentionOptions,
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       fileDownloadHandler,
       // eslint-disable-next-line react-hooks/exhaustive-deps
       new Date().toDateString()

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -32,7 +32,7 @@ import { memoizeFnAll, MessageStatus } from '@internal/acs-ui-common';
 import { useLocale } from '../localization/LocalizationProvider';
 import { isNarrowWidth, _useContainerWidth } from './utils/responsive';
 import getParticipantsWhoHaveReadMessage from './utils/getParticipantsWhoHaveReadMessage';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata, FileDownloadHandler } from '../types/Attachment';
 import { useTheme } from '../theming';
 import { FluentV9ThemeProvider } from './../theming/FluentV9ThemeProvider';
@@ -210,7 +210,7 @@ export interface MessageThreadStrings {
   actionMenuMoreOptions?: string;
   /** Aria label to announce when a message is deleted */
   messageDeletedAnnouncementAriaLabel: string;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /** String for download file button in attachment card */
   downloadAttachment: string;
   /* @conditional-compile-remove(data-loss-prevention) */
@@ -219,7 +219,7 @@ export interface MessageThreadStrings {
   /* @conditional-compile-remove(data-loss-prevention) */
   /** String for policy violation message removal details link */
   blockedWarningLinkText: string;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /** String for aria text in file attachment group*/
   attachmentCardGroupMessage: string;
 }
@@ -345,9 +345,9 @@ const getLastChatMessageForCurrentUser = (messages: Message[]): ChatMessage | un
 export type UpdateMessageCallback = (
   messageId: string,
   content: string,
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   options?: {
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     metadata?: Record<string, string>;
     attachmentMetadata?: AttachmentMetadata[];
   }
@@ -457,7 +457,7 @@ export type MessageThreadProps = {
    * `messageRenderer` is not provided for `CustomMessage` and thus only available for `ChatMessage` and `SystemMessage`.
    */
   onRenderMessage?: (messageProps: MessageProps, messageRenderer?: MessageRenderer) => JSX.Element;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optional callback to render attached files in the message component.
    * @beta
@@ -509,7 +509,7 @@ export type MessageThreadProps = {
    */
   strings?: Partial<MessageThreadStrings>;
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * @beta
    * Optional function called when someone clicks on the file download icon.
@@ -666,7 +666,7 @@ export const MessageThreadWrapper = (props: MessageThreadProps): JSX.Element => 
     /* @conditional-compile-remove(mention) */
     mentionOptions,
     inlineImageOptions,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     onRenderFileDownloads
   } = props;
   // We need this state to wait for one tick and scroll to bottom after messages have been initialized.
@@ -1114,14 +1114,14 @@ export const MessageThreadWrapper = (props: MessageThreadProps): JSX.Element => 
                   onActionButtonClick={onActionButtonClickMemo}
                   readCount={readCountForHoveredIndicator}
                   participantCount={participantCount}
-                  /* @conditional-compile-remove(file-sharing) */
+                  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
                   fileDownloadHandler={props.fileDownloadHandler}
                   inlineImageOptions={inlineImageOptions}
                   /* @conditional-compile-remove(date-time-customization) */
                   onDisplayDateTimeString={onDisplayDateTimeString}
                   /* @conditional-compile-remove(mention) */
                   mentionOptions={mentionOptions}
-                  /* @conditional-compile-remove(file-sharing) */
+                  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
                   onRenderFileDownloads={onRenderFileDownloads}
                 />
               );

--- a/packages/react-components/src/components/RichTextEditor/RichTextInputBoxComponent.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextInputBoxComponent.tsx
@@ -39,9 +39,9 @@ export interface RichTextInputBoxComponentProps {
   strings: Partial<RichTextSendBoxStrings>;
   disabled: boolean;
   actionComponents: ReactNode;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   onRenderFileUploads?: () => JSX.Element;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   hasFiles?: boolean;
   // props for min and max height for the rich text editor
   // otherwise the editor will grow to fit the content
@@ -62,9 +62,9 @@ export const RichTextInputBoxComponent = (props: RichTextInputBoxComponentProps)
     disabled,
     strings,
     actionComponents,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     onRenderFileUploads,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     hasFiles,
     richTextEditorStyleProps,
     isHorizontalLayoutDisabled = false
@@ -135,12 +135,12 @@ export const RichTextInputBoxComponent = (props: RichTextInputBoxComponentProps)
     return (
       !isHorizontalLayoutDisabled &&
       !showRichTextEditorFormatting &&
-      /* @conditional-compile-remove(file-sharing) */ !hasFiles
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ !hasFiles
     );
   }, [
     isHorizontalLayoutDisabled,
     showRichTextEditorFormatting,
-    /* @conditional-compile-remove(file-sharing) */ hasFiles
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ hasFiles
   ]);
 
   return (
@@ -172,7 +172,10 @@ export const RichTextInputBoxComponent = (props: RichTextInputBoxComponentProps)
               styles={richTextEditorStyle}
             />
           </Stack.Item>
-          {/* @conditional-compile-remove(file-sharing) */ onRenderFileUploads && onRenderFileUploads()}
+          {
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ onRenderFileUploads &&
+              onRenderFileUploads()
+          }
         </Stack>
         {actionButtons}
       </Stack>

--- a/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
@@ -13,13 +13,13 @@ import { isMessageTooLong, sanitizeText } from '../utils/SendBoxUtils';
 import { RichTextEditorComponentRef } from './RichTextEditor';
 import { useTheme } from '../../theming';
 import { richTextActionButtonsStyle, sendBoxRichTextEditorStyle } from '../styles/RichTextEditor.styles';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ActiveFileUpload, _AttachmentUploadCards } from '../AttachmentUploadCards';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { hasCompletedFileUploads, hasIncompleteFileUploads } from '../utils/SendBoxUtils';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { SendBoxErrorBarError } from '../SendBoxErrorBar';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { attachmentUploadCardsStyles } from '../styles/SendBox.styles';
 
 /**
@@ -81,14 +81,14 @@ export interface RichTextSendBoxProps {
    * Optional text for system message above the text box
    */
   systemMessage?: string;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optional array of active file uploads where each object has attributes
    * of a file upload like name, progress, errorMessage etc.
    * @beta
    */
   activeFileUploads?: ActiveFileUpload[];
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optional callback to remove the file upload before sending by clicking on
    * cancel icon.
@@ -111,9 +111,9 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
     disabled = false,
     systemMessage,
     onSendMessage,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     activeFileUploads,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     onCancelFileUpload
   } = props;
 
@@ -132,7 +132,7 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
 
   const [contentValue, setContentValue] = useState('');
   const [contentValueOverflow, setContentValueOverflow] = useState(false);
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const [attachmentUploadsPendingError, setFileUploadsPendingError] = useState<SendBoxErrorBarError | undefined>(
     undefined
   );
@@ -157,10 +157,10 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
       return;
     }
     // Don't send message until all files have been uploaded successfully
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     setFileUploadsPendingError(undefined);
 
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     if (hasIncompleteFileUploads(activeFileUploads)) {
       setFileUploadsPendingError({ message: strings.attachmentUploadsPendingError, timestamp: Date.now() });
       return;
@@ -171,7 +171,9 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
     // Message can be empty if there is a valid file upload
     if (
       sanitizeText(message).length > 0 ||
-      /* @conditional-compile-remove(file-sharing) */ hasCompletedFileUploads(activeFileUploads)
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ hasCompletedFileUploads(
+        activeFileUploads
+      )
     ) {
       onSendMessage(message);
       setContentValue('');
@@ -183,24 +185,24 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
     contentValueOverflow,
     disabled,
     onSendMessage,
-    /* @conditional-compile-remove(file-sharing) */ activeFileUploads,
-    /* @conditional-compile-remove(file-sharing) */ strings.attachmentUploadsPendingError
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ activeFileUploads,
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ strings.attachmentUploadsPendingError
   ]);
 
   const hasErrorMessage = useMemo(() => {
     return (
       !!systemMessage ||
       !!contentTooLongMessage ||
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       !!attachmentUploadsPendingError ||
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       !!activeFileUploads?.filter((attachmentUpload) => attachmentUpload.error).pop()?.error
     );
   }, [
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     activeFileUploads,
     contentTooLongMessage,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     attachmentUploadsPendingError,
     systemMessage
   ]);
@@ -212,7 +214,7 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
         className={sendIconStyle({
           theme,
           hasText: !!contentValue,
-          /* @conditional-compile-remove(file-sharing) */
+          /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
           hasFile: false,
           hasErrorMessage: hasErrorMessage,
           defaultTextColor: theme.palette.neutralSecondary,
@@ -225,23 +227,23 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
 
   const sendBoxErrorsProps: RichTextSendBoxErrorsProps = useMemo(() => {
     return {
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       attachmentUploadsPendingError: attachmentUploadsPendingError,
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       attachmentUploadError: activeFileUploads?.filter((attachmentUpload) => attachmentUpload.error).pop()?.error,
       systemMessage: systemMessage,
       textTooLongMessage: contentTooLongMessage
     };
   }, [
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     activeFileUploads,
     contentTooLongMessage,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     attachmentUploadsPendingError,
     systemMessage
   ]);
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const onRenderFileUploads = useCallback(() => {
     return (
       <Stack className={attachmentUploadCardsStyles}>
@@ -273,7 +275,7 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
     );
   }, [localeStrings.sendButtonAriaLabel, onRenderSendIcon, sendMessageOnClick]);
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const hasFileUploads = useMemo(() => {
     return hasCompletedFileUploads(activeFileUploads) || hasIncompleteFileUploads(activeFileUploads);
   }, [activeFileUploads]);
@@ -290,9 +292,9 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
         disabled={disabled}
         actionComponents={sendButton}
         richTextEditorStyleProps={sendBoxRichTextEditorStyle}
-        /* @conditional-compile-remove(file-sharing) */
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
         onRenderFileUploads={onRenderFileUploads}
-        /* @conditional-compile-remove(file-sharing) */
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
         hasFiles={hasFileUploads}
       />
     </Stack>

--- a/packages/react-components/src/components/RichTextEditor/RichTextSendBoxErrors.test.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextSendBoxErrors.test.tsx
@@ -28,7 +28,7 @@ describe('RichTextSendBoxErrors should be shown correctly', () => {
     expect(sendBoxErrorComponent).not.toBeNull();
   });
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   test('MessageBar should show file uploads pending error', async () => {
     const text = 'Test file uploads pending error';
     render(<RichTextSendBoxErrors attachmentUploadsPendingError={{ message: text, timestamp: Date.now() }} />);
@@ -37,7 +37,7 @@ describe('RichTextSendBoxErrors should be shown correctly', () => {
     expect(sendBoxErrorComponent).not.toBeNull();
   });
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   test('MessageBar should show file uploads error', async () => {
     const text = 'Test file uploads error';
     render(<RichTextSendBoxErrors attachmentUploadError={{ message: text, timestamp: Date.now() }} />);

--- a/packages/react-components/src/components/RichTextEditor/RichTextSendBoxErrors.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextSendBoxErrors.tsx
@@ -8,9 +8,9 @@ import { SendBoxErrorBar, SendBoxErrorBarError } from '../SendBoxErrorBar';
  * @private
  */
 export interface RichTextSendBoxErrorsProps {
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   attachmentUploadsPendingError?: SendBoxErrorBarError;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   attachmentUploadError?: SendBoxErrorBarError;
   systemMessage?: string;
   textTooLongMessage?: string;
@@ -21,9 +21,9 @@ export interface RichTextSendBoxErrorsProps {
  */
 export const RichTextSendBoxErrors = (props: RichTextSendBoxErrorsProps): JSX.Element => {
   const {
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     attachmentUploadError,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     attachmentUploadsPendingError,
     systemMessage,
     textTooLongMessage
@@ -57,11 +57,11 @@ export const RichTextSendBoxErrors = (props: RichTextSendBoxErrorsProps): JSX.El
       if (prev) {
         errors.push(prev);
       }
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       if (attachmentUploadsPendingError) {
         errors.push(attachmentUploadsPendingError);
       }
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       if (attachmentUploadError) {
         errors.push(attachmentUploadError);
       }
@@ -73,8 +73,8 @@ export const RichTextSendBoxErrors = (props: RichTextSendBoxErrorsProps): JSX.El
       return sortedErrors[0];
     });
   }, [
-    /* @conditional-compile-remove(file-sharing) */ attachmentUploadError,
-    /* @conditional-compile-remove(file-sharing) */ attachmentUploadsPendingError
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ attachmentUploadError,
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ attachmentUploadsPendingError
   ]);
 
   const onDismiss = useCallback(() => {

--- a/packages/react-components/src/components/SendBox.tsx
+++ b/packages/react-components/src/components/SendBox.tsx
@@ -10,20 +10,20 @@ import { useLocale } from '../localization';
 import { useIdentifiers } from '../identifiers';
 import { InputBoxComponent } from './InputBoxComponent';
 import { InputBoxButton } from './InputBoxButton';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { SendBoxErrors } from './SendBoxErrors';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ActiveFileUpload, _AttachmentUploadCards } from './AttachmentUploadCards';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { attachmentUploadCardsStyles } from './styles/SendBox.styles';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { SendBoxErrorBarError } from './SendBoxErrorBar';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { hasCompletedFileUploads, hasIncompleteFileUploads } from './utils/SendBoxUtils';
 import { MAXIMUM_LENGTH_OF_MESSAGE, isMessageTooLong, sanitizeText } from './utils/SendBoxUtils';
 /* @conditional-compile-remove(mention) */
 import { MentionLookupOptions } from './MentionPopover';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FluentV9ThemeProvider } from '../theming/FluentV9ThemeProvider';
 
 /**
@@ -62,22 +62,22 @@ export interface SendBoxStrings {
    * Aria label for send message button
    */
   sendButtonAriaLabel: string;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Error message indicating that all attachment uploads are not complete.
    */
   attachmentUploadsPendingError: string;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Aria label to notify user when focus is on cancel attachment upload button.
    */
   removeAttachment: string;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Aria label to notify user attachment uploading starts.
    */
   uploading: string;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Aria label to notify user attachment is uploaded.
    */
@@ -146,7 +146,7 @@ export interface SendBoxProps {
    * When undefined nothing has focus on render
    */
   autoFocus?: 'sendBoxTextField';
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optional callback to render uploaded files in the SendBox. The sendBox will expand
    * vertically to accommodate the uploaded files. File uploads will
@@ -154,14 +154,14 @@ export interface SendBoxProps {
    * @beta
    */
   onRenderFileUploads?: () => JSX.Element;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optional array of active attachment uploads where each object has attributes
    * of a attachment upload like name, progress, errorMessage etc.
    * @beta
    */
   activeFileUploads?: ActiveFileUpload[];
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optional callback to remove the attachment upload before sending by clicking on
    * cancel icon.
@@ -191,7 +191,7 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
     autoFocus,
     /* @conditional-compile-remove(mention) */
     mentionLookupOptions,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     activeFileUploads
   } = props;
   const theme = useTheme();
@@ -204,7 +204,7 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
 
   const sendTextFieldRef = React.useRef<ITextField>(null);
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const [attachmentUploadsPendingError, setAttachmentUploadsPendingError] = useState<SendBoxErrorBarError | undefined>(
     undefined
   );
@@ -216,10 +216,10 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
     }
 
     // Don't send message until all files have been uploaded successfully
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     setAttachmentUploadsPendingError(undefined);
 
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     if (hasIncompleteFileUploads(activeFileUploads)) {
       setAttachmentUploadsPendingError({ message: strings.attachmentUploadsPendingError, timestamp: Date.now() });
       return;
@@ -230,7 +230,9 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
     // Message can be empty if there is a valid attachment upload
     if (
       sanitizeText(message).length > 0 ||
-      /* @conditional-compile-remove(file-sharing) */ hasCompletedFileUploads(activeFileUploads)
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ hasCompletedFileUploads(
+        activeFileUploads
+      )
     ) {
       onSendMessage && onSendMessage(message);
       setTextValue('');
@@ -262,14 +264,15 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
       sendIconStyle({
         theme,
         hasText: !!textValue,
-        /* @conditional-compile-remove(file-sharing) */ hasFile: hasCompletedFileUploads(activeFileUploads),
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ hasFile:
+          hasCompletedFileUploads(activeFileUploads),
         hasErrorMessage: !!errorMessage,
         customSendIconStyle: styles?.sendMessageIcon
       }),
     [
       theme,
       textValue,
-      /* @conditional-compile-remove(file-sharing) */ activeFileUploads,
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ activeFileUploads,
       errorMessage,
       styles?.sendMessageIcon
     ]
@@ -286,14 +289,14 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
   );
 
   // Ensure that errors are cleared when there are no files in sendBox
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   React.useEffect(() => {
     if (!activeFileUploads?.filter((upload) => !upload.error).length) {
       setAttachmentUploadsPendingError(undefined);
     }
   }, [activeFileUploads]);
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const sendBoxErrorsProps = useMemo(() => {
     return {
       attachmentUploadsPendingError: attachmentUploadsPendingError,
@@ -301,7 +304,7 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
     };
   }, [activeFileUploads, attachmentUploadsPendingError]);
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const onRenderFileUploads = useCallback(() => {
     if (!activeFileUploads?.filter((upload) => !upload.error).length) {
       return null;
@@ -339,7 +342,11 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
         { overflow: 'visible' } // This is needed for the mention popup to be visible
       )}
     >
-      {/* @conditional-compile-remove(file-sharing) */ <SendBoxErrors {...sendBoxErrorsProps} />}
+      {
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ <SendBoxErrors
+          {...sendBoxErrorsProps}
+        />
+      }
       <Stack
         className={borderAndBoxShadowStyle({
           theme,
@@ -387,7 +394,7 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
           />
         </InputBoxComponent>
         {
-          /* @conditional-compile-remove(file-sharing) */
+          /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
           onRenderFileUploads()
         }
       </Stack>

--- a/packages/react-components/src/components/index.ts
+++ b/packages/react-components/src/components/index.ts
@@ -43,7 +43,7 @@ export type { ImageOverlayProps } from './ImageOverlay';
 
 export type { InlineImageOptions, InlineImage } from './ChatMessage/ChatMessageContent';
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 export type { ActiveFileUpload } from './AttachmentUploadCards';
 
 export { MessageStatusIndicator } from './MessageStatusIndicator';
@@ -203,7 +203,7 @@ export type {
 } from './PictureInPictureInPicture/PictureInPictureInPictureTile';
 
 export * from './Drawer';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 export type { SendBoxErrorBarError } from './SendBoxErrorBar';
 export * from './AttachmentCard';
 export * from './AttachmentCardGroup';
@@ -219,7 +219,7 @@ export type {
   FileUploadError
 } from '../types/Attachment';
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 export type { FileDownloadHandler, FileDownloadError } from '../types/Attachment';
 
 export { _useContainerHeight, _useContainerWidth } from './utils/responsive';

--- a/packages/react-components/src/components/styles/SendBox.styles.ts
+++ b/packages/react-components/src/components/styles/SendBox.styles.ts
@@ -39,7 +39,7 @@ export const sendButtonStyle = mergeStyles({
 export const sendIconStyle = (props: {
   theme: Theme;
   hasText: boolean;
-  /* @conditional-compile-remove(file-sharing) */ hasFile: boolean;
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ hasFile: boolean;
   disabled?: boolean;
   hasErrorMessage: boolean;
   customSendIconStyle?: IStyle;
@@ -49,12 +49,14 @@ export const sendIconStyle = (props: {
     theme,
     hasText,
     disabled = false,
-    /* @conditional-compile-remove(file-sharing) */ hasFile,
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ hasFile,
     hasErrorMessage,
     customSendIconStyle,
     defaultTextColor = theme.palette.neutralTertiary
   } = props;
-  const hasNoContent = !hasText && /* @conditional-compile-remove(file-sharing) */ !hasFile;
+  const hasNoContent =
+    !hasText &&
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ !hasFile;
   return mergeStyles(
     editorTextBoxButtonStyle,
     {

--- a/packages/react-components/src/components/utils/ChatMessageComponentAsEditBoxUtils.tsx
+++ b/packages/react-components/src/components/utils/ChatMessageComponentAsEditBoxUtils.tsx
@@ -3,10 +3,10 @@
 
 import React from 'react';
 import { Icon } from '@fluentui/react';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata } from '../../types/Attachment';
 import { isMessageTooLong } from './SendBoxUtils';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ChatMessage } from '../../types';
 
 /**
@@ -27,10 +27,10 @@ type MessageState = 'OK' | 'too short' | 'too long';
 
 function isMessageEmpty(
   messageText: string,
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   attachmentMetadata?: AttachmentMetadata[]
 ): boolean {
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   return messageText.trim().length === 0 && attachmentMetadata?.length === 0;
   return messageText.trim().length === 0;
 }
@@ -40,16 +40,19 @@ function isMessageEmpty(
  */
 export function getMessageState(
   messageText: string,
-  /* @conditional-compile-remove(file-sharing) */ attachmentMetadata: AttachmentMetadata[]
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ attachmentMetadata: AttachmentMetadata[]
 ): MessageState {
-  return isMessageEmpty(messageText, /* @conditional-compile-remove(file-sharing) */ attachmentMetadata)
+  return isMessageEmpty(
+    messageText,
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ attachmentMetadata
+  )
     ? 'too short'
     : isMessageTooLong(messageText.length)
     ? 'too long'
     : 'OK';
 }
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 /**
  * @private
  * @TODO: Remove when file-sharing feature becomes stable.

--- a/packages/react-components/src/components/utils/ChatMessageComponentUtils.tsx
+++ b/packages/react-components/src/components/utils/ChatMessageComponentUtils.tsx
@@ -13,7 +13,7 @@ import { MessageThreadStrings } from '../MessageThread';
 /* @conditional-compile-remove(mention) */
 import { MentionDisplayOptions } from '../MentionPopover';
 import { _AttachmentDownloadCards } from '../AttachmentDownloadCards';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileDownloadHandler } from '../../types/Attachment';
 import { formatTimeForChatMessage, formatTimestampForChatMessage } from './Datetime';
 import { ComponentLocale } from '../../localization/LocalizationProvider';
@@ -39,11 +39,11 @@ export function getMessageBubbleContent(
   strings: MessageThreadStrings,
   userId: string,
   inlineImageOptions: InlineImageOptions | undefined,
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   onRenderFileDownloads?: (userId: string, message: ChatMessage) => JSX.Element,
   /* @conditional-compile-remove(mention) */
   mentionDisplayOptions?: MentionDisplayOptions,
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   fileDownloadHandler?: FileDownloadHandler
 ): JSX.Element {
   /* @conditional-compile-remove(data-loss-prevention) */
@@ -64,13 +64,13 @@ export function getMessageBubbleContent(
         inlineImageOptions={inlineImageOptions}
       />
       {
-        /* @conditional-compile-remove(file-sharing) */ onRenderFileDownloads
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ onRenderFileDownloads
           ? onRenderFileDownloads(userId, message)
           : defaultOnRenderFileDownloads(
               userId,
               message,
               strings,
-              /* @conditional-compile-remove(file-sharing) */ fileDownloadHandler
+              /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ fileDownloadHandler
             )
       }
     </div>
@@ -80,23 +80,23 @@ export function getMessageBubbleContent(
 /**
  * Default component for rendering file downloads.
  */
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 const defaultOnRenderFileDownloads = (
   userId: string,
   message: ChatMessage | /* @conditional-compile-remove(data-loss-prevention) */ BlockedMessage,
   strings: MessageThreadStrings,
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   fileDownloadHandler?: FileDownloadHandler
 ): JSX.Element | undefined => {
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   return (
     <_AttachmentDownloadCards
       userId={userId}
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       fileMetadata={(message as ChatMessage).files || []}
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       downloadHandler={fileDownloadHandler}
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       strings={{
         downloadAttachment: strings.downloadAttachment,
         attachmentCardGroupMessage: strings.attachmentCardGroupMessage

--- a/packages/react-components/src/components/utils/SendBoxUtils.ts
+++ b/packages/react-components/src/components/utils/SendBoxUtils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ActiveFileUpload } from '../AttachmentUploadCards';
 
 /**
@@ -10,7 +10,7 @@ import { ActiveFileUpload } from '../AttachmentUploadCards';
 export const MAXIMUM_LENGTH_OF_MESSAGE = 8000;
 const EMPTY_MESSAGE_REGEX = /^\s*$/;
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 /**
  * @private
  */
@@ -23,7 +23,7 @@ export const hasIncompleteFileUploads = (activeFileUploads: ActiveFileUpload[] |
   );
 };
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 /**
  * @private
  */

--- a/packages/react-components/src/components/utils/common.ts
+++ b/packages/react-components/src/components/utils/common.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { _AttachmentUploadCardsStrings } from '../AttachmentUploadCards';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { useLocale } from '../../localization';
 import { ParticipantState } from '../../types';
 
@@ -11,7 +11,7 @@ import { ParticipantState } from '../../types';
  * @returns file upload card strings
  */
 export const useLocaleAttachmentCardStringsTrampoline = (): _AttachmentUploadCardsStrings => {
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   return useLocale().strings.sendBox;
   return {
     removeAttachment: '',

--- a/packages/react-components/src/theming/icons.tsx
+++ b/packages/react-components/src/theming/icons.tsx
@@ -88,7 +88,7 @@ import { Backspace20Regular } from '@fluentui/react-icons';
 /* @conditional-compile-remove(call-readiness) */
 import { Sparkle20Filled, VideoProhibited20Filled, MicProhibited20Filled } from '@fluentui/react-icons';
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ArrowDownload16Regular } from '@fluentui/react-icons';
 /* @conditional-compile-remove(PSTN-calls) */
 import { CallPause20Regular, CallPause20Filled, Play20Regular } from '@fluentui/react-icons';
@@ -277,9 +277,9 @@ export const DEFAULT_COMPONENT_ICONS = {
   LowerHandContextualMenuItem: <HandRightOff20Regular />,
   /* @conditional-compile-remove(reaction) */
   ReactionButtonIcon: <Emoji20Regular />,
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   CancelFileUpload: <Dismiss16Regular />,
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   DownloadFile: <ArrowDownload16Regular />,
   /* @conditional-compile-remove(data-loss-prevention) */
   DataLossPreventionProhibited: <DataLossPreventionProhibited16Regular />,

--- a/packages/react-components/src/types/Attachment.ts
+++ b/packages/react-components/src/types/Attachment.ts
@@ -16,7 +16,7 @@ export interface AttachmentMetadata {
   /**
    * Unique ID of the attachment.
    */
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   id: string;
   /**
    * File name to be displayed.
@@ -26,7 +26,7 @@ export interface AttachmentMetadata {
    * Download URL for the attachment.
    */
   url: string;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /*
    * Optional dictionary of meta data associated with the attachment.
    */

--- a/packages/react-components/src/types/ChatMessage.ts
+++ b/packages/react-components/src/types/ChatMessage.ts
@@ -3,7 +3,7 @@
 
 import { MessageStatus } from '@internal/acs-ui-common';
 import { CommunicationParticipant } from './CommunicationParticipant';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata } from './Attachment';
 
 /**
@@ -71,7 +71,7 @@ export interface ChatMessage extends MessageCommon {
    * {@link @azure/communication-chat#ChatMessage.metadata}
    */
   metadata?: Record<string, string>;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * @beta
    * A list of file attachments for the message.

--- a/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
+++ b/packages/react-composites/src/composites/CallWithChatComposite/CallWithChatComposite.tsx
@@ -26,7 +26,7 @@ import {
   useTheme
 } from '@internal/react-components';
 import { useId } from '@fluentui/react-hooks';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileSharingOptions } from '../ChatComposite';
 import { containerDivStyles } from '../common/ContainerRectProps';
 import { useCallWithChatCompositeStrings } from './hooks/useCallWithChatCompositeStrings';
@@ -102,7 +102,7 @@ export type CallWithChatCompositeOptions = {
    * If using the boolean values, true will cause default behavior across the whole control bar. False hides the whole control bar.
    */
   callControls?: boolean | CallWithChatControlOptions;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Properties for configuring the File Sharing feature.
    * If undefined, file sharing feature will be disabled.
@@ -282,7 +282,7 @@ type CallWithChatScreenProps = {
   callControls?: boolean | CallWithChatControlOptions;
   onFetchAvatarPersonaData?: AvatarPersonaDataCallback;
   onFetchParticipantMenuItems?: ParticipantMenuItemsCallback;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   fileSharing?: FileSharingOptions;
   rtl?: boolean;
   /* @conditional-compile-remove(call-readiness) */
@@ -574,7 +574,7 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
           topic: false,
           /* @conditional-compile-remove(chat-composite-participant-pane) */
           participantPane: false,
-          /* @conditional-compile-remove(file-sharing) */
+          /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
           fileSharing: props.fileSharing
         }}
         onFetchAvatarPersonaData={props.onFetchAvatarPersonaData}
@@ -582,7 +582,7 @@ const CallWithChatScreen = (props: CallWithChatScreenProps): JSX.Element => {
     ),
     [
       chatAdapter,
-      /* @conditional-compile-remove(file-sharing) */ props.fileSharing,
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ props.fileSharing,
       props.onFetchAvatarPersonaData,
       theme
     ]
@@ -684,7 +684,7 @@ export const CallWithChatComposite = (props: CallWithChatCompositeProps): JSX.El
         joinInvitationURL={joinInvitationURL}
         fluentTheme={fluentTheme}
         remoteVideoTileMenuOptions={options?.remoteVideoTileMenuOptions}
-        /* @conditional-compile-remove(file-sharing) */
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
         fileSharing={options?.fileSharing}
         localVideoTile={options?.localVideoTile}
         galleryOptions={options?.galleryOptions}

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -23,7 +23,7 @@ import { StartCaptionsOptions } from '@azure/communication-calling';
 import { AddPhoneNumberOptions } from '@azure/communication-calling';
 import { DtmfTone } from '@azure/communication-calling';
 import { CreateVideoStreamViewResult, VideoStreamOptions } from '@internal/react-components';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata, FileUploadManager } from '@internal/react-components';
 import {
   ParticipantsJoinedListener,
@@ -213,19 +213,19 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
     this.deleteMessage.bind(this);
     this.on.bind(this);
     this.off.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.registerActiveFileUploads = this.registerActiveFileUploads.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.registerCompletedFileUploads = this.registerCompletedFileUploads.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.clearFileUploads = this.clearFileUploads.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.cancelFileUpload = this.cancelFileUpload.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.updateFileUploadProgress = this.updateFileUploadProgress.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.updateFileUploadErrorMessage = this.updateFileUploadErrorMessage.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.updateFileUploadMetadata = this.updateFileUploadMetadata.bind(this);
     this.downloadResourceToCache = this.downloadResourceToCache.bind(this);
     this.removeResourceFromCache = this.removeResourceFromCache.bind(this);
@@ -427,7 +427,7 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
     content: string,
     metadata?: Record<string, string>,
     options?: {
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       attachmentMetadata?: AttachmentMetadata[];
     }
   ): Promise<void> {
@@ -435,38 +435,38 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
       messageId,
       content,
       metadata,
-      /* @conditional-compile-remove(file-sharing) */ options
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ options
     );
   }
   /** Delete an existing message. */
   public async deleteMessage(messageId: string): Promise<void> {
     return await this.chatAdapter.deleteMessage(messageId);
   }
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public registerActiveFileUploads = (files: File[]): FileUploadManager[] => {
     return this.chatAdapter.registerActiveFileUploads(files);
   };
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public registerCompletedFileUploads = (metadata: AttachmentMetadata[]): FileUploadManager[] => {
     return this.chatAdapter.registerCompletedFileUploads(metadata);
   };
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public clearFileUploads = (): void => {
     this.chatAdapter.clearFileUploads();
   };
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public cancelFileUpload = (id: string): void => {
     this.chatAdapter.cancelFileUpload(id);
   };
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public updateFileUploadProgress = (id: string, progress: number): void => {
     this.chatAdapter.updateFileUploadProgress(id, progress);
   };
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public updateFileUploadErrorMessage = (id: string, errorMessage: string): void => {
     this.chatAdapter.updateFileUploadErrorMessage(id, errorMessage);
   };
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public updateFileUploadMetadata = (id: string, metadata: AttachmentMetadata): void => {
     this.chatAdapter.updateFileUploadMetadata(id, metadata);
   };

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
@@ -44,9 +44,9 @@ import { DtmfTone } from '@azure/communication-calling';
 import { CreateVideoStreamViewResult, VideoStreamOptions } from '@internal/react-components';
 import { SendMessageOptions } from '@azure/communication-chat';
 import { JoinCallOptions } from '../../CallComposite/adapter/CallAdapter';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata } from '@internal/react-components';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileUploadManager } from '@internal/react-components';
 /* @conditional-compile-remove(PSTN-calls) */
 import { PhoneNumberIdentifier } from '@azure/communication-common';
@@ -376,25 +376,25 @@ export interface CallWithChatAdapterManagement {
    * @public
    */
   loadPreviousChatMessages(messagesToLoad: number): Promise<boolean>;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /** @beta */
   registerActiveFileUploads: (files: File[]) => FileUploadManager[];
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /** @beta */
   registerCompletedFileUploads: (metadata: AttachmentMetadata[]) => FileUploadManager[];
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /** @beta */
   clearFileUploads: () => void;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /** @beta */
   cancelFileUpload: (id: string) => void;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /** @beta */
   updateFileUploadProgress: (id: string, progress: number) => void;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /** @beta */
   updateFileUploadErrorMessage: (id: string, errorMessage: string) => void;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /** @beta */
   updateFileUploadMetadata: (id: string, metadata: AttachmentMetadata) => void;
   /** @public */

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedChatAdapter.ts
@@ -4,9 +4,9 @@
 import { CallWithChatAdapter } from './CallWithChatAdapter';
 import { ChatAdapter, ChatAdapterState } from '../../ChatComposite';
 import { ResourceDetails } from '../../ChatComposite';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileUploadManager } from '@internal/react-components';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata } from '@internal/react-components';
 import { ErrorBarStrings } from '@internal/react-components';
 import { CallWithChatAdapterState } from '../state/CallWithChatAdapterState';
@@ -93,37 +93,37 @@ export class CallWithChatBackedChatAdapter implements ChatAdapter {
     throw new Error(`Chat Topics are not supported in CallWithChatComposite.`);
   };
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public registerActiveFileUploads = (files: File[]): FileUploadManager[] => {
     return this.callWithChatAdapter.registerActiveFileUploads(files);
   };
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public registerCompletedFileUploads = (metadata: AttachmentMetadata[]): FileUploadManager[] => {
     return this.callWithChatAdapter.registerCompletedFileUploads(metadata);
   };
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public clearFileUploads = (): void => {
     this.callWithChatAdapter.clearFileUploads();
   };
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public cancelFileUpload = (id: string): void => {
     this.callWithChatAdapter.cancelFileUpload(id);
   };
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public updateFileUploadProgress = (id: string, progress: number): void => {
     this.callWithChatAdapter.updateFileUploadProgress(id, progress);
   };
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public updateFileUploadErrorMessage = (id: string, errorMessage: string): void => {
     this.callWithChatAdapter.updateFileUploadErrorMessage(id, errorMessage);
   };
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   public updateFileUploadMetadata = (id: string, metadata: AttachmentMetadata): void => {
     this.callWithChatAdapter.updateFileUploadMetadata(id, metadata);
   };
@@ -148,7 +148,7 @@ function chatAdapterStateFromCallWithChatAdapterState(
     displayName: callWithChatAdapterState.displayName || '',
     thread: callWithChatAdapterState.chat,
     latestErrors: callWithChatAdapterState.latestChatErrors,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     fileUploads: callWithChatAdapterState.fileUploads
   };
 }

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatTypeAssertions.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatTypeAssertions.ts
@@ -12,7 +12,7 @@ import { ChatAdapterThreadManagement, ChatAdapterUiState } from '../../ChatCompo
 import { CallWithChatControlOptions } from '../CallWithChatComposite';
 import { CallWithChatAdapterUiState, CallWithChatClientState } from '../state/CallWithChatAdapterState';
 import { CallWithChatAdapterManagement } from './CallWithChatAdapter';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileUploadAdapter } from '../../ChatComposite';
 
 /// IMPORTANT
@@ -30,7 +30,7 @@ import { FileUploadAdapter } from '../../ChatComposite';
 type CallWithChatAdapterManagementInternal = Omit<CallAdapterCallManagement, 'removeParticipant' | 'onReactionClick'> &
   CallAdapterDeviceManagement &
   Omit<ChatAdapterThreadManagement, 'removeParticipant' | 'setTopic'> &
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   FileUploadAdapter;
 
 const CallWithChatAdapterManagementTypeAssertion = (

--- a/packages/react-composites/src/composites/CallWithChatComposite/state/CallWithChatAdapterState.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/state/CallWithChatAdapterState.ts
@@ -10,7 +10,7 @@ import { VideoBackgroundImage, VideoBackgroundEffect } from '../../CallComposite
 
 import { VideoBackgroundEffectsDependency } from '@internal/calling-component-bindings';
 import { ChatAdapter, ChatAdapterState } from '../../ChatComposite';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileUploadsUiState } from '../../ChatComposite';
 import { AdapterErrors } from '../../common/adapters';
 /* @conditional-compile-remove(unsupported-browser) */
@@ -36,7 +36,7 @@ export interface CallWithChatAdapterUiState {
    * @public
    */
   page: CallCompositePage;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Files being uploaded by a user in the current thread.
    * Should be set to null once the upload is complete.
@@ -133,7 +133,7 @@ export function callWithChatAdapterStateFromBackingStates(
     isTeamsCall: callAdapterState.isTeamsCall,
     latestCallErrors: callAdapterState.latestErrors,
     latestChatErrors: chatAdapterState.latestErrors,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     fileUploads: chatAdapterState.fileUploads,
     /* @conditional-compile-remove(PSTN-calls) */
     alternateCallerId: callAdapterState.alternateCallerId,
@@ -164,7 +164,7 @@ export function mergeChatAdapterStateIntoCallWithChatAdapterState(
     ...existingCallWithChatAdapterState,
     chat: chatAdapterState.thread,
     latestChatErrors: chatAdapterState.latestErrors,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     fileUploads: chatAdapterState.fileUploads
   };
 }

--- a/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatComposite.tsx
@@ -9,7 +9,7 @@ import { ChatAdapter } from './adapter/ChatAdapter';
 import { ChatAdapterProvider } from './adapter/ChatAdapterProvider';
 import { chatScreenContainerStyle } from './styles/Chat.styles';
 import { ChatScreen } from './ChatScreen';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileSharingOptions } from './ChatScreen';
 
 /**
@@ -37,7 +37,7 @@ export interface ChatCompositeProps extends BaseCompositeProps<ChatCompositeIcon
    * Flags to enable/disable visual elements of the {@link ChatComposite}.
    */
   options?: ChatCompositeOptions;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Optimizes the composite form factor for either desktop or mobile.
    * @remarks `mobile` is currently only optimized for Portrait mode on mobile devices and does not support landscape.
@@ -77,7 +77,7 @@ export type ChatCompositeOptions = {
    */
   autoFocus?: 'sendBoxTextField';
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Properties for configuring the File Sharing feature.
    * If undefined, file sharing feature will be disabled.
@@ -120,7 +120,7 @@ export const ChatComposite = (props: ChatCompositeProps): JSX.Element => {
     onFetchParticipantMenuItems
   } = props;
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const formFactor = props['formFactor'] || 'desktop';
 
   return (
@@ -128,14 +128,14 @@ export const ChatComposite = (props: ChatCompositeProps): JSX.Element => {
       <BaseProvider {...props}>
         <ChatAdapterProvider adapter={adapter}>
           <ChatScreen
-            /* @conditional-compile-remove(file-sharing) */
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
             formFactor={formFactor}
             options={options}
             onFetchAvatarPersonaData={onFetchAvatarPersonaData}
             onRenderTypingIndicator={onRenderTypingIndicator}
             onRenderMessage={onRenderMessage}
             onFetchParticipantMenuItems={onFetchParticipantMenuItems}
-            /* @conditional-compile-remove(file-sharing) */
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
             fileSharing={options?.fileSharing}
           />
         </ChatAdapterProvider>

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -17,7 +17,7 @@ import {
   TypingIndicatorStylesProps,
   useTheme
 } from '@internal/react-components';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ChatMessage } from '@internal/react-components';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useState } from 'react';
@@ -25,7 +25,7 @@ import { AvatarPersona, AvatarPersonaDataCallback, AvatarPersonaProps } from '..
 import { useAdapter } from './adapter/ChatAdapterProvider';
 import { ChatCompositeOptions } from './ChatComposite';
 import { ChatHeader, getHeaderProps } from './ChatHeader';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileDownloadHandler } from '@internal/react-components';
 import { FileUploadHandler } from '@internal/react-components';
 import { FileUploadButtonWrapper as FileUploadButton } from './file-sharing';
@@ -44,7 +44,7 @@ import { participantListContainerPadding } from '../common/styles/ParticipantCon
 /* @conditional-compile-remove(chat-composite-participant-pane) */
 import { ChatScreenPeoplePane } from './ChatScreenPeoplePane';
 import { toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileDownloadErrorBar } from './FileDownloadErrorBar';
 import { _AttachmentDownloadCards } from '@internal/react-components';
 import { ImageOverlay } from '@internal/react-components';
@@ -99,7 +99,7 @@ export interface FileSharingOptions {
    * @beta
    */
   uploadHandler: FileUploadHandler;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * A function of type {@link FileDownloadHandler} for handling file downloads.
    * If the function is not specified, the file's `url` will be opened in a new tab to
@@ -135,7 +135,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
   } = props;
 
   const defaultNumberOfChatMessagesToReload = 5;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const [downloadErrorMessage, setDownloadErrorMessage] = React.useState('');
   const [overlayImageItem, setOverlayImageItem] = useState<OverlayImageItem>();
   const [isImageOverlayOpen, setIsImageOverlayOpen] = useState<boolean>(false);
@@ -227,15 +227,15 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
         return;
       }
 
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       const fileUploads = adapter.registerActiveFileUploads(Array.from(files));
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       fileSharing?.uploadHandler(userId, fileUploads);
     },
     [adapter, fileSharing, userId]
   );
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const onRenderFileDownloads = useCallback(
     (userId: string, message: ChatMessage) => (
       <_AttachmentDownloadCards
@@ -391,7 +391,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
         <Stack className={chatWrapper} grow>
           {options?.errorBar !== false && <ErrorBar {...errorBarProps} />}
           {
-            /* @conditional-compile-remove(file-sharing) */
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
             <FileDownloadErrorBar
               onDismissDownloadErrorMessage={useCallback(() => {
                 setDownloadErrorMessage('');
@@ -403,7 +403,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
             {...messageThreadProps}
             onRenderAvatar={onRenderAvatarCallback}
             onRenderMessage={onRenderMessage}
-            /* @conditional-compile-remove(file-sharing) */
+            /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
             onRenderFileDownloads={onRenderFileDownloads}
             inlineImageOptions={inlineImageOptions}
             numberOfChatMessagesToReload={defaultNumberOfChatMessagesToReload}
@@ -427,7 +427,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
                 <SendBox
                   options={options}
                   styles={styles?.sendBox}
-                  /* @conditional-compile-remove(file-sharing) */
+                  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
                   adapter={adapter}
                 />
               </Stack>

--- a/packages/react-composites/src/composites/ChatComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/Strings.tsx
@@ -14,7 +14,7 @@ export interface ChatCompositeStrings {
    */
   chatListHeader: string;
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Upload File Button text
    */

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -34,15 +34,15 @@ import {
 } from './ChatAdapter';
 import { ResourceDetails } from './ChatAdapter';
 import { AdapterError } from '../../common/adapters';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileUploadAdapter, convertFileUploadsUiStateToMessageMetadata } from './AzureCommunicationFileUploadAdapter';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AzureCommunicationFileUploadAdapter } from './AzureCommunicationFileUploadAdapter';
 import { useEffect, useRef, useState } from 'react';
 import { _isValidIdentifier } from '@internal/acs-ui-common';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata } from '@internal/react-components';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileUploadManager } from '@internal/react-components';
 
 /**
@@ -102,7 +102,7 @@ export class ChatContext {
       latestErrors: clientState.latestErrors
     };
 
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     updatedState = { ...updatedState, fileUploads: this.state.fileUploads };
 
     this.setState(updatedState);
@@ -116,7 +116,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
   private chatClient: StatefulChatClient;
   private chatThreadClient: ChatThreadClient;
   private context: ChatContext;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   private fileUploadAdapter: FileUploadAdapter;
   private handlers: ChatHandlers;
   private emitter: EventEmitter = new EventEmitter();
@@ -126,7 +126,7 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
     this.chatClient = chatClient;
     this.chatThreadClient = chatThreadClient;
     this.context = new ChatContext(chatClient.getState(), chatThreadClient.threadId);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.fileUploadAdapter = new AzureCommunicationFileUploadAdapter(this.context);
 
     const onStateChange = (clientState: ChatClientState): void => {
@@ -160,19 +160,19 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
     this.loadPreviousChatMessages = this.loadPreviousChatMessages.bind(this);
     this.on = this.on.bind(this);
     this.off = this.off.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.registerActiveFileUploads = this.registerActiveFileUploads.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.registerCompletedFileUploads = this.registerCompletedFileUploads.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.clearFileUploads = this.clearFileUploads.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.cancelFileUpload = this.cancelFileUpload.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.updateFileUploadProgress = this.updateFileUploadProgress.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.updateFileUploadErrorMessage = this.updateFileUploadErrorMessage.bind(this);
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     this.updateFileUploadMetadata = this.updateFileUploadMetadata.bind(this);
     this.downloadResourceToCache = this.downloadResourceToCache.bind(this);
     this.removeResourceFromCache = this.removeResourceFromCache.bind(this);
@@ -210,13 +210,13 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
 
   async sendMessage(content: string, options: SendMessageOptions = {}): Promise<void> {
     await this.asyncTeeErrorToEventEmitter(async () => {
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       options.metadata = {
         ...options.metadata,
         ...convertFileUploadsUiStateToMessageMetadata(this.context.getState().fileUploads)
       };
 
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       /**
        * All the current uploads need to be clear from the state before a message has been sent.
        * This ensures the following behavior:
@@ -265,14 +265,14 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
     content: string,
     metadata?: Record<string, string>,
     options?: {
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       attachmentMetadata?: AttachmentMetadata[];
     }
   ): Promise<void> {
     return await this.asyncTeeErrorToEventEmitter(async () => {
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       const updatedOptions = { attachmentMetadata: options?.attachmentMetadata, metadata: metadata };
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       return await this.handlers.onUpdateMessage(messageId, content, updatedOptions);
       return await this.handlers.onUpdateMessage(messageId, content);
     });
@@ -284,37 +284,37 @@ export class AzureCommunicationChatAdapter implements ChatAdapter {
     });
   }
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   registerActiveFileUploads(files: File[]): FileUploadManager[] {
     return this.fileUploadAdapter.registerActiveFileUploads(files);
   }
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   registerCompletedFileUploads(metadata: AttachmentMetadata[]): FileUploadManager[] {
     return this.fileUploadAdapter.registerCompletedFileUploads(metadata);
   }
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   clearFileUploads(): void {
     this.fileUploadAdapter.clearFileUploads();
   }
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   cancelFileUpload(id: string): void {
     this.fileUploadAdapter.cancelFileUpload(id);
   }
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   updateFileUploadProgress(id: string, progress: number): void {
     this.fileUploadAdapter.updateFileUploadProgress(id, progress);
   }
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   updateFileUploadErrorMessage(id: string, errorMessage: string): void {
     this.fileUploadAdapter.updateFileUploadErrorMessage(id, errorMessage);
   }
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   updateFileUploadMetadata(id: string, metadata: AttachmentMetadata): void {
     this.fileUploadAdapter.updateFileUploadMetadata(id, metadata);
   }

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationFileUploadAdapter.test.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationFileUploadAdapter.test.ts
@@ -1,24 +1,24 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ChatErrors, ChatThreadClientState } from '@internal/chat-stateful-client';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { produce } from 'immer';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { v1 as generateGUID } from 'uuid';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ChatAdapterState } from '..';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ChatContext } from './AzureCommunicationChatAdapter';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AzureCommunicationFileUploadAdapter } from './AzureCommunicationFileUploadAdapter';
 
 test('workaround for conditional compilation. Test suite must contain at least one test', () => {
   expect(true).toBeTruthy();
 });
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 describe('registerFileUploads()', () => {
   test('should create file uploads in state', () => {
     const chatContext = createChatContext();
@@ -67,7 +67,7 @@ describe('registerFileUploads()', () => {
   });
 });
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 describe('clearFileUploads()', () => {
   test('should remove all file uploads from state', () => {
     const chatContext = createChatContext();
@@ -78,7 +78,7 @@ describe('clearFileUploads()', () => {
   });
 });
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 describe('cancelFileUpload()', () => {
   test('should remove file upload from state', () => {
     const chatContext = createChatContext();
@@ -91,7 +91,7 @@ describe('cancelFileUpload()', () => {
   });
 });
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 const createChatContext = (): ChatContext =>
   new ChatContext(
     {
@@ -105,7 +105,7 @@ const createChatContext = (): ChatContext =>
     'threadId'
   );
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 const generateFiles = (quantity: number): File[] => {
   return Array.from({ length: quantity }, () => new File([], generateGUID(), { type: 'text/plain' }));
 };

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationFileUploadAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationFileUploadAdapter.ts
@@ -3,13 +3,13 @@
 
 import { AttachmentMetadata } from '@internal/react-components';
 import { FileUploadManager, FileUploadState } from '@internal/react-components';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { produce } from 'immer';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileSharingMetadata, FileUpload } from '../file-sharing';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ChatContext } from './AzureCommunicationChatAdapter';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ChatAdapterState } from './ChatAdapter';
 
 /**
@@ -31,7 +31,7 @@ export interface FileUploadAdapter {
   updateFileUploadMetadata: (id: string, metadata: AttachmentMetadata) => void;
 }
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 /**
  * @internal
  */
@@ -88,7 +88,7 @@ class FileUploadContext {
   }
 }
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 /**
  * @internal
  */
@@ -184,7 +184,7 @@ export class AzureCommunicationFileUploadAdapter implements FileUploadAdapter {
   }
 }
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 /**
  * @param fileUploadUiState {@link FileUploadsUiState}
  * @private
@@ -207,7 +207,7 @@ export const convertFileUploadsUiStateToMessageMetadata = (
   return undefined;
 };
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 /**
  * @private
  */

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapter.ts
@@ -5,9 +5,9 @@ import type { ChatMessage, ChatParticipant, SendMessageOptions } from '@azure/co
 import type { CommunicationIdentifierKind, CommunicationUserKind } from '@azure/communication-common';
 import { ChatThreadClientState } from '@internal/chat-stateful-client';
 import type { AdapterError, AdapterErrors, AdapterState, Disposable } from '../../common/adapters';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { FileUploadAdapter, FileUploadsUiState } from './AzureCommunicationFileUploadAdapter';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata } from '@internal/react-components';
 
 /**
@@ -19,7 +19,7 @@ export type ChatAdapterUiState = {
   // FIXME(Delete?)
   // Self-contained state for composite
   error?: Error;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   /**
    * Files being uploaded by a user in the current thread.
    * Should be set to null once the upload is complete.
@@ -90,7 +90,7 @@ export interface ChatAdapterThreadManagement {
     messageId: string,
     content: string,
     metadata?: Record<string, string>,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     options?: {
       attachmentMetadata?: AttachmentMetadata[];
     }
@@ -217,7 +217,7 @@ export type ChatAdapter = ChatAdapterThreadManagement &
   AdapterState<ChatAdapterState> &
   Disposable &
   ChatAdapterSubscribers &
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   FileUploadAdapter;
 
 /**

--- a/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapterProvider.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/ChatAdapterProvider.tsx
@@ -39,7 +39,7 @@ export const useAdapter = (): ChatAdapter => {
  * @private
  */
 export const useFileUploadAdapter = (): FileUploadAdapter => {
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   return useAdapter();
   // A stub that short-circuits all logic because none of the fields are available.
   return {

--- a/packages/react-composites/src/composites/ChatComposite/file-sharing/FileUploadButton.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/file-sharing/FileUploadButton.tsx
@@ -4,7 +4,7 @@
 import { IconButton, mergeStyles, Stack, useTheme } from '@fluentui/react';
 import React from 'react';
 import { ChatCompositeIcon } from '../../common/icons';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { useLocale } from '../../localization';
 
 /**
@@ -93,7 +93,7 @@ export const FileUploadButton = (props: FileUploadButtonProps): JSX.Element => {
 };
 
 const SendBoxAttachFileIconTrampoline = (): JSX.Element => {
-  // @conditional-compile-remove(file-sharing)
+  // @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload)
   return <ChatCompositeIcon iconName="SendBoxAttachFile" />;
   // Return _some_ available icon, as the real icon is beta-only.
   return <ChatCompositeIcon iconName="EditBoxCancel" />;
@@ -112,7 +112,7 @@ export const FileUploadButtonWrapper = (
   return (
     <>
       {
-        /* @conditional-compile-remove(file-sharing) */
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
         <FileUploadButton {...props} />
       }
     </>
@@ -120,7 +120,7 @@ export const FileUploadButtonWrapper = (
 };
 
 const uploadFileButtonStringTrampoline = (): string => {
-  //@conditional-compile-remove(file-sharing)
+  //@conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload)
   //eslint-disable-next-line react-hooks/rules-of-hooks
   return useLocale().strings.chat.uploadFile;
   return '';

--- a/packages/react-composites/src/composites/ChatComposite/hooks/useHandlers.ts
+++ b/packages/react-composites/src/composites/ChatComposite/hooks/useHandlers.ts
@@ -8,7 +8,7 @@ import { ReactElement } from 'react';
 import memoizeOne from 'memoize-one';
 import { ChatAdapter } from '../adapter/ChatAdapter';
 import { useAdapter } from '../adapter/ChatAdapterProvider';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { AttachmentMetadata } from '@internal/react-components';
 
 /**
@@ -33,21 +33,21 @@ const createCompositeHandlers = memoizeOne(
     onUpdateMessage: (
       messageId: string,
       content: string,
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       options?: {
         metadata?: Record<string, string>;
-        /* @conditional-compile-remove(file-sharing) */
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
         attachmentMetadata?: AttachmentMetadata[];
       }
     ) => {
       const metadata = options?.metadata;
-      /* @conditional-compile-remove(file-sharing) */
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
       const updatedOptions = options?.attachmentMetadata ? { ...options.attachmentMetadata } : {};
       return adapter.updateMessage(
         messageId,
         content,
         metadata,
-        /* @conditional-compile-remove(file-sharing) */ updatedOptions
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ updatedOptions
       );
     },
     onDeleteMessage: adapter.deleteMessage

--- a/packages/react-composites/src/composites/ChatComposite/index.ts
+++ b/packages/react-composites/src/composites/ChatComposite/index.ts
@@ -33,9 +33,9 @@ export type { ResourceDetails } from './adapter/ChatAdapter';
 
 export * from './Strings';
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 export type { FileUploadHandler, FileUploadManager, FileUploadState, FileUploadError } from './file-sharing';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 export type { FileSharingOptions } from './ChatScreen';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 export type { FileUploadsUiState, FileUploadAdapter } from './adapter/AzureCommunicationFileUploadAdapter';

--- a/packages/react-composites/src/composites/ChatComposite/selectors/baseSelectors.ts
+++ b/packages/react-composites/src/composites/ChatComposite/selectors/baseSelectors.ts
@@ -14,7 +14,7 @@ export const getUserId = (state: ChatAdapterState): CommunicationIdentifierKind 
  * @private
  */
 export const getFileUploads = (state: ChatAdapterState): FileUploadsUiState | undefined => {
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   return state?.fileUploads;
   return undefined;
 };

--- a/packages/react-composites/src/composites/common/SendBox.tsx
+++ b/packages/react-composites/src/composites/common/SendBox.tsx
@@ -7,11 +7,11 @@ import { usePropsFor } from '../ChatComposite/hooks/usePropsFor';
 import { ChatCompositeOptions } from '../ChatComposite';
 /* @conditional-compile-remove(rich-text-editor) */
 import { Suspense } from 'react';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { ChatAdapter } from '../ChatComposite';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { fileUploadsSelector } from '../ChatComposite/selectors/fileUploadsSelector';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { useSelector } from '../ChatComposite/hooks/useSelector';
 
 /* @conditional-compile-remove(rich-text-editor) */
@@ -25,7 +25,7 @@ const RichTextSendBoxWrapper = React.lazy(() =>
 export type SendBoxProps = {
   options?: ChatCompositeOptions;
   styles?: SendBoxStylesProps;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   adapter: ChatAdapter;
 };
 
@@ -36,13 +36,13 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
   const {
     options,
     styles,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     adapter
   } = props;
 
   const sendBoxProps = usePropsFor(SimpleSendBox);
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   const activeFileUploads = useSelector(fileUploadsSelector).files;
 
   const sendBoxStyles = useMemo(() => {
@@ -55,9 +55,9 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
         {...sendBoxProps}
         autoFocus={options?.autoFocus}
         styles={sendBoxStyles}
-        /* @conditional-compile-remove(file-sharing) */
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
         activeFileUploads={activeFileUploads}
-        /* @conditional-compile-remove(file-sharing) */
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
         onCancelFileUpload={adapter.cancelFileUpload}
       />
     ),
@@ -65,8 +65,8 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
       sendBoxProps,
       options,
       sendBoxStyles,
-      /* @conditional-compile-remove(file-sharing) */ activeFileUploads,
-      /* @conditional-compile-remove(file-sharing) */ adapter
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ activeFileUploads,
+      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */ adapter
     ]
   );
 

--- a/packages/react-composites/src/composites/common/icons.tsx
+++ b/packages/react-composites/src/composites/common/icons.tsx
@@ -32,7 +32,7 @@ import { DEFAULT_COMPONENT_ICONS } from '@internal/react-components';
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { FontIcon, IIconProps, Spinner, SpinnerSize } from '@fluentui/react';
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 import { Attach20Regular } from '@fluentui/react-icons';
 
 import { VideoBackgroundEffect20Regular, VideoPerson20Filled } from '@fluentui/react-icons';
@@ -87,7 +87,7 @@ export const COMPOSITE_ONLY_ICONS: CompositeIcons = {
   NoticePageRoomNotValid: <Info20Filled />,
   NoticePageCallRejected: <Info20Filled />,
   NoticePageCallTimeout: <Info20Filled />,
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   SendBoxAttachFile: <Attach20Regular />,
   /* @conditional-compile-remove(PSTN-calls) */
   PeoplePaneAddPerson: <PersonAdd20Regular />,
@@ -146,7 +146,7 @@ export type ChatCompositeIcons = {
   ParticipantItemOptionsHovered?: JSX.Element;
   SendBoxSend?: JSX.Element;
   SendBoxSendHovered?: JSX.Element;
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   SendBoxAttachFile?: JSX.Element;
 };
 

--- a/packages/react-composites/tests/app/chat/FakeAdapterApp.tsx
+++ b/packages/react-composites/tests/app/chat/FakeAdapterApp.tsx
@@ -135,7 +135,7 @@ const handleFileUploads = (adapter: ChatAdapter, fileUploads: _MockFileUpload[])
         name: file.name,
         extension: file.extension,
         url: file.url,
-        /* @conditional-compile-remove(file-sharing) */
+        /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
         id: file.id
       });
     } else if (file.error) {

--- a/packages/react-composites/tests/browser/chat/hermetic/FileSharing.test.ts
+++ b/packages/react-composites/tests/browser/chat/hermetic/FileSharing.test.ts
@@ -6,7 +6,7 @@ import { sendMessage, waitForMessageDelivered } from '../../common/chatTestHelpe
 import { dataUiId, stableScreenshot, waitForSelector } from '../../common/utils';
 import { buildUrlForChatAppUsingFakeAdapter, DEFAULT_FAKE_CHAT_ADAPTER_ARGS, test, TEST_PARTICIPANTS } from './fixture';
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 test.describe('Filesharing Attach file icon', async () => {
   test('is not visible if filesharing options are undefined', async ({ serverUrl, page }) => {
     await page.goto(buildUrlForChatAppUsingFakeAdapter(serverUrl, DEFAULT_FAKE_CHAT_ADAPTER_ARGS));
@@ -25,7 +25,7 @@ test.describe('Filesharing Attach file icon', async () => {
   });
 });
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 test.describe('Filesharing SendBox', async () => {
   test('shows file cards for uploaded files', async ({ serverUrl, page }) => {
     await page.goto(
@@ -60,7 +60,7 @@ test.describe('Filesharing SendBox', async () => {
   });
 });
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 test.describe('Filesharing ProgressBar', async () => {
   test('is visible if progress is between 0 and 1', async ({ serverUrl, page }) => {
     await page.goto(
@@ -165,7 +165,7 @@ test.describe('Filesharing ProgressBar', async () => {
   });
 });
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 test.describe('Filesharing SendBox Errorbar', async () => {
   test('shows file upload error', async ({ serverUrl, page }) => {
     await page.goto(
@@ -217,7 +217,7 @@ test.describe('Filesharing SendBox Errorbar', async () => {
   });
 });
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 test.describe('Filesharing Global Errorbar', async () => {
   test('shows file download error', async ({ serverUrl, page }) => {
     await page.goto(
@@ -252,7 +252,7 @@ test.describe('Filesharing Global Errorbar', async () => {
   });
 });
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 test.describe('Filesharing Message Thread', async () => {
   test('contains File Download Card', async ({ serverUrl, page }) => {
     await page.goto(
@@ -285,7 +285,7 @@ test.describe('Filesharing Message Thread', async () => {
     ).toMatchSnapshot('filesharing-file-download-card-in-sent-messages.png');
   });
 
-  /* @conditional-compile-remove(file-sharing) */
+  /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
   test('contains File Download Card in remote message', async ({ serverUrl, page }) => {
     await page.goto(
       buildUrlForChatAppUsingFakeAdapter(serverUrl, {
@@ -307,7 +307,7 @@ test.describe('Filesharing Message Thread', async () => {
   });
 });
 
-/* @conditional-compile-remove(file-sharing) */
+/* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
 test.describe('Filesharing Edit Message', async () => {
   test.beforeEach(async ({ serverUrl, page }) => {
     await page.goto(

--- a/packages/storybook/stories/INTERNAL/RTE/RTESendBox.stories.tsx
+++ b/packages/storybook/stories/INTERNAL/RTE/RTESendBox.stories.tsx
@@ -70,11 +70,11 @@ export default {
     systemMessage: { control: 'text', defaultValue: undefined },
     isSendBoxWithWarning: { control: 'boolean', defaultValue: false, name: 'Has warning/information message' },
     strings: hiddenControl,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     onRenderFileUploads: hiddenControl,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     activeFileUploads: hiddenControl,
-    /* @conditional-compile-remove(file-sharing) */
+    /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
     onCancelFileUpload: hiddenControl,
     onSendMessage: hiddenControl
   },


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Split `file-sharing` conditional compile to attachment flags to `attachment-download` and `attachment-upload`
- No code change
- Separate PR will remove download/upload flag to things that are related to them respectively

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->