### PR TITLE
Fix width for code snippets sent in messages

### DIFF
--- a/change-beta/@azure-communication-react-fd1835e0-c025-40f4-8268-e05e3ca0bcbf.json
+++ b/change-beta/@azure-communication-react-fd1835e0-c025-40f4-8268-e05e3ca0bcbf.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "MessageThread",
+  "comment": "Fix width for code snippets sent in messages",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-fd1835e0-c025-40f4-8268-e05e3ca0bcbf.json
+++ b/change/@azure-communication-react-fd1835e0-c025-40f4-8268-e05e3ca0bcbf.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "MessageThread",
+  "comment": "Fix width for code snippets sent in messages",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/MessageThread.styles.ts
+++ b/packages/react-components/src/components/styles/MessageThread.styles.ts
@@ -291,6 +291,9 @@ export const useChatMessageStyles = makeStyles({
       ...shorthands.borderWidth('1px'),
       ...shorthands.borderColor(tokens.colorNeutralStroke1Selected),
       borderLeftWidth: '4px'
+    },
+    '& code': {
+      whiteSpace: 'pre-wrap'
     }
   },
   bodyWithPlaceholderImage: {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
|Previously|Now|
|---|---|
|![image](https://github.com/Azure/communication-ui-library/assets/98852890/37ae1cc9-3e92-451e-a43d-59d494e27c44)|![image](https://github.com/Azure/communication-ui-library/assets/98852890/10028849-12aa-4047-9c93-e09ab6b48935)|



# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->