### PR TITLE
[Storybook] Introduce MessageStatusIndicator component to storybook v8

### DIFF
--- a/packages/storybook8/stories/Components/MessageStatusIndicator/Docs.mdx
+++ b/packages/storybook8/stories/Components/MessageStatusIndicator/Docs.mdx
@@ -1,0 +1,23 @@
+import { Canvas, Meta, ArgTypes } from '@storybook/blocks';
+import * as MessageStatusIndicatorStories from './index.stories';
+
+import MessageStatusIndicatorStoriesExampleText from '!!raw-loader!./snippets/MessageStatusIndicator.snippet.tsx';
+
+<Meta of={MessageStatusIndicatorStories} />
+
+# Message Status Indicator
+
+MessageStatusIndicator is used to indicate whether a message has been read, delivered, currently sending, or failed to send.
+
+## Importing
+
+```ts
+import { MessageStatus, MessageStatusIndicator } from '@azure/communication-react';
+```
+
+## Example
+
+<Canvas
+  of={MessageStatusIndicatorStories.MessageStatusIndicatorSnippetDocsOnly}
+  source={{ code: MessageStatusIndicatorStoriesExampleText }}
+/>

--- a/packages/storybook8/stories/Components/MessageStatusIndicator/MessageStatusIndicator.story.tsx
+++ b/packages/storybook8/stories/Components/MessageStatusIndicator/MessageStatusIndicator.story.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import {
+  MessageStatus,
+  MessageStatusIndicator as MessageStatusIndicatorComponent,
+  DEFAULT_COMPONENT_ICONS
+} from '@azure/communication-react';
+import { initializeIcons, registerIcons } from '@fluentui/react';
+
+import React from 'react';
+
+initializeIcons();
+registerIcons({ icons: { ...DEFAULT_COMPONENT_ICONS } });
+
+const MessageStatusIndicatorStory = (args: {
+  status: string;
+  deliveredTooltipText: string;
+  sendingTooltipText: string;
+  seenTooltipText: string;
+  readByTooltipText: string;
+  failedToSendTooltipText: string;
+}): JSX.Element => {
+  return (
+    <MessageStatusIndicatorComponent
+      status={args.status as MessageStatus}
+      strings={{
+        deliveredTooltipText: args.deliveredTooltipText,
+        sendingTooltipText: args.sendingTooltipText,
+        seenTooltipText: args.seenTooltipText,
+        readByTooltipText: args.readByTooltipText,
+        failedToSendTooltipText: args.failedToSendTooltipText
+      }}
+    />
+  );
+};
+
+export const MessageStatusIndicator = MessageStatusIndicatorStory.bind({});

--- a/packages/storybook8/stories/Components/MessageStatusIndicator/index.stories.tsx
+++ b/packages/storybook8/stories/Components/MessageStatusIndicator/index.stories.tsx
@@ -3,7 +3,7 @@
 
 import { MessageStatusIndicator as MessageStatusIndicatorComponent } from '@azure/communication-react';
 import { Meta } from '@storybook/react';
-import { hiddenControl } from '../../controlsUtils';
+import { controlsToAdd, hiddenControl } from '../../controlsUtils';
 import { MessageStatusIndicatorExample } from './snippets/MessageStatusIndicator.snippet';
 export { MessageStatusIndicator } from './MessageStatusIndicator.story';
 
@@ -15,6 +15,12 @@ const meta: Meta = {
   component: MessageStatusIndicatorComponent,
   title: 'Components/Message Status Indicator',
   argTypes: {
+    status: controlsToAdd.messageStatus,
+    deliveredTooltipText: controlsToAdd.messageDeliveredTooltipText,
+    sendingTooltipText: controlsToAdd.messageSendingTooltipText,
+    seenTooltipText: controlsToAdd.messageSeenTooltipText,
+    readByTooltipText: controlsToAdd.messageReadByTooltipText,
+    failedToSendTooltipText: controlsToAdd.messageFailedToSendTooltipText,
     // Hide default controls
     readCount: hiddenControl,
     onToggleToolTip: hiddenControl,

--- a/packages/storybook8/stories/Components/MessageStatusIndicator/index.stories.tsx
+++ b/packages/storybook8/stories/Components/MessageStatusIndicator/index.stories.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { MessageStatusIndicator as MessageStatusIndicatorComponent } from '@azure/communication-react';
+import { Meta } from '@storybook/react';
+import { hiddenControl } from '../../controlsUtils';
+import { MessageStatusIndicatorExample } from './snippets/MessageStatusIndicator.snippet';
+export { MessageStatusIndicator } from './MessageStatusIndicator.story';
+
+export const MessageStatusIndicatorSnippetDocsOnly = {
+  render: MessageStatusIndicatorExample
+};
+
+const meta: Meta = {
+  component: MessageStatusIndicatorComponent,
+  title: 'Components/Message Status Indicator',
+  argTypes: {
+    // Hide default controls
+    readCount: hiddenControl,
+    onToggleToolTip: hiddenControl,
+    remoteParticipantsCount: hiddenControl,
+    styles: hiddenControl,
+    strings: hiddenControl
+  },
+  args: {
+    status: 'delivered',
+    deliveredTooltipText: 'Delivered',
+    sendingTooltipText: 'Sending',
+    seenTooltipText: 'Seen',
+    readByTooltipText: 'Read by',
+    failedToSendTooltipText: 'Failed to send'
+  }
+};
+
+export default meta;

--- a/packages/storybook8/stories/Components/MessageStatusIndicator/snippets/MessageStatusIndicator.snippet.tsx
+++ b/packages/storybook8/stories/Components/MessageStatusIndicator/snippets/MessageStatusIndicator.snippet.tsx
@@ -1,0 +1,21 @@
+import {
+  MessageStatus,
+  MessageStatusIndicator as MessageStatusIndicatorComponent,
+  DEFAULT_COMPONENT_ICONS
+} from '@azure/communication-react';
+import { initializeIcons, registerIcons, Stack } from '@fluentui/react';
+import React from 'react';
+
+initializeIcons();
+registerIcons({ icons: { ...DEFAULT_COMPONENT_ICONS } });
+
+export const MessageStatusIndicatorExample: () => JSX.Element = () => {
+  return (
+    <Stack horizontalAlign="start">
+      <MessageStatusIndicatorComponent status={'delivered' as MessageStatus} />
+      <MessageStatusIndicatorComponent status={'seen' as MessageStatus} />
+      <MessageStatusIndicatorComponent status={'sending' as MessageStatus} />
+      <MessageStatusIndicatorComponent status={'failed' as MessageStatus} />
+    </Stack>
+  );
+};


### PR DESCRIPTION
# What
Migrating to new storybook v8 
![image](https://github.com/Azure/communication-ui-library/assets/9044372/30e62b64-41d3-440c-b09f-4a94130d6bbb)
![image](https://github.com/Azure/communication-ui-library/assets/9044372/6c9f7242-8d53-43b3-acc7-ba14dca687b3)

# Why
Migration

# How Tested
in `packages/storybook8` 
run `rushx start`

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [x] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->