### PR TITLE
[A11y bugfix] reaction item aria narration

### DIFF
--- a/change-beta/@azure-communication-react-65051319-8cfd-4640-8453-20b68de47ab8.json
+++ b/change-beta/@azure-communication-react-65051319-8cfd-4640-8453-20b68de47ab8.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Add reaction items narratro strings",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-65051319-8cfd-4640-8453-20b68de47ab8.json
+++ b/change/@azure-communication-react-65051319-8cfd-4640-8453-20b68de47ab8.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Add reaction items narratro strings",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ReactionButton.tsx
+++ b/packages/react-components/src/components/ReactionButton.tsx
@@ -133,6 +133,7 @@ export const ReactionButton = (props: ReactionButtonProps): JSX.Element => {
                 dismissMenu();
               }}
               className={classname}
+              ariaLabel={emojiButtonTooltip.get(emoji)}
             />
           </TooltipHost>
         );


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add aria labels to each of the reaction items
# Why
<!--- What problem does this change solve? -->
Allows for the different narrators to read out each name
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3674307
# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated locally
