### PR TITLE
[Bugfix] Ensure touch events don't affect the popup menu on chat messages

### DIFF
--- a/change-beta/@azure-communication-react-7e1e2279-2955-4916-a382-6136ba336482.json
+++ b/change-beta/@azure-communication-react-7e1e2279-2955-4916-a382-6136ba336482.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Disable highlight of context menu on touch event in Android",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-7e1e2279-2955-4916-a382-6136ba336482.json
+++ b/change/@azure-communication-react-7e1e2279-2955-4916-a382-6136ba336482.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Disable highlight of context menu on touch event in Android",
+  "packageName": "@azure/communication-react",
+  "email": "3941071+emlynmac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/ChatMessageComponent.styles.ts
+++ b/packages/react-components/src/components/styles/ChatMessageComponent.styles.ts
@@ -126,7 +126,8 @@ export const chatMessageMenuStyle = mergeStyles({
   minWidth: '8.5rem',
   height: 'max-content',
   cursor: 'pointer',
-  overflow: 'hidden'
+  overflow: 'hidden',
+  '-webkit-tap-highlight-color': 'rgba(255, 255, 255, 0)' // Disable tap highlight on Android
 });
 
 /**


### PR DESCRIPTION
# What
It was found that tapping the context menu on a message will cause the whole menu to be highlighted. 
This change sets this event to transparent.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->