### PR TITLE
[bugfix][a11y] Add reactions role and change Reactions button to div

### DIFF
--- a/packages/react-components/src/components/ReactionButton.tsx
+++ b/packages/react-components/src/components/ReactionButton.tsx
@@ -134,8 +134,7 @@ export const ReactionButton = (props: ReactionButtonProps): JSX.Element => {
               }}
               className={classname}
               aria-label={emojiButtonTooltip.get(emoji)}
-            >
-            </div>
+            ></div>
           </TooltipHost>
         );
       })}

--- a/packages/react-components/src/components/ReactionButton.tsx
+++ b/packages/react-components/src/components/ReactionButton.tsx
@@ -6,7 +6,6 @@ import {
   DefaultPalette,
   IButtonStyles,
   ICalloutContentStyles,
-  IconButton,
   IContextualMenuItem,
   mergeStyles,
   Theme,
@@ -126,15 +125,17 @@ export const ReactionButton = (props: ReactionButtonProps): JSX.Element => {
             styles={reactionToolTipHostStyle()}
             calloutProps={{ ...calloutProps }}
           >
-            <IconButton
+            <div
+              role="menuitem"
               key={index}
               onClick={() => {
                 props.onReactionClick(emoji);
                 dismissMenu();
               }}
               className={classname}
-              ariaLabel={emojiButtonTooltip.get(emoji)}
-            />
+              aria-label={emojiButtonTooltip.get(emoji)}
+            >
+            </div>
           </TooltipHost>
         );
       })}


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Change reactions button to actionable divs and add roles

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Accessibility requirements that do not allow buttons to be children nor menuitems under a menu parent

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->