### PR TITLE
[Storybook8Migration] adding in callWithChat stories

### DIFF
--- a/packages/storybook8/stories/Composites/CallWithChatComposite/BasicExample.stories.tsx
+++ b/packages/storybook8/stories/Composites/CallWithChatComposite/BasicExample.stories.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { CallWithChatComposite } from '@azure/communication-react';
+import { Stack } from '@fluentui/react';
+import { Meta } from '@storybook/react';
+import React, { useState, useEffect } from 'react';
+import { compositeExperienceContainerStyle } from '../../constants';
+import {
+  ArgsFrom,
+  controlsToAdd,
+  defaultCallWithChatCompositeHiddenControls,
+  hiddenControl
+} from '../../controlsUtils';
+import { CallWithChatExampleProps } from './snippets/CallWithChat.snippet';
+import { CallWithChatExperienceWithErrorChecks } from './snippets/CallWithChatWithErrorChecks.snippet';
+import { createCallWithChat } from './snippets/Server.snippet';
+import { ConfigHintBanner } from './Utils';
+
+const storyControls = {
+  userId: controlsToAdd.userId,
+  token: controlsToAdd.token,
+  endpointUrl: controlsToAdd.endpointUrl,
+  displayName: controlsToAdd.requiredDisplayName,
+  compositeFormFactor: controlsToAdd.formFactor,
+  callWithChatControlOptions: controlsToAdd.callWithChatControlOptions,
+  richTextEditor: controlsToAdd.richTextEditor
+};
+
+const BasicStory = (args: ArgsFrom<typeof storyControls>, context: any): JSX.Element => {
+  const [callWithChatProps, setCallWithChatProps] = useState<CallWithChatExampleProps>();
+
+  useEffect(() => {
+    const fetchToken = async (): Promise<void> => {
+      if (args.token && args.userId && args.endpointUrl && args.displayName) {
+        const { callLocator, chatThreadId } = await createCallWithChat(
+          args.token,
+          args.userId,
+          args.endpointUrl,
+          args.displayName
+        );
+        setCallWithChatProps({
+          userId: { communicationUserId: args.userId },
+          token: args.token,
+          displayName: args.displayName,
+          endpointUrl: args.endpointUrl,
+          locator: {
+            callLocator,
+            chatThreadId
+          },
+          compositeOptions: { callControls: args.callWithChatControlOptions, richTextEditor: args.richTextEditor },
+          formFactor: args.compositeFormFactor
+        });
+      } else {
+        setCallWithChatProps(undefined);
+      }
+    };
+    fetchToken();
+  }, [
+    args.token,
+    args.userId,
+    args.endpointUrl,
+    args.displayName,
+    args.callWithChatControlOptions,
+    args.compositeFormFactor,
+    args.richTextEditor
+  ]);
+
+  return (
+    <>
+      <Stack horizontalAlign="center" verticalAlign="center" styles={compositeExperienceContainerStyle}>
+        {callWithChatProps ? (
+          <CallWithChatExperienceWithErrorChecks
+            fluentTheme={context.theme}
+            rtl={context.globals.rtl === 'rtl'}
+            {...callWithChatProps}
+          />
+        ) : (
+          <ConfigHintBanner />
+        )}
+      </Stack>
+    </>
+  );
+};
+
+export const BasicExample = BasicStory.bind({});
+
+export default {
+  id: 'composites-call-with-chat-basicexample--basic-example',
+  title: 'Composites/CallWithChatComposite/Basic Example',
+  component: CallWithChatComposite,
+  argTypes: {
+    ...storyControls,
+    // Hiding auto-generated controls
+    ...defaultCallWithChatCompositeHiddenControls
+  },
+  args: {
+    userId: '',
+    token: '',
+    endpointUrl: '',
+    displayName: 'John Smith',
+    formFactor: 'desktop',
+    callWithChatControlOptions: {
+      microphoneButton: true,
+      cameraButton: true,
+      screenShareButton: true,
+      devicesButton: true,
+      peopleButton: true,
+      chatButton: true,
+      displayType: 'default'
+    },
+    richTextEditor: false
+  },
+  parameters: {
+    useMaxHeightParent: true,
+    useMaxWidthParent: true
+  }
+} as Meta;

--- a/packages/storybook8/stories/Composites/CallWithChatComposite/Docs.mdx
+++ b/packages/storybook8/stories/Composites/CallWithChatComposite/Docs.mdx
@@ -19,8 +19,10 @@ participants entering and leaving the chat.
 <Stack horizontalAlign="center" style={overviewPageImagesStackStyle}>
   <Image src="images/call-with-chat-composite-hero.png" alt="Call with chat composite preview image" width="85%" />
 </Stack>
-<br />
-## Basic usage A CallWithChatComposite is comprised of two key underlying parts: an ACS Call and an ACS Chat thread. As
+
+## Basic usage
+
+A CallWithChatComposite is comprised of two key underlying parts: an ACS Call and an ACS Chat thread. As
 such you must provide details for both in the CallWithChatAdapter interface.
 
 A key thing to note is that initialization of the adapter is asynchronous. Thus, the initialization step
@@ -52,7 +54,7 @@ to be optimized for a mobile device.
   Note: Only Portrait mode is supported when the `formFactor` is set to "mobile". Landscape mode is not supported.
 </MessageBar>
 You can try out the form factor property in the [CallWithChatComposite Basic
-Example](./?path=/story/composites-call-with-chat-basicexample--basic-example).
+Example](./?path=/story/composites-call-with-chat-basicexample-basic-example--basic-example).
 
 Mobile devices have a pull-down to refresh feature that may impact users from scrolling through messages in
 chat. A simple and effective way to disable the pull-down to refresh feature is to set an `overflow='hidden'` OR
@@ -61,8 +63,8 @@ chat. A simple and effective way to disable the pull-down to refresh feature is 
 ## Theming
 
 CallWithChatComposite can be themed with Fluent UI themes, just like the base components. Look at the
-[CallComposite theme example](./?path=/story/composites-call-themeexample--theme-example) to see theming in
-action or the [overall theming example](./?path=/docs/theming--page) to see how theming works for all the
+[CallComposite theme example](./?path=/story/composites-callcomposite-theme-example--theme-example) to see theming in
+action or the [overall theming example](./?path=/docs/concepts-theming--docs) to see how theming works for all the
 components in this UI library.
 
 ## Custom Branding
@@ -103,7 +105,7 @@ logo image is 128x128 pixels.
 ## Customize Call Controls
 
 CallWithChatComposite provides a set of default controls for the call that can be customized similar to
-CallComposite. Check out [Customize Call Controls](./?path=/docs/composites-call-basicexample--basic-example#customize-call-controls)
+CallComposite. Check out [Customize Call Controls](./?path=/docs/composites-callcomposite--docs#customize-call-controls)
 to learn more.
 
 ## Adding image sharing
@@ -182,7 +184,7 @@ The CallWithChatComposite supports the PSTN Calling modality as well. With CallW
 provide a chat thread Id for instances where you will add a Azure Communications user to the call. If you are
 looking to use the CallWithChatComposite and are looking to hide the chat because you are only calling PSTN
 users please see our documentation on how to hide the [control bar
-buttons](./?path=/story/composites-call-with-chat-basicexample--basic-example).
+buttons](./?path=/story/composites-call-with-chat-basicexample-basic-example--basic-example).
 
 ## Rich Text Editor Support
 
@@ -191,5 +193,5 @@ buttons](./?path=/story/composites-call-with-chat-basicexample--basic-example).
 
 The CallWithChatComposite supports options to enable a rich text editor functionality in chat similar to
 ChatComposite. Check out [Rich Text Editor Support for
-ChatComposite](./?path=/docs/composites-chat-basicexample--basic-example#rich-text-editor-support) to learn
+ChatComposite](./?path=/docs/composites-chatcomposite--docs#rich-text-editor-support) to learn
 more.

--- a/packages/storybook8/stories/Composites/CallWithChatComposite/Docs.mdx
+++ b/packages/storybook8/stories/Composites/CallWithChatComposite/Docs.mdx
@@ -1,0 +1,195 @@
+import { Image, Stack, MessageBar } from '@fluentui/react';
+import { Meta, Source } from '@storybook/addon-docs';
+import { useEffect, useRef } from 'react';
+import { SingleLineBetaBanner } from '../../BetaBanners/SingleLineBetaBanner';
+import containerText from '!!raw-loader!./snippets/CallWithChat.snippet.tsx';
+import serverText from '!!raw-loader!./snippets/Server.snippet.tsx';
+import { overviewPageImagesStackStyle } from '../../constants';
+
+<Meta title="Composites/CallWithChatComposite" />
+
+# CallWithChatComposite
+
+CallWithChatComposite brings together key components to provide a full call with chat experience out of the box.
+Inside the experience users can configure their devices, participate in the call with video and see other
+participants, including those with video turned on. The experience includes chat capabilities like sending and
+receiving messages, and notifications for message thread events such as typing indicators, message receipts,
+participants entering and leaving the chat.
+
+<Stack horizontalAlign="center" style={overviewPageImagesStackStyle}>
+  <Image src="images/call-with-chat-composite-hero.png" alt="Call with chat composite preview image" width="85%" />
+</Stack>
+<br />
+## Basic usage A CallWithChatComposite is comprised of two key underlying parts: an ACS Call and an ACS Chat thread. As
+such you must provide details for both in the CallWithChatAdapter interface.
+
+A key thing to note is that initialization of the adapter is asynchronous. Thus, the initialization step
+requires special handling, as the example code below shows.
+
+<Source code={containerText} />
+
+## Prerequisites
+
+CallWithChatComposite provides the UI for an _existing user_ to join a call and a chat. Thus, the user and
+thread must be created beforehand. Typically, the user and group call or teams meeting are created on a
+Contoso-owned service and provided to the client application that then passes it to the CallWithChatComposite.
+
+<Source code={serverText} />
+
+## Running in a Mobile browser
+
+CallWithChatComposite by default is optimized for desktop views. To provide an optimized mobile experience, you
+may set the `formFactor` property to `"mobile"`. The CallWithChatComposite does not detect if it is running on
+mobile device vs desktop, instead you must identify if your clients device is a mobile device and set the
+`formFactor` property to `"mobile"`. This prop can be set at any time and immediately updates the composite UI
+to be optimized for a mobile device.
+
+<Source code={`<CallWithChatComposite formFactor="mobile" />`} />
+<Stack horizontalAlign="center">
+  <Image src="images/call-with-chat-composite-mobile-hero.png" alt="Call with chat composite mobile preview image" />
+</Stack>
+<MessageBar>
+  Note: Only Portrait mode is supported when the `formFactor` is set to "mobile". Landscape mode is not supported.
+</MessageBar>
+You can try out the form factor property in the [CallWithChatComposite Basic
+Example](./?path=/story/composites-call-with-chat-basicexample--basic-example).
+
+Mobile devices have a pull-down to refresh feature that may impact users from scrolling through messages in
+chat. A simple and effective way to disable the pull-down to refresh feature is to set an `overflow='hidden'` OR
+`touch-action='none'` style on the body element for your app.
+
+## Theming
+
+CallWithChatComposite can be themed with Fluent UI themes, just like the base components. Look at the
+[CallComposite theme example](./?path=/story/composites-call-themeexample--theme-example) to see theming in
+action or the [overall theming example](./?path=/docs/theming--page) to see how theming works for all the
+components in this UI library.
+
+## Custom Branding
+
+Along with applying a Fluent Theme to style the composites, you can also inject your own custom branding. You
+can inject a background and logo into the Composite configuration page to present to your users. This is done by
+passing background and logo properties to the `options` of the Composite.
+
+**Image recommendations.** The background image should be as simple and uncluttered as possible to avoid text
+becoming unreadable against the background. The background image should have a minimum size of 576x576 pixels
+and a maximum size of 2048x2048 pixels. The recommended size is 1280x720 pixels. The recommended size for the
+logo image is 128x128 pixels.
+
+<Stack horizontalAlign="center">
+  <img
+    style={{ width: '100%', maxWidth: '50rem' }}
+    src="images/composite-logo-background.png"
+    alt="CallWithChatComposite with a logo and background applied"
+  />
+</Stack>
+<Source
+  code={`
+<CallWithChatComposite options={{
+  branding: {
+    logo: {
+      url: 'https://...',
+      alt: 'My company logo',
+      shape: 'circle'
+    },
+    backgroundImage: {
+      url: 'https://...'
+    }
+  }
+}} />
+`}
+/>
+
+## Customize Call Controls
+
+CallWithChatComposite provides a set of default controls for the call that can be customized similar to
+CallComposite. Check out [Customize Call Controls](./?path=/docs/composites-call-basicexample--basic-example#customize-call-controls)
+to learn more.
+
+## Adding image sharing
+
+### Inline Image In Teams Interop Meeting Chat Thread
+
+<SingleLineBetaBanner />
+The Azure Communication Services end user can receive images shared by the Teams user without any additional setup when
+using the `CallWithChat` Composite in a Teams interop scenario,. Azure Communication Services end user would need to
+join the Teams meeting first, as soon as the Teams user sends a file from the Teams client, the Azure Communication
+Services end user will be see the image in the chat thread. Please check out the tutorial for [Enable inline image using
+UI Library in Teams Interoperability
+Chat](https://learn.microsoft.com/en-us/azure/communication-services/tutorials/inline-image-tutorial-interop-chat) for
+details.
+
+## Adding file sharing
+
+### File Sharing In Azure Communication Services Chat Thread
+
+<SingleLineBetaBanner />
+
+In a chat thread where all participants are Azure Communication Services end users, the `CallWithChat`
+Composite supports file capabilities in conjunction with your choice of a storage solution. Using the provided
+APIs, you can composite to support uploading files and displaying them on the send box before sending, and the
+once they have been sent or received. For an end to end tutorial on enabling file sharing with Azure Blob
+Storage as your choice of a storage solution, refer to our
+[tutorial](https://docs.microsoft.com/azure/communication-services/tutorials/file-sharing-tutorial).
+
+<Source
+  code={`<CallWithChatComposite
+adapter={chatAdapter}
+options={{
+  attachmentOptions: {
+    uploadOptions: {
+      supportedMediaTypes: ['image/png', 'image/jpeg'],
+      disableMultipleUploads: false,
+      handler: attachmentUploadHandler
+    },
+    /* If downloadOptions is not provided. The file URL is opened in a new tab.
+    You can find examples of downloadOptions and uploadOptions in this tutorial
+    https://docs.microsoft.com/en-us/azure/communication-services/tutorials/file-sharing-tutorial */
+    downloadOptions: {
+      actionsForAttachment: (attachment: AttachmentMetadata, message?: ChatMessage): AttachmentMenuAction[] => {
+        return [
+          defaultAttachmentMenuAction,
+          {
+            name: 'Open',
+            icon: <WindowNew24Regular />,
+            onClick: () => {
+              return new Promise((resolve) => {
+                window.alert('open button clicked');
+                resolve();
+              });
+            }
+          }
+        ];
+      }
+    }
+  }
+}} />`}
+/>
+
+### File Sharing In Teams Interop Meeting Chat Thread
+
+When using the `CallWithChat` Composite in a Teams interop scenario, the Azure Communication Services end user
+can recieve file attachments from Teams user without any additional setup. Simply join the Teams meeting as an
+Azure Communication Services end user, as soon as the Teams user sends a file from the Teams client, the Azure
+Communication Services end user will be able to see shared files in the chat thread.
+
+## PSTN and 1:N Calling
+
+<SingleLineBetaBanner />
+<MessageBar>Note: see CallComposite for detailed implementation description</MessageBar>
+
+The CallWithChatComposite supports the PSTN Calling modality as well. With CallWithChat you will need to still
+provide a chat thread Id for instances where you will add a Azure Communications user to the call. If you are
+looking to use the CallWithChatComposite and are looking to hide the chat because you are only calling PSTN
+users please see our documentation on how to hide the [control bar
+buttons](./?path=/story/composites-call-with-chat-basicexample--basic-example).
+
+## Rich Text Editor Support
+
+<SingleLineBetaBanner />
+<MessageBar>Note: see ChatComposite for detailed implementation description</MessageBar>
+
+The CallWithChatComposite supports options to enable a rich text editor functionality in chat similar to
+ChatComposite. Check out [Rich Text Editor Support for
+ChatComposite](./?path=/docs/composites-chat-basicexample--basic-example#rich-text-editor-support) to learn
+more.

--- a/packages/storybook8/stories/Composites/CallWithChatComposite/JoinExample.stories.tsx
+++ b/packages/storybook8/stories/Composites/CallWithChatComposite/JoinExample.stories.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { CallWithChatComposite } from '@azure/communication-react';
+import { Stack } from '@fluentui/react';
+import { Meta } from '@storybook/react';
+import React, { useState, useEffect } from 'react';
+import { compositeExperienceContainerStyle } from '../../constants';
+import { ArgsFrom, controlsToAdd, defaultCallWithChatCompositeHiddenControls } from '../../controlsUtils';
+import { CallWithChatExampleProps } from './snippets/CallWithChat.snippet';
+import { CallWithChatExperienceWithErrorChecks } from './snippets/CallWithChatWithErrorChecks.snippet';
+import { ConfigJoinMeetingHintBanner } from './Utils';
+
+const storyControls = {
+  userId: controlsToAdd.userId,
+  token: controlsToAdd.token,
+  endpointUrl: controlsToAdd.endpointUrl,
+  displayName: controlsToAdd.requiredDisplayName,
+  teamsMeetingLink: controlsToAdd.teamsMeetingLink,
+  formFactor: controlsToAdd.formFactor,
+  richTextEditor: controlsToAdd.richTextEditor
+};
+
+const JoinTeamsMeetingStory = (args: ArgsFrom<typeof storyControls>, context: any): JSX.Element => {
+  const [meetingProps, setMeetingProps] = useState<CallWithChatExampleProps>();
+
+  useEffect(() => {
+    const fetchToken = async (): Promise<void> => {
+      if (!!args.token && !!args.userId && !!args.endpointUrl && !!args.displayName && !!args.teamsMeetingLink) {
+        setMeetingProps({
+          userId: { communicationUserId: args.userId },
+          token: args.token,
+          displayName: args.displayName,
+          endpointUrl: args.endpointUrl,
+          locator: { meetingLink: args.teamsMeetingLink },
+          compositeOptions: { richTextEditor: args.richTextEditor }
+        });
+      } else {
+        setMeetingProps(undefined);
+      }
+    };
+    fetchToken();
+  }, [args.token, args.userId, args.endpointUrl, args.displayName, args.teamsMeetingLink, args.richTextEditor]);
+
+  return (
+    <>
+      <Stack horizontalAlign="center" verticalAlign="center" styles={compositeExperienceContainerStyle}>
+        {meetingProps ? (
+          <CallWithChatExperienceWithErrorChecks
+            fluentTheme={context.theme}
+            rtl={context.globals.rtl === 'rtl'}
+            {...meetingProps}
+          />
+        ) : (
+          <ConfigJoinMeetingHintBanner />
+        )}
+      </Stack>
+    </>
+  );
+};
+
+export const JoinTeamsMeeting = JoinTeamsMeetingStory.bind({});
+
+export default {
+  title: 'Composites/CallWithChatComposite/Join Teams Meeting',
+  component: CallWithChatComposite,
+  argTypes: {
+    ...storyControls,
+    // Hiding auto-generated controls
+    ...defaultCallWithChatCompositeHiddenControls
+  },
+  args: {
+    userId: '',
+    token: '',
+    endpointUrl: '',
+    displayName: 'John Smith',
+    formFactor: 'desktop',
+    callWithChatControlOptions: {
+      microphoneButton: true,
+      cameraButton: true,
+      screenShareButton: true,
+      devicesButton: true,
+      peopleButton: true,
+      chatButton: true,
+      displayType: 'default'
+    },
+    richTextEditor: false
+  },
+  parameters: {
+    useMaxHeightParent: true,
+    useMaxWidthParent: true
+  }
+} as Meta;

--- a/packages/storybook8/stories/Composites/CallWithChatComposite/Utils.tsx
+++ b/packages/storybook8/stories/Composites/CallWithChatComposite/Utils.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React from 'react';
+import { CompositeConnectionParamsErrMessage } from '../../CompositeStringUtils';
+import { MICROSOFT_AZURE_ACCESS_TOKEN_QUICKSTART } from '../../constants';
+
+export const ConfigHintBanner = (): JSX.Element => {
+  const emptyConfigTips = (
+    <div>
+      <p>
+        Please provide an{' '}
+        <a href={MICROSOFT_AZURE_ACCESS_TOKEN_QUICKSTART} target="_blank" rel="noreferrer">
+          access token, userId
+        </a>
+        , endpointUrl and display name to use.
+      </p>
+      <p>A display name has already been set by default, but feel free to change it.</p>
+    </div>
+  );
+  return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;
+};
+
+export const ConfigJoinMeetingHintBanner = (): JSX.Element => {
+  const emptyConfigTips = (
+    <p>
+      Please provide the an{' '}
+      <a href={MICROSOFT_AZURE_ACCESS_TOKEN_QUICKSTART} target="_blank" rel="noreferrer">
+        access token, userId
+      </a>
+      , endpointUrl, display name, and teams meeting link.
+    </p>
+  );
+  return <>{CompositeConnectionParamsErrMessage([emptyConfigTips])}</>;
+};

--- a/packages/storybook8/stories/Composites/CallWithChatComposite/snippets/CallWithChat.snippet.tsx
+++ b/packages/storybook8/stories/Composites/CallWithChatComposite/snippets/CallWithChat.snippet.tsx
@@ -1,0 +1,72 @@
+import { TeamsMeetingIdLocator, TeamsMeetingLinkLocator } from '@azure/communication-calling';
+import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from '@azure/communication-common';
+import {
+  CallAndChatLocator,
+  CallWithChatComposite,
+  useAzureCommunicationCallWithChatAdapter,
+  CallWithChatCompositeOptions
+} from '@azure/communication-react';
+import { Theme, PartialTheme, Spinner, initializeIcons } from '@fluentui/react';
+import React, { useMemo } from 'react';
+
+initializeIcons();
+
+export type CallWithChatExampleProps = {
+  // Props needed for the construction of the CallWithChatAdapter
+  userId: CommunicationUserIdentifier;
+  token: string;
+  displayName: string;
+  endpointUrl: string;
+  /**
+   * For CallWithChat you need to provide either a teams meeting locator or a CallAndChat locator
+   * for the composite
+   *
+   * CallAndChatLocator: This locator is comprised of a groupId call locator and a chat thread
+   * threadId for the session. See documentation on the {@link CallAndChatLocator} to see types of calls supported.
+   * {callLocator: ..., threadId: ...}
+   *
+   * TeamsMeetingLinkLocator: this is a special locator comprised of a Teams meeting link
+   * {meetingLink: ...}
+   */
+  locator: TeamsMeetingLinkLocator | CallAndChatLocator | TeamsMeetingIdLocator;
+
+  // Props to customize the CallWithChatComposite experience
+  fluentTheme?: PartialTheme | Theme;
+  rtl?: boolean;
+  compositeOptions?: CallWithChatCompositeOptions;
+  callInvitationURL?: string;
+  formFactor?: 'desktop' | 'mobile';
+};
+
+export const CallWithChatExperience = (props: CallWithChatExampleProps): JSX.Element => {
+  // Construct a credential for the user with the token retrieved from your server. This credential
+  // must be memoized to ensure useAzureCommunicationCallWithChatAdapter is not retriggered on every render pass.
+  const credential = useMemo(() => new AzureCommunicationTokenCredential(props.token), [props.token]);
+
+  // Create the adapter using a custom react hook provided in the @azure/communication-react package.
+  // See https://aka.ms/acsstorybook?path=/docs/composite-adapters--page for more information on adapter construction and alternative constructors.
+  const adapter = useAzureCommunicationCallWithChatAdapter({
+    userId: props.userId,
+    displayName: props.displayName,
+    credential,
+    locator: props.locator,
+    endpoint: props.endpointUrl
+  });
+
+  // The adapter is created asynchronously by the useAzureCommunicationCallWithChatAdapter hook.
+  // Here we show a spinner until the adapter has finished constructing.
+  if (!adapter) {
+    return <Spinner label="Initializing..." />;
+  }
+
+  return (
+    <CallWithChatComposite
+      adapter={adapter}
+      fluentTheme={props.fluentTheme}
+      rtl={props.rtl}
+      formFactor={props.formFactor}
+      joinInvitationURL={props.callInvitationURL}
+      options={props.compositeOptions}
+    />
+  );
+};

--- a/packages/storybook8/stories/Composites/CallWithChatComposite/snippets/CallWithChat.snippet.tsx
+++ b/packages/storybook8/stories/Composites/CallWithChatComposite/snippets/CallWithChat.snippet.tsx
@@ -44,7 +44,7 @@ export const CallWithChatExperience = (props: CallWithChatExampleProps): JSX.Ele
   const credential = useMemo(() => new AzureCommunicationTokenCredential(props.token), [props.token]);
 
   // Create the adapter using a custom react hook provided in the @azure/communication-react package.
-  // See https://aka.ms/acsstorybook?path=/docs/composite-adapters--page for more information on adapter construction and alternative constructors.
+  // See https://aka.ms/acsstorybook/?path=/docs/composites-adapters--docs for more information on adapter construction and alternative constructors.
   const adapter = useAzureCommunicationCallWithChatAdapter({
     userId: props.userId,
     displayName: props.displayName,

--- a/packages/storybook8/stories/Composites/CallWithChatComposite/snippets/CallWithChatWithErrorChecks.snippet.tsx
+++ b/packages/storybook8/stories/Composites/CallWithChatComposite/snippets/CallWithChatWithErrorChecks.snippet.tsx
@@ -1,0 +1,71 @@
+import { TeamsMeetingLinkLocator, TeamsMeetingIdLocator } from '@azure/communication-calling';
+import { AzureCommunicationTokenCredential, CommunicationUserIdentifier } from '@azure/communication-common';
+import {
+  CallAndChatLocator,
+  CallWithChatComposite,
+  useAzureCommunicationCallWithChatAdapter,
+  CallWithChatCompositeOptions,
+  CallWithChatAdapter
+} from '@azure/communication-react';
+import { Theme, PartialTheme, Spinner } from '@fluentui/react';
+import React, { useMemo } from 'react';
+
+export type CallWithChatExampleProps = {
+  userId: CommunicationUserIdentifier;
+  token: string;
+  displayName: string;
+  endpointUrl: string;
+  locator: TeamsMeetingLinkLocator | CallAndChatLocator | TeamsMeetingIdLocator;
+  fluentTheme?: PartialTheme | Theme;
+  rtl?: boolean;
+  compositeOptions?: CallWithChatCompositeOptions;
+  callInvitationURL?: string;
+  formFactor?: 'desktop' | 'mobile';
+};
+
+export const CallWithChatExperienceWithErrorChecks = (props: CallWithChatExampleProps): JSX.Element => {
+  const credential = useMemo(() => {
+    try {
+      return new AzureCommunicationTokenCredential(props.token);
+    } catch (e) {
+      return undefined;
+    }
+  }, [props.token]);
+
+  const adapter = useAzureCommunicationCallWithChatAdapter(
+    {
+      userId: props.userId,
+      displayName: props.displayName,
+      credential,
+      locator: props.locator,
+      endpoint: props.endpointUrl
+    },
+    undefined,
+    leaveCall
+  );
+
+  if (!credential) {
+    return <>Failed to construct credential. Provided token is malformed.</>;
+  }
+
+  if (!adapter) {
+    return <Spinner label="Initializing..." />;
+  }
+
+  return (
+    <CallWithChatComposite
+      adapter={adapter}
+      fluentTheme={props.fluentTheme}
+      rtl={props.rtl}
+      formFactor={props.formFactor}
+      joinInvitationURL={props.callInvitationURL}
+      options={props.compositeOptions}
+    />
+  );
+};
+
+const leaveCall = async (adapter: CallWithChatAdapter): Promise<void> => {
+  await adapter.leaveCall().catch((e) => {
+    console.error('Failed to leave call', e);
+  });
+};

--- a/packages/storybook8/stories/Composites/CallWithChatComposite/snippets/Server.snippet.tsx
+++ b/packages/storybook8/stories/Composites/CallWithChatComposite/snippets/Server.snippet.tsx
@@ -1,0 +1,41 @@
+// Contoso server to create a new user and thread.
+
+import { GroupCallLocator } from '@azure/communication-calling';
+import { ChatClient, ChatParticipant } from '@azure/communication-chat';
+import { AzureCommunicationTokenCredential } from '@azure/communication-common';
+import { v1 as createGUID } from 'uuid';
+
+const createNewChatThread = async (chatClient: ChatClient, participants: ChatParticipant[]): Promise<string> => {
+  const chatThreadResponse = await chatClient.createChatThread(
+    { topic: 'Meeting with a friendly bot' },
+    { participants }
+  );
+  if (chatThreadResponse.invalidParticipants && chatThreadResponse.invalidParticipants.length > 0) {
+    throw 'Server could not add participants to the chat thread';
+  }
+
+  const chatThread = chatThreadResponse.chatThread;
+  if (!chatThread || !chatThread.id) {
+    throw 'Server could not create chat thread';
+  }
+
+  return chatThread.id;
+};
+
+export const createCallWithChat = async (
+  token: string,
+  userId: string,
+  endpointUrl: string,
+  displayName: string
+): Promise<{ callLocator: GroupCallLocator; chatThreadId: string }> => {
+  const locator = { groupId: createGUID() };
+  const chatClient = new ChatClient(endpointUrl, new AzureCommunicationTokenCredential(token));
+  const threadId = await createNewChatThread(chatClient, [
+    { id: { communicationUserId: userId }, displayName: displayName }
+  ]);
+
+  return {
+    callLocator: locator,
+    chatThreadId: threadId
+  };
+};

--- a/packages/storybook8/stories/controlsUtils.ts
+++ b/packages/storybook8/stories/controlsUtils.ts
@@ -572,6 +572,10 @@ export const defaultCallWithChatCompositeHiddenControls = {
   joinInvitationURL: hiddenControl,
   rtl: hiddenControl,
   options: hiddenControl,
+  locale: hiddenControl,
+  icons: hiddenControl,
+  onFetchAvatarPersonaData: hiddenControl,
+  onFetchParticipantMenuItems: hiddenControl,
   formFactor: hiddenControl // formFactor is hidden by default and compositeFormFactor is used as a prop instead to workaround a bug where formFactor is not put in the correct order when the controls are generated
 };
 


### PR DESCRIPTION
Added in CallWithChat stories
- had to hide additional controls on the ControlUtils
- can't  create multi line string variables so I had to do inline multi line strings in source components
- most of the links are broken since we don't seem to use ids anymore