### PR TITLE
[Bugfix] add RoomCallLocator to the types for CallWithChatComposite

### DIFF
--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -9,6 +9,7 @@ import {
   Call,
   CallAgent,
   GroupCallLocator,
+  RoomCallLocator,
   PermissionConstraints,
   PropertyChangedEvent,
   TeamsMeetingLinkLocator,
@@ -958,7 +959,7 @@ export type CommunicationAdapter =
  */
 export interface CallAndChatLocator {
   /** Locator used by {@link createAzureCommunicationCallWithChatAdapter} to locate the call to join */
-  callLocator: GroupCallLocator | /* @conditional-compile-remove(teams-adhoc-call) */ CallParticipantsLocator;
+  callLocator: GroupCallLocator | /* @conditional-compile-remove(teams-adhoc-call) */ CallParticipantsLocator | RoomCallLocator;
   /** Chat thread ID used by {@link createAzureCommunicationCallWithChatAdapter} to locate the chat thread to join */
   chatThreadId: string;
 }


### PR DESCRIPTION
# What
missing the `RoomCallLocator` from `CallAndChatLocator` in AzureCommunicationCallWithChatAdapter.ts

# Why
adds the `RoomCallLocator` to the `CallAndChatLocator` types

# How Tested
ran up an instance of the CallWithChatComposite and it works, it was working without this change, but added types to make it consistent.

# Process & policy checklist

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.