### PR TITLE
Update recording state from stopped to off only after the banner is displayed 

### DIFF
--- a/change-beta/@azure-communication-react-ca89e17c-28a0-406b-b7fd-287e5144d1f4.json
+++ b/change-beta/@azure-communication-react-ca89e17c-28a0-406b-b7fd-287e5144d1f4.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Compliance Banner",
+  "comment": "Fix bug when recording stopped banner is not showing up",
+  "packageName": "@azure/communication-react",
+  "email": "96077406+carocao-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-ca89e17c-28a0-406b-b7fd-287e5144d1f4.json
+++ b/change/@azure-communication-react-ca89e17c-28a0-406b-b7fd-287e5144d1f4.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Compliance Banner",
+  "comment": "Fix bug when recording stopped banner is not showing up",
+  "packageName": "@azure/communication-react",
+  "email": "96077406+carocao-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ComplianceBanner/ComplianceBanner.tsx
+++ b/packages/react-components/src/components/ComplianceBanner/ComplianceBanner.tsx
@@ -75,7 +75,7 @@ export const _ComplianceBanner = (props: _ComplianceBannerProps): JSX.Element =>
 
   // [3]: Transition the state machine again to deal with some end-states.
   if (
-    shouldUpdateCached &&
+    !shouldUpdateCached &&
     cachedProps.current.latestStringState.callRecordState === 'stopped' &&
     cachedProps.current.latestStringState.callTranscribeState === 'stopped'
   ) {


### PR DESCRIPTION
# What
update recording state from stopped to off only after the banner is displayed 

# Why
The Recording stopped banner is not showing up 

# How Tested
Testing with samples 

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->