### PR TITLE
[RTE][A11Y] Resolve A11Y issue where show richTextEditor button didn't have aria-expanded attribute

### DIFF
--- a/change-beta/@azure-communication-react-1f618629-3200-482d-8f7e-d013383f6b8c.json
+++ b/change-beta/@azure-communication-react-1f618629-3200-482d-8f7e-d013383f6b8c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Resolve A11Y issue where show richTextEditor button didn't have aria-expanded attribute",
+  "packageName": "@azure/communication-react",
+  "email": "73612854+palatter@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-1f618629-3200-482d-8f7e-d013383f6b8c.json
+++ b/change/@azure-communication-react-1f618629-3200-482d-8f7e-d013383f6b8c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Resolve A11Y issue where show richTextEditor button didn't have aria-expanded attribute",
+  "packageName": "@azure/communication-react",
+  "email": "73612854+palatter@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/InputBoxButton.tsx
+++ b/packages/react-components/src/components/InputBoxButton.tsx
@@ -21,6 +21,7 @@ export type InputBoxButtonProps = {
   tooltipContent?: string;
   'data-testId'?: string;
   ariaDisabled?: boolean;
+  ariaExpanded?: boolean;
 };
 
 /**
@@ -35,7 +36,8 @@ export const InputBoxButton = (props: InputBoxButtonProps): JSX.Element => {
     id,
     tooltipContent,
     'data-testId': dataTestId,
-    ariaDisabled = false
+    ariaDisabled = false,
+    ariaExpanded = false
   } = props;
   const [isHover, setIsHover] = useState(false);
   const mergedButtonStyle = mergeStyles(inputBoxButtonStyle, className);
@@ -69,6 +71,7 @@ export const InputBoxButton = (props: InputBoxButtonProps): JSX.Element => {
           // VoiceOver fix: Avoid icon from stealing focus when IconButton is double-tapped to send message by wrapping with Stack with pointerEvents style to none
           onRenderIcon={() => <Stack className={iconWrapperStyle}>{onRenderIcon(isHover)}</Stack>}
           data-testid={dataTestId}
+          aria-expanded={ariaExpanded}
         />
       </Stack>
     </TooltipHost>

--- a/packages/react-components/src/components/RichTextEditor/RichTextInputBoxComponent.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextInputBoxComponent.tsx
@@ -122,6 +122,7 @@ export const RichTextInputBoxComponent = (props: RichTextInputBoxComponentProps)
             tooltipContent={strings.richTextFormatButtonTooltip}
             className={richTextActionButtonsStyle}
             data-testId={'rich-text-input-box-format-button'}
+            ariaExpanded={showRichTextEditorFormatting}
           />
           <Icon iconName="RichTextDividerIcon" className={richTextActionButtonsDividerStyle(theme)} />
           {actionComponents}


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

Show richTextEditor should indicate to Voice Over whether its expanded or collapsed.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->