### PR TITLE
[A11y][Chat] Update Participant pane title to h2 heading

### DIFF
--- a/change-beta/@azure-communication-react-afc2afcd-8293-436e-a619-de53bd78b010.json
+++ b/change-beta/@azure-communication-react-afc2afcd-8293-436e-a619-de53bd78b010.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Fix participant pane title to h2",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-afc2afcd-8293-436e-a619-de53bd78b010.json
+++ b/change/@azure-communication-react-afc2afcd-8293-436e-a619-de53bd78b010.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Fix participant pane title to h2",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/common/ParticipantContainer.tsx
+++ b/packages/react-composites/src/composites/common/ParticipantContainer.tsx
@@ -71,9 +71,12 @@ export const ParticipantListWithHeading = (props: {
   const subheadingStyleThemed = useMemo(
     () => ({
       root: {
-        color: theme.palette.neutralSecondary,
-        margin: props.isMobile ? '0.5rem 1rem' : '0.5rem',
-        fontSize: theme.fonts.smallPlus.fontSize
+        h2: {
+          color: theme.palette.neutralSecondary,
+          margin: props.isMobile ? '0.5rem 1rem' : '0.5rem',
+          fontSize: theme.fonts.smallPlus.fontSize,
+          fontWeight: 'normal'
+        }
       }
     }),
     [theme.palette.neutralSecondary, theme.fonts.smallPlus.fontSize, props.isMobile]
@@ -83,10 +86,12 @@ export const ParticipantListWithHeading = (props: {
     <Stack className={participantListStack}>
       <Stack horizontal horizontalAlign="space-between" verticalAlign="center">
         <Stack.Item grow styles={subheadingStyleThemed} aria-label={title} id={subheadingUniqueId}>
-          {paneTitleTrampoline(
-            title ?? '',
-            /* @conditional-compile-remove(total-participant-count) */ totalParticipantCount
-          )}
+          <h2>
+            {paneTitleTrampoline(
+              title ?? '',
+              /* @conditional-compile-remove(total-participant-count) */ totalParticipantCount
+            )}
+          </h2>
         </Stack.Item>
         {(onClickHeadingMoreButton ||
           (headingMoreButtonMenuProps?.items && headingMoreButtonMenuProps.items.length > 0)) && (


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Update Participant pane title to h2 heading
<img width="1030" alt="image" src="https://github.com/Azure/communication-ui-library/assets/77021369/e3db5af7-1312-431b-92d3-9a850af27e32">

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
- Accessibility requirement https://skype.visualstudio.com/SPOOL/_workitems/edit/3741235

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->