### PR TITLE
[Chat] Fix default constant maxWidth value for fluent chat components

### DIFF
--- a/change-beta/@azure-communication-react-ad973b68-7c17-42c1-8545-6c23b7c4aadc.json
+++ b/change-beta/@azure-communication-react-ad973b68-7c17-42c1-8545-6c23b7c4aadc.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "MessageThread",
+  "comment": "Fix default constant maxWidth value for fluent chat components",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-ad973b68-7c17-42c1-8545-6c23b7c4aadc.json
+++ b/change/@azure-communication-react-ad973b68-7c17-42c1-8545-6c23b7c4aadc.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "MessageThread",
+  "comment": "Fix default constant maxWidth value for fluent chat components",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/MessageThread.styles.ts
+++ b/packages/react-components/src/components/styles/MessageThread.styles.ts
@@ -61,6 +61,8 @@ export const noMessageStatusStyle = mergeStyles({
  */
 export const useChatStyles = makeStyles({
   root: {
+    // chat components sets max width value to 1056px, override it to 100%
+    maxWidth: '100%',
     paddingTop: '0.8rem',
     paddingBottom: '0.5rem',
     paddingRight: '0.6rem',


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- fluentui contrib set default max width value to 1056px, this PR resets it to 100% of the containing block's width so the containing component can set the value. This value can also be updated by Contoso by setting `chatContainer` in `styles` prop for `MessageThread`.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Storybook and Chat.

To test this:
- for Chat Composite, find the component that has maxWidth =  41.25 rem (CHAT_CONTAINER_MAX_WIDTH_REM) and disble it
- for MessageThread update `MessageThreadStoryContainerStyles` to
```
export const MessageThreadStoryContainerStyles = {
  width: '100%',
  height: '100%',
  maxWidth: '100%', // or any other value
  padding: '1rem'
};
```

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->