### PR TITLE
[RTE] Updated how RoosterJS dependencies are loaded for MessageThread

### DIFF
--- a/change/@azure-communication-react-b13010d5-a240-4452-81e7-01aefadef278.json
+++ b/change/@azure-communication-react-b13010d5-a240-4452-81e7-01aefadef278.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "improvement",
+  "workstream": "RTE",
+  "comment": "Add early import for the edit box in MessageThread to load RoosterJS dependencies early",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMessageComponentAsEditBoxPicker.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMessageComponentAsEditBoxPicker.tsx
@@ -19,6 +19,7 @@ const ChatMessageComponentAsRichTextEditBox = React.lazy(() => import('./ChatMes
 /**
  * @private
  * Use this function to load RoosterJS dependencies early in the lifecycle.
+ * It should be the same import as used for lazy loading.
  */
 export const loadChatMessageComponentAsRichTextEditBox = (): Promise<{
   default: React.ComponentType<ChatMessageComponentAsRichTextEditBoxProps>;

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMessageComponentAsEditBoxPicker.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMessageComponentAsEditBoxPicker.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React from 'react';
+import React, { useMemo } from 'react';
 /* @conditional-compile-remove(rich-text-editor) */
 import { Suspense } from 'react';
 import { ChatMessage } from '../../../types';
@@ -11,13 +11,18 @@ import { MessageThreadStrings } from '../../MessageThread';
 import { ChatMessageComponentAsEditBox } from './ChatMessageComponentAsEditBox';
 /* @conditional-compile-remove(mention) */
 import { MentionLookupOptions } from '../../MentionPopover';
+import type { ChatMessageComponentAsRichTextEditBoxProps } from './ChatMessageComponentAsRichTextEditBox';
 
 /* @conditional-compile-remove(rich-text-editor) */
-const ChatMessageComponentAsRichTextEditBox = React.lazy(() =>
-  import('./ChatMessageComponentAsRichTextEditBox').then((module) => ({
-    default: module.ChatMessageComponentAsRichTextEditBox
-  }))
-);
+const ChatMessageComponentAsRichTextEditBox = React.lazy(() => import('./ChatMessageComponentAsRichTextEditBox'));
+
+/**
+ * @private
+ * Use this function to load RoosterJS dependencies early in the lifecycle.
+ */
+export const loadChatMessageComponentAsRichTextEditBox = (): Promise<{
+  default: React.ComponentType<ChatMessageComponentAsRichTextEditBoxProps>;
+}> => import('./ChatMessageComponentAsRichTextEditBox');
 
 /**
  * @private
@@ -46,14 +51,18 @@ export const ChatMessageComponentAsEditBoxPicker = (props: ChatMessageComponentA
   /* @conditional-compile-remove(rich-text-editor) */
   const { richTextEditor } = props;
 
+  const simpleEditBox = useMemo(() => {
+    return <ChatMessageComponentAsEditBox {...props} />;
+  }, [props]);
+
   /* @conditional-compile-remove(rich-text-editor) */
   if (richTextEditor) {
     return (
-      <Suspense>
+      <Suspense fallback={simpleEditBox}>
         <ChatMessageComponentAsRichTextEditBox {...props} />
       </Suspense>
     );
   }
 
-  return <ChatMessageComponentAsEditBox {...props} />;
+  return simpleEditBox;
 };

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMessageComponentAsEditBoxPicker.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMessageComponentAsEditBoxPicker.tsx
@@ -11,7 +11,10 @@ import { MessageThreadStrings } from '../../MessageThread';
 import { ChatMessageComponentAsEditBox } from './ChatMessageComponentAsEditBox';
 /* @conditional-compile-remove(mention) */
 import { MentionLookupOptions } from '../../MentionPopover';
+/* @conditional-compile-remove(rich-text-editor) */
 import type { ChatMessageComponentAsRichTextEditBoxProps } from './ChatMessageComponentAsRichTextEditBox';
+/* @conditional-compile-remove(rich-text-editor) */
+import { ErrorBoundary } from '../../ErrorBoundary';
 
 /* @conditional-compile-remove(rich-text-editor) */
 const ChatMessageComponentAsRichTextEditBox = React.lazy(() => import('./ChatMessageComponentAsRichTextEditBox'));
@@ -20,6 +23,8 @@ const ChatMessageComponentAsRichTextEditBox = React.lazy(() => import('./ChatMes
  * @private
  * Use this function to load RoosterJS dependencies early in the lifecycle.
  * It should be the same import as used for lazy loading.
+ *
+ * @conditional-compile-remove(rich-text-editor)
  */
 export const loadChatMessageComponentAsRichTextEditBox = (): Promise<{
   default: React.ComponentType<ChatMessageComponentAsRichTextEditBoxProps>;
@@ -59,9 +64,11 @@ export const ChatMessageComponentAsEditBoxPicker = (props: ChatMessageComponentA
   /* @conditional-compile-remove(rich-text-editor) */
   if (richTextEditor) {
     return (
-      <Suspense fallback={simpleEditBox}>
-        <ChatMessageComponentAsRichTextEditBox {...props} />
-      </Suspense>
+      <ErrorBoundary fallback={simpleEditBox}>
+        <Suspense fallback={simpleEditBox}>
+          <ChatMessageComponentAsRichTextEditBox {...props} />
+        </Suspense>
+      </ErrorBoundary>
     );
   }
 

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMessageComponentAsRichTextEditBox.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMessageComponentAsRichTextEditBox.tsx
@@ -217,3 +217,5 @@ export const ChatMessageComponentAsRichTextEditBox = (
     </ChatMyMessage>
   );
 };
+
+export default ChatMessageComponentAsRichTextEditBox;

--- a/packages/react-components/src/components/ErrorBoundary.tsx
+++ b/packages/react-components/src/components/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React, { ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  fallback: ReactNode;
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * @private
+ * ErrorBoundary component to handle errors in React components.
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error): void {
+    console.error(error);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      // handle error
+      return this.props.fallback;
+    }
+    // otherwise render children
+    return this.props.children;
+  }
+}

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -716,8 +716,8 @@ export const MessageThreadWrapper = (props: MessageThreadProps): JSX.Element => 
   const [deletedMessageAriaLabel, setDeletedMessageAriaLabel] = useState<string | undefined>(undefined);
 
   useEffect(() => {
+    // if rich text editor is enabled, the rich text editor component should be loaded early for good UX
     if (richTextEditor !== undefined && richTextEditor) {
-      // if rich text editor is enabled, the rich text editor component should be loaded early for good UX
       // this line is needed to load the Rooster JS dependencies early in the lifecycle
       // when the rich text editor is enabled
       loadChatMessageComponentAsRichTextEditBox();

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -47,6 +47,7 @@ import {
 import { InlineImageOptions } from './ChatMessage/ChatMessageContent';
 import { MessageStatusIndicatorInternal } from './MessageStatusIndicatorInternal';
 import { Announcer } from './Announcer';
+import { loadChatMessageComponentAsRichTextEditBox } from './ChatMessage/MyMessageComponents/ChatMessageComponentAsEditBoxPicker';
 
 const isMessageSame = (first: ChatMessage, second: ChatMessage): boolean => {
   return (
@@ -713,6 +714,15 @@ export const MessageThreadWrapper = (props: MessageThreadProps): JSX.Element => 
   const previousMessagesRef = useRef<Message[]>([]);
   // an aria label for Narrator to notify when a message is deleted
   const [deletedMessageAriaLabel, setDeletedMessageAriaLabel] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (richTextEditor !== undefined && richTextEditor) {
+      // if rich text editor is enabled, the rich text editor component should be loaded early for good UX
+      // this line is needed to load the Rooster JS dependencies early in the lifecycle
+      // when the rich text editor is enabled
+      loadChatMessageComponentAsRichTextEditBox();
+    }
+  }, [richTextEditor]);
 
   const onDeleteMessageCallback = useCallback(
     async (messageId: string): Promise<void> => {

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -47,6 +47,7 @@ import {
 import { InlineImageOptions } from './ChatMessage/ChatMessageContent';
 import { MessageStatusIndicatorInternal } from './MessageStatusIndicatorInternal';
 import { Announcer } from './Announcer';
+/* @conditional-compile-remove(rich-text-editor) */
 import { loadChatMessageComponentAsRichTextEditBox } from './ChatMessage/MyMessageComponents/ChatMessageComponentAsEditBoxPicker';
 
 const isMessageSame = (first: ChatMessage, second: ChatMessage): boolean => {
@@ -714,7 +715,7 @@ export const MessageThreadWrapper = (props: MessageThreadProps): JSX.Element => 
   const previousMessagesRef = useRef<Message[]>([]);
   // an aria label for Narrator to notify when a message is deleted
   const [deletedMessageAriaLabel, setDeletedMessageAriaLabel] = useState<string | undefined>(undefined);
-
+  /* @conditional-compile-remove(rich-text-editor) */
   useEffect(() => {
     // if rich text editor is enabled, the rich text editor component should be loaded early for good UX
     if (richTextEditor !== undefined && richTextEditor) {

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -395,6 +395,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
             inlineImageOptions={inlineImageOptions}
             numberOfChatMessagesToReload={defaultNumberOfChatMessagesToReload}
             styles={messageThreadStyles}
+            richTextEditor={true}
           />
           <Stack className={mergeStyles(sendboxContainerStyles)}>
             <div className={mergeStyles(typingIndicatorContainerStyles)}>

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -395,7 +395,6 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
             inlineImageOptions={inlineImageOptions}
             numberOfChatMessagesToReload={defaultNumberOfChatMessagesToReload}
             styles={messageThreadStyles}
-            richTextEditor={true}
           />
           <Stack className={mergeStyles(sendboxContainerStyles)}>
             <div className={mergeStyles(typingIndicatorContainerStyles)}>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add import for the edit box in MessageThread to load RoosterJS dependencies early

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
improve UX

# How Tested
<!--- How did you test your change. What tests have you added. -->
Chat Sample app for 3g and 2g throttling.
To test:
- set `richTextEditor` to true in ChatScreen (composites folder) for MessageThread component 
- start the Chat sample app. 
- enable throttling
- check that when `richTextEditor` = true, an additional js file is loaded for rich text editor and rich edit box is loaded during message edit without any delays.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->