### PR TITLE
[End Call options] Add option to hide the end call prompt

### DIFF
--- a/change-beta/@azure-communication-react-ef9e339c-0b46-428e-93b5-28a479eddf65.json
+++ b/change-beta/@azure-communication-react-ef9e339c-0b46-428e-93b5-28a479eddf65.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "feature",
+  "workstream": "End Call Options",
+  "comment": "Add disable option for end call modal",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-ef9e339c-0b46-428e-93b5-28a479eddf65.json
+++ b/change/@azure-communication-react-ef9e339c-0b46-428e-93b5-28a479eddf65.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "feature",
+  "workstream": "End Call Options",
+  "comment": "Add disable option for end call modal",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1976,6 +1976,7 @@ export type CommonCallControlOptions = {
     };
     endCallButton?: boolean | /* @conditional-compile-remove(end-call-options) */ {
         hangUpForEveryone?: false | 'endCallOptions';
+        disableEndCallModal?: boolean;
     };
     microphoneButton?: boolean | /* @conditional-compile-remove(PSTN-calls) */ {
         disabled: boolean;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -1670,6 +1670,7 @@ export type CommonCallControlOptions = {
     cameraButton?: boolean;
     endCallButton?: boolean | /* @conditional-compile-remove(end-call-options) */ {
         hangUpForEveryone?: false | 'endCallOptions';
+        disableEndCallModal?: boolean;
     };
     microphoneButton?: boolean;
     devicesButton?: boolean;

--- a/packages/react-composites/src/composites/CallComposite/components/buttons/EndCall.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/buttons/EndCall.tsx
@@ -21,6 +21,7 @@ export const EndCall = (props: {
   mobileView?: boolean;
   /* @conditional-compile-remove(end-call-options) */
   enableEndCallMenu?: boolean;
+  disableEndCallModal?: boolean;
 }): JSX.Element => {
   const compactMode = props.displayType === 'compact';
   const hangUpButtonProps = usePropsFor(EndCallButton);
@@ -119,7 +120,7 @@ export const EndCall = (props: {
         data-ui-id="call-composite-hangup-button"
         {...hangUpButtonProps}
         /* @conditional-compile-remove(end-call-options) */
-        onHangUp={hangUpOverride}
+        onHangUp={props.disableEndCallModal ? onHangUp : hangUpOverride}
         styles={styles}
         showLabel={!compactMode}
         /* @conditional-compile-remove(end-call-options) */

--- a/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
@@ -471,6 +471,11 @@ export const CommonCallControlBar = (props: CommonCallControlBarProps & Containe
                         !isTeams && // Temporary disable it for Teams call, since capability does not give the right value
                         props.callControls?.endCallButton?.hangUpForEveryone === 'endCallOptions'
                       }
+                      disableEndCallModal={
+                        !isBoolean(props.callControls) &&
+                        !isBoolean(props.callControls?.endCallButton) &&
+                        props.callControls?.endCallButton?.disableEndCallModal
+                      }
                     />
                   </ControlBar>
                 </div>

--- a/packages/react-composites/src/composites/common/types/CommonCallControlOptions.tsx
+++ b/packages/react-composites/src/composites/common/types/CommonCallControlOptions.tsx
@@ -47,6 +47,10 @@ export type CommonCallControlOptions = {
          * @defaultValue false
          */
         hangUpForEveryone?: false | 'endCallOptions';
+        /**
+         * Wether to disable the end call confirmation modal.
+         */
+        disableEndCallModal?: boolean;
       };
   /**
    * Show or Hide Microphone button during a call.

--- a/samples/Calling/src/app/views/CallCompositeContainer.tsx
+++ b/samples/Calling/src/app/views/CallCompositeContainer.tsx
@@ -26,8 +26,7 @@ export const CallCompositeContainer = (props: CallCompositeContainerProps): JSX.
         screenShareButton: shouldHideScreenShare ? false : undefined,
         /* @conditional-compile-remove(end-call-options) */
         endCallButton: {
-          hangUpForEveryone: 'endCallOptions',
-          disableEndCallModal: true
+          hangUpForEveryone: 'endCallOptions'
         }
       },
       autoShowDtmfDialer: true

--- a/samples/Calling/src/app/views/CallCompositeContainer.tsx
+++ b/samples/Calling/src/app/views/CallCompositeContainer.tsx
@@ -26,7 +26,8 @@ export const CallCompositeContainer = (props: CallCompositeContainerProps): JSX.
         screenShareButton: shouldHideScreenShare ? false : undefined,
         /* @conditional-compile-remove(end-call-options) */
         endCallButton: {
-          hangUpForEveryone: 'endCallOptions'
+          hangUpForEveryone: 'endCallOptions',
+          disableEndCallModal: true
         }
       },
       autoShowDtmfDialer: true


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Introduces new API to hide the end call modal
# Why
<!--- What problem does this change solve? -->
Allows the user to end the call without the prompt if configured correctly
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3767128
# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated locally