### PR TITLE
[Chat] Added Aria Roles to Attachment Components

### DIFF
--- a/change-beta/@azure-communication-react-f5fc64ea-6aee-4446-80dd-1ef2b06e33c3.json
+++ b/change-beta/@azure-communication-react-f5fc64ea-6aee-4446-80dd-1ef2b06e33c3.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "File Sharing",
+  "comment": "Added Aria Roles for A11y",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-f5fc64ea-6aee-4446-80dd-1ef2b06e33c3.json
+++ b/change/@azure-communication-react-f5fc64ea-6aee-4446-80dd-1ef2b06e33c3.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "File Sharing",
+  "comment": "Added Aria Roles for A11y",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/Attachment/AttachmentCard.tsx
+++ b/packages/react-components/src/components/Attachment/AttachmentCard.tsx
@@ -124,6 +124,7 @@ export const _AttachmentCard = (props: _AttachmentCardProps): JSX.Element => {
                     imageFileType: 'svg'
                   }).iconName
                 }
+                role="img"
               />
             </div>
           }
@@ -181,6 +182,7 @@ const MappedMenuItems = (
     <TooltipHost content={menuActions[0].name}>
       <ToolbarButton
         aria-label={menuActions[0].name}
+        role="tooltip"
         icon={menuActions[0].icon}
         onClick={() => {
           try {
@@ -197,7 +199,7 @@ const MappedMenuItems = (
         <TooltipHost content={localeStrings.attachmentMoreMenu}>
           <MenuTrigger>
             <ToolbarButton
-              icon={<Icon iconName="AttachmentMoreMenu" aria-label={localeStrings.attachmentMoreMenu} />}
+              icon={<Icon iconName="AttachmentMoreMenu" aria-label={localeStrings.attachmentMoreMenu} role="button" />}
             />
           </MenuTrigger>
         </TooltipHost>

--- a/packages/react-components/src/components/Attachment/AttachmentCardGroup.tsx
+++ b/packages/react-components/src/components/Attachment/AttachmentCardGroup.tsx
@@ -54,6 +54,7 @@ export const _AttachmentCardGroup = (props: _AttachmentCardGroupProps): JSX.Elem
         attachmentGroupLayout === _AttachmentCardGroupLayout.Grid ? attachmentCardGirdLayout : attachmentCardFlexLayout
       )}
       aria-label={ariaLabel}
+      role="list"
     >
       {children}
     </Stack>

--- a/packages/react-components/src/components/Attachment/AttachmentUploadCards.tsx
+++ b/packages/react-components/src/components/Attachment/AttachmentUploadCards.tsx
@@ -75,7 +75,11 @@ export const _AttachmentUploadCards = (props: AttachmentUploadCardsProps): JSX.E
                 {
                   name: props.strings?.removeAttachment ?? 'Remove',
                   icon: (
-                    <div aria-label={removeAttachmentButtonString()} data-testid="attachment-upload-card-remove">
+                    <div
+                      aria-label={removeAttachmentButtonString()}
+                      data-testid="attachment-upload-card-remove"
+                      role="button"
+                    >
                       <Icon iconName="CancelAttachmentUpload" className={mergeStyles(actionIconStyle)} />
                     </div>
                   ),


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Addressed the A11y issue where aria roles are missing for attachment card components

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
bug fix

# How Tested
<!--- How did you test your change. What tests have you added. -->
1. run sample code
2. attach a file in sendbox
3. inspect in web tool
4. check if aria role presents

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [X] I have updated the project documentation to reflect my changes if necessary.
- [X] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->