### PR TITLE
Fix missing remove participant drawer menu item

### DIFF
--- a/change-beta/@azure-communication-react-30ceae58-a866-4095-8c53-86fef5c19b5d.json
+++ b/change-beta/@azure-communication-react-30ceae58-a866-4095-8c53-86fef5c19b5d.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Remove participant",
+  "comment": "Fix the absence of remove participant drawer menu item in group and interop calls on mobile",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-30ceae58-a866-4095-8c53-86fef5c19b5d.json
+++ b/change/@azure-communication-react-30ceae58-a866-4095-8c53-86fef5c19b5d.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Remove participant",
+  "comment": "Fix the absence of remove participant drawer menu item in group and interop calls on mobile",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
+++ b/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
@@ -223,8 +223,11 @@ const createDefaultContextualMenuItems = (
 };
 
 const canRemoveParticipants = (adapter: CommonCallAdapter): boolean => {
-  const removeParticipantCapability = adapter.getState().call?.capabilitiesFeature?.capabilities.removeParticipant;
-  // If 'removeParticipant' capability is undefined then we will default to true
-  const canRemoveParticipants = removeParticipantCapability ? removeParticipantCapability.isPresent : true;
-  return canRemoveParticipants;
+  // TODO: We should be using the removeParticipant capability here but there is an SDK bug for Rooms where a
+  // Presenter's removeParticipant capability is {isPresent: false, reason: 'CapabilityNotApplicableForTheCallType'}.
+  // But a Presenter in Rooms should be able to remove participants according to the following documentation
+  // https://learn.microsoft.com/en-us/azure/communication-services/concepts/rooms/room-concept#predefined-participant-roles-and-permissions
+  const role = adapter.getState().call?.role;
+  const canRemove = role === 'Presenter' || role === 'Unknown' || role === undefined;
+  return canRemove;
 };

--- a/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
+++ b/packages/react-composites/src/composites/common/PeoplePaneContent.tsx
@@ -19,6 +19,7 @@ import { ParticipantListWithHeading } from '../common/ParticipantContainer';
 import { peoplePaneContainerTokens } from '../common/styles/ParticipantContainer.styles';
 import { participantListContainerStyles, peoplePaneContainerStyle } from './styles/PeoplePaneContent.styles';
 import { convertContextualMenuItemToDrawerMenuItem } from './ConvertContextualMenuItemToDrawerMenuItem';
+import { CommonCallAdapter } from '../CallComposite';
 /* @conditional-compile-remove(one-to-n-calling) @conditional-compile-remove(PSTN-calls) */
 import { CallCompositeStrings } from '../CallComposite';
 import { AddPeopleButton } from './AddPeopleButton';
@@ -78,7 +79,7 @@ export const PeoplePaneContent = (props: {
   const alternateCallerId = adapter.getState().alternateCallerId;
 
   const participantListDefaultProps = usePropsFor(ParticipantList);
-  const removeButtonAllowed = adapter.getState().call?.capabilitiesFeature?.capabilities.removeParticipant.isPresent;
+  const removeButtonAllowed = canRemoveParticipants(adapter);
   const setDrawerMenuItemsForParticipant: (participant?: ParticipantListParticipant) => void = useMemo(() => {
     return (participant?: ParticipantListParticipant) => {
       if (participant) {
@@ -219,4 +220,11 @@ const createDefaultContextualMenuItems = (
     });
   }
   return menuItems;
+};
+
+const canRemoveParticipants = (adapter: CommonCallAdapter): boolean => {
+  const removeParticipantCapability = adapter.getState().call?.capabilitiesFeature?.capabilities.removeParticipant;
+  // If 'removeParticipant' capability is undefined then we will default to true
+  const canRemoveParticipants = removeParticipantCapability ? removeParticipantCapability.isPresent : true;
+  return canRemoveParticipants;
 };


### PR DESCRIPTION
# What
Fix the absence of remove participant drawer menu item in group calls and interop due to the capability for removeParticipant being undefined.

Bug introduced from my PR: https://github.com/Azure/communication-ui-library/pull/4312/files#diff-f58bdd76c9f8e75269e3e181a242a9e249fa15c77497d9cfddbe0c93f051c295R72

# Why
Remove participant menu item is not showing up on mobile during bug bash for 1.15.0-beta.1 release

# How Tested
Verified the fix on Android phone

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->