### PR TITLE
[Chat] Fixed the issue where RTE doesn't send HTML messages if there are attached files

### DIFF
--- a/change-beta/@azure-communication-react-cc2ef409-ce98-484f-8b0e-d047cc26af08.json
+++ b/change-beta/@azure-communication-react-cc2ef409-ce98-484f-8b0e-d047cc26af08.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "File Sharing",
+  "comment": "Fixed the issue where RTE cannot send rich text with file attachments",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-cc2ef409-ce98-484f-8b0e-d047cc26af08.json
+++ b/change-beta/@azure-communication-react-cc2ef409-ce98-484f-8b0e-d047cc26af08.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "File Sharing",
-  "comment": "Fixed the issue where RTE cannot send rich text with file attachments",
+  "comment": "Fixed the issue where Rich Text Editor cannot send rich text with file attachments",
   "packageName": "@azure/communication-react",
   "email": "109105353+jpeng-ms@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@azure-communication-react-cc2ef409-ce98-484f-8b0e-d047cc26af08.json
+++ b/change/@azure-communication-react-cc2ef409-ce98-484f-8b0e-d047cc26af08.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "File Sharing",
+  "comment": "Fixed the issue where RTE cannot send rich text with file attachments",
+  "packageName": "@azure/communication-react",
+  "email": "109105353+jpeng-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-cc2ef409-ce98-484f-8b0e-d047cc26af08.json
+++ b/change/@azure-communication-react-cc2ef409-ce98-484f-8b0e-d047cc26af08.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "File Sharing",
-  "comment": "Fixed the issue where RTE cannot send rich text with file attachments",
+  "comment": "Fixed the issue where Rich Text Editor cannot send rich text with file attachments",
   "packageName": "@azure/communication-react",
   "email": "109105353+jpeng-ms@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/chat-component-bindings/src/handlers/createHandlers.ts
+++ b/packages/chat-component-bindings/src/handlers/createHandlers.ts
@@ -76,7 +76,8 @@ export const createDefaultChatHandlers = memoizeOne(
             metadata: {
               ...options?.metadata,
               fileSharingMetadata: JSON.stringify(options?.attachments)
-            }
+            },
+            type: options.type
           };
           await chatThreadClient.sendMessage(sendMessageRequest, chatSDKOptions);
           return;


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

when sending messages with attachments via RTE, raw HTML would be sending out and this PR address this issue:



|   before |   after |
|-----|-----|
| <img width="314" alt="image" src="https://github.com/Azure/communication-ui-library/assets/109105353/8a04aefb-5a60-45a1-b36b-83a176ba4031"> |  <img width="314" alt="image" src="https://github.com/Azure/communication-ui-library/assets/109105353/f7f3071d-5afc-4e18-bb7b-d70a36d12a42"> | 

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
bug fix

# How Tested
<!--- How did you test your change. What tests have you added. -->
sample app
enable RTE
send a message with any attachments

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->