### PR TITLE
[Beta blocking] Fix missing pinned icon when it is the only icon

### DIFF
--- a/change-beta/@azure-communication-react-6d999d69-0527-4c82-96c8-3dd5dded13a2.json
+++ b/change-beta/@azure-communication-react-6d999d69-0527-4c82-96c8-3dd5dded13a2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Pinned participants",
+  "comment": "Fix missing pinned icon when it is the only icon for a remote participant",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-6d999d69-0527-4c82-96c8-3dd5dded13a2.json
+++ b/change/@azure-communication-react-6d999d69-0527-4c82-96c8-3dd5dded13a2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Pinned participants",
+  "comment": "Fix missing pinned icon when it is the only icon for a remote participant",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ParticipantList.tsx
+++ b/packages/react-components/src/components/ParticipantList.tsx
@@ -152,8 +152,10 @@ const onRenderParticipantDefault = (
 
   const callingPalette = (theme as unknown as CallingTheme).callingPalette;
 
+  const isPinned = pinnedParticipants && pinnedParticipants?.includes(participant.userId);
+
   const onRenderIcon =
-    callingParticipant?.isScreenSharing || callingParticipant?.isMuted || callingParticipant?.raisedHand
+    callingParticipant?.isScreenSharing || callingParticipant?.isMuted || callingParticipant?.raisedHand || isPinned
       ? () => (
           <Stack horizontal={true} tokens={{ childrenGap: '0.5rem' }}>
             {callingParticipant.raisedHand && (
@@ -189,9 +191,7 @@ const onRenderParticipantDefault = (
             )}
             {callingParticipant.spotlight && <Icon iconName="ParticipantItemSpotlighted" className={iconStyles} />}
 
-            {pinnedParticipants && pinnedParticipants?.includes(participant.userId) && (
-              <Icon iconName="ParticipantItemPinned" className={iconStyles} />
-            )}
+            {isPinned && <Icon iconName="ParticipantItemPinned" className={iconStyles} />}
           </Stack>
         )
       : () => null;


### PR DESCRIPTION
# What
Fix missing pinned icon when it is the only icon by updating logic for onRenderIcon prop in ParticipantList

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3765795

# How Tested
Testing locally on CallWithChat app
![image](https://github.com/Azure/communication-ui-library/assets/79475487/53cc8e30-a007-4af4-ae1f-a393fbd5abcd)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->