### PR TITLE
[RTE] Add styles for tables in my message component

### DIFF
--- a/packages/react-components/src/components/ChatMessage/MessageComponents/ChatMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/MessageComponents/ChatMessageComponentAsMessageBubble.tsx
@@ -136,7 +136,7 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
 
   const chatMessageStyles = useChatMessageStyles();
   const chatItemMessageContainerClassName = mergeClasses(
-    // messageContainerStyle used in className and style prop as style prop can't handle CSS selectors
+    chatMessageCommonStyles.body,
     chatMessageStyles.body,
     // disable placeholder functionality for GA releases as it might confuse users
     chatMessageStyles.bodyWithPlaceholderImage,
@@ -149,6 +149,7 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
     message.attached === 'top' || message.attached === false
       ? chatMessageStyles.bodyWithAvatar
       : chatMessageStyles.bodyWithoutAvatar,
+    // messageContainerStyle used in className and style prop as style prop can't handle CSS selectors
     mergeStyles(messageContainerStyle)
   );
 

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMyMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMyMessageComponentAsMessageBubble.tsx
@@ -216,6 +216,7 @@ const MessageBubble = (props: ChatMyMessageComponentAsMessageBubbleProps): JSX.E
           body={{
             // messageContainerStyle used in className and style prop as style prop can't handle CSS selectors
             className: mergeClasses(
+              chatMessageCommonStyles.body,
               chatMyMessageStyles.body,
               isBlockedMessage
                 ? chatMessageCommonStyles.blocked

--- a/packages/react-components/src/components/styles/MessageThread.styles.ts
+++ b/packages/react-components/src/components/styles/MessageThread.styles.ts
@@ -284,24 +284,6 @@ export const useChatMessageStyles = makeStyles({
       ...shorthands.borderWidth('1px'),
       ...shorthands.borderColor(tokens.colorNeutralStroke1Selected),
       borderLeftWidth: '4px'
-    },
-    '& table': {
-      backgroundColor: tokens.colorBrandBackgroundInverted,
-      ...shorthands.borderColor(tokens.colorNeutralStroke1Selected),
-      borderCollapse: 'collapse',
-      tableLayout: 'auto',
-      width: '100%',
-
-      '& tr': {
-        ...shorthands.border('1px', 'solid', `${tokens.colorNeutralStroke1Selected}`),
-
-        '& td': {
-          ...shorthands.border('1px', 'solid', `${tokens.colorNeutralStroke1Selected}`),
-          wordBreak: 'normal',
-          paddingTop: '0px',
-          paddingRight: '5px'
-        }
-      }
     }
   },
   bodyWithPlaceholderImage: {
@@ -340,6 +322,26 @@ export const useChatMessageStyles = makeStyles({
  * @private
  */
 export const useChatMessageCommonStyles = makeStyles({
+  body: {
+    '& table': {
+      backgroundColor: tokens.colorBrandBackgroundInverted,
+      ...shorthands.borderColor(tokens.colorNeutralStroke1Selected),
+      borderCollapse: 'collapse',
+      tableLayout: 'auto',
+      width: '100%',
+
+      '& tr': {
+        ...shorthands.border('1px', 'solid', `${tokens.colorNeutralStroke1Selected}`),
+
+        '& td': {
+          ...shorthands.border('1px', 'solid', `${tokens.colorNeutralStroke1Selected}`),
+          wordBreak: 'normal',
+          paddingTop: '0px',
+          paddingRight: '5px'
+        }
+      }
+    }
+  },
   failed: {
     //TODO: can we reuse a theme color here?
     backgroundColor: 'rgba(168, 0, 0, 0.2)'


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Add missed styles for tables in my message component
- create a common styles to reuse between messages and my messages

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
CallWithChatComposite and storybook
![image](https://github.com/Azure/communication-ui-library/assets/98852890/e6facb2f-9bc6-4efb-9648-eb2560811d32)
![image](https://github.com/Azure/communication-ui-library/assets/98852890/c1e86c65-81ea-444d-9f8c-304e79a43dda)


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->