### PR TITLE
[Chat] Store the image upload respond id under the image src attribute

### DIFF
--- a/packages/react-composites/src/composites/ChatComposite/ImageUpload/ImageUploadUtils.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ImageUpload/ImageUploadUtils.tsx
@@ -124,7 +124,10 @@ const inlineImageUploadHandler = async (
 
     try {
       const response = await adapter.uploadImage(image, task.metadata?.name);
-      uploadTask.notifyUploadCompleted(response.id, task.metadata.url || '');
+      // Use response id as the image src because we need to keep the original image id as a reference to find the image.
+      // Also the html content we send to ChatSDK does not need image src,
+      // it only need the response id to match the uploaded image, url is not needed.
+      uploadTask.notifyUploadCompleted(task.metadata.id, response.id);
     } catch (error) {
       console.error(error);
       uploadTask.notifyUploadFailed(strings.uploadImageFailed);
@@ -257,7 +260,7 @@ export const cancelInlineImageUpload = (
     deleteExistingInlineImageForEditBox(imageAttributes.id, messageId, adapter);
     return;
   }
-  const imageUpload = imageUploads[messageId].find((upload) => upload.metadata.url === imageAttributes.src);
+  const imageUpload = imageUploads[messageId].find((upload) => upload.metadata.id === imageAttributes.id);
 
   if (!imageUpload || !imageUpload?.metadata.id) {
     deleteExistingInlineImageForEditBox(imageAttributes.id, messageId, adapter);
@@ -269,7 +272,7 @@ export const cancelInlineImageUpload = (
     id: imageUpload?.metadata.id,
     messageId
   });
-  // TODO: remove local blob
+
   if (imageUpload?.metadata.progress === 1) {
     deleteInlineImageFromServer(imageUpload?.metadata.id, adapter);
   }
@@ -306,12 +309,13 @@ export const updateContentStringWithUploadedInlineImages = (
   const document = new DOMParser().parseFromString(content ?? '', 'text/html');
   document.querySelectorAll('img').forEach((img) => {
     const uploadInlineImage = messageUploads.find(
-      (upload) => !upload.metadata.error && upload.metadata.progress === 1 && upload.metadata.url === img.src
+      (upload) => !upload.metadata.error && upload.metadata.progress === 1 && upload.metadata.id === img.id
     );
 
     if (uploadInlineImage) {
-      img.id = uploadInlineImage.metadata.id;
-      img.src = uploadInlineImage.metadata.url ?? img.src;
+      // ChatSDK uses the respond id provided by the upload response. We store the response id in the image src attribute previously.
+      img.id = uploadInlineImage.metadata.url ?? img.id;
+      img.src = '';
     }
   });
   content = document.body.innerHTML;


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Store the image upload respond id under the image src attribute and when send, replace it internal message id using the image src attribute
- We cannot add a new prop to store the response id under AttachmentMetaData because currently we use the metadata.id and metadata.url to calculate the length of the content string and displaying message too long errors

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->