### PR TITLE
Fix an accessibility issue where a send box button disabled state wasn't announced

### DIFF
--- a/change-beta/@azure-communication-react-1d59fe3a-65d3-45a6-bee8-01c68420eb06.json
+++ b/change-beta/@azure-communication-react-1d59fe3a-65d3-45a6-bee8-01c68420eb06.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Fix an accessibility issue where a send box button disabled state wasn't announced",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-1d59fe3a-65d3-45a6-bee8-01c68420eb06.json
+++ b/change/@azure-communication-react-1d59fe3a-65d3-45a6-bee8-01c68420eb06.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Fix an accessibility issue where a send box button disabled state wasn't announced",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/InputBoxButton.tsx
+++ b/packages/react-components/src/components/InputBoxButton.tsx
@@ -20,13 +20,23 @@ export type InputBoxButtonProps = {
   ariaLabel?: string;
   tooltipContent?: string;
   'data-testId'?: string;
+  ariaDisabled?: boolean;
 };
 
 /**
  * @private
  */
 export const InputBoxButton = (props: InputBoxButtonProps): JSX.Element => {
-  const { onRenderIcon, onClick, ariaLabel, className, id, tooltipContent, 'data-testId': dataTestId } = props;
+  const {
+    onRenderIcon,
+    onClick,
+    ariaLabel,
+    className,
+    id,
+    tooltipContent,
+    'data-testId': dataTestId,
+    ariaDisabled = false
+  } = props;
   const [isHover, setIsHover] = useState(false);
   const mergedButtonStyle = mergeStyles(inputBoxButtonStyle, className);
 
@@ -41,21 +51,26 @@ export const InputBoxButton = (props: InputBoxButtonProps): JSX.Element => {
   };
   return (
     <TooltipHost hostClassName={inputBoxButtonTooltipStyle} content={tooltipContent} calloutProps={{ ...calloutProps }}>
-      <IconButton
-        className={mergedButtonStyle}
-        ariaLabel={ariaLabel}
-        onClick={onClick}
-        id={id}
-        onMouseEnter={() => {
-          setIsHover(true);
-        }}
-        onMouseLeave={() => {
-          setIsHover(false);
-        }}
-        // VoiceOver fix: Avoid icon from stealing focus when IconButton is double-tapped to send message by wrapping with Stack with pointerEvents style to none
-        onRenderIcon={() => <Stack className={iconWrapperStyle}>{onRenderIcon(isHover)}</Stack>}
-        data-testid={dataTestId}
-      />
+      {/* IconButton doesn't support aria-disabled so adding a parent element that wil have this value set */}
+      {/* in this case aria-disabled will be set to the same value for all children elements */}
+      {/* see aria-disabled documentation for more information */}
+      <Stack aria-disabled={ariaDisabled}>
+        <IconButton
+          className={mergedButtonStyle}
+          ariaLabel={ariaLabel}
+          onClick={onClick}
+          id={id}
+          onMouseEnter={() => {
+            setIsHover(true);
+          }}
+          onMouseLeave={() => {
+            setIsHover(false);
+          }}
+          // VoiceOver fix: Avoid icon from stealing focus when IconButton is double-tapped to send message by wrapping with Stack with pointerEvents style to none
+          onRenderIcon={() => <Stack className={iconWrapperStyle}>{onRenderIcon(isHover)}</Stack>}
+          data-testid={dataTestId}
+        />
+      </Stack>
     </TooltipHost>
   );
 };

--- a/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
@@ -366,7 +366,12 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
       hasError: hasErrorMessage,
       disabled
     });
-  }, [attachmentsWithProgress, disabled, hasContent, hasErrorMessage]);
+  }, [
+    /* @conditional-compile-remove(attachment-upload) */ attachmentsWithProgress,
+    disabled,
+    hasContent,
+    hasErrorMessage
+  ]);
 
   const sendButton = useMemo(() => {
     return (

--- a/packages/react-components/src/components/SendBox.tsx
+++ b/packages/react-components/src/components/SendBox.tsx
@@ -22,7 +22,12 @@ import { attachmentUploadCardsStyles } from './styles/SendBox.styles';
 import { SendBoxErrorBarError } from './SendBoxErrorBar';
 /* @conditional-compile-remove(attachment-upload) */
 import { hasCompletedAttachmentUploads, hasIncompleteAttachmentUploads } from './utils/SendBoxUtils';
-import { MAXIMUM_LENGTH_OF_MESSAGE, isMessageTooLong, sanitizeText } from './utils/SendBoxUtils';
+import {
+  MAXIMUM_LENGTH_OF_MESSAGE,
+  isMessageTooLong,
+  sanitizeText,
+  isSendBoxButtonAriaDisabled
+} from './utils/SendBoxUtils';
 /* @conditional-compile-remove(mention) */
 import { MentionLookupOptions } from './MentionPopover';
 /* @conditional-compile-remove(attachment-upload) */
@@ -241,8 +246,8 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
     ) {
       onSendMessage && onSendMessage(message);
       setTextValue('');
+      sendTextFieldRef.current?.focus();
     }
-    sendTextFieldRef.current?.focus();
   };
 
   const setText = (newValue?: string | undefined): void => {
@@ -268,20 +273,32 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
     () =>
       sendIconStyle({
         theme,
-        hasText: !!textValue,
+        hasText: sanitizeText(textValue).length > 0,
         /* @conditional-compile-remove(attachment-upload) */ hasAttachment:
           hasCompletedAttachmentUploads(attachmentsWithProgress),
         hasErrorMessage: !!errorMessage,
-        customSendIconStyle: styles?.sendMessageIcon
+        customSendIconStyle: styles?.sendMessageIcon,
+        disabled: !!disabled
       }),
     [
       theme,
       textValue,
       /* @conditional-compile-remove(attachment-upload) */ attachmentsWithProgress,
       errorMessage,
-      styles?.sendMessageIcon
+      styles?.sendMessageIcon,
+      disabled
     ]
   );
+
+  const isSendBoxButtonAriaDisabledValue = useMemo(() => {
+    return isSendBoxButtonAriaDisabled({
+      hasContent: sanitizeText(textValue).length > 0,
+      /* @conditional-compile-remove(attachment-upload) */ hasCompletedAttachmentUploads:
+        hasCompletedAttachmentUploads(attachmentsWithProgress),
+      hasError: !!errorMessage,
+      disabled: !!disabled
+    });
+  }, [attachmentsWithProgress, disabled, errorMessage, textValue]);
 
   const onRenderSendIcon = useCallback(
     (isHover: boolean) =>
@@ -408,6 +425,7 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
             className={mergedSendButtonStyle}
             ariaLabel={localeStrings.sendButtonAriaLabel}
             tooltipContent={localeStrings.sendButtonAriaLabel}
+            ariaDisabled={isSendBoxButtonAriaDisabledValue}
           />
         </InputBoxComponent>
         {

--- a/packages/react-components/src/components/SendBox.tsx
+++ b/packages/react-components/src/components/SendBox.tsx
@@ -298,7 +298,7 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
       hasError: !!errorMessage,
       disabled: !!disabled
     });
-  }, [attachmentsWithProgress, disabled, errorMessage, textValue]);
+  }, [/* @conditional-compile-remove(attachment-upload) */ attachmentsWithProgress, disabled, errorMessage, textValue]);
 
   const onRenderSendIcon = useCallback(
     (isHover: boolean) =>

--- a/packages/react-components/src/components/utils/SendBoxUtils.ts
+++ b/packages/react-components/src/components/utils/SendBoxUtils.ts
@@ -52,3 +52,34 @@ export const sanitizeText = (message: string): string => {
     return message;
   }
 };
+
+/**
+ * Determines whether the send box should be disabled for ARIA accessibility.
+ *
+ * @param hasContent - Indicates whether the send box has content.
+ * @param hasCompletedAttachmentUploads - Indicates whether attachment uploads have completed.
+ * @param hasError - Indicates whether there is an error.
+ * @param disabled - Indicates whether the send box is disabled.
+ * @returns A boolean value indicating whether the send box should be disabled for ARIA accessibility.
+ */
+export const isSendBoxButtonAriaDisabled = ({
+  hasContent,
+  /* @conditional-compile-remove(attachment-upload) */
+  hasCompletedAttachmentUploads,
+  hasError,
+  disabled
+}: {
+  hasContent: boolean;
+  /* @conditional-compile-remove(attachment-upload) */
+  hasCompletedAttachmentUploads: boolean;
+  hasError: boolean;
+  disabled: boolean;
+}): boolean => {
+  return (
+    // no content
+    !(hasContent || /* @conditional-compile-remove(attachment-upload) */ hasCompletedAttachmentUploads) ||
+    //error message exists
+    hasError ||
+    disabled
+  );
+};


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fix an accessibility issue where a send box button disabled state wasn't announced. `aria-disabled` prop is used for this and different screen readers may announce this state in different ways. For example, Narrator on Windows might say "dimmed", while VoiceOver on macOS might say "dimmed" or "disabled". This is determined by the screen reader software and is not something that can be changed from the web page.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Stoybook, Chat sample app

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->