### PR TITLE
Update @azure/communication-calling to 1.24.1 and 1.24.2-beta.1

### DIFF
--- a/change-beta/@azure-communication-react-2f860295-be05-4ebd-99da-6de2c1361d33.json
+++ b/change-beta/@azure-communication-react-2f860295-be05-4ebd-99da-6de2c1361d33.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Update @azure/communication-calling to 1.24.1 for stable builds, and 1.24.2-beta.1 for beta builds",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-2f860295-be05-4ebd-99da-6de2c1361d33.json
+++ b/change/@azure-communication-react-2f860295-be05-4ebd-99da-6de2c1361d33.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Update @azure/communication-calling to 1.24.1 for stable builds, and 1.24.2-beta.1 for beta builds",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -24,7 +24,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "@azure/communication-calling": "1.24.1-beta.2",
+    "@azure/communication-calling": "1.24.2-beta.1",
     "@azure/communication-common": "2.3.0",
     "@azure/communication-chat": "1.6.0-beta.1",
     "@azure/communication-signaling": "1.0.0-beta.23",
@@ -55,7 +55,7 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
-    "@azure/communication-calling": ["1.24.1-beta.2"],
+    "@azure/communication-calling": ["1.24.2-beta.1"],
     "@azure/communication-common": ["2.3.0"],
     "@azure/communication-chat": ["1.6.0-beta.1"],
     "@azure/communication-signaling": ["1.0.0-beta.23"],

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@azure/communication-calling':
-    specifier: 1.24.1-beta.2
-    version: 1.24.1-beta.2
+    specifier: 1.24.2-beta.1
+    version: 1.24.2-beta.1
   '@azure/communication-chat':
     specifier: 1.6.0-beta.1
     version: 1.6.0-beta.1
@@ -145,8 +145,8 @@ packages:
       events: 3.3.0
     dev: false
 
-  /@azure/communication-calling@1.24.1-beta.2:
-    resolution: {integrity: sha512-tSHbACQYnvl19NSznDg8yVKKnB8AtyOjT2XMT03qsM6/FXI8L8wxxTCCXprUHpR2wxNXRqUEd9YgLp50RBtWcg==}
+  /@azure/communication-calling@1.24.2-beta.1:
+    resolution: {integrity: sha512-DD/gUcbMOG3JXS5q71AVCk4t7P9xhYam/wrNyrLFFTKw8B/12JZ/HbIhtLUzhlkBa39+o3kpB/VdlDT58GTX+Q==}
     dependencies:
       '@azure/communication-common': 2.3.0
       '@azure/logger': 1.0.4
@@ -23277,11 +23277,11 @@ packages:
     dev: false
 
   file:projects/calling-component-bindings.tgz:
-    resolution: {integrity: sha512-ap98u7ggrahT5kjkvKMiedwP+HFzvMD28+2VRtV97MHVlvjoIbCgqzVmk/C/krzzly2rKREEGB58IZyfPPN3bQ==, tarball: file:projects/calling-component-bindings.tgz}
+    resolution: {integrity: sha512-El24vP/btFgmUAg0+SDEWPoNyzRB+iQ4KGZnVpKj/fjcSVNZMht4WvOdL/V6fPdtKsKPZGF/nsmW8EETy1Ar/g==, tarball: file:projects/calling-component-bindings.tgz}
     name: '@rush-temp/calling-component-bindings'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-calling-effects': 1.0.1
       '@azure/communication-common': 2.3.1
       '@babel/cli': 7.23.9(@babel/core@7.24.4)
@@ -23324,11 +23324,11 @@ packages:
     dev: false
 
   file:projects/calling-stateful-client.tgz:
-    resolution: {integrity: sha512-AEm+vxUL2I8mcP10mpWTFFup4lglooURZEj80xA707kLIptA+qHuT4Uu70asaLpOIV+/mgx5kG2UNHnMU6NrNA==, tarball: file:projects/calling-stateful-client.tgz}
+    resolution: {integrity: sha512-Kn9664RLmpdIiUgdou4t4T4XJJMl/6WSCcTe3KA3CNbURap+ioDVmhHxYtjYosthf6D148CxRVCFE3s7hpns/Q==, tarball: file:projects/calling-stateful-client.tgz}
     name: '@rush-temp/calling-stateful-client'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/core-auth': 1.6.0
       '@azure/logger': 1.0.4
@@ -23371,12 +23371,12 @@ packages:
     dev: false
 
   file:projects/calling.tgz:
-    resolution: {integrity: sha512-TW/fMorMQr0bKirih/k8KM2JOqmbtLArAG0DqnMqSn5HpXBaB5tRY1oOsP5Pr3vOmROBSZR/UQMOQHARAPPB5w==, tarball: file:projects/calling.tgz}
+    resolution: {integrity: sha512-54CGCGOL/+6ZaHV34d9wSDVVB5LiOmUL/AAr4tCurAVyzmTVThaKEuB6LP0cp7o7ihKVR07R3uM7vZhcrVgz5w==, tarball: file:projects/calling.tgz}
     name: '@rush-temp/calling'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
       '@azure/logger': 1.0.4
@@ -23462,12 +23462,12 @@ packages:
     dev: false
 
   file:projects/callwithchat.tgz:
-    resolution: {integrity: sha512-9cciVSMGXyL0dqvjDca19IeY9kFpzaHYLWrBoKbC8XEVuzgiLBNKwoW5AkBNLL11XyeLNClA4bZNqQNmvrYZcA==, tarball: file:projects/callwithchat.tgz}
+    resolution: {integrity: sha512-3JwTLGYBz74CXsBnQw5SdGJ5E5hv/yrBi8fDXfYUpw3+UlLVMvIVVWVSDT9TJgX1FjuDwM5XZMIC13EjT8cFzg==, tarball: file:projects/callwithchat.tgz}
     name: '@rush-temp/callwithchat'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-chat': 1.6.0-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -23552,7 +23552,7 @@ packages:
     dev: false
 
   file:projects/chat-component-bindings.tgz:
-    resolution: {integrity: sha512-59Q91vEG7ORtAsCQUODQhVrFWAFYJkSYuBR25/pYzAck0Gm8Z55X8Un74dx2HOsJHVbduVhDWHsyGyjqZebpuw==, tarball: file:projects/chat-component-bindings.tgz}
+    resolution: {integrity: sha512-1UBRpfSTE1RfXquQJbGEejIygDPfddIOsMVAfpqSfUbdpBkgVDFd96GBSySlc+AEO+34F5z0OwIn9u/uuSgq0g==, tarball: file:projects/chat-component-bindings.tgz}
     name: '@rush-temp/chat-component-bindings'
     version: 0.0.0
     dependencies:
@@ -23594,7 +23594,7 @@ packages:
     dev: false
 
   file:projects/chat-stateful-client.tgz:
-    resolution: {integrity: sha512-B9/BDbYVFBgEsxCgHkKFIp790Tezl8SU/0otA7B04q5xx8xEQh4r3zgUE6tl8Trk5lLadjtkijYePXYpOYYNkw==, tarball: file:projects/chat-stateful-client.tgz}
+    resolution: {integrity: sha512-6Ylp1hStXeEz7g6nTnaFqMLSS0UOvqMOtEPGUFwmt0zlp3790dcX6ffme2xDCYqz63/k3cSPVbuFg+MvxTCCuw==, tarball: file:projects/chat-stateful-client.tgz}
     name: '@rush-temp/chat-stateful-client'
     version: 0.0.0
     dependencies:
@@ -23644,7 +23644,7 @@ packages:
     dev: false
 
   file:projects/chat.tgz:
-    resolution: {integrity: sha512-uZzFcbIV2hcD3CiNkO47AwB01KQXJEouniC99tMtD2qdcw90aYWIOTvih99P2wCyXQArAJXEzv6OA7L1/iCU6w==, tarball: file:projects/chat.tgz}
+    resolution: {integrity: sha512-ucQNOl3euzAxtbWikNnb6vC+F6lqqpldv/whT7Vybrjblffc0gcKhZZeVJQosGhrBF5LSb1PXLx8a2hqZvdyKA==, tarball: file:projects/chat.tgz}
     name: '@rush-temp/chat'
     version: 0.0.0
     dependencies:
@@ -23730,7 +23730,7 @@ packages:
     dev: false
 
   file:projects/check-treeshaking.tgz:
-    resolution: {integrity: sha512-twOztePTWTToSLOOVDhqjKyv1Yk6RvD7/fpNeu3wIo2brc/WkId6mVFUg3J5rFzhsuW273nrGJHEIwrSsaFuHg==, tarball: file:projects/check-treeshaking.tgz}
+    resolution: {integrity: sha512-Irdn5Sh/XXrLff7rE+ZjZP8TRw/PfKjBHWmRl+A0rEp1opZTP8DxHlpYEb5FbK0ri09d9EfG1RRg3A3NyRVwpA==, tarball: file:projects/check-treeshaking.tgz}
     name: '@rush-temp/check-treeshaking'
     version: 0.0.0
     dependencies:
@@ -23757,7 +23757,7 @@ packages:
     dev: false
 
   file:projects/check-typescript-regression.tgz:
-    resolution: {integrity: sha512-PJ9OWOjrGCpkcIghyqPr69xvITibEskmWZ6acGWsXpJC1VOTwAOOMDbwZz7Fao23SH1+3oer2C+f8Z/m5ZtqUg==, tarball: file:projects/check-typescript-regression.tgz}
+    resolution: {integrity: sha512-XYocdFsOO4w0Aj+GVM1Z9UpX3DZu9cDdY93n3nPz6rbPmmFq+UUFjY/DEHM8wbrmC51beyu+MTD0mX1jUIUl5Q==, tarball: file:projects/check-typescript-regression.tgz}
     name: '@rush-temp/check-typescript-regression'
     version: 0.0.0
     dependencies:
@@ -23774,11 +23774,11 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-ieA5+IUfMWyA+s10SZguDsyA/RR59aWFBGx7zBt0e7vWHdxFVADuqqVYINnvH6fH2m1chLrVF6I3NyQjTJ9tpw==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-G6kHJA4rhsXZ3fKLGkL5ZnJBtS26OaA7GmZRR/Eb99JLCbouKoQRSK2DLV4zNRqp69HsTiHp3BezFzKxbyFwEw==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-calling-effects': 1.0.1
       '@azure/communication-chat': 1.6.0-beta.1
       '@azure/communication-common': 2.3.1
@@ -23882,11 +23882,11 @@ packages:
     dev: false
 
   file:projects/component-examples.tgz:
-    resolution: {integrity: sha512-yck9OqRqnwAqalzqo+0fw4F7is8w8iPb4AkJwpn4405EHCtT2Hc46DnBNC6hMBS8bKdrHXb7171U6WTMgqBO5g==, tarball: file:projects/component-examples.tgz}
+    resolution: {integrity: sha512-Ta5WY29dkI8SLQIyJf7uBYUQFSX90IXipQwGAcXxwm53/8te3hJsK57SMyauQ6GkWhur76LlorcKfOOzwmjhMQ==, tarball: file:projects/component-examples.tgz}
     name: '@rush-temp/component-examples'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-chat': 1.6.0-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -23969,7 +23969,7 @@ packages:
     dev: false
 
   file:projects/fake-backends.tgz:
-    resolution: {integrity: sha512-+z+HNi3P2T5vEGNG9sTnfsrv3cQ3e/dx7FgymDsqq7Rx/brWAdur6G172TSWnXgsDv55nOntutFdlxmmT7HObA==, tarball: file:projects/fake-backends.tgz}
+    resolution: {integrity: sha512-Ao8dIi0CwwC/Inbxehv6jJXzy4JNpDDj0K/e5jDcwzYuL71NGIKIBHuTN/ku0XU0HCll/2SJ7IfNsocaJZptSA==, tarball: file:projects/fake-backends.tgz}
     name: '@rush-temp/fake-backends'
     version: 0.0.0
     dependencies:
@@ -24023,7 +24023,7 @@ packages:
     dev: false
 
   file:projects/react-components.tgz:
-    resolution: {integrity: sha512-3K/dtJj4CbACdFEr1eUIxS404OVYcBnLN73ArAHwMQ/1pfQoARwh2iwLgqOu2Y5/ERsS2zBNw+oZtlu+uy1CcQ==, tarball: file:projects/react-components.tgz}
+    resolution: {integrity: sha512-kUIR80YLfNHAApaEDyzXV2CQiPY6UFUlRvfyfB+7TiLmXz5wsGxzDXmWr005wWBAzSN0SAnct686A8IUiXyCFw==, tarball: file:projects/react-components.tgz}
     name: '@rush-temp/react-components'
     version: 0.0.0
     dependencies:
@@ -24142,11 +24142,11 @@ packages:
     dev: false
 
   file:projects/react-composites.tgz:
-    resolution: {integrity: sha512-gjjv7pypA9FsKHpb/2Do0Ys+Kq9wt1enwHig7W3IlLfdM88aQWnv9V3ECJm8Jw7dSFrSp00RydpWvD1vcM8Taw==, tarball: file:projects/react-composites.tgz}
+    resolution: {integrity: sha512-QlKTvrIP4cYCiKBnXWezzhGDco2O18uHB3juheEeXC96lLPWwQ8l86g/X+7VO6r9VpWqK6urExJpUuSk5KeNig==, tarball: file:projects/react-composites.tgz}
     name: '@rush-temp/react-composites'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-calling-effects': 1.0.1
       '@azure/communication-chat': 1.6.0-beta.1
       '@azure/communication-common': 2.3.1
@@ -24261,11 +24261,11 @@ packages:
     dev: false
 
   file:projects/sample-automation-tests.tgz:
-    resolution: {integrity: sha512-wbrcMoprXMsv0BHn4KjL4R9gyl/D4gkahBYLdyPg4TtYfroGvgysore/jypVJhF9JF60OHfUiCuaVGXnnDioYA==, tarball: file:projects/sample-automation-tests.tgz}
+    resolution: {integrity: sha512-phMxjhCSM4sNQc8ob/siFn8a6fXwcgBreRQS2Jotmpw7CS2/UWw5vY9S3vU1jxWapfF417y15D1MjlQLWptLuA==, tarball: file:projects/sample-automation-tests.tgz}
     name: '@rush-temp/sample-automation-tests'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-chat': 1.6.0-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -24286,11 +24286,11 @@ packages:
     dev: false
 
   file:projects/sample-static-html-composites.tgz:
-    resolution: {integrity: sha512-/9LU4y2Xxl4Q99UvS+1VUIEefysG7ADepiQluqz73iB/gVL8qEaBo72wWce5SyYvaPubNXbUP+h+St/5AFYYtA==, tarball: file:projects/sample-static-html-composites.tgz}
+    resolution: {integrity: sha512-HzWsGoTJMjggBFNtMjwf69N/5u2g/JPZCGsVIRIk3PwrntHeWpjmLByZhFlToW6KJAiy5i9avQQqCifzve1WVA==, tarball: file:projects/sample-static-html-composites.tgz}
     name: '@rush-temp/sample-static-html-composites'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-chat': 1.6.0-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -24418,11 +24418,11 @@ packages:
     dev: false
 
   file:projects/storybook.tgz:
-    resolution: {integrity: sha512-ggW5QL7B8uwxWggyFK+BuX+G0/uTeTgXTF+QRC64sRvuK4+sPgfKVPrwBESQm4mIXfjVSbCHWHVQ8SpxsAi1UQ==, tarball: file:projects/storybook.tgz}
+    resolution: {integrity: sha512-IyCuNXmiyhRW4zBxjrYsihP5CW46KJ0NW5VVdKzTnwexMPepML11drzt/8oAV0In7N/mP8pdNup5Ja8OemiXmw==, tarball: file:projects/storybook.tgz}
     name: '@rush-temp/storybook'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-chat': 1.6.0-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -24562,11 +24562,11 @@ packages:
     dev: false
 
   file:projects/storybook8.tgz:
-    resolution: {integrity: sha512-RH6Mf3JruiuWZywhbWcB0duozRZNJKZV8fyRE37I72criXcWMmwl2wwm0hI75Eph22DH8aQnmiRwXirarvvvhg==, tarball: file:projects/storybook8.tgz}
+    resolution: {integrity: sha512-/bXWy/XZnc/T3CBu22WxC7Fw9hKamwMZ24VE0MHAqJSfiIhPFzV3gEoLthr5u2N7mod8KEuSdbAZ5NhDIzMAJQ==, tarball: file:projects/storybook8.tgz}
     name: '@rush-temp/storybook8'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.24.1-beta.2
+      '@azure/communication-calling': 1.24.2-beta.1
       '@azure/communication-chat': 1.6.0-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0

--- a/common/config/rush/variants/stable/common-versions.json
+++ b/common/config/rush/variants/stable/common-versions.json
@@ -25,7 +25,7 @@
      */
     // "some-library": "1.2.3"
     // This is the version for stable build (please also update allowedAlternativeVersions below)
-    "@azure/communication-calling": "^1.23.2",
+    "@azure/communication-calling": "^1.24.1",
     "@azure/communication-common": "2.3.0",
     "@azure/communication-chat": "^1.5.0",
     "@azure/communication-signaling": "1.0.0-beta.26"
@@ -57,7 +57,7 @@
    */
   "allowedAlternativeVersions": {
     // This is the version for stable build (please also update preferredVersions above)
-    "@azure/communication-calling": ["^1.23.2"],
+    "@azure/communication-calling": ["^1.24.1"],
     "@azure/communication-common": ["2.3.0"],
     "@azure/communication-chat": ["^1.5.0"],
     "@azure/communication-signaling": ["1.0.0-beta.26"],

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@azure/communication-calling':
-    specifier: ^1.23.2
-    version: 1.23.2
+    specifier: ^1.24.1
+    version: 1.24.1
   '@azure/communication-chat':
     specifier: ^1.5.0
     version: 1.5.0
@@ -145,8 +145,8 @@ packages:
       events: 3.3.0
     dev: false
 
-  /@azure/communication-calling@1.23.2:
-    resolution: {integrity: sha512-/V1RSCROyrJOwAnxmLuH6pkkT8V0WkDwugRh9/W6VYkyS4M4KcfReZmZnQo3XmoyBzhnUajnOK1FHy/ObmaR9Q==}
+  /@azure/communication-calling@1.24.1:
+    resolution: {integrity: sha512-hjAazjrPU6GufexAaGOTBf9dOTM/8CNVRbzR1YusD1zhEdB8NE/xsCFcFemYOIv7ewPNKHIXVD0tmoG5mO4mjQ==}
     dependencies:
       '@azure/communication-common': 2.3.0
       '@azure/logger': 1.0.4
@@ -23305,11 +23305,11 @@ packages:
     dev: false
 
   file:projects/calling-component-bindings.tgz:
-    resolution: {integrity: sha512-e7S7evDm3qtjY5iYKxDtR/9AaWXgcHkhzfkbiur+IghR/FihN/Jn8J7FVJEMm9YE6nLEIUgLNZ0v/BSiXJ+Egg==, tarball: file:projects/calling-component-bindings.tgz}
+    resolution: {integrity: sha512-El24vP/btFgmUAg0+SDEWPoNyzRB+iQ4KGZnVpKj/fjcSVNZMht4WvOdL/V6fPdtKsKPZGF/nsmW8EETy1Ar/g==, tarball: file:projects/calling-component-bindings.tgz}
     name: '@rush-temp/calling-component-bindings'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-calling-effects': 1.0.1
       '@azure/communication-common': 2.3.1
       '@babel/cli': 7.23.9(@babel/core@7.24.4)
@@ -23352,11 +23352,11 @@ packages:
     dev: false
 
   file:projects/calling-stateful-client.tgz:
-    resolution: {integrity: sha512-zrn8oDvhBCsYKsmGcdkkwFl4Mdc2Do5D/QRAY8nmZQmNVAKwS+5Be6gn/EfDisljZmMy/jBZBDEy4HuEpr7z2w==, tarball: file:projects/calling-stateful-client.tgz}
+    resolution: {integrity: sha512-Kn9664RLmpdIiUgdou4t4T4XJJMl/6WSCcTe3KA3CNbURap+ioDVmhHxYtjYosthf6D148CxRVCFE3s7hpns/Q==, tarball: file:projects/calling-stateful-client.tgz}
     name: '@rush-temp/calling-stateful-client'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-common': 2.3.1
       '@azure/core-auth': 1.6.0
       '@azure/logger': 1.0.4
@@ -23399,12 +23399,12 @@ packages:
     dev: false
 
   file:projects/calling.tgz:
-    resolution: {integrity: sha512-gwC5Mi7v7wAhX4zHGSVAh+figyzVoe13XYMmSWDYhN1viCHP3SLfQD+YKyjV0te0+sYXE8dp5QUCZM0vmXQmuw==, tarball: file:projects/calling.tgz}
+    resolution: {integrity: sha512-54CGCGOL/+6ZaHV34d9wSDVVB5LiOmUL/AAr4tCurAVyzmTVThaKEuB6LP0cp7o7ihKVR07R3uM7vZhcrVgz5w==, tarball: file:projects/calling.tgz}
     name: '@rush-temp/calling'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
       '@azure/logger': 1.0.4
@@ -23490,12 +23490,12 @@ packages:
     dev: false
 
   file:projects/callwithchat.tgz:
-    resolution: {integrity: sha512-qzEXAY884KaEVZRIENiSN17NmFpKFzKHL69zn3k3p9LmQ7+3R022wnAobQ/7fRIwZs7d64icfTz9iY7EwJIZmw==, tarball: file:projects/callwithchat.tgz}
+    resolution: {integrity: sha512-3JwTLGYBz74CXsBnQw5SdGJ5E5hv/yrBi8fDXfYUpw3+UlLVMvIVVWVSDT9TJgX1FjuDwM5XZMIC13EjT8cFzg==, tarball: file:projects/callwithchat.tgz}
     name: '@rush-temp/callwithchat'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-chat': 1.5.0
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -23580,7 +23580,7 @@ packages:
     dev: false
 
   file:projects/chat-component-bindings.tgz:
-    resolution: {integrity: sha512-59Q91vEG7ORtAsCQUODQhVrFWAFYJkSYuBR25/pYzAck0Gm8Z55X8Un74dx2HOsJHVbduVhDWHsyGyjqZebpuw==, tarball: file:projects/chat-component-bindings.tgz}
+    resolution: {integrity: sha512-1UBRpfSTE1RfXquQJbGEejIygDPfddIOsMVAfpqSfUbdpBkgVDFd96GBSySlc+AEO+34F5z0OwIn9u/uuSgq0g==, tarball: file:projects/chat-component-bindings.tgz}
     name: '@rush-temp/chat-component-bindings'
     version: 0.0.0
     dependencies:
@@ -23622,7 +23622,7 @@ packages:
     dev: false
 
   file:projects/chat-stateful-client.tgz:
-    resolution: {integrity: sha512-B9/BDbYVFBgEsxCgHkKFIp790Tezl8SU/0otA7B04q5xx8xEQh4r3zgUE6tl8Trk5lLadjtkijYePXYpOYYNkw==, tarball: file:projects/chat-stateful-client.tgz}
+    resolution: {integrity: sha512-6Ylp1hStXeEz7g6nTnaFqMLSS0UOvqMOtEPGUFwmt0zlp3790dcX6ffme2xDCYqz63/k3cSPVbuFg+MvxTCCuw==, tarball: file:projects/chat-stateful-client.tgz}
     name: '@rush-temp/chat-stateful-client'
     version: 0.0.0
     dependencies:
@@ -23672,7 +23672,7 @@ packages:
     dev: false
 
   file:projects/chat.tgz:
-    resolution: {integrity: sha512-uZzFcbIV2hcD3CiNkO47AwB01KQXJEouniC99tMtD2qdcw90aYWIOTvih99P2wCyXQArAJXEzv6OA7L1/iCU6w==, tarball: file:projects/chat.tgz}
+    resolution: {integrity: sha512-ucQNOl3euzAxtbWikNnb6vC+F6lqqpldv/whT7Vybrjblffc0gcKhZZeVJQosGhrBF5LSb1PXLx8a2hqZvdyKA==, tarball: file:projects/chat.tgz}
     name: '@rush-temp/chat'
     version: 0.0.0
     dependencies:
@@ -23758,7 +23758,7 @@ packages:
     dev: false
 
   file:projects/check-treeshaking.tgz:
-    resolution: {integrity: sha512-twOztePTWTToSLOOVDhqjKyv1Yk6RvD7/fpNeu3wIo2brc/WkId6mVFUg3J5rFzhsuW273nrGJHEIwrSsaFuHg==, tarball: file:projects/check-treeshaking.tgz}
+    resolution: {integrity: sha512-Irdn5Sh/XXrLff7rE+ZjZP8TRw/PfKjBHWmRl+A0rEp1opZTP8DxHlpYEb5FbK0ri09d9EfG1RRg3A3NyRVwpA==, tarball: file:projects/check-treeshaking.tgz}
     name: '@rush-temp/check-treeshaking'
     version: 0.0.0
     dependencies:
@@ -23785,7 +23785,7 @@ packages:
     dev: false
 
   file:projects/check-typescript-regression.tgz:
-    resolution: {integrity: sha512-PJ9OWOjrGCpkcIghyqPr69xvITibEskmWZ6acGWsXpJC1VOTwAOOMDbwZz7Fao23SH1+3oer2C+f8Z/m5ZtqUg==, tarball: file:projects/check-typescript-regression.tgz}
+    resolution: {integrity: sha512-XYocdFsOO4w0Aj+GVM1Z9UpX3DZu9cDdY93n3nPz6rbPmmFq+UUFjY/DEHM8wbrmC51beyu+MTD0mX1jUIUl5Q==, tarball: file:projects/check-typescript-regression.tgz}
     name: '@rush-temp/check-typescript-regression'
     version: 0.0.0
     dependencies:
@@ -23802,11 +23802,11 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-KY5Emc0T6I/IC6cYtrVL51EF3JUMm7yYfgsGOtJSzep3y3njPG3CFYifmsvO3coLQiAURMijUWB0CqYfT6w+Qg==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-G6kHJA4rhsXZ3fKLGkL5ZnJBtS26OaA7GmZRR/Eb99JLCbouKoQRSK2DLV4zNRqp69HsTiHp3BezFzKxbyFwEw==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-calling-effects': 1.0.1
       '@azure/communication-chat': 1.5.0
       '@azure/communication-common': 2.3.1
@@ -23910,11 +23910,11 @@ packages:
     dev: false
 
   file:projects/component-examples.tgz:
-    resolution: {integrity: sha512-0JrlXpIxg9kXVMJSmAgLL2C/pNrDoWaMlBkISSXdHLuq85vGIXDIir9hvrKWa/RgmWvZk3hu/lGdfccEexXSwQ==, tarball: file:projects/component-examples.tgz}
+    resolution: {integrity: sha512-Ta5WY29dkI8SLQIyJf7uBYUQFSX90IXipQwGAcXxwm53/8te3hJsK57SMyauQ6GkWhur76LlorcKfOOzwmjhMQ==, tarball: file:projects/component-examples.tgz}
     name: '@rush-temp/component-examples'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-chat': 1.5.0
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -23997,7 +23997,7 @@ packages:
     dev: false
 
   file:projects/fake-backends.tgz:
-    resolution: {integrity: sha512-+z+HNi3P2T5vEGNG9sTnfsrv3cQ3e/dx7FgymDsqq7Rx/brWAdur6G172TSWnXgsDv55nOntutFdlxmmT7HObA==, tarball: file:projects/fake-backends.tgz}
+    resolution: {integrity: sha512-Ao8dIi0CwwC/Inbxehv6jJXzy4JNpDDj0K/e5jDcwzYuL71NGIKIBHuTN/ku0XU0HCll/2SJ7IfNsocaJZptSA==, tarball: file:projects/fake-backends.tgz}
     name: '@rush-temp/fake-backends'
     version: 0.0.0
     dependencies:
@@ -24051,7 +24051,7 @@ packages:
     dev: false
 
   file:projects/react-components.tgz:
-    resolution: {integrity: sha512-3K/dtJj4CbACdFEr1eUIxS404OVYcBnLN73ArAHwMQ/1pfQoARwh2iwLgqOu2Y5/ERsS2zBNw+oZtlu+uy1CcQ==, tarball: file:projects/react-components.tgz}
+    resolution: {integrity: sha512-kUIR80YLfNHAApaEDyzXV2CQiPY6UFUlRvfyfB+7TiLmXz5wsGxzDXmWr005wWBAzSN0SAnct686A8IUiXyCFw==, tarball: file:projects/react-components.tgz}
     name: '@rush-temp/react-components'
     version: 0.0.0
     dependencies:
@@ -24170,11 +24170,11 @@ packages:
     dev: false
 
   file:projects/react-composites.tgz:
-    resolution: {integrity: sha512-3LHQQuFWEEB0+nYUBDm2rDxzOcoHyZJJZeXgqpp9C0SqjAVGmL9OdUSnKqiO56mY6Lr5J4Su0bZ/sPKRlx6/mQ==, tarball: file:projects/react-composites.tgz}
+    resolution: {integrity: sha512-QlKTvrIP4cYCiKBnXWezzhGDco2O18uHB3juheEeXC96lLPWwQ8l86g/X+7VO6r9VpWqK6urExJpUuSk5KeNig==, tarball: file:projects/react-composites.tgz}
     name: '@rush-temp/react-composites'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-calling-effects': 1.0.1
       '@azure/communication-chat': 1.5.0
       '@azure/communication-common': 2.3.1
@@ -24289,11 +24289,11 @@ packages:
     dev: false
 
   file:projects/sample-automation-tests.tgz:
-    resolution: {integrity: sha512-PV2W179eFJTi2fkY1yko4/LfHC0xsMebCoA9jZN8ep7m5LgYL1z+OLmBkz8JiZy39M6D/jZ/ASKnC+GMQGVM/w==, tarball: file:projects/sample-automation-tests.tgz}
+    resolution: {integrity: sha512-phMxjhCSM4sNQc8ob/siFn8a6fXwcgBreRQS2Jotmpw7CS2/UWw5vY9S3vU1jxWapfF417y15D1MjlQLWptLuA==, tarball: file:projects/sample-automation-tests.tgz}
     name: '@rush-temp/sample-automation-tests'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-chat': 1.5.0
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -24314,11 +24314,11 @@ packages:
     dev: false
 
   file:projects/sample-static-html-composites.tgz:
-    resolution: {integrity: sha512-Zg5TeEqMYxpezaQYIjCn3JmzjZilCLe6pznVNJb21NotF9kv7gCEYVbREHpEgexurrFhetJgpxsBx+AWXU7s9g==, tarball: file:projects/sample-static-html-composites.tgz}
+    resolution: {integrity: sha512-HzWsGoTJMjggBFNtMjwf69N/5u2g/JPZCGsVIRIk3PwrntHeWpjmLByZhFlToW6KJAiy5i9avQQqCifzve1WVA==, tarball: file:projects/sample-static-html-composites.tgz}
     name: '@rush-temp/sample-static-html-composites'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-chat': 1.5.0
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -24446,11 +24446,11 @@ packages:
     dev: false
 
   file:projects/storybook.tgz:
-    resolution: {integrity: sha512-AlxY2Ju0ZqH2stFsJrYbw/1nipt0SzcCzdx4R023s22rXNS8JjSg9u7PQzXo4jkZYJWoZpG5ggJ2dDcQ+OmMCw==, tarball: file:projects/storybook.tgz}
+    resolution: {integrity: sha512-IyCuNXmiyhRW4zBxjrYsihP5CW46KJ0NW5VVdKzTnwexMPepML11drzt/8oAV0In7N/mP8pdNup5Ja8OemiXmw==, tarball: file:projects/storybook.tgz}
     name: '@rush-temp/storybook'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-chat': 1.5.0
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -24590,11 +24590,11 @@ packages:
     dev: false
 
   file:projects/storybook8.tgz:
-    resolution: {integrity: sha512-mFfU+Oir1puSlZpNXN8zS8aWj62TMQhL52k297BEVXE8PcpEBlfeWgR1fYkqCz7FiD3mvpc5dcm0BTQfjOlCJA==, tarball: file:projects/storybook8.tgz}
+    resolution: {integrity: sha512-/bXWy/XZnc/T3CBu22WxC7Fw9hKamwMZ24VE0MHAqJSfiIhPFzV3gEoLthr5u2N7mod8KEuSdbAZ5NhDIzMAJQ==, tarball: file:projects/storybook8.tgz}
     name: '@rush-temp/storybook8'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.23.2
+      '@azure/communication-calling': 1.24.1
       '@azure/communication-chat': 1.5.0
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0

--- a/packages/calling-component-bindings/package.json
+++ b/packages/calling-component-bindings/package.json
@@ -38,13 +38,13 @@
     "reselect": "^4.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-calling-effects": "1.0.1",
     "@types/react": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-calling-effects": "1.0.1",
     "@babel/cli": "^7.23.9",
     "@babel/core": "^7.24.3",

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -36,10 +36,10 @@
     "immer": "10.0.4"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2"
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/core-auth": "^1.4.0",
     "@babel/cli": "^7.23.9",
     "@babel/core": "^7.24.3",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -56,7 +56,7 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-calling-effects": "1.0.1",
     "@azure/communication-chat": "1.6.0-beta.1 || >=1.5.0",
     "@types/react": ">=16.8.0 <19.0.0",
@@ -98,7 +98,7 @@
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-calling-effects": "1.0.1",
     "@azure/communication-chat": "1.6.0-beta.1 || ^1.5.0",
     "@azure/core-auth": "^1.4.0",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -71,7 +71,7 @@
     "nanoid": "3.3.6"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-calling-effects": "1.0.1",
     "@azure/communication-chat": "1.6.0-beta.1 || >=1.5.0",
     "@types/react": ">=16.8.0 <19.0.0",
@@ -80,7 +80,7 @@
     "react-dom": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-calling-effects": "1.0.1",
     "@azure/communication-chat": "1.6.0-beta.1 || ^1.5.0",
     "@azure/communication-identity": "^1.3.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-chat": "1.6.0-beta.1 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-identity": "^1.3.0",

--- a/packages/storybook8/package.json
+++ b/packages/storybook8/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-chat": "1.6.0-beta.1 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-identity": "^1.3.0",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-chat": "1.6.0-beta.1 || ^1.5.0",
     "@azure/communication-react": "1.16.0-beta.1",
     "@azure/communication-common": "^2.3.1",

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -34,7 +34,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.16.0-beta.1",
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-common": "^2.3.1",
     "@azure/logger": "^1.0.4",
     "@babel/preset-react": "^7.12.7",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-chat": "1.6.0-beta.1 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-identity": "^1.3.0",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@azure/communication-react": "1.16.0-beta.1",
     "@azure/communication-common": "^2.3.1",
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-chat": "1.6.0-beta.1 || ^1.5.0",
     "@fluentui/react": "^8.117.1",
     "react": "18.2.0",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.24.1-beta.2 || ^1.23.2",
+    "@azure/communication-calling": "1.24.2-beta.1 || ^1.24.1",
     "@azure/communication-chat": "1.6.0-beta.1 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "uuid": "^9.0.0",


### PR DESCRIPTION
# What

Update `@azure/communication-calling` to `1.24.1` for stable builds and `1.24.2-beta.1` for beta builds

# Why

Has support for short meeting URLs amongst other things.

# How Tested

CI only