### PR TITLE
remove meta tag

### DIFF
--- a/change-beta/@azure-communication-react-ef6b632a-c0de-42a8-a0d3-e6159affcc38.json
+++ b/change-beta/@azure-communication-react-ef6b632a-c0de-42a8-a0d3-e6159affcc38.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Remove <meta> tag embedded inside the composite to fix a11y bug",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-ef6b632a-c0de-42a8-a0d3-e6159affcc38.json
+++ b/change/@azure-communication-react-ef6b632a-c0de-42a8-a0d3-e6159affcc38.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Remove <meta> tag embedded inside the composite to fix a11y bug",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/BaseComposite.tsx
+++ b/packages/react-composites/src/composites/common/BaseComposite.tsx
@@ -115,7 +115,6 @@ export const BaseProvider = (
   // which stop polluting global dom tree and increase compatibility with react-full-screen
   const CompositeElement = (
     <FluentThemeProvider fluentTheme={fluentTheme} rtl={rtl}>
-      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
       <Customizer scopedSettings={{ Layer: { hostId: globalLayerHostId } }}>
         <ACSAudioProvider audioContext={compositeAudioContext}>
           <WithBackgroundColor>{props.children}</WithBackgroundColor>


### PR DESCRIPTION
# What

Remove `meta` htaml tag that's embedded in each composite

# Why

A11y bug: https://skype.visualstudio.com/SPOOL/_workitems/edit/3674479

And we should not be dictating this as we are not in control of the entire webpage or how the composite is hosted.

# How Tested

tbd... no discernable change on desktop or android...