### PR TITLE
[RTE] Resolve issue where placeholder didn't always hide.

### DIFF
--- a/change-beta/@azure-communication-react-79a14e38-b554-456d-b853-44e099501e51.json
+++ b/change-beta/@azure-communication-react-79a14e38-b554-456d-b853-44e099501e51.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Resolve issue where placeholder didn't always hide.",
+  "packageName": "@azure/communication-react",
+  "email": "palatter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-79a14e38-b554-456d-b853-44e099501e51.json
+++ b/change/@azure-communication-react-79a14e38-b554-456d-b853-44e099501e51.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Resolve issue where placeholder didn't always hide.",
+  "packageName": "@azure/communication-react",
+  "email": "palatter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/RichTextEditor/Plugins/PlaceholderPlugin.tsx
+++ b/packages/react-components/src/components/RichTextEditor/Plugins/PlaceholderPlugin.tsx
@@ -22,6 +22,10 @@ export class PlaceholderPlugin extends WatermarkPlugin {
   initialize(editor: IEditor): void {
     this.editorValue = editor;
     super.initialize(editor);
+
+    // Hide/show the placeholder as workaround for the placeholder not hiding in some cases
+    this.hide(this.editorValue);
+    this.show(this.editorValue);
   }
   dispose(): void {
     this.editorValue = null;


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

When editing a message with a large amount text, the placeholder fails to hide.

<img width="453" alt="image" src="https://github.com/Azure/communication-ui-library/assets/73612854/f69da5ce-c2cc-4a6f-b37c-ec531af96251">

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->