### PR TITLE
[Calling] Reaction button background color fixes when active

### DIFF
--- a/change-beta/@azure-communication-react-d90f35e6-2bf3-4848-92c8-4aca03989b68.json
+++ b/change-beta/@azure-communication-react-d90f35e6-2bf3-4848-92c8-4aca03989b68.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Reaction",
+  "comment": "Reaction button background color fixes on click",
+  "packageName": "@azure/communication-react",
+  "email": "mbellah@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-d90f35e6-2bf3-4848-92c8-4aca03989b68.json
+++ b/change/@azure-communication-react-d90f35e6-2bf3-4848-92c8-4aca03989b68.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Reaction",
+  "comment": "Reaction button background color fixes on click",
+  "packageName": "@azure/communication-react",
+  "email": "mbellah@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/ReactionButton.styles.ts
+++ b/packages/react-components/src/components/styles/ReactionButton.styles.ts
@@ -49,7 +49,10 @@ export const emojiStyles = (backgroundImage: string, frameCount: number): IStyle
       animationDuration: '8.12s',
       animationTimingFunction: `steps(${steps})`,
       animationIterationCount: 'infinite',
-      backgroundColor: 'unset'
+      backgroundColor: 'transparent'
+    },
+    ':active': {
+      backgroundColor: 'transparent'
     }
   };
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
* Reaction button background color fixes when active
# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->