### PR TITLE
Connect to chat only after call is connected

### DIFF
--- a/samples/CallWithChat/src/app/App.tsx
+++ b/samples/CallWithChat/src/app/App.tsx
@@ -30,7 +30,6 @@ import { CallScreen } from './views/CallScreen';
 import { HomeScreen } from './views/HomeScreen';
 import { UnsupportedBrowserPage } from './views/UnsupportedBrowserPage';
 import { getEndpointUrl } from './utils/getEndpointUrl';
-import { joinThread } from './utils/joinThread';
 import { getThread } from './utils/getThread';
 import { getExistingThreadIdFromURL } from './utils/getThreadId';
 import { WEB_APP_TITLE } from './utils/constants';
@@ -168,7 +167,6 @@ const generateCallWithChatArgs = async (
     const callLocator = callLocatorGen(outboundParticipants);
 
     const chatThreadId = await getThread();
-    await joinThread(chatThreadId, credentials.userId.communicationUserId, displayName);
     ensureJoinableChatThreadPushedToUrl(chatThreadId);
 
     locator = {

--- a/samples/CallWithChat/src/app/views/CallScreen.tsx
+++ b/samples/CallWithChat/src/app/views/CallScreen.tsx
@@ -25,6 +25,7 @@ import { createAutoRefreshingCredential } from '../utils/credential';
 import { WEB_APP_TITLE } from '../utils/constants';
 import { useIsMobile } from '../utils/useIsMobile';
 import { isIOS } from '../utils/utils';
+import { joinThread } from '../utils/joinThread';
 
 export interface CallScreenProps {
   token: string;
@@ -141,6 +142,18 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
           console.log(`Call Id: ${callIdRef.current}`);
         }
       });
+
+      /* send add participant request to chat only after call is connected */
+      const joinThreadWhenCallConnected = async (): Promise<void> => {
+        if (adapter.getState().call?.state === 'Connected' && locator && 'chatThreadId' in locator) {
+          adapter.offStateChange(joinThreadWhenCallConnected);
+          console.log('Joining chat thread');
+          joinThread(locator.chatThreadId, userId.communicationUserId, displayName);
+        }
+      };
+
+      adapter.onStateChange(joinThreadWhenCallConnected);
+
       return adapter;
     },
     [callIdRef]


### PR DESCRIPTION
# What

Fix bug when user joined chat before call and message about join appears first.
I've added call to join chat only after call is connected.
Updated ChatAdapter to wait when user joined thread for operations.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->