### PR TITLE
Move survey and captions to storybook concept page 

### DIFF
--- a/change-beta/@azure-communication-react-f37ae78c-b007-4768-9d4f-4fefdefdb7d7.json
+++ b/change-beta/@azure-communication-react-f37ae78c-b007-4768-9d4f-4fefdefdb7d7.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "feature",
+  "workstream": "Feature Storybook",
+  "comment": "Move survey and captions to concept page",
+  "packageName": "@azure/communication-react",
+  "email": "96077406+carocao-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/storybook/stories/ClosedCaptions/ClosedCaptions.stories.tsx
+++ b/packages/storybook/stories/ClosedCaptions/ClosedCaptions.stories.tsx
@@ -6,7 +6,7 @@ import { Description, Heading, Source, Subheading, Title } from '@storybook/addo
 import { Meta } from '@storybook/react/types-6-0';
 import React from 'react';
 import { SingleLineBetaBanner } from '../BetaBanners/SingleLineBetaBanner';
-import { EXAMPLES_FOLDER_PREFIX, overviewPageImagesStackStyle } from '../constants';
+import { CONCEPTS_FOLDER_PREFIX, EXAMPLES_FOLDER_PREFIX, overviewPageImagesStackStyle } from '../constants';
 import { exampleDisableCaptions } from './ClosedCaptions';
 
 const getDocs: () => JSX.Element = () => {
@@ -122,8 +122,8 @@ const ClosedCaptionsStory = (): JSX.Element => {
 export const ClosedCaptions = ClosedCaptionsStory.bind({});
 
 export default {
-  id: `${EXAMPLES_FOLDER_PREFIX}-ClosedCaptions`,
-  title: `${EXAMPLES_FOLDER_PREFIX}/ClosedCaptions`,
+  id: `${CONCEPTS_FOLDER_PREFIX}-ClosedCaptions`,
+  title: `${CONCEPTS_FOLDER_PREFIX}/ClosedCaptions`,
   parameters: {
     previewTabs: { canvas: { disable: true, hidden: true } },
     docs: {

--- a/packages/storybook/stories/ClosedCaptions/ClosedCaptions.stories.tsx
+++ b/packages/storybook/stories/ClosedCaptions/ClosedCaptions.stories.tsx
@@ -6,7 +6,7 @@ import { Description, Heading, Source, Subheading, Title } from '@storybook/addo
 import { Meta } from '@storybook/react/types-6-0';
 import React from 'react';
 import { SingleLineBetaBanner } from '../BetaBanners/SingleLineBetaBanner';
-import { CONCEPTS_FOLDER_PREFIX, EXAMPLES_FOLDER_PREFIX, overviewPageImagesStackStyle } from '../constants';
+import { CONCEPTS_FOLDER_PREFIX, overviewPageImagesStackStyle } from '../constants';
 import { exampleDisableCaptions } from './ClosedCaptions';
 
 const getDocs: () => JSX.Element = () => {

--- a/packages/storybook/stories/Survey/Survey.stories.tsx
+++ b/packages/storybook/stories/Survey/Survey.stories.tsx
@@ -5,7 +5,7 @@ import { mergeStyles, useTheme } from '@fluentui/react';
 import { Description, Heading, Source, Subheading, Title } from '@storybook/addon-docs';
 import { Meta } from '@storybook/react/types-6-0';
 import React from 'react';
-import { EXAMPLES_FOLDER_PREFIX } from '../constants';
+import { CONCEPTS_FOLDER_PREFIX } from '../constants';
 import { SurveyExample } from './components/SurveyExample';
 import { exampleDisableSurvey, exampleOnSurveyClosed, exampleOnSurveySubmitted } from './SurveyDocs';
 
@@ -92,8 +92,8 @@ const SurveyStory = (): JSX.Element => {
 export const Survey = SurveyStory.bind({});
 
 export default {
-  id: `${EXAMPLES_FOLDER_PREFIX}-Survey`,
-  title: `${EXAMPLES_FOLDER_PREFIX}/Survey`,
+  id: `${CONCEPTS_FOLDER_PREFIX}-Survey`,
+  title: `${CONCEPTS_FOLDER_PREFIX}/Survey`,
   component: SurveyExample,
   parameters: {
     docs: {


### PR DESCRIPTION
# What
Move survey and captions to storybook concept page 

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->