### PR TITLE
[Storybook 8] MessageThread updates and story visibility control

### DIFF
--- a/packages/storybook8/.storybook/main.ts
+++ b/packages/storybook8/.storybook/main.ts
@@ -36,6 +36,11 @@ const storybookConfig: StorybookConfig = {
     name: '@storybook/react-webpack5',
     options: { }
   },
+  // Use this to remove stories if we don't want to show; name <NameOfStory>DocsOnly
+  managerHead: (head) => `
+  ${head}
+  <style>div[data-item-id$="-docs-only"] { display: none; }</style>
+  `,
   staticDirs: ['../public', '.'],
   stories: DEVELOPMENT_BUILD ? storybookDevGlobPaths : storybookProdGlobPaths,
   typescript: { reactDocgen: 'react-docgen' },

--- a/packages/storybook8/stories/Components/MessageThread/MessageThread.mdx
+++ b/packages/storybook8/stories/Components/MessageThread/MessageThread.mdx
@@ -1,11 +1,11 @@
 import { Canvas, Description, Meta, Source } from '@storybook/blocks';
 import { SingleLineBetaBanner } from '../../BetaBanners/SingleLineBetaBanner';
 
-import * as MessageThreadStory from './MessageThread.stories';
+import * as MessageThreadStories from './index.stories';
 
 import { MessageThreadWithBlockedMessagesExample } from './snippets/BlockedMessages.snippet';
 import { MessageThreadWithCustomAvatarExample } from './snippets/CustomAvatar.snippet';
-import { MessageThreadWithCustoBlockedmMessageContainerExample } from './snippets/CustomBlockedMessage.snippet';
+import { MessageThreadWithCustomBlockedMessageContainerExample } from './snippets/CustomBlockedMessage.snippet';
 import { MessageThreadWithCustomChatContainerExample } from './snippets/CustomChatContainer.snippet';
 import { MessageThreadWithCustomMessageContainerExample } from './snippets/CustomMessageContainer.snippet';
 import { MessageThreadWithCustomMessagesExample } from './snippets/CustomMessages.snippet';
@@ -40,7 +40,7 @@ import MessageThreadWithSystemMessagesExampleText from '!!raw-loader!./snippets/
 import MessageThreadWithInlineImageExampleText from '!!raw-loader!./snippets/WithInlineImageMessage.snippet.tsx';
 import MessageThreadWithMessageDateExampleText from '!!raw-loader!./snippets/WithMessageDate.snippet.tsx';
 
-<Meta of={MessageThreadStory} />
+<Meta of={MessageThreadStories} />
 
 # MessageThread
 
@@ -68,23 +68,17 @@ into that file.
 By default, MessageThread displays Chat messages with display name of only for other users and creation time
 of message when available.
 
-<Canvas mdxSource={DefaultMessageThreadExampleText}>
-  <DefaultMessageThreadExample />
-</Canvas>
+<Canvas of={MessageThreadStories.DefaultMessageThreadDocsOnly} source={{ code: DefaultMessageThreadExampleText }} />
 
 ## MessageThread With Message Date
 
-<Canvas mdxSource={MessageThreadWithMessageDateExampleText}>
-  <MessageThreadWithMessageDateExample />
-</Canvas>
+<Canvas of={MessageThreadStories.DateExampleDocsOnly} source={{ code: MessageThreadWithMessageDateExampleText }} />
 
 ## System Message
 
 The example below shows a message thread with a system message.
 
-<Canvas mdxSource={MessageThreadWithSystemMessagesExampleText}>
-  <MessageThreadWithSystemMessagesExample />
-</Canvas>
+<Canvas of={MessageThreadStories.SystemMessageDocsOnly} source={{ code: MessageThreadWithSystemMessagesExample }} />
 
 ## Blocked Message
 
@@ -92,25 +86,25 @@ The example below shows a message thread with a system message.
 
 The example below shows a message thread with a blocked message. If `link` is not provided, it will omit the hyperlink.
 
-<Canvas mdxSource={MessageThreadWithBlockedMessagesExampleText}>
-  <MessageThreadWithBlockedMessagesExample />
-</Canvas>
+<Canvas of={MessageThreadStories.BlockedMessagesDocsOnly} source={{ code: MessageThreadWithBlockedMessagesExample }} />
 
 ## Custom Message
 
 he example below shows how to render a `custom` message with `onRenderMessage` in `MessageThread`
 
-<Canvas mdxSource={MessageThreadWithCustomChatContainerExampleText}>
-  <MessageThreadWithCustomChatContainerExample />
-</Canvas>
+<Canvas
+  of={MessageThreadStories.CustomMessagesDocsOnly}
+  source={{ code: MessageThreadWithCustomChatContainerExample }}
+/>
 
 ## Messages with Customized Chat Container
 
 The example below shows how to render a `custom` chat container with `styles.chatContainer` in `MessageThread`
 
-<Canvas mdxSource={MessageThreadWithCustomChatContainerExampleText}>
-  <MessageThreadWithCustomChatContainerExample />
-</Canvas>
+<Canvas
+  of={MessageThreadStories.CustomChatContainerDocsOnly}
+  source={{ code: MessageThreadWithCustomChatContainerExample }}
+/>
 
 ## Messages with Customized Message Container
 
@@ -120,9 +114,10 @@ The example below shows how to render a `custom` message container with `styles.
 Note: In the code example, all `%` characters were replaced by their unicode value `\u0025` due to URI
 malformed issue when loading the storybook snippets
 
-<Canvas mdxSource={MessageThreadWithCustomMessageContainerExampleText}>
-  <MessageThreadWithCustomMessageContainerExample />
-</Canvas>
+<Canvas
+  of={MessageThreadStories.CustomMessageContainerDocsOnly}
+  source={{ code: MessageThreadWithCustomMessageContainerExample }}
+/>
 
 ## Messages with Customized Blocked message Container
 
@@ -132,30 +127,31 @@ The example below shows how to render a `blocked` message with custom `warningTe
 `styles.blockedMessageContainer` for styling, and rendering your own JSX.Element with with `onRenderMessage`
 in `MessageThread`
 
-<Canvas mdxSource={MessageThreadWithCustoBlockedmMessageContainerExampleText}>
-  <MessageThreadWithCustoBlockedmMessageContainerExample />
-</Canvas>
+<Canvas
+  of={MessageThreadStories.CustomBlockedMessageDocsOnly}
+  source={{ code: MessageThreadWithCustomBlockedMessageContainerExample }}
+/>
 
 ## Default Message Status Indicator
 
-<Canvas mdxSource={MessageThreadWithMessageStatusIndicatorExampleText}>
-  <MessageThreadWithMessageStatusIndicatorExample />
-</Canvas>
+<Canvas
+  of={MessageThreadStories.MessageStatusIndicatorDocsOnly}
+  source={{ code: MessageThreadWithMessageStatusIndicatorExample }}
+/>
 
 ## Custom Message Status Indicator
 
 The example below shows how to render a `custom` message status indicator with `onRenderMessageStatus` in
 `MessageThread`
 
-<Canvas mdxSource={MessageThreadWithCustomMessageStatusIndicatorExampleText}>
-  <MessageThreadWithCustomMessageStatusIndicatorExample />
-</Canvas>
+<Canvas
+  of={MessageThreadStories.CustomStatusIndicatorDocsOnly}
+  source={{ code: MessageThreadWithCustomMessageStatusIndicatorExample }}
+/>
 
 ## Custom Avatar
 
-<Canvas mdxSource={MessageThreadWithCustomAvatarExampleText}>
-  <MessageThreadWithCustomAvatarExample />
-</Canvas>
+<Canvas of={MessageThreadStories.CustomAvatarDocsOnly} source={{ code: MessageThreadWithCustomAvatarExample }} />
 
 Note: You can view the details of the
 [Persona](https://developer.microsoft.com/fluentui#/controls/web/persona) component
@@ -163,15 +159,14 @@ Note: You can view the details of the
 ## Custom Timestamp
 
 <SingleLineBetaBanner />
-<Canvas mdxSource={MessageThreadWithCustomTimestampExampleText}>
-  <MessageThreadWithCustomTimestampExample />
-</Canvas>
+<Canvas
+  of={MessageThreadStories.CustomTimestampExampleDocsOnly}
+  source={{ code: MessageThreadWithCustomTimestampExample }}
+/>
 
 ## Tapping Inline Images on Messages
 
-<Canvas mdxSource={MessageThreadWithInlineImageExampleText}>
-  <MessageThreadWithInlineImageExample />
-</Canvas>
+<Canvas of={MessageThreadStories.InlineImageDocsOnly} source={{ code: MessageThreadWithInlineImageExample }} />
 
 ## Display Messages with Attachments
 
@@ -186,16 +181,12 @@ content along with associated attachments.
 By default, the button associated with the attachment card will open the attachment in a new tab.
 Specifically, `window.open` method will be called for target `URL` defined in `AttachmentMetadata`.
 
-<Canvas mdxSource={MessageWithAttachmentText}>
-  <MessageWithAttachment />
-</Canvas>
+<Canvas of={MessageThreadStories.AttachmentsDocsOnly} source={{ code: MessageWithAttachment }} />
 
 If the identity of message sender is a Microsoft Teams user, the attachment will be rendered with an `open`
 icon shown below.
 
-<Canvas mdxSource={MessageWithAttachmentFromTeamsText}>
-  <MessageWithAttachmentFromTeams />
-</Canvas>
+<Canvas of={MessageThreadStories.AttachmentFromTeamsDocsOnly} source={{ code: MessageWithAttachmentFromTeams }} />
 
 ### Advanced Usage: Customizing Attachment Rendering
 
@@ -208,9 +199,7 @@ a static list for all secanrios.
 
 For example, the following code snippet demonstrates how to customize the download options for attachments.
 
-<Canvas mdxSource={MessageWithCustomAttachmentText}>
-  <MessageWithCustomAttachment />
-</Canvas>
+<Canvas of={MessageThreadStories.CustomAttachmentsDocsOnly} source={{ code: MessageWithCustomAttachment }} />
 
 ## Mention of Users with a custom renderer within Message
 
@@ -224,6 +213,4 @@ further customization. The HTML Tag is defined:
 <msft-mention id="<id>">Displayable Text</msft-mention>
 ```
 
-<Canvas mdxSource={MessageWithCustomMentionRendererText}>
-  <MessageWithCustomMentionRenderer />
-</Canvas>
+<Canvas of={MessageThreadStories.CustomMentionsDocsOnly} source={{ code: MessageWithCustomMentionRenderer }} />

--- a/packages/storybook8/stories/Components/MessageThread/MessageThread.mdx
+++ b/packages/storybook8/stories/Components/MessageThread/MessageThread.mdx
@@ -23,7 +23,7 @@ import { MessageThreadWithMessageDateExample } from './snippets/WithMessageDate.
 
 import MessageThreadWithBlockedMessagesExampleText from '!!raw-loader!./snippets/BlockedMessages.snippet.tsx';
 import MessageThreadWithCustomAvatarExampleText from '!!raw-loader!./snippets/CustomAvatar.snippet.tsx';
-import MessageThreadWithCustoBlockedmMessageContainerExampleText from '!!raw-loader!./snippets/CustomBlockedMessage.snippet.tsx';
+import MessageThreadWithCustomBlockedMessageContainerExampleText from '!!raw-loader!./snippets/CustomBlockedMessage.snippet.tsx';
 import MessageThreadWithCustomChatContainerExampleText from '!!raw-loader!./snippets/CustomChatContainer.snippet.tsx';
 import MessageThreadWithCustomMessageContainerExampleText from '!!raw-loader!./snippets/CustomMessageContainer.snippet.tsx';
 import MessageThreadWithCustomMessagesExampleText from '!!raw-loader!./snippets/CustomMessages.snippet.tsx';
@@ -78,7 +78,7 @@ of message when available.
 
 The example below shows a message thread with a system message.
 
-<Canvas of={MessageThreadStories.SystemMessageDocsOnly} source={{ code: MessageThreadWithSystemMessagesExample }} />
+<Canvas of={MessageThreadStories.SystemMessageDocsOnly} source={{ code: MessageThreadWithSystemMessagesExampleText }} />
 
 ## Blocked Message
 
@@ -86,7 +86,10 @@ The example below shows a message thread with a system message.
 
 The example below shows a message thread with a blocked message. If `link` is not provided, it will omit the hyperlink.
 
-<Canvas of={MessageThreadStories.BlockedMessagesDocsOnly} source={{ code: MessageThreadWithBlockedMessagesExample }} />
+<Canvas
+  of={MessageThreadStories.BlockedMessagesDocsOnly}
+  source={{ code: MessageThreadWithBlockedMessagesExampleText }}
+/>
 
 ## Custom Message
 
@@ -94,7 +97,7 @@ he example below shows how to render a `custom` message with `onRenderMessage` i
 
 <Canvas
   of={MessageThreadStories.CustomMessagesDocsOnly}
-  source={{ code: MessageThreadWithCustomChatContainerExample }}
+  source={{ code: MessageThreadWithCustomMessagesExampleText }}
 />
 
 ## Messages with Customized Chat Container
@@ -103,7 +106,7 @@ The example below shows how to render a `custom` chat container with `styles.cha
 
 <Canvas
   of={MessageThreadStories.CustomChatContainerDocsOnly}
-  source={{ code: MessageThreadWithCustomChatContainerExample }}
+  source={{ code: MessageThreadWithCustomChatContainerExampleText }}
 />
 
 ## Messages with Customized Message Container
@@ -116,7 +119,7 @@ malformed issue when loading the storybook snippets
 
 <Canvas
   of={MessageThreadStories.CustomMessageContainerDocsOnly}
-  source={{ code: MessageThreadWithCustomMessageContainerExample }}
+  source={{ code: MessageThreadWithCustomMessageContainerExampleText }}
 />
 
 ## Messages with Customized Blocked message Container
@@ -129,14 +132,14 @@ in `MessageThread`
 
 <Canvas
   of={MessageThreadStories.CustomBlockedMessageDocsOnly}
-  source={{ code: MessageThreadWithCustomBlockedMessageContainerExample }}
+  source={{ code: MessageThreadWithCustomBlockedMessageContainerExampleText }}
 />
 
 ## Default Message Status Indicator
 
 <Canvas
   of={MessageThreadStories.MessageStatusIndicatorDocsOnly}
-  source={{ code: MessageThreadWithMessageStatusIndicatorExample }}
+  source={{ code: MessageThreadWithMessageStatusIndicatorExampleText }}
 />
 
 ## Custom Message Status Indicator
@@ -146,12 +149,12 @@ The example below shows how to render a `custom` message status indicator with `
 
 <Canvas
   of={MessageThreadStories.CustomStatusIndicatorDocsOnly}
-  source={{ code: MessageThreadWithCustomMessageStatusIndicatorExample }}
+  source={{ code: MessageThreadWithCustomMessageStatusIndicatorExampleText }}
 />
 
 ## Custom Avatar
 
-<Canvas of={MessageThreadStories.CustomAvatarDocsOnly} source={{ code: MessageThreadWithCustomAvatarExample }} />
+<Canvas of={MessageThreadStories.CustomAvatarDocsOnly} source={{ code: MessageThreadWithCustomAvatarExampleText }} />
 
 Note: You can view the details of the
 [Persona](https://developer.microsoft.com/fluentui#/controls/web/persona) component
@@ -161,12 +164,12 @@ Note: You can view the details of the
 <SingleLineBetaBanner />
 <Canvas
   of={MessageThreadStories.CustomTimestampExampleDocsOnly}
-  source={{ code: MessageThreadWithCustomTimestampExample }}
+  source={{ code: MessageThreadWithCustomTimestampExampleText }}
 />
 
 ## Tapping Inline Images on Messages
 
-<Canvas of={MessageThreadStories.InlineImageDocsOnly} source={{ code: MessageThreadWithInlineImageExample }} />
+<Canvas of={MessageThreadStories.InlineImageDocsOnly} source={{ code: MessageThreadWithInlineImageExampleText }} />
 
 ## Display Messages with Attachments
 
@@ -181,12 +184,12 @@ content along with associated attachments.
 By default, the button associated with the attachment card will open the attachment in a new tab.
 Specifically, `window.open` method will be called for target `URL` defined in `AttachmentMetadata`.
 
-<Canvas of={MessageThreadStories.AttachmentsDocsOnly} source={{ code: MessageWithAttachment }} />
+<Canvas of={MessageThreadStories.AttachmentsDocsOnly} source={{ code: MessageWithAttachmentText }} />
 
 If the identity of message sender is a Microsoft Teams user, the attachment will be rendered with an `open`
 icon shown below.
 
-<Canvas of={MessageThreadStories.AttachmentFromTeamsDocsOnly} source={{ code: MessageWithAttachmentFromTeams }} />
+<Canvas of={MessageThreadStories.AttachmentFromTeamsDocsOnly} source={{ code: MessageWithAttachmentFromTeamsText }} />
 
 ### Advanced Usage: Customizing Attachment Rendering
 
@@ -199,7 +202,7 @@ a static list for all secanrios.
 
 For example, the following code snippet demonstrates how to customize the download options for attachments.
 
-<Canvas of={MessageThreadStories.CustomAttachmentsDocsOnly} source={{ code: MessageWithCustomAttachment }} />
+<Canvas of={MessageThreadStories.CustomAttachmentsDocsOnly} source={{ code: MessageWithCustomAttachmentText }} />
 
 ## Mention of Users with a custom renderer within Message
 
@@ -213,4 +216,4 @@ further customization. The HTML Tag is defined:
 <msft-mention id="<id>">Displayable Text</msft-mention>
 ```
 
-<Canvas of={MessageThreadStories.CustomMentionsDocsOnly} source={{ code: MessageWithCustomMentionRenderer }} />
+<Canvas of={MessageThreadStories.CustomMentionsDocsOnly} source={{ code: MessageWithCustomMentionRendererText }} />

--- a/packages/storybook8/stories/Components/MessageThread/MessageThread.story.tsx
+++ b/packages/storybook8/stories/Components/MessageThread/MessageThread.story.tsx
@@ -21,10 +21,9 @@ import {
   IDropdownOption
 } from '@fluentui/react';
 import { Divider } from '@fluentui/react-components';
-import { Meta } from '@storybook/react';
+
 import React, { useRef, useState } from 'react';
 
-import { controlsToAdd, hiddenControl } from '../../controlsUtils';
 import {
   GenerateMockNewChatMessage,
   UserOne,
@@ -260,37 +259,4 @@ const MessageThreadStory = (args): JSX.Element => {
   );
 };
 
-export const MessageThread = MessageThreadStory.bind({});
-
-const meta: Meta<typeof MessageThreadComponent> = {
-  title: 'Components/Message Thread',
-  component: MessageThreadComponent,
-  argTypes: {
-    showMessageDate: controlsToAdd.showMessageDate,
-    showMessageStatus: controlsToAdd.showMessageStatus,
-    enableJumpToNewMessageButton: controlsToAdd.enableJumpToNewMessageButton,
-    // Hiding auto-generated controls
-    styles: hiddenControl,
-    strings: hiddenControl,
-    userId: hiddenControl,
-    messages: hiddenControl,
-    disableJumpToNewMessageButton: hiddenControl,
-    numberOfChatMessagesToReload: hiddenControl,
-    onMessageSeen: hiddenControl,
-    onRenderMessageStatus: hiddenControl,
-    onRenderAvatar: hiddenControl,
-    onRenderJumpToNewMessageButton: hiddenControl,
-    onLoadPreviousChatMessages: hiddenControl,
-    onRenderMessage: hiddenControl,
-    onUpdateMessage: hiddenControl,
-    onDeleteMessage: hiddenControl,
-    disableEditing: hiddenControl,
-    richTextEditor: hiddenControl,
-    // hide unnecessary props since we "send message with attachments" option
-    onRenderAttachmentDownloads: hiddenControl,
-    attachmentOptions: hiddenControl,
-    onSendMessage: hiddenControl
-  }
-};
-
-export default meta;
+export const Preview = MessageThreadStory.bind({});

--- a/packages/storybook8/stories/Components/MessageThread/index.stories.tsx
+++ b/packages/storybook8/stories/Components/MessageThread/index.stories.tsx
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { MessageThread as MessageThreadComponent } from '@azure/communication-react';
+import { Meta } from '@storybook/react';
+import { controlsToAdd, hiddenControl } from '../../controlsUtils';
+
+import { MessageThreadWithBlockedMessagesExample } from './snippets/BlockedMessages.snippet';
+import { MessageThreadWithCustomAvatarExample } from './snippets/CustomAvatar.snippet';
+import { MessageThreadWithCustomBlockedMessageContainerExample } from './snippets/CustomBlockedMessage.snippet';
+import { MessageThreadWithCustomChatContainerExample } from './snippets/CustomChatContainer.snippet';
+import { MessageThreadWithCustomMessageContainerExample } from './snippets/CustomMessageContainer.snippet';
+import { MessageThreadWithCustomMessagesExample } from './snippets/CustomMessages.snippet';
+import { MessageThreadWithCustomMessageStatusIndicatorExample } from './snippets/CustomMessageStatusIndicator.snippet';
+import { MessageThreadWithCustomTimestampExample } from './snippets/CustomTimestamp.snippet';
+import { DefaultMessageThreadExample } from './snippets/Default.snippet';
+import { MessageThreadWithMessageStatusIndicatorExample } from './snippets/MessageStatusIndicator.snippet';
+import { MessageWithAttachment } from './snippets/MessageWithAttachment.snippet';
+import { MessageWithAttachmentFromTeams } from './snippets/MessageWithAttachmentFromTeams.snippet';
+import { MessageWithCustomAttachment } from './snippets/MessageWithCustomAttachment.snippet';
+import { MessageWithCustomMentionRenderer } from './snippets/MessageWithCustomMentionRenderer.snippet';
+import { MessageThreadWithSystemMessagesExample } from './snippets/SystemMessages.snippet';
+import { MessageThreadWithInlineImageExample } from './snippets/WithInlineImageMessage.snippet';
+import { MessageThreadWithMessageDateExample } from './snippets/WithMessageDate.snippet';
+
+// Main story
+export { Preview } from './MessageThread.story';
+
+// Snippet wrapping to stories
+export const BlockedMessagesDocsOnly = {
+  render: MessageThreadWithBlockedMessagesExample,
+  title: '--docs-only'
+};
+export const CustomAvatarDocsOnly = {
+  render: MessageThreadWithCustomAvatarExample
+};
+export const CustomBlockedMessageDocsOnly = {
+  render: MessageThreadWithCustomBlockedMessageContainerExample
+};
+export const CustomChatContainerDocsOnly = {
+  render: MessageThreadWithCustomChatContainerExample
+};
+export const CustomMessageContainerDocsOnly = {
+  render: MessageThreadWithCustomMessageContainerExample
+};
+export const CustomMessagesDocsOnly = {
+  render: MessageThreadWithCustomMessagesExample
+};
+export const CustomStatusIndicatorDocsOnly = {
+  render: MessageThreadWithCustomMessageStatusIndicatorExample
+};
+export const CustomTimestampExampleDocsOnly = {
+  render: MessageThreadWithCustomTimestampExample
+};
+export const DefaultMessageThreadDocsOnly = {
+  render: DefaultMessageThreadExample
+};
+export const MessageStatusIndicatorDocsOnly = {
+  render: MessageThreadWithMessageStatusIndicatorExample
+};
+export const AttachmentsDocsOnly = {
+  render: MessageWithAttachment
+};
+export const AttachmentFromTeamsDocsOnly = {
+  render: MessageWithAttachmentFromTeams
+};
+export const CustomAttachmentsDocsOnly = {
+  render: MessageWithCustomAttachment
+};
+export const CustomMentionsDocsOnly = {
+  render: MessageWithCustomMentionRenderer
+};
+export const SystemMessageDocsOnly = {
+  render: MessageThreadWithSystemMessagesExample
+};
+export const InlineImageDocsOnly = {
+  render: MessageThreadWithInlineImageExample
+};
+export const DateExampleDocsOnly = {
+  render: MessageThreadWithMessageDateExample
+};
+
+// Main story meta export
+const meta: Meta = {
+  title: 'Components/Message Thread',
+  component: MessageThreadComponent,
+  argTypes: {
+    showMessageDate: controlsToAdd.showMessageDate,
+    showMessageStatus: controlsToAdd.showMessageStatus,
+    enableJumpToNewMessageButton: controlsToAdd.enableJumpToNewMessageButton,
+    // Hiding auto-generated controls
+    styles: hiddenControl,
+    strings: hiddenControl,
+    userId: hiddenControl,
+    messages: hiddenControl,
+    disableJumpToNewMessageButton: hiddenControl,
+    numberOfChatMessagesToReload: hiddenControl,
+    onMessageSeen: hiddenControl,
+    onRenderMessageStatus: hiddenControl,
+    onRenderAvatar: hiddenControl,
+    onRenderJumpToNewMessageButton: hiddenControl,
+    onLoadPreviousChatMessages: hiddenControl,
+    onRenderMessage: hiddenControl,
+    onUpdateMessage: hiddenControl,
+    onDeleteMessage: hiddenControl,
+    disableEditing: hiddenControl,
+    richTextEditor: hiddenControl,
+    // hide unnecessary props since we "send message with attachments" option
+    onRenderAttachmentDownloads: hiddenControl,
+    attachmentOptions: hiddenControl,
+    onSendMessage: hiddenControl
+  }
+};
+
+export default meta;

--- a/packages/storybook8/stories/Components/MessageThread/snippets/CustomBlockedMessage.snippet.tsx
+++ b/packages/storybook8/stories/Components/MessageThread/snippets/CustomBlockedMessage.snippet.tsx
@@ -8,7 +8,7 @@ import {
 } from '@azure/communication-react';
 import React from 'react';
 
-export const MessageThreadWithCustoBlockedmMessageContainerExample: () => JSX.Element = () => {
+export const MessageThreadWithCustomBlockedMessageContainerExample: () => JSX.Element = () => {
   const messageThreadStyle: MessageThreadStyles = {
     blockedMessageContainer: {
       '& i': { paddingTop: '0.25rem' },


### PR DESCRIPTION
Add ability to show/hide stories in the layout tree; implement MessageThread stories

# What
Allows show/hide of storybook stories via naming `*DocsOnly`
Breaks out snippets of `MessageThread` to showcase properly

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->