### PR TITLE
Fix vulnerability of having NaN from calculations in overflow gallery

### DIFF
--- a/change-beta/@azure-communication-react-c115b8a8-0e97-4435-a191-627982b65631.json
+++ b/change-beta/@azure-communication-react-c115b8a8-0e97-4435-a191-627982b65631.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Overflow gallery",
+  "comment": "Fix vulnerability of convertRemToPx function to return NaN",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-c115b8a8-0e97-4435-a191-627982b65631.json
+++ b/change-beta/@azure-communication-react-c115b8a8-0e97-4435-a191-627982b65631.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "Overflow gallery",
-  "comment": "Fix vulnerability of convertRemToPx function to return NaN",
+  "comment": "Fix vulnerability of having NaN from calculations in horizontal or vertical overflow gallery",
   "packageName": "@azure/communication-react",
   "email": "79475487+mgamis-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@azure-communication-react-c115b8a8-0e97-4435-a191-627982b65631.json
+++ b/change/@azure-communication-react-c115b8a8-0e97-4435-a191-627982b65631.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Overflow gallery",
+  "comment": "Fix vulnerability of convertRemToPx function to return NaN",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-c115b8a8-0e97-4435-a191-627982b65631.json
+++ b/change/@azure-communication-react-c115b8a8-0e97-4435-a191-627982b65631.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "Overflow gallery",
-  "comment": "Fix vulnerability of convertRemToPx function to return NaN",
+  "comment": "Fix vulnerability of having NaN from calculations in horizontal or vertical overflow gallery",
   "packageName": "@azure/communication-react",
   "email": "79475487+mgamis-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/acs-ui-common/src/common.ts
+++ b/packages/acs-ui-common/src/common.ts
@@ -23,7 +23,7 @@ export const _convertPxToRem = (px: number): number => {
 
 const getBrowserFontSizeInPx = (): number => {
   let fontSizeInPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
-  // If font size is not a number, default to 16px
+  // If browser font size is not a number, default to 16 px
   if (Number.isNaN(fontSizeInPx)) {
     fontSizeInPx = 16;
   }

--- a/packages/acs-ui-common/src/common.ts
+++ b/packages/acs-ui-common/src/common.ts
@@ -8,7 +8,7 @@
  * @returns units of pixels
  */
 export const _convertRemToPx = (rem: number): number => {
-  return rem * parseFloat(getComputedStyle(document.documentElement).fontSize);
+  return rem * getBrowserFontSizeInPx();
 };
 
 /**
@@ -18,7 +18,16 @@ export const _convertRemToPx = (rem: number): number => {
  * @returns units of rem
  */
 export const _convertPxToRem = (px: number): number => {
-  return px / parseFloat(getComputedStyle(document.documentElement).fontSize);
+  return px / getBrowserFontSizeInPx();
+};
+
+const getBrowserFontSizeInPx = (): number => {
+  let fontSizeInPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
+  // If font size is not a number, default to 16px
+  if (Number.isNaN(fontSizeInPx)) {
+    fontSizeInPx = 16;
+  }
+  return fontSizeInPx;
 };
 
 /**

--- a/packages/react-components/src/components/ResponsiveHorizontalGallery.tsx
+++ b/packages/react-components/src/components/ResponsiveHorizontalGallery.tsx
@@ -27,10 +27,14 @@ export const ResponsiveHorizontalGallery = (props: {
 
   const leftPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingLeft) : 0;
   const rightPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingRight) : 0;
+  let containerWidthWithoutPadding = Math.max((containerWidth ?? 0) - leftPadding - rightPadding, 0);
+  if (Number.isNaN(containerWidthWithoutPadding)) {
+    containerWidthWithoutPadding = 0;
+  }
 
   const childrenPerPage = calculateHorizontalChildrenPerPage({
     numberOfChildren: React.Children.count(props.children),
-    containerWidth: (containerWidth ?? 0) - leftPadding - rightPadding,
+    containerWidth: containerWidthWithoutPadding,
     gapWidthRem,
     buttonWidthRem
   });

--- a/packages/react-components/src/components/ResponsiveVerticalGallery.tsx
+++ b/packages/react-components/src/components/ResponsiveVerticalGallery.tsx
@@ -55,10 +55,14 @@ export const ResponsiveVerticalGallery = (props: ResponsiveVerticalGalleryProps)
 
   const topPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingTop) : 0;
   const bottomPadding = containerRef.current ? parseFloat(getComputedStyle(containerRef.current).paddingBottom) : 0;
+  let containerHeightWithoutPadding = Math.max((containerHeight ?? 0) - topPadding - bottomPadding, 0);
+  if (Number.isNaN(containerHeightWithoutPadding)) {
+    containerHeightWithoutPadding = 0;
+  }
 
   const childrenPerPage = calculateVerticalChildrenPerPage({
     numberOfChildren: React.Children.count(children) ?? 0,
-    containerHeight: (containerHeight ?? 0) - topPadding - bottomPadding,
+    containerHeight: containerHeightWithoutPadding,
     gapHeightRem,
     controlBarHeight: controlBarHeightRem ?? 2,
     isShort: isShort ?? false

--- a/packages/react-components/src/components/utils/responsive.ts
+++ b/packages/react-components/src/components/utils/responsive.ts
@@ -16,7 +16,11 @@ export const _useContainerWidth = (containerRef: RefObject<HTMLElement>): number
   const observer = useRef(
     new ResizeObserver((entries) => {
       const { width } = entries[0].contentRect;
-      setWidth(width);
+      if (Number.isNaN(width)) {
+        setWidth(0);
+      } else {
+        setWidth(width);
+      }
     })
   );
 
@@ -46,7 +50,11 @@ export const _useContainerHeight = (containerRef: RefObject<HTMLElement>): numbe
   const observer = useRef(
     new ResizeObserver((entries) => {
       const { height } = entries[0].contentRect;
-      setHeight(height);
+      if (Number.isNaN(height)) {
+        setHeight(0);
+      } else {
+        setHeight(height);
+      }
     })
   );
 

--- a/samples/Calling/src/app/views/CallCompositeContainer.tsx
+++ b/samples/Calling/src/app/views/CallCompositeContainer.tsx
@@ -3,7 +3,7 @@
 
 import { GroupCallLocator, TeamsMeetingLinkLocator } from '@azure/communication-calling';
 import { CallAdapterLocator, CallComposite, CallCompositeOptions, CommonCallAdapter } from '@azure/communication-react';
-import { Spinner } from '@fluentui/react';
+import { mergeStyles, PrimaryButton, Spinner, Stack } from '@fluentui/react';
 import React, { useEffect, useMemo } from 'react';
 import { useSwitchableFluentTheme } from '../theming/SwitchableFluentThemeProvider';
 import { useIsMobile } from '../utils/useIsMobile';
@@ -34,6 +34,8 @@ export const CallCompositeContainer = (props: CallCompositeContainerProps): JSX.
       });
     };
   }, []);
+
+  const [showApp, setShowApp] = React.useState(true);
 
   const options: CallCompositeOptions = useMemo(
     () => ({
@@ -71,14 +73,26 @@ export const CallCompositeContainer = (props: CallCompositeContainerProps): JSX.
   }
 
   return (
-    <CallComposite
-      adapter={adapter}
-      fluentTheme={currentTheme.theme}
-      rtl={currentRtl}
-      callInvitationUrl={callInvitationUrl}
-      formFactor={isMobileSession ? 'mobile' : 'desktop'}
-      options={options}
-    />
+    <Stack className={mergeStyles({ width: '100%', height: '100%' })}>
+      <PrimaryButton onClick={() => setShowApp(!showApp)}>{showApp ? 'Hide session' : 'Back to session'}</PrimaryButton>
+      <PrimaryButton
+        onClick={() => {
+          document.documentElement.setAttribute('style', 'font-size: large');
+        }}
+      >
+        {'Change font size'}
+      </PrimaryButton>
+      {showApp && (
+        <CallComposite
+          adapter={adapter}
+          fluentTheme={currentTheme.theme}
+          rtl={currentRtl}
+          callInvitationUrl={callInvitationUrl}
+          formFactor={isMobileSession ? 'mobile' : 'desktop'}
+          options={options}
+        />
+      )}
+    </Stack>
   );
 };
 

--- a/samples/Calling/src/app/views/CallCompositeContainer.tsx
+++ b/samples/Calling/src/app/views/CallCompositeContainer.tsx
@@ -3,7 +3,7 @@
 
 import { GroupCallLocator, TeamsMeetingLinkLocator } from '@azure/communication-calling';
 import { CallAdapterLocator, CallComposite, CallCompositeOptions, CommonCallAdapter } from '@azure/communication-react';
-import { mergeStyles, PrimaryButton, Spinner, Stack } from '@fluentui/react';
+import { Spinner } from '@fluentui/react';
 import React, { useEffect, useMemo } from 'react';
 import { useSwitchableFluentTheme } from '../theming/SwitchableFluentThemeProvider';
 import { useIsMobile } from '../utils/useIsMobile';
@@ -34,8 +34,6 @@ export const CallCompositeContainer = (props: CallCompositeContainerProps): JSX.
       });
     };
   }, []);
-
-  const [showApp, setShowApp] = React.useState(true);
 
   const options: CallCompositeOptions = useMemo(
     () => ({
@@ -73,26 +71,14 @@ export const CallCompositeContainer = (props: CallCompositeContainerProps): JSX.
   }
 
   return (
-    <Stack className={mergeStyles({ width: '100%', height: '100%' })}>
-      <PrimaryButton onClick={() => setShowApp(!showApp)}>{showApp ? 'Hide session' : 'Back to session'}</PrimaryButton>
-      <PrimaryButton
-        onClick={() => {
-          document.documentElement.setAttribute('style', 'font-size: large');
-        }}
-      >
-        {'Change font size'}
-      </PrimaryButton>
-      {showApp && (
-        <CallComposite
-          adapter={adapter}
-          fluentTheme={currentTheme.theme}
-          rtl={currentRtl}
-          callInvitationUrl={callInvitationUrl}
-          formFactor={isMobileSession ? 'mobile' : 'desktop'}
-          options={options}
-        />
-      )}
-    </Stack>
+    <CallComposite
+      adapter={adapter}
+      fluentTheme={currentTheme.theme}
+      rtl={currentRtl}
+      callInvitationUrl={callInvitationUrl}
+      formFactor={isMobileSession ? 'mobile' : 'desktop'}
+      options={options}
+    />
   );
 };
 


### PR DESCRIPTION
# What
Fix vulnerability of having NaN from calculations in horizontal or vertical overflow gallery. Function `parseFloat` can return NaN according to the documentation
![image](https://github.com/user-attachments/assets/efa4bff7-7321-4977-81cd-1bf5136da712)

# Why
To resolve an issue EZRA is experiencing when HorizontalGallery is present where the composite crashes when it is re-rendered.

# How Tested
Could not reproduce issue on my side because EZRA is using an Angular wrapper around our composite. 
Confirmed with EZRA that they are seeing NaN when children per page is being calculated for the horizontal gallery.
![horizontal gallery NaN bug](https://github.com/user-attachments/assets/608f9637-0834-4f28-a973-a35f4cf8d3b0)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->