### PR TITLE
[A11y] Add context to error bar close button

### DIFF
--- a/change-beta/@azure-communication-react-e5b907bd-8132-45e5-9417-690d3c85acc6.json
+++ b/change-beta/@azure-communication-react-e5b907bd-8132-45e5-9417-690d3c85acc6.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Add message context to aria label",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-e5b907bd-8132-45e5-9417-690d3c85acc6.json
+++ b/change/@azure-communication-react-e5b907bd-8132-45e5-9417-690d3c85acc6.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Add message context to aria label",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ErrorBar.tsx
+++ b/packages/react-components/src/components/ErrorBar.tsx
@@ -324,7 +324,7 @@ export const ErrorBar = (props: ErrorBarProps): JSX.Element => {
               ? setDismissedErrors(dismissError(dismissedErrors, error))
               : props.onDismissError?.(error)
           }
-          dismissButtonAriaLabel={strings.dismissButtonAriaLabel}
+          dismissButtonAriaLabel={`${strings[error.type]}, ${strings.dismissButtonAriaLabel}`}
           dismissIconProps={{ iconName: 'ErrorBarClear' }}
         >
           {strings[error.type]}


### PR DESCRIPTION
# What
Resolve screen narrator missing context for button

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->