### PR TITLE
[Chat] Sanitize Message Content for Aria Label

### DIFF
--- a/change-beta/@azure-communication-react-eea4451a-68af-4a1d-922c-77adaa3bb833.json
+++ b/change-beta/@azure-communication-react-eea4451a-68af-4a1d-922c-77adaa3bb833.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Inline Image",
+  "comment": "Fix the issue where aria label contains spacial chars",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-eea4451a-68af-4a1d-922c-77adaa3bb833.json
+++ b/change/@azure-communication-react-eea4451a-68af-4a1d-922c-77adaa3bb833.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Inline Image",
+  "comment": "Fix the issue where aria label contains spacial chars",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -298,7 +298,9 @@ const processHtmlToReact = (props: ChatMessageContentProps): JSX.Element => {
 };
 
 const decodeEntities = (encodedString: string): string => {
+  // This regular expression matches HTML entities.
   const translate_re = /&(nbsp|amp|quot|lt|gt);/g;
+  // This object maps HTML entities to their respective characters.
   const translate: Record<string, string> = {
     nbsp: ' ',
     amp: '&',
@@ -306,12 +308,20 @@ const decodeEntities = (encodedString: string): string => {
     lt: '<',
     gt: '>'
   };
-  return encodedString
-    .replace(translate_re, function (match, entity) {
-      return translate[entity];
-    })
-    .replace(/&#(\d+);/gi, function (match, numStr) {
-      const num = parseInt(numStr, 10);
-      return String.fromCharCode(num);
-    });
+
+  return (
+    encodedString
+      // Find all matches of HTML entities defined in translate_re and
+      // replace them with the corresponding character from the translate object.
+      .replace(translate_re, function (match, entity) {
+        return translate[entity];
+      })
+      // Find numeric entities (e.g., &#65;)
+      // and replace them with the equivalent character using the String.fromCharCode method,
+      // which converts Unicode values into characters.
+      .replace(/&#(\d+);/gi, function (match, numStr) {
+        const num = parseInt(numStr, 10);
+        return String.fromCharCode(num);
+      })
+  );
 };

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -197,7 +197,9 @@ const extractContentForAllyMessage = (props: ChatMessageContentProps): string =>
     }
 
     // Strip all html tags from the content for aria.
-    const message = DOMPurify.sanitize(parsedContent, { ALLOWED_TAGS: [] });
+    let message = DOMPurify.sanitize(parsedContent, { ALLOWED_TAGS: [] });
+    // decode HTML entities so that screen reader can read the content properly.
+    message = decodeEntities(message);
     return message;
   }
   return '';
@@ -293,4 +295,23 @@ const processHtmlToReact = (props: ChatMessageContentProps): JSX.Element => {
     }
   };
   return <>{parse(props.message.content ?? '', options)}</>;
+};
+
+const decodeEntities = (encodedString: string): string => {
+  const translate_re = /&(nbsp|amp|quot|lt|gt);/g;
+  const translate: Record<string, string> = {
+    nbsp: ' ',
+    amp: '&',
+    quot: '"',
+    lt: '<',
+    gt: '>'
+  };
+  return encodedString
+    .replace(translate_re, function (match, entity) {
+      return translate[entity];
+    })
+    .replace(/&#(\d+);/gi, function (match, numStr) {
+      const num = parseInt(numStr, 10);
+      return String.fromCharCode(num);
+    });
 };


### PR DESCRIPTION
# What
When incoming messages contain encoded HTML entities such as `&amp`, it would be passed to aria-label as is without any formatting and it would cause confusion to the user since they are not supposed to be announced directly, we should decode them first, then pass it over to aria-label.


|before | after |
|---------|---------|
|        <img width="332" alt="Screenshot 2024-04-25 at 12 20 27 AM" src="https://github.com/Azure/communication-ui-library/assets/109105353/af790315-d2cf-4797-85bb-80dab71cc547">|       <img width="358" alt="Screenshot 2024-04-25 at 12 21 32 AM" src="https://github.com/Azure/communication-ui-library/assets/109105353/7c24b40e-6b31-45a8-90a5-7670dad6ac91">|


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
reported by A11y team

# How Tested
<!--- How did you test your change. What tests have you added. -->
1. run the storybook sample
2. join a meeting
3. send couple of inline images from teams side
4. check if aria label contains encoded html entities

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [X] I have updated the project documentation to reflect my changes if necessary.
- [X] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->