### PR TITLE
[Cherry-pick] Add documentation to indicate the RTE edit box doesn't support mention

### DIFF
--- a/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
+++ b/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
@@ -389,7 +389,7 @@ const Docs: () => JSX.Element = () => {
         <DetailedBetaBanner />
         <Description>
           The following example shows how to enable rich text editor for message editing by providing the
-          `richTextEditor` property. Rich text editor does not support mentioning users at the moment. By set
+          `richTextEditor` property. Rich text editor does not support mentioning users at the moment. By setting
           `richTextEditor` property to true, the `lookupOptions` under the `mentionOptions` property will be ignored.
         </Description>
         <Canvas mdxSource={MessageThreadWithRichTextEditorText}>

--- a/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
+++ b/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
@@ -374,6 +374,11 @@ const Docs: () => JSX.Element = () => {
           further customization. The HTML Tag is defined:
         </Description>
         <Source code={mentionTag} />
+        <Description>
+          The MessageThread component also supports mentioning users when editing a message if the `lookupOptions` under
+          the `mentionOptions` property is provided. However, if the `richTextEditor` property is set to true, the
+          `lookupOptions` will be ignored.
+        </Description>
         <Canvas mdxSource={MessageWithCustomMentionRendererText}>
           <MessageWithCustomMentionRenderer />
         </Canvas>
@@ -384,7 +389,8 @@ const Docs: () => JSX.Element = () => {
         <DetailedBetaBanner />
         <Description>
           The following example shows how to enable rich text editor for message editing by providing the
-          `richTextEditor`` property.
+          `richTextEditor` property. Rich text editor does not support mentioning users at the moment. By set
+          `richTextEditor` property to true, the `lookupOptions` under the `mentionOptions` property will be ignored.
         </Description>
         <Canvas mdxSource={MessageThreadWithRichTextEditorText}>
           <MessageThreadWithRichTextEditorExample />


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->