### PR TITLE
Stop showing initial notifications of capabilities being present when joining a call

### DIFF
--- a/change-beta/@azure-communication-react-314ab8c9-a41f-4f74-bbd4-3c31d086f35a.json
+++ b/change-beta/@azure-communication-react-314ab8c9-a41f-4f74-bbd4-3c31d086f35a.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Capabilities",
+  "comment": "Suppress initial notifications of capabilities being present when joining a call",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-314ab8c9-a41f-4f74-bbd4-3c31d086f35a.json
+++ b/change/@azure-communication-react-314ab8c9-a41f-4f74-bbd4-3c31d086f35a.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Capabilities",
+  "comment": "Suppress initial notifications of capabilities being present when joining a call",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# What
Stop showing initial notifications of capabilities being present when joining a call

Note: the work to move these old style notifications to the the improved notifications is to be done in the future

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3811980

# How Tested
Tested in CTE scenario in stable where the bug above was originally reproduced and verified that the fix works. 
Also verified that mid-call role changes in ACS Teams meeting and Rooms calls still produced notifications for loss/gain of mic, audio, and screen share capabilities

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->