### PR TITLE
[Calling][Bug] Fix PPTLive Keyboard navigation 

### DIFF
--- a/change-beta/@azure-communication-react-df23adda-292c-4c34-b37a-8315971a735f.json
+++ b/change-beta/@azure-communication-react-df23adda-292c-4c34-b37a-8315971a735f.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Remove PPTLive overlay",
+  "comment": "Remove PPTLive overlay",
+  "packageName": "@azure/communication-react",
+  "email": "93549644+ShaunaSong@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-df23adda-292c-4c34-b37a-8315971a735f.json
+++ b/change/@azure-communication-react-df23adda-292c-4c34-b37a-8315971a735f.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Remove PPTLive overlay",
+  "comment": "Remove PPTLive overlay",
+  "packageName": "@azure/communication-react",
+  "email": "93549644+ShaunaSong@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -296,6 +296,7 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
     return () => currentObserver.disconnect();
   }, [videoTileRef]);
 
+  /* @conditional-compile-remove(ppt-live) */
   // TODO: Remove after calling sdk fix the keybaord focus
   useEffect(() => {
     // PPTLive display name is undefined, return as it is not screen share

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -12,7 +12,7 @@ import {
   Stack,
   Text
 } from '@fluentui/react';
-import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useIdentifiers } from '../identifiers';
 import { ComponentLocale, useLocale } from '../localization';
 import { useTheme } from '../theming';
@@ -295,6 +295,35 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
     const currentObserver = observer.current;
     return () => currentObserver.disconnect();
   }, [videoTileRef]);
+
+  // TODO: Remove after calling sdk fix the keybaord focus
+  useEffect(() => {
+    // PPTLive display name is undefined, return if it is screen share
+    if (displayName !== undefined) {
+      return;
+    }
+    let observer: MutationObserver | undefined;
+    if (videoTileRef.current) {
+      observer = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+          if (mutation.type === 'childList') {
+            const iframe = document.querySelector('iframe');
+            if (iframe) {
+              if (!iframe.getAttribute('tabIndex')) {
+                iframe.setAttribute('tabIndex', '-1');
+              }
+            }
+          }
+        }
+      });
+
+      observer.observe(videoTileRef.current, { childList: true, subtree: true });
+    }
+
+    return () => {
+      observer?.disconnect();
+    };
+  }, [displayName, renderElement]);
 
   const useLongPressProps = useMemo(() => {
     return {

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -41,8 +41,6 @@ import { moreButtonStyles } from './styles/VideoTile.styles';
 import { raiseHandContainerStyles } from './styles/VideoTile.styles';
 /* @conditional-compile-remove(reaction) */
 import { ReactionResources } from '../types/ReactionTypes';
-/* @conditional-compile-remove(ppt-live) */
-import { pptLiveOverlayStyles } from './styles/VideoGallery.styles';
 
 /**
  * Strings of {@link VideoTile} that can be overridden.
@@ -403,11 +401,6 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
         {
           /* @conditional-compile-remove(reaction) */
           reactionOverlay
-        }
-        {
-          /* @conditional-compile-remove(ppt-live) */
-          // TODO Can be removed once the overlay mitigation has been implemented at the SDK layer
-          <Stack className={mergeStyles(videoContainerStyles, pptLiveOverlayStyles)}></Stack>
         }
         {(canShowLabel || participantStateString) && (
           <Stack horizontal className={tileInfoContainerStyle} tokens={tileInfoContainerTokens}>

--- a/packages/react-components/src/components/VideoTile.tsx
+++ b/packages/react-components/src/components/VideoTile.tsx
@@ -298,7 +298,7 @@ export const VideoTile = (props: VideoTileProps): JSX.Element => {
 
   // TODO: Remove after calling sdk fix the keybaord focus
   useEffect(() => {
-    // PPTLive display name is undefined, return if it is screen share
+    // PPTLive display name is undefined, return as it is not screen share
     if (displayName !== undefined) {
       return;
     }

--- a/packages/react-components/src/components/styles/VideoGallery.styles.ts
+++ b/packages/react-components/src/components/styles/VideoGallery.styles.ts
@@ -59,20 +59,3 @@ export const localVideoCameraCycleButtonStyles = (theme: Theme, size?: 'small' |
 export const localVideoTileContainerStyles: IStackStyles = {
   root: { width: '100%', height: '100%' }
 };
-
-/**
- * @private
- */
-//TODO Can be removed once the overlay mitigation has been implemented at the SDK layer
-export const pptLiveOverlayStyles: IStackStyles = {
-  root: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    backgroundColor: 'transparent',
-    pointerEvents: 'none',
-    zIndex: 0
-  }
-};


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Delete original logic adding overlay
- Add the observer to add tabIndex to iframe to avoid the keyboard navigation 

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->