### PR TITLE
Switch auto running td to trigger from inside ADO instead of GH

### DIFF
--- a/.github/workflows/run-td-build.yml
+++ b/.github/workflows/run-td-build.yml
@@ -1,11 +1,6 @@
 name: Send strings for translation, and optionally commit back current translations
 
 on:
-  # Runs workflow on commits to important branches
-  # Never commits updated string files back in this mode.
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       commit_strings:

--- a/.github/workflows/touchdown-pipeline/touchdown-build.yml
+++ b/.github/workflows/touchdown-pipeline/touchdown-build.yml
@@ -1,5 +1,7 @@
 # Touchdown build pipeline
 
+# Test change
+
 trigger:
   branches:
     include:

--- a/.github/workflows/touchdown-pipeline/touchdown-build.yml
+++ b/.github/workflows/touchdown-pipeline/touchdown-build.yml
@@ -1,7 +1,5 @@
 # Touchdown build pipeline
 
-# Test change
-
 trigger:
   branches:
     include:

--- a/.github/workflows/touchdown-pipeline/touchdown-build.yml
+++ b/.github/workflows/touchdown-pipeline/touchdown-build.yml
@@ -1,6 +1,10 @@
 # Touchdown build pipeline
 
-trigger: none
+trigger:
+  branches:
+    include:
+      - main
+
 pr: none
 
 resources:


### PR DESCRIPTION
# What

Move trigger to ADO yml file

# Why

Goal is to remove the run-td github action and just have the touchdown yaml file

# How Tested

Needs checked into main to test :/