### PR TITLE
[bugfix] Add adapter options to CallComposite.js files

### DIFF
--- a/change-beta/@azure-communication-react-dc352c41-5c98-409f-b5fb-4f1a485abfca.json
+++ b/change-beta/@azure-communication-react-dc352c41-5c98-409f-b5fb-4f1a485abfca.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Add Adapter options to JS bundles to allow for custom bot displayNames",
+  "comment": "add adapter options to JS bundles",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-dc352c41-5c98-409f-b5fb-4f1a485abfca.json
+++ b/change/@azure-communication-react-dc352c41-5c98-409f-b5fb-4f1a485abfca.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Add Adapter options to JS bundles to allow for custom bot displayNames",
+  "comment": "add adapter options to JS bundles",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/samples/Calling/src/app/views/CallScreen.tsx
+++ b/samples/Calling/src/app/views/CallScreen.tsx
@@ -19,7 +19,7 @@ import { useTeamsCallAdapter, TeamsCallAdapter } from '@azure/communication-reac
 
 import { onResolveVideoEffectDependencyLazy } from '@azure/communication-react';
 /* @conditional-compile-remove(teams-identity-support) */
-import type { TeamsAdapterOptions } from '@azure/communication-react';
+import type { Profile, TeamsAdapterOptions } from '@azure/communication-react';
 import type { StartCallIdentifier } from '@azure/communication-react';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { createAutoRefreshingCredential } from '../utils/credential';
@@ -211,6 +211,12 @@ const AzureCommunicationOutboundCallScreen = (props: AzureCommunicationCallScree
         laughReaction: { url: '/assets/reactions/laughEmoji.png', frameCount: 102 },
         applauseReaction: { url: '/assets/reactions/clapEmoji.png', frameCount: 102 },
         surprisedReaction: { url: '/assets/reactions/surprisedEmoji.png', frameCount: 102 }
+      },
+      onFetchProfile: async (userId: string, defaultProfile?: Profile): Promise<Profile | undefined> => {
+        if (userId === '<28:orgid:Enter your teams app here>') {
+          return { displayName: 'Teams app display name' };
+        }
+        return defaultProfile;
       }
     };
   }, []);

--- a/samples/StaticHtmlComposites/outboundCallComposite.html
+++ b/samples/StaticHtmlComposites/outboundCallComposite.html
@@ -30,7 +30,14 @@
         userId: user,
         token: token,
         displayName: displayName,
-        targetCallees: [{ teamsAppId: '<Enter your teams app id>', cloud: 'public' }] // Provide the identifier you want to call, can be flat as a string.
+        targetCallees: [{ teamsAppId: '<Enter your teams app id here>', cloud: 'public' }], // Provide the identifier you want to call, can be flat as a string.
+        options: {
+          onFetchProfile: async (userId) => {
+            if (userId === '<28:orgid:Enter your teams bot name here>') {
+              return { displayName: 'displayName' };
+            }
+          }
+        }
       },
       document.getElementById('outbound-call-composite-container')
     );

--- a/samples/StaticHtmlComposites/src/callComposite.js
+++ b/samples/StaticHtmlComposites/src/callComposite.js
@@ -8,12 +8,13 @@ import { CallComposite, createAzureCommunicationCallAdapter } from '@azure/commu
 import { initializeIcons } from '@fluentui/react';
 initializeIcons();
 export const loadCallComposite = async function (args, htmlElement, props) {
-  const { userId, token, groupId, displayName, locator } = args;
+  const { userId, token, groupId, displayName, locator, options } = args;
   const adapter = await createAzureCommunicationCallAdapter({
     userId,
     displayName: displayName ?? 'anonymous',
     credential: new AzureCommunicationTokenCredential(token),
-    locator: locator || { groupId }
+    locator: locator || { groupId },
+    options
   });
 
   if (!htmlElement) {

--- a/samples/StaticHtmlComposites/src/outboundCallComposite.js
+++ b/samples/StaticHtmlComposites/src/outboundCallComposite.js
@@ -12,7 +12,8 @@ import {
 import { initializeIcons } from '@fluentui/react';
 initializeIcons();
 export const loadCallComposite = async function (args, htmlElement, props) {
-  const { userId, token, displayName, targetCallees } = args;
+  const { userId, token, displayName, targetCallees, options } = args;
+  console.log(options);
   const adapter = await createAzureCommunicationCallAdapter({
     userId,
     displayName: displayName ?? 'anonymous',
@@ -21,7 +22,8 @@ export const loadCallComposite = async function (args, htmlElement, props) {
       targetCallees.foreach((callee) => {
         return fromFlatCommunicationIdentifier(callee);
       })
-    ]
+    ],
+    options
   });
 
   if (!htmlElement) {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add adapter options to the CallComposite JS files
# Why
<!--- What problem does this change solve? -->
Allows Contoso to use the following with the JS bundle:
- reactions
- calling sounds
- Teams bot rename
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3653697
# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated locally, will make a new release of the JS bundles following next beta release