### PR TITLE
Set targetCallee to undefined in sample when it is not set (#4857)

### DIFF
--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -55,7 +55,7 @@ const App = (): JSX.Element => {
 
   // Call details to join a call - these are collected from the user on the home screen
   const [callLocator, setCallLocator] = useState<CallAdapterLocator>();
-  const [targetCallees, setTargetCallees] = useState<StartCallIdentifier[]>([]);
+  const [targetCallees, setTargetCallees] = useState<StartCallIdentifier[] | undefined>(undefined);
   const [displayName, setDisplayName] = useState<string>('');
 
   /* @conditional-compile-remove(teams-identity-support) */
@@ -126,7 +126,7 @@ const App = (): JSX.Element => {
                 return fromFlatCommunicationIdentifier(user);
               });
               callLocator = undefined;
-              setTargetCallees(outboundUsers ?? []);
+              setTargetCallees(outboundUsers);
             }
 
             if (callDetails.option === 'TeamsAdhoc') {
@@ -134,7 +134,7 @@ const App = (): JSX.Element => {
                 return fromFlatCommunicationIdentifier(user) as StartCallIdentifier;
               });
               callLocator = undefined;
-              setTargetCallees(outboundTeamsUsers ?? []);
+              setTargetCallees(outboundTeamsUsers);
             }
 
             // There is an API call involved with creating a room so lets only create one if we know we have to


### PR DESCRIPTION
* Make targetCallee to undefined when it is not set
# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->