### PR TITLE
Fix missing PR links in changelogs - Update to use new `changeDir` option in beachball

### DIFF
--- a/common/config/package.json
+++ b/common/config/package.json
@@ -22,7 +22,7 @@
     "@rollup/plugin-commonjs": "~25.0.7",
     "@rollup/plugin-json": "^6.0.1",
     "@types/node": "^20.14.12",
-    "beachball": "2.31.13",
+    "beachball": "^2.44.0",
     "rollup": "^4.12.1",
     "rollup-plugin-sourcemaps": "~0.6.3",
     "rollup-plugin-svg": "~2.0.0",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -11374,14 +11374,14 @@ packages:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
     dev: false
 
-  /beachball@2.31.13:
-    resolution: {integrity: sha512-VEzTJc4zUlxSuKJDh44GQjhvhaCCz06E4uzBsWLhsYBFAt71FBu2KdSkPg0zzIwyom02tvC59rDeUWCYm0Hr+g==}
-    engines: {node: '>=12.0.0'}
+  /beachball@2.44.0(typescript@5.4.5):
+    resolution: {integrity: sha512-gpODT4gD4fttLlkfm6VpHjMwlVMvN40ML1SujW6sAf6DgL6XN2TEyFSxOCkdnQxUAuGNe3I0p2BmKuwaYAuBGA==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      cosmiconfig: 7.1.0
+      cosmiconfig: 8.3.6(typescript@5.4.5)
       execa: 5.1.1
-      fs-extra: 10.1.0
+      fs-extra: 11.2.0
       lodash: 4.17.21
       minimatch: 3.1.2
       p-limit: 3.1.0
@@ -11389,8 +11389,10 @@ packages:
       semver: 7.6.0
       toposort: 2.0.2
       uuid: 9.0.1
-      workspace-tools: 0.30.0
+      workspace-tools: 0.36.4
       yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - typescript
     dev: false
 
   /before-after-hook@2.2.3:
@@ -12542,6 +12544,22 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+    dev: false
+
+  /cosmiconfig@8.3.6(typescript@5.4.5):
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      typescript: 5.4.5
     dev: false
 
   /cp-file@7.0.0:
@@ -24994,10 +25012,11 @@ packages:
       microevent.ts: 0.1.1
     dev: false
 
-  /workspace-tools@0.30.0:
-    resolution: {integrity: sha512-vQrzjAFvQYI2Zg9kFAo43aIgQNX5VSTtWLvOxCKhgjKnPdyLMXcPNxPTCKu3v+tjDW+YJNXUAigVv+pykrwOsQ==}
+  /workspace-tools@0.36.4:
+    resolution: {integrity: sha512-v0UFVvw9BjHtRu2Dau5PEJKkuG8u4jPlpXZQWjSz9XgbSutpPURqtO2P0hp3cVmQVATh8lkMFCewFgJuDnyC/w==}
     dependencies:
       '@yarnpkg/lockfile': 1.1.0
+      fast-glob: 3.3.2
       git-url-parse: 13.1.1
       globby: 11.1.0
       jju: 1.4.0
@@ -26157,7 +26176,7 @@ packages:
     dev: false
 
   file:projects/config.tgz:
-    resolution: {integrity: sha512-D/SWkStVgT3eIsJ+oUxMCxzYzauOpOca9ftXqSER9yBhkZ6vNeX7nUc+qBZLoCN7Xh9X2Mp6rjPyFLXDGz/hVA==, tarball: file:projects/config.tgz}
+    resolution: {integrity: sha512-K+G3IjrQOzuz1Dv/AWkMaty4XkgsLeDVgs4N08asKNpcvfKf2PtQl3W6RXR2iALjzh/ayAiJSs97fLOwCio4AA==, tarball: file:projects/config.tgz}
     name: '@rush-temp/config'
     version: 0.0.0
     dependencies:
@@ -26167,7 +26186,7 @@ packages:
       '@rollup/plugin-commonjs': 25.0.7(rollup@4.12.1)
       '@rollup/plugin-json': 6.1.0(rollup@4.12.1)
       '@types/node': 20.14.12
-      beachball: 2.31.13
+      beachball: 2.44.0(typescript@5.4.5)
       rollup: 4.12.1
       rollup-plugin-sourcemaps: 0.6.3(@types/node@20.14.12)(rollup@4.12.1)
       rollup-plugin-svg: 2.0.0

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -11399,14 +11399,14 @@ packages:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
     dev: false
 
-  /beachball@2.31.13:
-    resolution: {integrity: sha512-VEzTJc4zUlxSuKJDh44GQjhvhaCCz06E4uzBsWLhsYBFAt71FBu2KdSkPg0zzIwyom02tvC59rDeUWCYm0Hr+g==}
-    engines: {node: '>=12.0.0'}
+  /beachball@2.44.0(typescript@5.4.5):
+    resolution: {integrity: sha512-gpODT4gD4fttLlkfm6VpHjMwlVMvN40ML1SujW6sAf6DgL6XN2TEyFSxOCkdnQxUAuGNe3I0p2BmKuwaYAuBGA==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      cosmiconfig: 7.1.0
+      cosmiconfig: 8.3.6(typescript@5.4.5)
       execa: 5.1.1
-      fs-extra: 10.1.0
+      fs-extra: 11.2.0
       lodash: 4.17.21
       minimatch: 3.1.2
       p-limit: 3.1.0
@@ -11414,8 +11414,10 @@ packages:
       semver: 7.6.0
       toposort: 2.0.2
       uuid: 9.0.1
-      workspace-tools: 0.30.0
+      workspace-tools: 0.36.4
       yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - typescript
     dev: false
 
   /before-after-hook@2.2.3:
@@ -12572,6 +12574,22 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
+    dev: false
+
+  /cosmiconfig@8.3.6(typescript@5.4.5):
+    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      typescript: 5.4.5
     dev: false
 
   /cp-file@7.0.0:
@@ -24979,10 +24997,11 @@ packages:
       microevent.ts: 0.1.1
     dev: false
 
-  /workspace-tools@0.30.0:
-    resolution: {integrity: sha512-vQrzjAFvQYI2Zg9kFAo43aIgQNX5VSTtWLvOxCKhgjKnPdyLMXcPNxPTCKu3v+tjDW+YJNXUAigVv+pykrwOsQ==}
+  /workspace-tools@0.36.4:
+    resolution: {integrity: sha512-v0UFVvw9BjHtRu2Dau5PEJKkuG8u4jPlpXZQWjSz9XgbSutpPURqtO2P0hp3cVmQVATh8lkMFCewFgJuDnyC/w==}
     dependencies:
       '@yarnpkg/lockfile': 1.1.0
+      fast-glob: 3.3.2
       git-url-parse: 13.1.1
       globby: 11.1.0
       jju: 1.4.0
@@ -26142,7 +26161,7 @@ packages:
     dev: false
 
   file:projects/config.tgz:
-    resolution: {integrity: sha512-D/SWkStVgT3eIsJ+oUxMCxzYzauOpOca9ftXqSER9yBhkZ6vNeX7nUc+qBZLoCN7Xh9X2Mp6rjPyFLXDGz/hVA==, tarball: file:projects/config.tgz}
+    resolution: {integrity: sha512-K+G3IjrQOzuz1Dv/AWkMaty4XkgsLeDVgs4N08asKNpcvfKf2PtQl3W6RXR2iALjzh/ayAiJSs97fLOwCio4AA==, tarball: file:projects/config.tgz}
     name: '@rush-temp/config'
     version: 0.0.0
     dependencies:
@@ -26152,7 +26171,7 @@ packages:
       '@rollup/plugin-commonjs': 25.0.7(rollup@4.12.1)
       '@rollup/plugin-json': 6.1.0(rollup@4.12.1)
       '@types/node': 20.14.12
-      beachball: 2.31.13
+      beachball: 2.44.0(typescript@5.4.5)
       rollup: 4.12.1
       rollup-plugin-sourcemaps: 0.6.3(@types/node@20.14.12)(rollup@4.12.1)
       rollup-plugin-svg: 2.0.0

--- a/common/scripts/changelog/change.mjs
+++ b/common/scripts/changelog/change.mjs
@@ -17,7 +17,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { BEACHBALL, CHANGE_DIR, CHANGE_DIR_BETA } from './constants.mjs';
+import { BEACHBALL, CHANGE_DIR_STABLE, CHANGE_DIR_BETA } from './constants.mjs';
 import { parseNewChangeFiles } from './utils.mjs';
 import { exec, exec_output } from '../lib/index.mjs';
 
@@ -57,7 +57,7 @@ async function adjustAndCommitChangeFile() {
     }
 
     const changeFilename = newChangeFilesFilenames[0];
-    const filepath = path.join(CHANGE_DIR, changeFilename);
+    const filepath = path.join(CHANGE_DIR_STABLE, changeFilename);
     const changeFile = JSON.parse(fs.readFileSync(filepath, 'utf-8'));
     console.log(`Duplicating ${filepath} change files into ${CHANGE_DIR_BETA}`);
     fs.copyFileSync(filepath, path.join(CHANGE_DIR_BETA, changeFilename));
@@ -67,7 +67,7 @@ async function adjustAndCommitChangeFile() {
     if (changeFile.type === "prerelease") {
         console.log(`Deleting stable change file ${filepath}`);
         fs.unlinkSync(filepath);
-        await exec(`git add ${CHANGE_DIR}`);
+        await exec(`git add ${CHANGE_DIR_STABLE}`);
     }
 
     await exec(`git commit -m 'Change files'`);

--- a/common/scripts/changelog/changelog.mjs
+++ b/common/scripts/changelog/changelog.mjs
@@ -13,12 +13,16 @@ import { getPackageInfos } from '../../config/node_modules/beachball/lib/monorep
 import {gatherBumpInfo} from '../../config/node_modules/beachball/lib/bump/gatherBumpInfo.js';
 import {performBump} from '../../config/node_modules/beachball/lib/bump/performBump.js';
 import { getOptions } from '../../config/node_modules/beachball/lib/options/getOptions.js';
-import { CHANGE_DIR } from './constants.mjs';
+import { CHANGE_DIR, CHANGE_DIR_BETA } from './constants.mjs';
 
 import fs from 'fs';
 
-export async function generateChangelogs() {
+/**
+ * @param {'stable' | 'beta-release'} buildFlavor
+ */
+export async function generateChangelogs(buildFlavor) {
   const options = getOptions([]);
+  options.changeDir = buildFlavor === 'beta-release' ? CHANGE_DIR_BETA : CHANGE_DIR;
   const packageInfos = getPackageInfos(options.path);
   // Preserve(deep clone) the current packageInfo before bump, we don't change version number using beachball
   const preservedPackages = Object.fromEntries(Object.entries(packageInfos).map(([name, info]) => ([name, clone(info)])));

--- a/common/scripts/changelog/changelog.mjs
+++ b/common/scripts/changelog/changelog.mjs
@@ -13,7 +13,7 @@ import { getPackageInfos } from '../../config/node_modules/beachball/lib/monorep
 import {gatherBumpInfo} from '../../config/node_modules/beachball/lib/bump/gatherBumpInfo.js';
 import {performBump} from '../../config/node_modules/beachball/lib/bump/performBump.js';
 import { getOptions } from '../../config/node_modules/beachball/lib/options/getOptions.js';
-import { CHANGE_DIR, CHANGE_DIR_BETA } from './constants.mjs';
+import { CHANGE_DIR_BETA, CHANGE_DIR_STABLE, BETA_CHANGE_DIR_NAME, STABLE_CHANGE_DIR_NAME } from './constants.mjs';
 
 import fs from 'fs';
 
@@ -21,8 +21,12 @@ import fs from 'fs';
  * @param {'stable' | 'beta-release'} buildFlavor
  */
 export async function generateChangelogs(buildFlavor) {
+  if (buildFlavor !== 'stable' && buildFlavor !== 'beta-release') {
+    throw new Error(`Unknown build flavor in generateChangelogs: ${buildFlavor}. Flavor must be 'stable' or 'beta-release'.`);
+  }
+
   const options = getOptions([]);
-  options.changeDir = buildFlavor === 'beta-release' ? CHANGE_DIR_BETA : CHANGE_DIR;
+  options.changeDir = buildFlavor === 'beta-release' ? BETA_CHANGE_DIR_NAME : STABLE_CHANGE_DIR_NAME;
   const packageInfos = getPackageInfos(options.path);
   // Preserve(deep clone) the current packageInfo before bump, we don't change version number using beachball
   const preservedPackages = Object.fromEntries(Object.entries(packageInfos).map(([name, info]) => ([name, clone(info)])));
@@ -36,7 +40,7 @@ export async function generateChangelogs(buildFlavor) {
 
   // Beachball deletes the change file directory which causes confusion for scripts
   // that manipulate working directory paths.
-  ensureDirectory(CHANGE_DIR);
+  ensureDirectory('beta-release' ? CHANGE_DIR_BETA : CHANGE_DIR_STABLE);
 }
 
 

--- a/common/scripts/changelog/check.mjs
+++ b/common/scripts/changelog/check.mjs
@@ -10,15 +10,14 @@
  *   node common/scripts/changelog/check.mjs origin/main origin/feature-pony
  */
 
-import { REPO_ROOT } from "../lib/constants.mjs";
 import { exec_output } from "../lib/exec.mjs";
-import path from 'path';
 import { parseNewChangeFiles } from "./utils.mjs";
+import { CHANGE_DIR_BETA, CHANGE_DIR_STABLE } from "./constants.mjs";
 
 async function main() {
   const [base, head] = parseArgs(process.argv);
-  const gitLogStdoutStableChangeFiles = await exec_output(`git log --name-status ${base}..${head} -- ${path.join(REPO_ROOT, 'change/')}`);
-  const gitLogStdoutBetaChangeFiles = await exec_output(`git log --name-status ${base}..${head} -- ${path.join(REPO_ROOT, 'change-beta/')}`);
+  const gitLogStdoutStableChangeFiles = await exec_output(`git log --name-status ${base}..${head} -- ${CHANGE_DIR_STABLE}`);
+  const gitLogStdoutBetaChangeFiles = await exec_output(`git log --name-status ${base}..${head} -- ${CHANGE_DIR_BETA}`);
 
   const newStableChangeFiles = parseNewChangeFiles(gitLogStdoutStableChangeFiles);
   const newBetaChangeFiles = parseNewChangeFiles(gitLogStdoutBetaChangeFiles);

--- a/common/scripts/changelog/collect.mjs
+++ b/common/scripts/changelog/collect.mjs
@@ -12,11 +12,10 @@
  *   node common/scripts/changelog/collect.mjs beta
  */
 
-import { copyFile, open, rm, readFile, rename, writeFile, mkdir } from 'fs/promises';
+import { copyFile, open, rm, readFile, writeFile } from 'fs/promises';
 import { exec } from "../lib/exec.mjs";
-import { CHANGE_DIR, CHANGE_DIR_BETA, CHANGE_DIR_STABLE_TEMP, COMMUNICATION_REACT_CHANGELOG_BETA, COMMUNICATION_REACT_CHANGELOG_STABLE, COMMUNICATION_REACT_CHANGELOG_TEMPORARY } from './constants.mjs';
+import { CHANGE_DIR, CHANGE_DIR_BETA, COMMUNICATION_REACT_CHANGELOG_BETA, COMMUNICATION_REACT_CHANGELOG_STABLE, COMMUNICATION_REACT_CHANGELOG_TEMPORARY } from './constants.mjs';
 import { generateChangelogs } from './changelog.mjs';
-import { existsSync } from 'fs';
 
 async function main() {
     const args = process.argv;
@@ -38,33 +37,17 @@ async function main() {
 }
 
 async function collectionBetaChangelog() {
-    await swapInBetaChangeFiles();
     await createTemporaryChangelog(COMMUNICATION_REACT_CHANGELOG_BETA);
-    await generateChangelogs();
+    await generateChangelogs('beta-release');
     const prsFromStableChangelog = await getPRsFromFile(COMMUNICATION_REACT_CHANGELOG_STABLE);
     await removePRsFromLatestReleaseOfChangelogFile(COMMUNICATION_REACT_CHANGELOG_TEMPORARY, prsFromStableChangelog);
-    await restoreStableChangeFiles();
     await commitChangelog(COMMUNICATION_REACT_CHANGELOG_BETA);
 }
 
 async function collectionStableChangelog() {
     await createTemporaryChangelog(COMMUNICATION_REACT_CHANGELOG_STABLE);
-    await generateChangelogs();
+    await generateChangelogs('stable');
     await commitChangelog(COMMUNICATION_REACT_CHANGELOG_STABLE);
-}
-
-async function swapInBetaChangeFiles() {
-    await rm(CHANGE_DIR_STABLE_TEMP, { recursive: true, force: true })
-    await rename(CHANGE_DIR, CHANGE_DIR_STABLE_TEMP);
-    if(!existsSync(CHANGE_DIR_BETA)) {
-        await mkdir(CHANGE_DIR_BETA);
-    }
-    await rename(CHANGE_DIR_BETA, CHANGE_DIR);
-}
-
-async function restoreStableChangeFiles() {
-    await rename(CHANGE_DIR, CHANGE_DIR_BETA);
-    await rename(CHANGE_DIR_STABLE_TEMP, CHANGE_DIR);
 }
 
 async function ensureCleanWorkingDirectory() {

--- a/common/scripts/changelog/collect.mjs
+++ b/common/scripts/changelog/collect.mjs
@@ -14,7 +14,7 @@
 
 import { copyFile, open, rm, readFile, writeFile } from 'fs/promises';
 import { exec } from "../lib/exec.mjs";
-import { CHANGE_DIR, CHANGE_DIR_BETA, COMMUNICATION_REACT_CHANGELOG_BETA, COMMUNICATION_REACT_CHANGELOG_STABLE, COMMUNICATION_REACT_CHANGELOG_TEMPORARY } from './constants.mjs';
+import { CHANGE_DIR_STABLE, CHANGE_DIR_BETA, COMMUNICATION_REACT_CHANGELOG_BETA, COMMUNICATION_REACT_CHANGELOG_STABLE, COMMUNICATION_REACT_CHANGELOG_TEMPORARY } from './constants.mjs';
 import { generateChangelogs } from './changelog.mjs';
 
 async function main() {
@@ -68,7 +68,7 @@ async function commitChangelog(target) {
     await copyFile(COMMUNICATION_REACT_CHANGELOG_TEMPORARY, target);
     await exec(`git add ${target}`);
     await exec(`git add **/CHANGELOG.json`);
-    await exec(`git add ${CHANGE_DIR} ${CHANGE_DIR_BETA}`);
+    await exec(`git add ${CHANGE_DIR_STABLE} ${CHANGE_DIR_BETA}`);
     await exec('git commit -m "Collect CHANGELOG"');
 }
 

--- a/common/scripts/changelog/constants.mjs
+++ b/common/scripts/changelog/constants.mjs
@@ -7,8 +7,6 @@ import { REPO_ROOT } from '../lib/index.mjs';
 export const BEACHBALL = path.join(REPO_ROOT, 'common', 'config', 'node_modules', 'beachball', 'bin', 'beachball');
 export const CHANGE_DIR = path.join(REPO_ROOT, 'change');
 export const CHANGE_DIR_BETA = path.join(REPO_ROOT, 'change-beta');
-// .gitignored
-export const CHANGE_DIR_STABLE_TEMP = path.join(REPO_ROOT, 'change-stable');
 
 const COMMUNICATION_REACT_PACKLET = path.join(REPO_ROOT, 'packages', 'communication-react');
 export const COMMUNICATION_REACT_CHANGELOG_STABLE = path.join(COMMUNICATION_REACT_PACKLET, 'CHANGELOG.stable.md');

--- a/common/scripts/changelog/constants.mjs
+++ b/common/scripts/changelog/constants.mjs
@@ -5,8 +5,10 @@ import path from 'path';
 import { REPO_ROOT } from '../lib/index.mjs';
 
 export const BEACHBALL = path.join(REPO_ROOT, 'common', 'config', 'node_modules', 'beachball', 'bin', 'beachball');
-export const CHANGE_DIR = path.join(REPO_ROOT, 'change');
-export const CHANGE_DIR_BETA = path.join(REPO_ROOT, 'change-beta');
+export const STABLE_CHANGE_DIR_NAME = 'change';
+export const BETA_CHANGE_DIR_NAME = 'change-beta';
+export const CHANGE_DIR_STABLE = path.join(REPO_ROOT, STABLE_CHANGE_DIR_NAME);
+export const CHANGE_DIR_BETA = path.join(REPO_ROOT, BETA_CHANGE_DIR_NAME);
 
 const COMMUNICATION_REACT_PACKLET = path.join(REPO_ROOT, 'packages', 'communication-react');
 export const COMMUNICATION_REACT_CHANGELOG_STABLE = path.join(COMMUNICATION_REACT_PACKLET, 'CHANGELOG.stable.md');


### PR DESCRIPTION
# What

- Update beachball version to `2.44.0` that has  `changeDir` options from https://github.com/microsoft/beachball/pull/969
- Stop moving files from `change-beta` to `change` and instead use the `changeDir` option

# Why

Our changelogs weren't grabbing the correct PR. Once the file was moved from change-beta to change, it no longer had any associated commit behind it.

# How Tested

Generated both stable and beta changelogs locally and they pulled commits and PRs