### PR TITLE
[RTE] Fix for an issue where focus is set incorrectly for Safari

### DIFF
--- a/change/@azure-communication-react-822d1d28-ec07-459a-838e-b38cb01d5e5f.json
+++ b/change/@azure-communication-react-822d1d28-ec07-459a-838e-b38cb01d5e5f.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "RTE",
+  "comment": "Fix for an issue where focus is set incorrectly for Safari",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextEditor.tsx
@@ -4,7 +4,11 @@ import React, { useCallback, useEffect, useImperativeHandle, useMemo, useRef } f
 import { ContentEdit, Watermark } from 'roosterjs-editor-plugins';
 import { Editor } from 'roosterjs-editor-core';
 import type { DefaultFormat, EditorOptions, IEditor } from 'roosterjs-editor-types-compatible';
-import { CompatibleGetContentMode } from 'roosterjs-editor-types-compatible';
+import {
+  CompatibleContentPosition,
+  CompatibleGetContentMode,
+  CompatiblePositionType
+} from 'roosterjs-editor-types-compatible';
 import {
   Rooster,
   createUpdateContentPlugin,
@@ -232,8 +236,15 @@ export const RichTextEditor = React.forwardRef<RichTextEditorComponentRef, RichT
 });
 
 const focusAndUpdateContent = (editor: Editor, content: string): void => {
-  // focus the editor to set correct selection position
-  editor.focus();
-  // set initial content
+  // setting focus before setting content, works for Chrome and Edge but not Safari
   editor.setContent(content);
+  // this is a recommended way (by RoosterJS team) to set focus at the end of the text
+  // RoosterJS v9 has this issue fixed and this code can be removed
+  editor.insertContent('<span id="focus-position-span"></span>', { position: CompatibleContentPosition.DomEnd });
+  const elements = editor.queryElements('#focus-position-span');
+  if (elements.length > 0) {
+    const placeholder = editor.queryElements('#focus-position-span')[0];
+    editor.select(placeholder, CompatiblePositionType.Before);
+    placeholder.remove();
+  }
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Fix for an issue where focus is set incorrectly for Safari

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Steps:
In Safari: 

- Open toolbar
- Increase indentation and enter some text
- Hide toolbar

Expected/Current result: cursor should be at the end of the text
Previous result: cursor is before the text

# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook in Chrome/Safari/Edge

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->