### PR TITLE
Strip conditional-compile lines out of the preprocessed files

### DIFF
--- a/common/scripts/babel-conditional-preprocess.js
+++ b/common/scripts/babel-conditional-preprocess.js
@@ -147,22 +147,36 @@ exports.default = babelHelper.declare((_api, opts) => {
 function Handle(path, featureSet, stabilizedFeatureSet, relaceWith = undefined) {
   let { node } = path;
 
+  // If Node has no comments, it hence has no conditional compilation directives, skip this node.
   if (!node.leadingComments) {
     return;
   }
 
-  const removalInstructions = node.leadingComments.map((comment) => nodeRemovalInstruction(node, comment, featureSet, stabilizedFeatureSet));
-  if (!shouldRemoveNode(removalInstructions)) {
+  // If Node has no conditional-compile directives, skip this node.
+  const firstConditionalCompileInstructionIdx = node.leadingComments.findIndex((comment) => nodeRemovalInstruction(node, comment, featureSet, stabilizedFeatureSet) !== 'none');
+  if (firstConditionalCompileInstructionIdx === -1) {
     return;
   }
 
-  const firstRemovalInstructionIdx = node.leadingComments.findIndex((comment) => nodeRemovalInstruction(node, comment, featureSet, stabilizedFeatureSet) === 'remove');
-  if (firstRemovalInstructionIdx === -1) {
+  // If Node has conditional-compile directives, but at least one of them is to keep the node, skip this node - but still remove the conditional compile line from the code
+  const shouldKeepNode = node.leadingComments.some((comment) => nodeRemovalInstruction(node, comment, featureSet, stabilizedFeatureSet) === 'keep');
+  if (shouldKeepNode) {
+    // Strip conditional compile comments only
+    node.leadingComments.forEach((comment) => {
+      if (nodeRemovalInstruction(node, comment, featureSet, stabilizedFeatureSet) !== 'none') {
+        comment.ignore = true;
+        comment.value = '';
+      }
+    });
     return;
   }
 
   // Remove the first removal instruction as well as all following comments so that
   // those comments aren't added to the AST node that follows the removed node.
+  const firstRemovalInstructionIdx = node.leadingComments.findIndex((comment) => nodeRemovalInstruction(node, comment, featureSet, stabilizedFeatureSet) === 'remove');
+  if (firstRemovalInstructionIdx === -1) {
+    return;
+  }
   node.leadingComments.slice(firstRemovalInstructionIdx).forEach((comment) => {
     comment.ignore = true;
     // Comment is inherited by next line even it is set to 'ignore'.


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested

Preprocessed code:

| before | after |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/3ed803a8-aa1d-4f4a-84e0-ca481c668833) | ![image](https://github.com/user-attachments/assets/61149dd2-314a-4c79-bf0c-d846099ec67f) |

Example APIView change on beta-release flavor:

![image](https://github.com/user-attachments/assets/9a3780b4-1664-4ee6-8601-01fdc265929d)
