### PR TITLE
Migrate top level Components pages to storybook8

### DIFF
--- a/packages/storybook8/stories/Components/GettingStarted/Docs.mdx
+++ b/packages/storybook8/stories/Components/GettingStarted/Docs.mdx
@@ -1,0 +1,151 @@
+import { Meta, Source } from '@storybook/addon-docs';
+import { CompletedComponentsApp } from './snippets/CompletedComponentsApp.story';
+import AppText from '!!raw-loader!./snippets/App.snippet.tsx';
+import CallingComponentsText from '!!raw-loader!./snippets/CallingComponents.tsx';
+import ChatComponentsText from '!!raw-loader!./snippets/ChatComponents.tsx';
+import CompletedComponentsAppText from '!!raw-loader!./snippets/CompletedComponentsApp.story.tsx';
+
+<Meta title="Components/Get Started" />
+
+# Quickstart: Get started with UI Components
+
+Get started with Azure Communication Services by using the UI Library to quickly integrate communication experiences into your applications. In this quickstart, you'll learn how to integrate UI Library base components into your application to build communication experiences.
+
+UI Library components come in two flavors: UI and Composite.
+
+- **UI components** represent discrete communication capabilities; they're the basic building blocks that can be used to build complex communication experiences.
+- **Composite components** are turn-key experiences for common communication scenarios that have been built using **base components** as building blocks and packaged to be easily integrated into applications.
+
+## Download the code
+
+You can find the completed code for this quickstart here: [Get started with UI Components](https://github.com/Azure-Samples/communication-services-javascript-quickstarts/tree/main/ui-library-quickstart-ui-components)
+
+## Prerequisites
+
+- An Azure account with an active subscription. [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
+- [Node.js](https://nodejs.org/) Active LTS and Maintenance LTS versions (Node 18.0.0 and above).
+
+## Setting Up
+
+UI Library requires a React environment to be setup. Next we will do that.
+
+### Install the Package
+
+Use the `npm install` command to install the Azure Communication Services UI Library for JavaScript.
+
+```bash
+
+npm install @azure/communication-react
+
+```
+
+`@azure/communication-react` specifies core Azure Communication Services as `peerDependencies` so that
+you can most consistently use the API from the core libraries in your application. You need to install those libraries as well:
+
+```bash
+
+npm install @azure/communication-calling
+npm install @azure/communication-chat
+
+```
+
+### Run Create React App
+
+Let's test the Create React App installation by running:
+
+```bash
+
+npm run start
+
+```
+
+## Object Model
+
+The following classes and interfaces handle some of the major features of the Azure Communication Services UI client library:
+
+| Name                                                                        | Description                                                                              |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [FluentThemeProvider](./?path=/docs/concepts-theming--docs)                 | Provider that controls Theming on the components. Can be used to override theme          |
+| [GridLayout](./?path=/story/components-grid-layout--grid-layout)            | Base component that organizes video tiles into a grid                                    |
+| [VideoTile](./?path=/story/components-video-tile--video-tile)               | Base component to render participants either with or without video                       |
+| [ControlBar](./?path=/story/components-controlbar-control-bar--control-bar) | Base component to control call including mute, video, share screen                       |
+| [MessageThread](./?path=/story/components-message-thread--message-thread)   | Base component that renders a chat thread with typing indicators, read receipts, etc.    |
+| [SendBox](./?path=/story/components-sendbox-send-box--send-box)             | Base component that allows user to input messages that will be sent to the joined thread |
+
+## Set Up Fluent Theme Provider and Icons
+
+The `FluentThemeProvider` is a required wrapper around the UI Library components to provide theming that makes the components look amazing!
+It is in charge of allowing developer customize the theme of the components as well. Check out [Theming](./?path=/docs/concepts-theming--docs) for more information. `FluentThemeProvider` defaults to using light theme.
+
+`App.tsx`
+
+<Source code={AppText} />
+
+Inside the `FluentThemeProvider`, you can add additional components.
+Next we'll use various UI components to showcase a sample experience.
+You can customize the layout of these components and add any other custom components that you want to render with them.
+
+## Calling UI Components
+
+For Calling, we'll use the [`GridLayout`](./?path=/story/components-grid-layout--grid-layout) and [`ControlBar`](./?path=/story/components-controlbar-control-bar--control-bar) components.
+To start, in the `src` folder, create a new file called `CallingComponents.tsx`.
+Here we'll initialize a function component that will hold our base components to then import in `App.tsx`.
+You can add extra layout and styling around the components.
+
+`CallingComponents.tsx`
+
+<Source code={CallingComponentsText} />
+
+For this example, we added one [`VideoTile`](./?path=/story/components-video-tile--video-tile) to the grid, but more can be added.
+
+## Chat UI Components
+
+For Chat, we will use the [`MessageThread`](./?path=/story/components-message-thread--message-thread) and [`SendBox`](./?path=/story/components-sendbox-send-box--send-box) components.
+To start, in the `src` folder, create a new file called `ChatComponents.tsx`.
+Here we'll initialize a function component that will hold our base components to then import in `App.tsx`.
+
+`ChatComponents.tsx`
+
+<Source code={ChatComponentsText} />
+
+## Add Calling and Chat Components
+
+Back in the `App.tsx` file, we will now add the components to the `FluentThemeProvider` like shown below.
+
+`App.tsx`
+
+<Source code={CompletedComponentsAppText} />
+<div>
+  <CompletedComponentsApp />
+</div>
+
+## Run Quickstart
+
+To run the code above use the command:
+
+```console
+
+npm run start
+
+```
+
+## Troubleshooting
+
+See the [troubleshooting page](./?path=/docs/concepts-troubleshooting--docs) for some common problems and recommended solutions.
+
+## Clean Up Resources
+
+If you want to clean up and remove a Communication Services subscription, you can delete the resource or resource group.
+Deleting the resource group also deletes any other resources associated with it.
+Learn more about [cleaning up resources](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp#clean-up-resources).
+
+## Next Steps
+
+- [Try UI Library Stateful Call Client](./?path=/docs/stateful-client-get-started-call--docs)
+- [Try UI Library Stateful Chat Client](./?path=/docs/stateful-client-get-started-chat--docs)
+
+For more information, see the following resources:
+
+- [UI Library Use Cases](./?path=/docs/use-cases--docs)
+- [UI Library Styling](./?path=/docs/concepts-styling--docs)
+- [UI Library Theming](./?path=/docs/concepts-theming--docs)

--- a/packages/storybook8/stories/Components/GettingStarted/snippets/App.snippet.tsx
+++ b/packages/storybook8/stories/Components/GettingStarted/snippets/App.snippet.tsx
@@ -1,0 +1,18 @@
+import { FluentThemeProvider, DEFAULT_COMPONENT_ICONS } from '@azure/communication-react';
+import { initializeIcons, registerIcons } from '@fluentui/react';
+import React from 'react';
+
+// If you don't want to provide custom icons, you can register the default ones included with the library.
+// This will ensure that all the icons are rendered correctly.
+initializeIcons();
+registerIcons({ icons: DEFAULT_COMPONENT_ICONS });
+
+function App(): JSX.Element {
+  return (
+    <FluentThemeProvider>
+      <h1>Hooray! You set up Fluent Theme Provider 🎉🎉🎉</h1>
+    </FluentThemeProvider>
+  );
+}
+
+export default App;

--- a/packages/storybook8/stories/Components/GettingStarted/snippets/CallingComponents.tsx
+++ b/packages/storybook8/stories/Components/GettingStarted/snippets/CallingComponents.tsx
@@ -1,0 +1,58 @@
+import {
+  CameraButton,
+  ControlBar,
+  EndCallButton,
+  GridLayout,
+  MicrophoneButton,
+  DevicesButton,
+  ScreenShareButton,
+  VideoTile
+} from '@azure/communication-react';
+
+import { IContextualMenuProps, mergeStyles, Stack } from '@fluentui/react';
+import React, { useState } from 'react';
+
+export const CallingComponents = (): JSX.Element => {
+  const exampleOptionsMenuProps: IContextualMenuProps = {
+    items: [
+      {
+        key: '1',
+        name: 'Choose Camera',
+        iconProps: { iconName: 'LocationCircle' },
+        onClick: () => alert('Choose Camera Menu Item Clicked!')
+      }
+    ]
+  };
+
+  const controlBarStyle = {
+    root: {
+      justifyContent: 'center'
+    }
+  };
+  const [videoButtonChecked, setVideoButtonChecked] = useState<boolean>(false);
+  const [audioButtonChecked, setAudioButtonChecked] = useState<boolean>(false);
+  const [screenshareButtonChecked, setScreenshareButtonChecked] = useState<boolean>(false);
+
+  return (
+    <Stack className={mergeStyles({ height: '100%' })}>
+      {/* GridLayout Component relies on the parent's height and width, so it's required to set the height and width on its parent. */}
+      <div style={{ height: '30rem', width: '30rem', border: '1px solid' }}>
+        <GridLayout>
+          <VideoTile displayName={'Michael'} />
+        </GridLayout>
+      </div>
+
+      {/* Control Bar with default set up */}
+      <ControlBar styles={controlBarStyle}>
+        <CameraButton checked={videoButtonChecked} onClick={() => setVideoButtonChecked(!videoButtonChecked)} />
+        <MicrophoneButton checked={audioButtonChecked} onClick={() => setAudioButtonChecked(!audioButtonChecked)} />
+        <ScreenShareButton
+          checked={screenshareButtonChecked}
+          onClick={() => setScreenshareButtonChecked(!screenshareButtonChecked)}
+        />
+        <DevicesButton menuProps={exampleOptionsMenuProps} />
+        <EndCallButton />
+      </ControlBar>
+    </Stack>
+  );
+};

--- a/packages/storybook8/stories/Components/GettingStarted/snippets/ChatComponents.tsx
+++ b/packages/storybook8/stories/Components/GettingStarted/snippets/ChatComponents.tsx
@@ -1,0 +1,67 @@
+import {
+  MessageThread,
+  ChatMessage as WebUiChatMessage,
+  SendBox,
+  MessageStatus,
+  MessageContentType
+} from '@azure/communication-react';
+import React from 'react';
+
+export const ChatComponents = (): JSX.Element => {
+  //A sample chat history
+  const GetHistoryChatMessages = (): WebUiChatMessage[] => {
+    return [
+      {
+        messageType: 'chat',
+        contentType: 'text' as MessageContentType,
+        senderId: '1',
+        senderDisplayName: 'User1',
+        messageId: Math.random().toString(),
+        content: 'Hi everyone, I created this awesome group chat for us!',
+        createdOn: new Date('2019-04-13T00:00:00.000+08:10'),
+        mine: true,
+        attached: false,
+        status: 'seen' as MessageStatus
+      },
+      {
+        messageType: 'chat',
+        contentType: 'text' as MessageContentType,
+        senderId: '2',
+        senderDisplayName: 'User2',
+        messageId: Math.random().toString(),
+        content: 'Nice! This looks great!',
+        createdOn: new Date('2019-04-13T00:00:00.000+08:09'),
+        mine: false,
+        attached: false
+      },
+      {
+        messageType: 'chat',
+        contentType: 'text' as MessageContentType,
+        senderId: '3',
+        senderDisplayName: 'User3',
+        messageId: Math.random().toString(),
+        content: "Yeah agree, let's chat here from now on!",
+        createdOn: new Date('2019-04-13T00:00:00.000+08:09'),
+        mine: false,
+        attached: false
+      }
+    ];
+  };
+
+  return (
+    <div style={{ height: '30rem', width: '30rem' }}>
+      {/* Chat thread component with message status indicator feature enabled */}
+      <MessageThread userId={'1'} messages={GetHistoryChatMessages()} showMessageStatus={true} />
+
+      <SendBox
+        disabled={false}
+        onSendMessage={async () => {
+          return;
+        }}
+        onTyping={async () => {
+          return;
+        }}
+      />
+    </div>
+  );
+};

--- a/packages/storybook8/stories/Components/GettingStarted/snippets/CompletedComponentsApp.story.tsx
+++ b/packages/storybook8/stories/Components/GettingStarted/snippets/CompletedComponentsApp.story.tsx
@@ -1,0 +1,26 @@
+import { DEFAULT_COMPONENT_ICONS, FluentThemeProvider } from '@azure/communication-react';
+import { Stack, registerIcons, initializeIcons } from '@fluentui/react';
+import React from 'react';
+import { CallingComponents } from './CallingComponents';
+import { ChatComponents } from './ChatComponents';
+
+// If you don't want to provide custom icons, you can register the default ones included with the library.
+// This will ensure that all the icons are rendered correctly.
+initializeIcons();
+registerIcons({ icons: DEFAULT_COMPONENT_ICONS });
+
+export const CompletedComponentsApp: () => JSX.Element = () => {
+  const stackStyle = {
+    root: {
+      width: '100%'
+    }
+  };
+  return (
+    <FluentThemeProvider>
+      <Stack horizontal horizontalAlign="space-evenly" styles={stackStyle}>
+        <CallingComponents />
+        <ChatComponents />
+      </Stack>
+    </FluentThemeProvider>
+  );
+};

--- a/packages/storybook8/stories/Components/Overview.mdx
+++ b/packages/storybook8/stories/Components/Overview.mdx
@@ -1,0 +1,47 @@
+import { Stack } from '@fluentui/react';
+import { Meta } from '@storybook/addon-docs';
+import { overviewPageImagesStackStyle } from '../constants';
+
+<Meta title="Components/Overview" />
+
+# UI Component Overview
+
+Pure UI Components that can be used by developers to compose communication experiences, from stitching video tiles into a grid to showcase remote participants, to organizing components to fit your applications specifications.
+UI Components support customization to give the components the right feel and look to match an applications branding and style.
+
+Following are lists of components that can be used for specific areas.
+
+## Main Components for Calling
+
+<Stack tokens={{ childrenGap: '3rem' }} style={overviewPageImagesStackStyle}>
+  <Stack.Item align="center">
+    <img src="images/components_calling.png" alt="example of components that can be used for calling" />
+  </Stack.Item>
+  <Stack.Item align="center">
+    <img src="images/components_common.png" alt="example of components that can be used for chat" />
+  </Stack.Item>
+</Stack>
+
+| Component                                                                          | Description                                                                                        |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| [Grid Layout](./?path=/story/components-grid-layout--grid-layout)                | Grid component to organize Video Tiles into an NxN grid                                            |
+| [Video Tile](./?path=/story/components-video-tile--video-tile)                   | Component that displays video stream when available and a default static component when not        |
+| [Control Bar](./?path=/story/components-controlbar-control-bar--control-bar)                | Container to organize DefaultButtons to hook up to specific call actions like mute or share screen |
+| [Video Gallery](./?path=/story/components-video-gallery--gallery-layout)          | Turn-key video gallery component which dynamically changes as participants are added               |
+| [Participant Item](./?path=/story/components-participant-item--participant-item) | Common component to render a call or chat participant including avatar and display name            |
+| [Participant List](./?path=/story/components-participant-list--participant-list) | Common component to render a call or chat participant list including avatar and display name       |
+
+## Main Components for Chat
+
+<Stack style={overviewPageImagesStackStyle}>
+  <Stack.Item align="center">
+    <img src="images/components_chat.png" alt="example of components that can be used for chat" />
+  </Stack.Item>
+</Stack>
+
+| Component                                                                                                 | Description                                                                   |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [Message Thread](./?path=/story/components-message-thread--message-thread)                              | Container that renders chat messages, system messages, and custom messages    |
+| [Send Box](./?path=/story/components-sendbox-send-box--send-box)                                                | Text input component with a discrete send button                              |
+| [Message Status Indicator](./?path=/story/components-message-status-indicator--message-status-indicator) | Multi-state message status indicator component to show status of sent message |
+| [Typing indicator](./?path=/story/components-typing-indicator--typing-indicator)                        | Text component to render the participants who are actively typing on a thread |


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Migrate top level Components pages to storybook8: : Overview, Get Started
- Known issue
  - styling issue for Get Started story
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/4c5b8f7a-1f5d-4bc3-b863-3e10fea5a931">
<img width="1585" alt="image" src="https://github.com/user-attachments/assets/b966fe60-aa13-4457-90e9-cbc198d9f928">


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->