### PR TITLE
[RTE] Table insert menu fix when zooming in or out

### DIFF
--- a/change/@azure-communication-react-cf02895f-28af-4425-ad05-042fb83f20cd.json
+++ b/change/@azure-communication-react-cf02895f-28af-4425-ad05-042fb83f20cd.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "area": "fix",
+  "workstream": "RTE",
+  "comment": "Fix an issue where the insert table grid was shown incorrectly when zoom is less than 100%",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/react-components/src/components/styles/RichTextEditor.styles.ts
+++ b/packages/react-components/src/components/styles/RichTextEditor.styles.ts
@@ -260,7 +260,9 @@ export const insertTableMenuCellButtonStyles = (theme: Theme): IStyle => {
     border: `solid 0.0625rem ${theme.palette.neutralTertiaryAlt}`,
     display: 'inline-block',
     cursor: 'pointer',
-    background: 'transparent'
+    background: 'transparent',
+    // include border into width value as the parent element has fixed width
+    boxSizing: 'border-box'
   };
 };
 
@@ -288,9 +290,11 @@ export const insertTableMenuTablePane = mergeStyles({
 export const insertTableMenuFocusZone = (theme: Theme): string => {
   return mergeStyles({
     lineHeight: '12px',
-    width: '5.125rem',
+    // fixed width is required to show columns in a grid correctly
+    width: '5rem',
     border: `solid 0.0625rem ${theme.palette.neutralTertiaryAlt}`,
-    boxSizing: 'border-box'
+    // don't include border into width value as otherwise it may be broken when zoom value is changed
+    boxSizing: 'content-box'
   });
 };
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fix an issue where the insert table grid was shown incorrectly when zoom is less than 100%

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Previously:
![image](https://github.com/Azure/communication-ui-library/assets/98852890/bafd050e-4ce5-433e-ac51-dc8dc42d5605)
Now: 
![image](https://github.com/Azure/communication-ui-library/assets/98852890/ceb0ada4-5249-4605-a172-382113cb9b3f)


# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook + different browser with different zoom value

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->