### PR TITLE
[bugfix][a11y] Add aria level to sidepane header with role heading

### DIFF
--- a/packages/react-composites/src/composites/common/SidePaneHeader.tsx
+++ b/packages/react-composites/src/composites/common/SidePaneHeader.tsx
@@ -45,7 +45,7 @@ export const SidePaneHeader = (props: {
 
   return (
     <Stack horizontal horizontalAlign="space-between" styles={sidePaneHeaderContainerStyles} verticalAlign="center">
-      <Stack.Item role="heading" styles={sidePaneHeaderStyles} aria-label={props.headingText}>
+      <Stack.Item role="heading" styles={sidePaneHeaderStyles} aria-label={props.headingText} aria-level={2}>
         {props.headingText}
       </Stack.Item>
       <Stack.Item>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add aria-level which is required when role="heading" is set

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
accessibility requirement with heading roles

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->