### PR TITLE
[RTE][A11Y] Resolve A11Y issue around rich text editor table size selection buttons.

### DIFF
--- a/change-beta/@azure-communication-react-d66256a5-944b-4963-b815-254ca8594d91.json
+++ b/change-beta/@azure-communication-react-d66256a5-944b-4963-b815-254ca8594d91.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Resolve issue around rich text editor table size selection buttons.",
+  "packageName": "@azure/communication-react",
+  "email": "palatter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-d66256a5-944b-4963-b815-254ca8594d91.json
+++ b/change/@azure-communication-react-d66256a5-944b-4963-b815-254ca8594d91.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Resolve issue around rich text editor table size selection buttons.",
+  "packageName": "@azure/communication-react",
+  "email": "palatter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/RichTextEditor.styles.ts
+++ b/packages/react-components/src/components/styles/RichTextEditor.styles.ts
@@ -265,8 +265,8 @@ export const sendBoxRichTextEditorStyle = (isExpanded: boolean): RichTextEditorS
  */
 export const insertTableMenuCellButtonStyles = (theme: Theme): IStyle => {
   return {
-    width: '16px',
-    height: '16px',
+    width: '24px',
+    height: '24px',
     border: `solid 1px ${theme.palette.neutralTertiaryAlt}`,
     cursor: 'pointer',
     background: 'transparent'


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

As part of new A11Y guidelines, button size must be a minimum of 24x24.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->