### PR TITLE
Fix for an issue where links were opened in the same tab

### DIFF
--- a/change-beta/@azure-communication-react-709b49ae-fd98-4efd-9a58-645221215a26.json
+++ b/change-beta/@azure-communication-react-709b49ae-fd98-4efd-9a58-645221215a26.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Chat",
+  "comment": "Fix an issue where links were opened in the same tab",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-709b49ae-fd98-4efd-9a58-645221215a26.json
+++ b/change-beta/@azure-communication-react-709b49ae-fd98-4efd-9a58-645221215a26.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "Chat",
-  "comment": "Fix an issue where links were opened in the same tab",
+  "comment": "Fix for an issue where links were opened in the same tab",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@azure-communication-react-709b49ae-fd98-4efd-9a58-645221215a26.json
+++ b/change/@azure-communication-react-709b49ae-fd98-4efd-9a58-645221215a26.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Chat",
+  "comment": "Fix an issue where links were opened in the same tab",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-709b49ae-fd98-4efd-9a58-645221215a26.json
+++ b/change/@azure-communication-react-709b49ae-fd98-4efd-9a58-645221215a26.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "Chat",
-  "comment": "Fix an issue where links were opened in the same tab",
+  "comment": "Fix for an issue where links were opened in the same tab",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -286,8 +286,15 @@ const processHtmlToReact = (props: ChatMessageContentProps): JSX.Element => {
           return props.inlineImageOptions?.onRenderInlineImage
             ? props.inlineImageOptions.onRenderInlineImage(inlineImageProps, defaultOnRenderInlineImage)
             : defaultOnRenderInlineImage(inlineImageProps);
+        }
 
-          return <img key={imgProps.id as string} {...imgProps} />;
+        // Transform links to open in new tab
+        if (domNode.name === 'a' && React.isValidElement(reactNode)) {
+          const reactElement = reactNode as JSX.Element;
+          return React.cloneElement(reactElement, {
+            target: '_blank',
+            rel: 'noreferrer noopener'
+          });
         }
       }
       // Pass through the original node

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -289,9 +289,8 @@ const processHtmlToReact = (props: ChatMessageContentProps): JSX.Element => {
         }
 
         // Transform links to open in new tab
-        if (domNode.name === 'a' && React.isValidElement(reactNode)) {
-          const reactElement = reactNode as JSX.Element;
-          return React.cloneElement(reactElement, {
+        if (domNode.name === 'a' && React.isValidElement<React.AnchorHTMLAttributes<HTMLAnchorElement>>(reactNode)) {
+          return React.cloneElement(reactNode, {
             target: '_blank',
             rel: 'noreferrer noopener'
           });


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- process anchor elemets and updatehow the links will be opened 

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
CallWithChat sample app. To test:
- create a loop component
- create a Teams meeting
- join it
- - open a loop component from loop.microsoft.com page
- share it (try both options) 
![image](https://github.com/Azure/communication-ui-library/assets/98852890/067c27d1-76e5-42c5-8c67-02ef472ab83f)
- the link should always be opened in a new tab


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->