### PR TITLE
[Chat]Get image file name for redo images

### DIFF
--- a/packages/acs-ui-common/src/constants.ts
+++ b/packages/acs-ui-common/src/constants.ts
@@ -6,3 +6,10 @@
  * @internal
  */
 export const _MAX_EVENT_LISTENERS = 50;
+
+/* @conditional-compile-remove(rich-text-editor-image-upload) */
+/**
+ * The key for the rich text editor inline image file name attribute
+ * @internal
+ */
+export const _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY = 'data-image-file-name';

--- a/packages/acs-ui-common/src/index.ts
+++ b/packages/acs-ui-common/src/index.ts
@@ -26,6 +26,8 @@ export type { _IObjectMap } from './localizationUtils';
 export type { _TelemetryImplementationHint } from './telemetry';
 
 export { _MAX_EVENT_LISTENERS } from './constants';
+/* @conditional-compile-remove(rich-text-editor-image-upload) */
+export { _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY } from './constants';
 
 export { _pxToRem } from './cssUtils';
 

--- a/packages/react-components/src/components/RichTextEditor/Plugins/CopyPastePlugin.tsx
+++ b/packages/react-components/src/components/RichTextEditor/Plugins/CopyPastePlugin.tsx
@@ -3,11 +3,7 @@
 import type { PluginEvent, EditorPlugin, IEditor } from 'roosterjs-content-model-types';
 import { ContentChangedEventSource, PluginEventType } from '../../utils/RichTextEditorUtils';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
-import { getInlineImageAttributes } from '../../utils/RichTextEditorUtils';
-/* @conditional-compile-remove(rich-text-editor-image-upload) */
-import { _base64ToBlob } from '@internal/acs-ui-common';
-/* @conditional-compile-remove(rich-text-editor-image-upload) */
-import { removeImageTags } from '@internal/acs-ui-common';
+import { _base64ToBlob, removeImageTags, _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { v1 as generateGUID } from 'uuid';
 
@@ -84,7 +80,11 @@ export const handleInlineImage = (
   if (event.eventType === PluginEventType.BeforePaste && event.pasteType === 'normal' && onInsertInlineImage) {
     event.fragment.querySelectorAll('img').forEach((image) => {
       const clipboardImage = event.clipboardData.image;
-      const fileName = clipboardImage?.name || clipboardImage?.type.replace('/', '.');
+      const fileName =
+        clipboardImage?.name ||
+        clipboardImage?.type.replace('/', '.') ||
+        image.getAttribute(_IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY) ||
+        '';
       // If the image src is an external url, call the onInsertInlineImage callback with the url.
       let imageUrl = image.src;
       if (image.src.startsWith('data:image/')) {

--- a/packages/react-components/src/components/RichTextEditor/Plugins/CopyPastePlugin.tsx
+++ b/packages/react-components/src/components/RichTextEditor/Plugins/CopyPastePlugin.tsx
@@ -3,6 +3,8 @@
 import type { PluginEvent, EditorPlugin, IEditor } from 'roosterjs-content-model-types';
 import { ContentChangedEventSource, PluginEventType } from '../../utils/RichTextEditorUtils';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
+import { getInlineImageAttributes } from '../../utils/RichTextEditorUtils';
+/* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { _base64ToBlob, removeImageTags, _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { v1 as generateGUID } from 'uuid';

--- a/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ChatScreen.tsx
@@ -47,7 +47,7 @@ import { participantListContainerPadding } from '../common/styles/ParticipantCon
 import { ChatScreenPeoplePane } from './ChatScreenPeoplePane';
 import { toFlatCommunicationIdentifier } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
-import { removeImageTags } from '@internal/acs-ui-common';
+import { removeImageTags, _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentDownloadErrorBar } from './AttachmentDownloadErrorBar';
 import { _AttachmentDownloadCards } from '@internal/react-components';
@@ -70,6 +70,7 @@ import { loadRichTextSendBox, RichTextSendBoxOptions } from '../common/SendBoxPi
 import {
   cancelInlineImageUpload,
   getEditBoxMessagesInlineImages,
+  getImageFileNameFromAttributes,
   getSendBoxInlineImages,
   onInsertInlineImageForEditBox,
   onInsertInlineImageForSendBox,
@@ -80,11 +81,7 @@ import type { ChatAdapterState } from './adapter/ChatAdapter';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { isMicrosoftTeamsUserIdentifier } from '@azure/communication-common';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
-import {
-  SEND_BOX_UPLOADS_KEY_VALUE,
-  _DEFAULT_INLINE_IMAGE_FILE_NAME,
-  _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY
-} from '../common/constants';
+import { SEND_BOX_UPLOADS_KEY_VALUE, _DEFAULT_INLINE_IMAGE_FILE_NAME } from '../common/constants';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { ImageUploadReducer } from './ImageUpload/ImageUploadReducer';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
@@ -609,7 +606,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
           onInsertInlineImage: (imageAttributes: Record<string, string>, messageId: string) => {
             onInsertInlineImageForEditBox(
               imageAttributes,
-              imageAttributes[_IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY] || _DEFAULT_INLINE_IMAGE_FILE_NAME,
+              getImageFileNameFromAttributes(imageAttributes),
               messageId,
               adapter,
               handleEditBoxInlineImageUploadAction,
@@ -648,7 +645,7 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
           onInsertInlineImage: (imageAttributes: Record<string, string>) => {
             onInsertInlineImageForSendBox(
               imageAttributes,
-              imageAttributes[_IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY] || _DEFAULT_INLINE_IMAGE_FILE_NAME,
+              getImageFileNameFromAttributes(imageAttributes),
               adapter,
               handleSendBoxInlineImageUploadAction,
               localeStrings.chat

--- a/packages/react-composites/src/composites/ChatComposite/ImageUpload/ImageUploadUtils.tsx
+++ b/packages/react-composites/src/composites/ChatComposite/ImageUpload/ImageUploadUtils.tsx
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
-import { AttachmentMetadataInProgress } from '@internal/acs-ui-common';
+import { AttachmentMetadataInProgress, _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { AttachmentUpload, AttachmentUploadActionType, AttachmentUploadTask } from '../file-sharing/AttachmentUpload';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
-import { SEND_BOX_UPLOADS_KEY_VALUE } from '../../common/constants';
+import { _DEFAULT_INLINE_IMAGE_FILE_NAME, SEND_BOX_UPLOADS_KEY_VALUE } from '../../common/constants';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { ChatAdapter } from '../adapter/ChatAdapter';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
@@ -317,4 +317,16 @@ export const updateContentStringWithUploadedInlineImages = (
   content = document.body.innerHTML;
 
   return content;
+};
+
+/* @conditional-compile-remove(rich-text-editor-image-upload) */
+/**
+ * @internal
+ */
+export const getImageFileNameFromAttributes = (imageAttributes: Record<string, string>): string => {
+  const fileName = imageAttributes[_IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY];
+  if (!fileName || fileName === '' || fileName === 'undefined' || fileName === 'null') {
+    return _DEFAULT_INLINE_IMAGE_FILE_NAME;
+  }
+  return fileName;
 };

--- a/packages/react-composites/src/composites/common/constants.ts
+++ b/packages/react-composites/src/composites/common/constants.ts
@@ -30,10 +30,3 @@ export const SEND_BOX_UPLOADS_KEY_VALUE = 'send-box';
  * @internal
  */
 export const _DEFAULT_INLINE_IMAGE_FILE_NAME = 'image.png';
-
-/* @conditional-compile-remove(rich-text-editor-image-upload) */
-/**
- * The key for the rich text editor inline image file name attribute
- * @internal
- */
-export const _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY = 'data-image-file-name';

--- a/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
+++ b/packages/storybook/stories/MessageThread/MessageThread.stories.tsx
@@ -26,10 +26,8 @@ import { Divider } from '@fluentui/react-components';
 import { Canvas, Description, Heading, Props, Source, Subtitle, Title } from '@storybook/addon-docs';
 import { Meta } from '@storybook/react/types-6-0';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  _DEFAULT_INLINE_IMAGE_FILE_NAME,
-  _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY
-} from '../../../react-composites/src/composites/common/constants';
+import { getImageFileNameFromAttributes } from '../../../react-composites/src/composites/ChatComposite/ImageUpload/ImageUploadUtils';
+/* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { DetailedBetaBanner } from '../BetaBanners/DetailedBetaBanner';
 import { SingleLineBetaBanner } from '../BetaBanners/SingleLineBetaBanner';
 
@@ -637,7 +635,7 @@ const MessageThreadStory = (args): JSX.Element => {
         const inlineImagesWithProgress = messagesInlineImagesWithProgress?.[messageId] ?? [];
         const newImage: AttachmentMetadataInProgress = {
           id: imageAttributes.id,
-          name: imageAttributes[_IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY] ?? _DEFAULT_INLINE_IMAGE_FILE_NAME,
+          name: getImageFileNameFromAttributes(imageAttributes),
           progress: 1,
           url: imageAttributes.src,
           error: undefined

--- a/packages/storybook/stories/SendBox/RichTextSendBox.stories.tsx
+++ b/packages/storybook/stories/SendBox/RichTextSendBox.stories.tsx
@@ -5,10 +5,8 @@ import { AttachmentMetadataInProgress, RichTextSendBox as RichTextSendBoxCompone
 import { Title, Description, Props, Heading, Canvas, Source } from '@storybook/addon-docs';
 import { Meta } from '@storybook/react/types-6-0';
 import React, { useState } from 'react';
-import {
-  _DEFAULT_INLINE_IMAGE_FILE_NAME,
-  _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY
-} from '../../../react-composites/src/composites/common/constants';
+import { getImageFileNameFromAttributes } from '../../../react-composites/src/composites/ChatComposite/ImageUpload/ImageUploadUtils';
+/* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { DetailedBetaBanner } from '../BetaBanners/DetailedBetaBanner';
 import { SingleLineBetaBanner } from '../BetaBanners/SingleLineBetaBanner';
 import { COMPONENT_FOLDER_PREFIX } from '../constants';
@@ -140,7 +138,7 @@ const RichTextSendBoxStory = (args): JSX.Element => {
         onInsertInlineImage={(imageAttributes: Record<string, string>) => {
           const newImage = {
             id: imageAttributes.id,
-            name: imageAttributes[_IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY] ?? _DEFAULT_INLINE_IMAGE_FILE_NAME,
+            name: getImageFileNameFromAttributes(imageAttributes),
             progress: 1,
             url: imageAttributes.src,
             error: undefined

--- a/packages/storybook8/stories/Components/MessageThread/MessageThread.story.tsx
+++ b/packages/storybook8/stories/Components/MessageThread/MessageThread.story.tsx
@@ -23,13 +23,8 @@ import {
   IDropdownOption
 } from '@fluentui/react';
 import { Divider } from '@fluentui/react-components';
-
 import React, { useMemo, useRef, useState } from 'react';
 
-import {
-  _DEFAULT_INLINE_IMAGE_FILE_NAME,
-  _IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY
-} from '../../../../react-composites/src/composites/common/constants';
 import {
   GenerateMockNewChatMessage,
   UserOne,
@@ -200,7 +195,7 @@ const MessageThreadStory = (args): JSX.Element => {
         const inlineImagesWithProgress = messagesInlineImagesWithProgress?.[messageId] ?? [];
         const newImage: AttachmentMetadataInProgress = {
           id: imageAttributes.id,
-          name: imageAttributes[_IMAGE_ATTRIBUTE_INLINE_IMAGE_FILE_NAME_KEY] ?? _DEFAULT_INLINE_IMAGE_FILE_NAME,
+          name: getImageFileNameFromAttributes(imageAttributes),
           progress: 1,
           url: imageAttributes.src,
           error: undefined


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

Rooster doesn't not provide clipboard data for redo images.
Need to read it from the imageAttributes

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->