### PR TITLE
[A11y][chat]Remove theme8 color palette for <Link>

### DIFF
--- a/change-beta/@azure-communication-react-df473728-79d9-43a2-a609-34c30d17ca0b.json
+++ b/change-beta/@azure-communication-react-df473728-79d9-43a2-a609-34c30d17ca0b.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Remove the themeV8 version for the link color",
+  "packageName": "@azure/communication-react",
+  "email": "longamy@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-df473728-79d9-43a2-a609-34c30d17ca0b.json
+++ b/change/@azure-communication-react-df473728-79d9-43a2-a609-34c30d17ca0b.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Remove the themeV8 version for the link color",
+  "packageName": "@azure/communication-react",
+  "email": "longamy@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/theming/v9ThemeShim.ts
+++ b/packages/react-components/src/theming/v9ThemeShim.ts
@@ -231,7 +231,6 @@ export const createV9Theme = (themeV8: ThemeV8, baseThemeV9?: ThemeV9): ThemeV9 
     errorText: themeV8.semanticColors.errorText,
     colorNeutralStroke1Selected: themeV8.palette.neutralQuaternary,
     colorNeutralForeground2: themeV8.palette.neutralSecondary,
-    colorBrandForegroundLink: themeV8.palette.themePrimary,
     colorBrandForegroundLinkHover: themeV8.palette.themeDarker,
     colorNeutralBackground1Selected: themeV8.palette.neutralQuaternaryAlt,
     colorNeutralStroke2: themeV8.palette.neutralTertiaryAlt,


### PR DESCRIPTION
# What
Fix A11y issue for the [ticket
](https://skype.visualstudio.com/SPOOL/_workitems/edit/3740660)

The v9 theme pattern has the correct schema based on Alex P's input. So remove the v8 color theme overwrite in the token. 

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->