### PR TITLE
[Chat] Announce File Attachments in New Messages

### DIFF
--- a/change-beta/@azure-communication-react-e07ac585-a2a7-490b-9b4c-41edf4847a6e.json
+++ b/change-beta/@azure-communication-react-e07ac585-a2a7-490b-9b4c-41edf4847a6e.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "File Sharing",
+  "comment": "Add Chat Attachments in Live Messages",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-e07ac585-a2a7-490b-9b4c-41edf4847a6e.json
+++ b/change/@azure-communication-react-e07ac585-a2a7-490b-9b4c-41edf4847a6e.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "File Sharing",
+  "comment": "Add Chat Attachments in Live Messages",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/AttachmentDownloadCards.tsx
+++ b/packages/react-components/src/components/AttachmentDownloadCards.tsx
@@ -8,6 +8,8 @@ import { useMemo } from 'react';
 import { useLocale } from '../localization';
 import { _AttachmentCard } from './AttachmentCard';
 import { _AttachmentCardGroup } from './AttachmentCardGroup';
+/* @conditional-compile-remove(attachment-download) */
+import { getAttachmentCountLiveMessage } from './ChatMessage/ChatMessageContent';
 import { _formatString } from '@internal/acs-ui-common';
 import { AttachmentMenuAction, AttachmentMetadata } from '../types/Attachment';
 import { ChatMessage } from '../types';
@@ -102,15 +104,12 @@ export const _AttachmentDownloadCards = (props: _AttachmentDownloadCardsProps): 
 
   const attachmentCardGroupDescription = useMemo(
     () => () => {
-      const attachmentGroupLocaleString =
-        props.strings?.attachmentCardGroupMessage ?? localeStrings.attachmentCardGroupMessage;
-      /* @conditional-compile-remove(attachment-download) @conditional-compile-remove(attachment-upload) */
-      return _formatString(attachmentGroupLocaleString, {
-        attachmentCount: `${attachments?.length ?? 0}`
-      });
-      return _formatString(attachmentGroupLocaleString, {
-        attachmentCount: `${attachments?.length ?? 0}`
-      });
+      /* @conditional-compile-remove(attachment-download) */
+      return getAttachmentCountLiveMessage(
+        attachments ?? [],
+        props.strings?.attachmentCardGroupMessage ?? localeStrings.attachmentCardGroupMessage
+      );
+      return '';
     },
     [props.strings?.attachmentCardGroupMessage, localeStrings.attachmentCardGroupMessage, attachments]
   );

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -20,6 +20,9 @@ import LiveMessage from '../Announcer/LiveMessage';
 /* @conditional-compile-remove(mention) */
 import { defaultOnMentionRender } from './MentionRenderer';
 import DOMPurify from 'dompurify';
+import { _AttachmentDownloadCardsStrings } from '../AttachmentDownloadCards';
+/* @conditional-compile-remove(attachment-download) */
+import { AttachmentMetadata } from '../../types';
 
 type ChatMessageContentProps = {
   message: ChatMessage;
@@ -187,7 +190,7 @@ const extractContentForAllyMessage = (props: ChatMessageContentProps): string =>
     if (attachments) {
       let attachmentList = '';
       /* @conditional-compile-remove(attachment-download) */
-      attachmentList = attachments.map((attachment) => attachment.name).join(', ');
+      attachmentList = attachmentCardGroupDescription(props);
       const attachmentTextNode = document.createElement('div');
       attachmentTextNode.innerHTML = ` ${attachmentList} `;
       parsedContent.appendChild(attachmentTextNode);
@@ -218,6 +221,33 @@ const messageContentAriaText = (props: ChatMessageContentProps): string | undefi
         author: `${props.message.senderDisplayName}`,
         message: message
       });
+};
+
+/* @conditional-compile-remove(attachment-download) */
+const attachmentCardGroupDescription = (props: ChatMessageContentProps): string => {
+  /* @conditional-compile-remove(attachment-download) */
+  const attachments = props.message.attachments;
+  /* @conditional-compile-remove(attachment-download) */
+  return getAttachmentCountLiveMessage(attachments ?? [], props.strings.attachmentCardGroupMessage);
+  return '';
+};
+
+/* @conditional-compile-remove(attachment-download) */
+/**
+ * @private
+ */
+export const getAttachmentCountLiveMessage = (
+  attachments: AttachmentMetadata[],
+  attachmentCardGroupMessage: string
+): string => {
+  if (attachments.length === 0) {
+    return '';
+  }
+  /* @conditional-compile-remove(attachment-download) */
+  return _formatString(attachmentCardGroupMessage, {
+    attachmentCount: `${attachments.length}`
+  });
+  return '';
 };
 
 const defaultOnRenderInlineImage = (inlineImage: InlineImage): JSX.Element => {

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -182,9 +182,9 @@ const extractContentForAllyMessage = (props: ChatMessageContentProps): string =>
 
     // Inject attachment names for aria.
     if (props.message.attachments) {
-      const attachmentLists = props.message.attachments.map((attachment) => attachment.name).join(', ');
+      const attachmentList = props.message.attachments.map((attachment) => attachment.name).join(', ');
       const attachmentTextNode = document.createElement('div');
-      attachmentTextNode.innerHTML = ` ${attachmentLists} `;
+      attachmentTextNode.innerHTML = ` ${attachmentList} `;
       parsedContent.appendChild(attachmentTextNode);
     }
 

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -164,9 +164,9 @@ export const BlockedMessageContent = (props: BlockedMessageContentProps): JSX.El
 };
 
 const extractContentForAllyMessage = (props: ChatMessageContentProps): string => {
-  if (props.message.content) {
+  if (props.message.content || props.message.attachments) {
     // Replace all <img> tags with 'image' for aria.
-    const parsedContent = DOMPurify.sanitize(props.message.content, {
+    const parsedContent = DOMPurify.sanitize(props.message.content ?? '', {
       ALLOWED_TAGS: ['img'],
       RETURN_DOM_FRAGMENT: true
     });
@@ -179,6 +179,14 @@ const extractContentForAllyMessage = (props: ChatMessageContentProps): string =>
       imageTextNode.innerHTML = 'image ';
       parsedContent.replaceChild(imageTextNode, child);
     });
+
+    // Inject attachment names for aria.
+    if (props.message.attachments) {
+      const attachmentLists = props.message.attachments.map((attachment) => attachment.name).join(', ');
+      const attachmentTextNode = document.createElement('div');
+      attachmentTextNode.innerHTML = ` ${attachmentLists} `;
+      parsedContent.appendChild(attachmentTextNode);
+    }
 
     // Strip all html tags from the content for aria.
     const message = DOMPurify.sanitize(parsedContent, { ALLOWED_TAGS: [] });

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -225,11 +225,8 @@ const messageContentAriaText = (props: ChatMessageContentProps): string | undefi
 
 /* @conditional-compile-remove(attachment-download) */
 const attachmentCardGroupDescription = (props: ChatMessageContentProps): string => {
-  /* @conditional-compile-remove(attachment-download) */
   const attachments = props.message.attachments;
-  /* @conditional-compile-remove(attachment-download) */
   return getAttachmentCountLiveMessage(attachments ?? [], props.strings.attachmentCardGroupMessage);
-  return '';
 };
 
 /* @conditional-compile-remove(attachment-download) */
@@ -243,7 +240,6 @@ export const getAttachmentCountLiveMessage = (
   if (attachments.length === 0) {
     return '';
   }
-  /* @conditional-compile-remove(attachment-download) */
   return _formatString(attachmentCardGroupMessage, {
     attachmentCount: `${attachments.length}`
   });

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -164,7 +164,10 @@ export const BlockedMessageContent = (props: BlockedMessageContentProps): JSX.El
 };
 
 const extractContentForAllyMessage = (props: ChatMessageContentProps): string => {
-  if (props.message.content || props.message.attachments) {
+  let attachments = undefined;
+  /* @conditional-compile-remove(attachment-download) */
+  attachments = props.message.attachments;
+  if (props.message.content || attachments) {
     // Replace all <img> tags with 'image' for aria.
     const parsedContent = DOMPurify.sanitize(props.message.content ?? '', {
       ALLOWED_TAGS: ['img'],
@@ -181,8 +184,10 @@ const extractContentForAllyMessage = (props: ChatMessageContentProps): string =>
     });
 
     // Inject attachment names for aria.
-    if (props.message.attachments) {
-      const attachmentList = props.message.attachments.map((attachment) => attachment.name).join(', ');
+    if (attachments) {
+      let attachmentList = '';
+      /* @conditional-compile-remove(attachment-download) */
+      attachmentList = attachments.map((attachment) => attachment.name).join(', ');
       const attachmentTextNode = document.createElement('div');
       attachmentTextNode.innerHTML = ` ${attachmentList} `;
       parsedContent.appendChild(attachmentTextNode);


### PR DESCRIPTION
# What
Fixed the issue where live messages don't announce file attachments

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
A11Y bug fix

# How Tested
<!--- How did you test your change. What tests have you added. -->
there are 3 scenarios:
- message with attachments only and no content
- message with attachments and text content
- message with attachments and image content

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [X] I have updated the project documentation to reflect my changes if necessary.
- [X] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->