### PR TITLE
[DRAFT] [A11Y] Status icon should not be keyboard tab navigable

### DIFF
--- a/packages/react-components/src/components/MessageStatusIcon.tsx
+++ b/packages/react-components/src/components/MessageStatusIcon.tsx
@@ -29,10 +29,7 @@ export const MessageStatusIcon = (props: MessageStatusIconProps): JSX.Element =>
     <>
       {/* live message is used here so that aria labels are announced on mobile */}
       {ariaLabel && shouldAnnounce && <LiveMessage message={ariaLabel} ariaLive="polite" />}
-      <div
-        // make icon accessible
-        tabIndex={0}
-      >
+      <div>
         <Icon
           role={'status'}
           // Role `status` is one of the live region roles and is used to notify screen readers of changes to the status of the message


### PR DESCRIPTION
Status icon should not be keyboard tab navigable, it should only be navigable by voiceover.

# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->