### PR TITLE
[Chat] Fix Sample App Uploading Incomplete File

### DIFF
--- a/change-beta/@azure-communication-react-7eb8d133-2621-4733-8d1d-40f6110430aa.json
+++ b/change-beta/@azure-communication-react-7eb8d133-2621-4733-8d1d-40f6110430aa.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "File Sharing",
+  "comment": "Fixed Upload Issue in Chat Sample App",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-7eb8d133-2621-4733-8d1d-40f6110430aa.json
+++ b/change/@azure-communication-react-7eb8d133-2621-4733-8d1d-40f6110430aa.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "File Sharing",
+  "comment": "Fixed Upload Issue in Chat Sample App",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/samples/Server/src/routes/uploadToAzureBlobStorage.ts
+++ b/samples/Server/src/routes/uploadToAzureBlobStorage.ts
@@ -104,9 +104,8 @@ router.post('/file/:filename/:containername', upload.single('file'), async funct
   const fileName = req.params.filename;
   const containerName = req.params.containername;
 
-  const fileblob = new Blob([fileData as unknown as BlobPart], { type: fileData.mimetype });
-  const fileContentBuffer = await new Response(fileblob).arrayBuffer();
-  const size = fileContentBuffer.byteLength;
+  const fileContentBuffer = fileData.buffer;
+  const size = fileData.size;
 
   // create blob service client
   let connectionString: string;


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
This PR fixes the issue where sample app failed to upload the completed files to azure blob. 

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
it was getting the first batch of array buffer (15 bytes) instead of a completed buffer
<img width="429" alt="image" src="https://github.com/Azure/communication-ui-library/assets/109105353/247210c6-36a8-4ab6-9285-3de3032b8a60">

# How Tested
<!--- How did you test your change. What tests have you added. -->
clone this PR
provide connection string for communication and azure blob
go to chat sample
upload a valid file
download it to confirm it's still valid

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [X] I have updated the project documentation to reflect my changes if necessary.
- [X] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->