### PR TITLE
Add mobile banner for breakout rooms and handle scenario of being unassigned from breakout room

### DIFF
--- a/packages/calling-stateful-client/src/BreakoutRoomsSubscriber.ts
+++ b/packages/calling-stateful-client/src/BreakoutRoomsSubscriber.ts
@@ -52,26 +52,27 @@ export class BreakoutRoomsSubscriber {
   }
 
   private onBreakoutRoomsUpdated = (eventData: BreakoutRoomsEventData): void => {
-    if (!eventData.data) {
-      return;
-    }
-
     if (eventData.type === 'assignedBreakoutRooms') {
       this.onAssignedBreakoutRoomUpdated(eventData.data);
     } else if (eventData.type === 'join') {
       this.onBreakoutRoomsJoined(eventData.data);
-    } else if (eventData.type === 'breakoutRoomsSettings') {
+    } else if (eventData.type === 'breakoutRoomsSettings' && eventData.data) {
       this.onBreakoutRoomSettingsUpdated(eventData.data);
     }
   };
 
-  private onAssignedBreakoutRoomUpdated = (breakoutRoom: BreakoutRoom): void => {
+  private onAssignedBreakoutRoomUpdated = (breakoutRoom?: BreakoutRoom): void => {
     const callState = this._context.getState().calls[this._callIdRef.callId];
     const currentAssignedBreakoutRoom = callState?.breakoutRooms?.assignedBreakoutRoom;
 
     // This call won't exist in the calls array in state if this call is a breakout room that was re-assigned.
     // If so, do nothing.
     if (callState === undefined) {
+      return;
+    }
+
+    if (!breakoutRoom) {
+      this._context.setAssignedBreakoutRoom(this._callIdRef.callId, breakoutRoom);
       return;
     }
 

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -629,7 +629,7 @@ export class CallContext {
   }
 
   /* @conditional-compile-remove(breakout-rooms) */
-  public setAssignedBreakoutRoom(callId: string, breakoutRoom: BreakoutRoom): void {
+  public setAssignedBreakoutRoom(callId: string, breakoutRoom?: BreakoutRoom): void {
     this.modifyState((draft: CallClientState) => {
       const call = draft.calls[this._callIdHistory.latestCallId(callId)];
       if (call) {

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -873,6 +873,8 @@ export interface CallCompositeStrings {
     invalidMeetingIdentifier: string;
     inviteToRoomRemovedDetails?: string;
     inviteToRoomRemovedTitle: string;
+    joinBreakoutRoomBannerButtonLabel: string;
+    joinBreakoutRoomBannerTitle: string;
     joinBreakoutRoomButtonLabel: string;
     learnMore: string;
     leaveBreakoutRoomAndMeetingButtonLabel: string;
@@ -947,6 +949,8 @@ export interface CallCompositeStrings {
     resumeCallButtonLabel: string;
     resumingCallButtonAriaLabel: string;
     resumingCallButtonLabel: string;
+    returnFromBreakoutRoomBannerButtonLabel: string;
+    returnFromBreakoutRoomBannerTitle: string;
     returnFromBreakoutRoomButtonLabel: string;
     returnToCallButtonAriaDescription?: string;
     returnToCallButtonAriaLabel?: string;

--- a/packages/react-composites/src/composites/CallComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Strings.tsx
@@ -887,4 +887,26 @@ export interface CallCompositeStrings {
    * Notification title for when a user joins a breakout room
    */
   breakoutRoomJoinedNotificationTitle: string;
+  /* @conditional-compile-remove(breakout-rooms) */
+  /**
+   * Title for banner to join the assigned breakout room. The banner is shown in mobile view instead of the
+   * notification.
+   */
+  joinBreakoutRoomBannerTitle: string;
+  /* @conditional-compile-remove(breakout-rooms) */
+  /**
+   * Label for button in banner to join breakout room. The banner is shown in mobile view instead of the notification.
+   */
+  joinBreakoutRoomBannerButtonLabel: string;
+  /* @conditional-compile-remove(breakout-rooms) */
+  /**
+   * Title for banner to return from breakout room. The banner is shown in mobile view instead of the notification.
+   */
+  returnFromBreakoutRoomBannerTitle: string;
+  /* @conditional-compile-remove(breakout-rooms) */
+  /**
+   * Label for button in banner to return from breakout room. The banner is shown in mobile view instead of the
+   * notification.
+   */
+  returnFromBreakoutRoomBannerButtonLabel: string;
 }

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -1347,20 +1347,20 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | TeamsCa
 
   /* @conditional-compile-remove(breakout-rooms) */
   private breakoutRoomsUpdated(eventData: BreakoutRoomsEventData): void {
-    if (eventData.data) {
-      if (eventData.type === 'assignedBreakoutRooms') {
-        this.assignedBreakoutRoomUpdated(eventData.data);
-      } else if (eventData.type === 'join') {
-        this.breakoutRoomJoined(eventData.data);
-      }
+    if (eventData.type === 'assignedBreakoutRooms') {
+      this.assignedBreakoutRoomUpdated(eventData.data);
+    } else if (eventData.type === 'join') {
+      this.breakoutRoomJoined(eventData.data);
     }
-
     this.emitter.emit('breakoutRoomsUpdated', eventData);
   }
 
   /* @conditional-compile-remove(breakout-rooms) */
-  private assignedBreakoutRoomUpdated(breakoutRoom: BreakoutRoom): void {
-    if (breakoutRoom.state === 'closed') {
+  private assignedBreakoutRoomUpdated(breakoutRoom?: BreakoutRoom): void {
+    if (this.call?.id === undefined) {
+      return;
+    }
+    if (!breakoutRoom || breakoutRoom.state === 'closed') {
       this.returnFromBreakoutRoom();
     }
   }

--- a/packages/react-composites/src/composites/CallComposite/components/Banner.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/Banner.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Theme, mergeStyles } from '@fluentui/react';
+import { DefaultButton, Theme, mergeStyles } from '@fluentui/react';
 import { _pxToRem } from '@internal/acs-ui-common';
 // eslint-disable-next-line no-restricted-imports
 import { IIconProps, Icon, PrimaryButton, Stack, Text, useTheme } from '@fluentui/react';
@@ -24,9 +24,14 @@ export interface BannerProps {
   iconProps?: IIconProps;
 
   /**
-   * Callback called when the primary button inside banner is clicked.
+   * Callback called when the button inside banner is clicked.
    */
-  onClickPrimaryButton?: () => void;
+  onClickButton?: () => void;
+
+  /**
+   * If true, the primary button will be styled as a primary button. Default is false.
+   */
+  primaryButton?: boolean;
 }
 
 /**
@@ -64,12 +69,19 @@ export const Banner = (props: BannerProps): JSX.Element => {
             )}
             <Text className={titleTextClassName}>{strings?.title}</Text>
           </Stack>
-
-          <PrimaryButton
-            text={strings?.primaryButtonLabel}
-            ariaLabel={strings?.primaryButtonLabel}
-            onClick={props.onClickPrimaryButton}
-          />
+          {props.primaryButton ? (
+            <PrimaryButton
+              text={strings?.primaryButtonLabel}
+              ariaLabel={strings?.primaryButtonLabel}
+              onClick={props.onClickButton}
+            />
+          ) : (
+            <DefaultButton
+              text={strings?.primaryButtonLabel}
+              ariaLabel={strings?.primaryButtonLabel}
+              onClick={props.onClickButton}
+            />
+          )}
         </Stack>
       </Stack>
     </Stack>

--- a/packages/react-composites/src/composites/CallComposite/components/Banner.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/Banner.tsx
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Theme, mergeStyles } from '@fluentui/react';
+import { _pxToRem } from '@internal/acs-ui-common';
+// eslint-disable-next-line no-restricted-imports
+import { IIconProps, Icon, PrimaryButton, Stack, Text, useTheme } from '@fluentui/react';
+import React from 'react';
+
+/**
+ * Props for {@link Banner}.
+ *
+ * @private
+ */
+export interface BannerProps {
+  /**
+   * Banner strings.
+   */
+  strings?: BannerStrings;
+
+  /**
+   * Banner icon.
+   */
+  iconProps?: IIconProps;
+
+  /**
+   * Callback called when the primary button inside banner is clicked.
+   */
+  onClickPrimaryButton?: () => void;
+}
+
+/**
+ * All strings that may be shown on the UI in the {@link Banner}.
+ *
+ * @private
+ */
+export interface BannerStrings {
+  /**
+   * Banner title.
+   */
+  title: string;
+  /**
+   * Banner primary button label.
+   */
+  primaryButtonLabel: string;
+}
+
+/**
+ * A component to show a banner in the UI.
+ *
+ * @private
+ */
+export const Banner = (props: BannerProps): JSX.Element => {
+  const strings = props.strings;
+  const theme = useTheme();
+
+  return (
+    <Stack horizontalAlign="center">
+      <Stack data-ui-id="banner" className={containerStyles(theme)}>
+        <Stack horizontal horizontalAlign="space-between">
+          <Stack horizontal>
+            {props.iconProps?.iconName && (
+              <Icon className={bannerIconClassName} iconName={props.iconProps?.iconName} {...props.iconProps} />
+            )}
+            <Text className={titleTextClassName}>{strings?.title}</Text>
+          </Stack>
+
+          <PrimaryButton
+            text={strings?.primaryButtonLabel}
+            ariaLabel={strings?.primaryButtonLabel}
+            onClick={props.onClickPrimaryButton}
+          />
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+};
+
+const titleTextClassName = mergeStyles({
+  fontWeight: 400,
+  fontSize: _pxToRem(14),
+  lineHeight: _pxToRem(16),
+  alignSelf: 'center'
+});
+
+const containerStyles = (theme: Theme): string =>
+  mergeStyles({
+    boxShadow: theme.effects.elevation8,
+    width: '20rem',
+    padding: '0.75rem',
+    borderRadius: '0.25rem',
+    position: 'relative',
+    backgroundColor: theme.palette.white
+  });
+
+const bannerIconClassName = mergeStyles({
+  fontSize: '1.25rem',
+  alignSelf: 'center',
+  marginRight: '0.5rem',
+  svg: {
+    width: '1.25rem',
+    height: '1.25rem'
+  }
+});

--- a/packages/react-composites/src/composites/CallComposite/components/BreakoutRoomsBanner.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/BreakoutRoomsBanner.tsx
@@ -48,7 +48,7 @@ export const BreakoutRoomsBanner = (props: {
               : locale.strings.call.joinBreakoutRoomBannerTitle,
             primaryButtonLabel: locale.strings.call.joinBreakoutRoomBannerButtonLabel
           }}
-          onClickPrimaryButton={() => assignedBreakoutRoom.join()}
+          onClickButton={() => assignedBreakoutRoom.join()}
           iconProps={{ iconName: 'DoorArrowRight' }}
         />
       </Stack>
@@ -61,7 +61,7 @@ export const BreakoutRoomsBanner = (props: {
             title: locale.strings.call.returnFromBreakoutRoomBannerTitle,
             primaryButtonLabel: locale.strings.call.returnFromBreakoutRoomBannerButtonLabel
           }}
-          onClickPrimaryButton={() => adapter.returnFromBreakoutRoom()}
+          onClickButton={() => adapter.returnFromBreakoutRoom()}
           iconProps={{ iconName: 'DoorArrowLeft' }}
         />
       </Stack>

--- a/packages/react-composites/src/composites/CallComposite/components/BreakoutRoomsBanner.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/BreakoutRoomsBanner.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/* @conditional-compile-remove(breakout-rooms) */
+import { Stack } from '@fluentui/react';
+/* @conditional-compile-remove(breakout-rooms) */
+import { ActiveNotification } from '@internal/react-components';
+/* @conditional-compile-remove(breakout-rooms) */
+import React from 'react';
+/* @conditional-compile-remove(breakout-rooms) */
+import { bannerNotificationStyles } from '../styles/CallPage.styles';
+/* @conditional-compile-remove(breakout-rooms) */
+import { CommonCallAdapter } from '../adapter';
+/* @conditional-compile-remove(breakout-rooms) */
+import { CompositeLocale } from '../../localization';
+/* @conditional-compile-remove(breakout-rooms) */
+import { BreakoutRoom, BreakoutRoomsSettings } from '@azure/communication-calling';
+/* @conditional-compile-remove(breakout-rooms) */
+import { Banner } from './Banner';
+
+/* @conditional-compile-remove(breakout-rooms) */
+/**
+ * @private
+ */
+export const BreakoutRoomsBanner = (props: {
+  assignedBreakoutRoom: BreakoutRoom | undefined;
+  breakoutRoomSettings: BreakoutRoomsSettings | undefined;
+  latestNotifications: ActiveNotification[] | undefined;
+  locale: CompositeLocale;
+  adapter: CommonCallAdapter;
+}): JSX.Element | undefined => {
+  const { assignedBreakoutRoom, breakoutRoomSettings, latestNotifications, locale, adapter } = props;
+
+  const autoMoveToBreakoutRoomCurrentlyInEffect =
+    assignedBreakoutRoom?.autoMoveParticipantToBreakoutRoom &&
+    latestNotifications?.find(
+      (notification) =>
+        notification.type === 'assignedBreakoutRoomOpened' || notification.type === 'assignedBreakoutRoomChanged'
+    );
+
+  if (assignedBreakoutRoom && assignedBreakoutRoom.state === 'open' && !autoMoveToBreakoutRoomCurrentlyInEffect) {
+    return (
+      <Stack styles={bannerNotificationStyles}>
+        <Banner
+          strings={{
+            title: assignedBreakoutRoom.displayName
+              ? locale.strings.call.joinBreakoutRoomBannerTitle.replace('{roomName}', assignedBreakoutRoom.displayName)
+              : locale.strings.call.joinBreakoutRoomBannerTitle,
+            primaryButtonLabel: locale.strings.call.joinBreakoutRoomBannerButtonLabel
+          }}
+          onClickPrimaryButton={() => assignedBreakoutRoom.join()}
+          iconProps={{ iconName: 'DoorArrowRight' }}
+        />
+      </Stack>
+    );
+  } else if (breakoutRoomSettings && breakoutRoomSettings.disableReturnToMainMeeting !== true) {
+    return (
+      <Stack styles={bannerNotificationStyles}>
+        <Banner
+          strings={{
+            title: locale.strings.call.returnFromBreakoutRoomBannerTitle,
+            primaryButtonLabel: locale.strings.call.returnFromBreakoutRoomBannerButtonLabel
+          }}
+          onClickPrimaryButton={() => adapter.returnFromBreakoutRoom()}
+          iconProps={{ iconName: 'DoorArrowLeft' }}
+        />
+      </Stack>
+    );
+  }
+  return undefined;
+};

--- a/packages/react-composites/src/composites/CallComposite/components/BreakoutRoomsBanner.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/BreakoutRoomsBanner.tsx
@@ -14,7 +14,9 @@ import { CommonCallAdapter } from '../adapter';
 /* @conditional-compile-remove(breakout-rooms) */
 import { CompositeLocale } from '../../localization';
 /* @conditional-compile-remove(breakout-rooms) */
-import { BreakoutRoom, BreakoutRoomsSettings } from '@azure/communication-calling';
+import { useSelector } from '../hooks/useSelector';
+/* @conditional-compile-remove(breakout-rooms) */
+import { getAssignedBreakoutRoom, getBreakoutRoomSettings } from '../selectors/baseSelectors';
 /* @conditional-compile-remove(breakout-rooms) */
 import { Banner } from './Banner';
 
@@ -23,13 +25,14 @@ import { Banner } from './Banner';
  * @private
  */
 export const BreakoutRoomsBanner = (props: {
-  assignedBreakoutRoom: BreakoutRoom | undefined;
-  breakoutRoomSettings: BreakoutRoomsSettings | undefined;
   latestNotifications: ActiveNotification[] | undefined;
   locale: CompositeLocale;
   adapter: CommonCallAdapter;
 }): JSX.Element | undefined => {
-  const { assignedBreakoutRoom, breakoutRoomSettings, latestNotifications, locale, adapter } = props;
+  const { latestNotifications, locale, adapter } = props;
+
+  const assignedBreakoutRoom = useSelector(getAssignedBreakoutRoom);
+  const breakoutRoomSettings = useSelector(getBreakoutRoomSettings);
 
   const autoMoveToBreakoutRoomCurrentlyInEffect =
     assignedBreakoutRoom?.autoMoveParticipantToBreakoutRoom &&
@@ -50,6 +53,7 @@ export const BreakoutRoomsBanner = (props: {
           }}
           onClickButton={() => assignedBreakoutRoom.join()}
           iconProps={{ iconName: 'DoorArrowRight' }}
+          primaryButton
         />
       </Stack>
     );

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -98,7 +98,7 @@ import { MoreDrawer } from '../../common/Drawer/MoreDrawer';
 /* @conditional-compile-remove(breakout-rooms) */
 import { useCompositeStringsForNotificationStackStrings } from '../hooks/useCompositeStringsForNotificationStack';
 /* @conditional-compile-remove(breakout-rooms) */
-import { Banner } from './Banner';
+import { BreakoutRoomsBanner } from './BreakoutRoomsBanner';
 
 /**
  * @private
@@ -506,15 +506,8 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
   // Filter out breakout room notification that prompts user to join breakout room when in mobile view. We will
   // replace it with a non-dismissible banner
   latestNotifications = props.mobileView
-    ? (latestNotifications ?? []).filter((n) => n.type !== 'assignedBreakoutRoomOpenedPromptJoin')
+    ? (latestNotifications ?? []).filter((notification) => notification.type !== 'assignedBreakoutRoomOpenedPromptJoin')
     : latestNotifications;
-
-  /* @conditional-compile-remove(breakout-rooms) */
-  const movingToBreakoutRoomAutomatically =
-    assignedBreakoutRoom?.autoMoveParticipantToBreakoutRoom &&
-    latestNotifications?.find(
-      (n) => n.type === 'assignedBreakoutRoomOpened' || n.type === 'assignedBreakoutRoomChanged'
-    );
 
   return (
     <div ref={containerRef} className={mergeStyles(containerDivStyles)} id={props.id}>
@@ -612,42 +605,16 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
                 <Stack verticalFill styles={mediaGalleryContainerStyles}>
                   <Stack.Item styles={notificationsContainerStyles}>
                     {
-                      /* @conditional-compile-remove(breakout-rooms) */ props.mobileView &&
-                        assignedBreakoutRoom &&
-                        assignedBreakoutRoom.state === 'open' &&
-                        !movingToBreakoutRoomAutomatically && (
-                          <Stack styles={bannerNotificationStyles}>
-                            <Banner
-                              strings={{
-                                title: assignedBreakoutRoom.displayName
-                                  ? locale.strings.call.joinBreakoutRoomBannerTitle.replace(
-                                      '{roomName}',
-                                      assignedBreakoutRoom.displayName
-                                    )
-                                  : locale.strings.call.joinBreakoutRoomBannerTitle,
-                                primaryButtonLabel: locale.strings.call.joinBreakoutRoomBannerButtonLabel
-                              }}
-                              onClickPrimaryButton={() => assignedBreakoutRoom.join()}
-                              iconProps={{ iconName: 'DoorArrowRight' }}
-                            />
-                          </Stack>
-                        )
-                    }
-                    {
-                      /* @conditional-compile-remove(breakout-rooms) */ props.mobileView &&
-                        breakoutRoomSettings &&
-                        !breakoutRoomSettings.disableReturnToMainMeeting && (
-                          <Stack styles={bannerNotificationStyles}>
-                            <Banner
-                              strings={{
-                                title: locale.strings.call.returnFromBreakoutRoomBannerTitle,
-                                primaryButtonLabel: locale.strings.call.returnFromBreakoutRoomBannerButtonLabel
-                              }}
-                              onClickPrimaryButton={() => adapter.returnFromBreakoutRoom()}
-                              iconProps={{ iconName: 'DoorArrowLeft' }}
-                            />
-                          </Stack>
-                        )
+                      /* @conditional-compile-remove(breakout-rooms) */
+                      props.mobileView && (
+                        <BreakoutRoomsBanner
+                          assignedBreakoutRoom={assignedBreakoutRoom}
+                          breakoutRoomSettings={breakoutRoomSettings}
+                          latestNotifications={latestNotifications}
+                          locale={locale}
+                          adapter={adapter}
+                        />
+                      )
                     }
                     {props.showErrorNotifications && (
                       <Stack styles={notificationStackStyles} horizontalAlign="center" verticalAlign="center">

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -47,8 +47,6 @@ import { callStatusSelector } from '../selectors/callStatusSelector';
 import { CallControlOptions } from '../types/CallControlOptions';
 import { PreparedMoreDrawer } from '../../common/Drawer/PreparedMoreDrawer';
 import { getIsTeamsMeeting, getRemoteParticipants } from '../selectors/baseSelectors';
-/* @conditional-compile-remove(breakout-rooms) */
-import { getBreakoutRoomSettings, getAssignedBreakoutRoom } from '../selectors/baseSelectors';
 /* @conditional-compile-remove(PSTN-calls) */ /* @conditional-compile-remove(one-to-n-calling) */
 import { getPage } from '../selectors/baseSelectors';
 import { getCallStatus, getCaptionsStatus } from '../selectors/baseSelectors';
@@ -496,11 +494,6 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
   /* @conditional-compile-remove(breakout-rooms) */
   const notificationStackStrings = useCompositeStringsForNotificationStackStrings(locale);
 
-  /* @conditional-compile-remove(breakout-rooms) */
-  const assignedBreakoutRoom = useSelector(getAssignedBreakoutRoom);
-  /* @conditional-compile-remove(breakout-rooms) */
-  const breakoutRoomSettings = useSelector(getBreakoutRoomSettings);
-
   let latestNotifications = props.latestNotifications;
   /* @conditional-compile-remove(breakout-rooms) */
   // Filter out breakout room notification that prompts user to join breakout room when in mobile view. We will
@@ -608,8 +601,6 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
                       /* @conditional-compile-remove(breakout-rooms) */
                       props.mobileView && (
                         <BreakoutRoomsBanner
-                          assignedBreakoutRoom={assignedBreakoutRoom}
-                          breakoutRoomSettings={breakoutRoomSettings}
                           latestNotifications={latestNotifications}
                           locale={locale}
                           adapter={adapter}

--- a/packages/react-composites/src/composites/CallComposite/selectors/baseSelectors.ts
+++ b/packages/react-composites/src/composites/CallComposite/selectors/baseSelectors.ts
@@ -28,6 +28,8 @@ import { CallAdapterState, CallCompositePage } from '../adapter/CallAdapter';
 import { VideoBackgroundEffect } from '../adapter/CallAdapter';
 import { _isInCall, _isPreviewOn, _dominantSpeakersWithFlatId } from '@internal/calling-component-bindings';
 import { AdapterErrors } from '../../common/adapters';
+/* @conditional-compile-remove(breakout-rooms) */
+import { AdapterNotifications } from '../../common/adapters';
 import { RaisedHandState } from '@internal/calling-stateful-client';
 import { CommunicationIdentifier } from '@azure/communication-common';
 /* @conditional-compile-remove(acs-close-captions) */
@@ -263,3 +265,9 @@ export const getBreakoutRoomSettings = (state: CallAdapterState): BreakoutRoomsS
  */
 export const getBreakoutRoomDisplayName = (state: CallAdapterState): string | undefined =>
   state.call?.breakoutRooms?.breakoutRoomDisplayName;
+
+/* @conditional-compile-remove(breakout-rooms) */
+/**
+ * @private
+ */
+export const getLatestNotifications = (state: CallAdapterState): AdapterNotifications => state.latestNotifications;

--- a/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
+++ b/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
@@ -268,6 +268,7 @@ type GetCallCompositePageFunction = ((
     call: CallState | undefined,
     previousCall: CallState | undefined,
     transferCall?: CallState,
+    originCall?: CallState,
     /* @conditional-compile-remove(unsupported-browser) */ unsupportedBrowserInfo?: {
       environmentInfo?: EnvironmentInfo;
       unsupportedBrowserVersionOptedIn?: boolean;
@@ -290,6 +291,7 @@ export const getCallCompositePage: GetCallCompositePageFunction = (
   call,
   previousCall?,
   transferCall?: CallState,
+  originCall?: CallState,
   unsupportedBrowserInfo?: {
     /* @conditional-compile-remove(unsupported-browser) */
     environmentInfo?: EnvironmentInfo;
@@ -335,6 +337,11 @@ export const getCallCompositePage: GetCallCompositePageFunction = (
       // transitional state.
       return 'configuration';
     }
+  }
+
+  // /* @conditional-compile-remove(breakout-rooms) */
+  if (previousCall?.breakoutRooms?.breakoutRoomOriginCallId && originCall) {
+    return 'call';
   }
 
   if (previousCall) {

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -689,12 +689,18 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
 
   /* @conditional-compile-remove(breakout-rooms) */
   public async returnFromBreakoutRoom(): Promise<void> {
-    if (this.originCallChatAdapter) {
+    if (
+      this.originCallChatAdapter &&
+      this.context.getState().chat?.threadId !== this.originCallChatAdapter.getState().thread.threadId
+    ) {
       this.breakoutRoomChatAdapter?.dispose();
       this.updateChatAdapter(this.originCallChatAdapter);
     }
 
-    await this.callAdapter.returnFromBreakoutRoom();
+    const originCallId = this.callAdapter.getState().call?.breakoutRooms?.breakoutRoomOriginCallId;
+    if (originCallId) {
+      await this.callAdapter.returnFromBreakoutRoom();
+    }
   }
 
   on(event: 'callParticipantsJoined', listener: ParticipantsJoinedListener): void;
@@ -823,6 +829,10 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         break;
       case 'spotlightChanged':
         this.callAdapter.on('spotlightChanged', listener);
+        break;
+      /* @conditional-compile-remove(breakout-rooms) */
+      case 'breakoutRoomsUpdated':
+        this.callAdapter.on('breakoutRoomsUpdated', listener);
         break;
       default:
         throw `Unknown AzureCommunicationCallWithChatAdapter Event: ${event}`;
@@ -954,6 +964,10 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         break;
       case 'spotlightChanged':
         this.callAdapter.off('spotlightChanged', listener);
+        break;
+      /* @conditional-compile-remove(breakout-rooms) */
+      case 'breakoutRoomsUpdated':
+        this.callAdapter.off('breakoutRoomsUpdated', listener);
         break;
       default:
         throw `Unknown AzureCommunicationCallWithChatAdapter Event: ${event}`;

--- a/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
@@ -368,7 +368,7 @@ export const CommonCallControlBar = (props: CommonCallControlBarProps & Containe
                   <ControlBar layout={props.displayVertical ? 'vertical' : 'horizontal'} styles={centerContainerStyles}>
                     {
                       /* @conditional-compile-remove(breakout-rooms) */
-                      assignedBreakoutRoom && assignedBreakoutRoom.state === 'open' && (
+                      !props.mobileView && assignedBreakoutRoom && assignedBreakoutRoom.state === 'open' && (
                         <PrimaryButton
                           text={callStrings.joinBreakoutRoomButtonLabel}
                           onClick={async (): Promise<void> => {

--- a/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
@@ -52,7 +52,11 @@ import { isBoolean } from '../utils';
 /* @conditional-compile-remove(end-call-options) */
 import { getIsTeamsCall } from '../../CallComposite/selectors/baseSelectors';
 /* @conditional-compile-remove(breakout-rooms) */
-import { getAssignedBreakoutRoom, getBreakoutRoomSettings } from '../../CallComposite/selectors/baseSelectors';
+import {
+  getAssignedBreakoutRoom,
+  getBreakoutRoomSettings,
+  getLatestNotifications
+} from '../../CallComposite/selectors/baseSelectors';
 import { callStatusSelector } from '../../CallComposite/selectors/callStatusSelector';
 /* @conditional-compile-remove(teams-meeting-conference) */
 import { MeetingConferencePhoneInfoModal } from '@internal/react-components';
@@ -145,7 +149,13 @@ export const CommonCallControlBar = (props: CommonCallControlBarProps & Containe
   /* @conditional-compile-remove(breakout-rooms) */
   const assignedBreakoutRoom = useSelector(getAssignedBreakoutRoom);
   /* @conditional-compile-remove(breakout-rooms) */
+  const latestNotifications = useSelector(getLatestNotifications);
+  /* @conditional-compile-remove(breakout-rooms) */
   const breakoutRoomSettings = useSelector(getBreakoutRoomSettings);
+  /* @conditional-compile-remove(breakout-rooms) */
+  const movingToBreakoutRoomAutomatically =
+    assignedBreakoutRoom?.autoMoveParticipantToBreakoutRoom &&
+    (latestNotifications['assignedBreakoutRoomOpened'] || latestNotifications['assignedBreakoutRoomChanged']);
 
   const handleResize = useCallback((): void => {
     setControlBarButtonsWidth(controlBarContainerRef.current ? controlBarContainerRef.current.offsetWidth : 0);
@@ -368,15 +378,18 @@ export const CommonCallControlBar = (props: CommonCallControlBarProps & Containe
                   <ControlBar layout={props.displayVertical ? 'vertical' : 'horizontal'} styles={centerContainerStyles}>
                     {
                       /* @conditional-compile-remove(breakout-rooms) */
-                      !props.mobileView && assignedBreakoutRoom && assignedBreakoutRoom.state === 'open' && (
-                        <PrimaryButton
-                          text={callStrings.joinBreakoutRoomButtonLabel}
-                          onClick={async (): Promise<void> => {
-                            assignedBreakoutRoom.join();
-                          }}
-                          styles={commonButtonStyles}
-                        />
-                      )
+                      !props.mobileView &&
+                        assignedBreakoutRoom &&
+                        assignedBreakoutRoom.state === 'open' &&
+                        !movingToBreakoutRoomAutomatically && (
+                          <PrimaryButton
+                            text={callStrings.joinBreakoutRoomButtonLabel}
+                            onClick={async (): Promise<void> => {
+                              assignedBreakoutRoom.join();
+                            }}
+                            styles={commonButtonStyles}
+                          />
+                        )
                     }
                     {microphoneButtonIsEnabled && (
                       <Microphone


### PR DESCRIPTION
# What
1. Add mobile banner for breakout rooms based on [Figma](https://www.figma.com/design/HsKBeDvhCvWobK11FNQfJ9/ACS-UI---Breakout-Rooms?node-id=72-3031&t=zdwqFeYBGUOgrzgI-0)
2. Handle scenario of being unassigned from breakout room
3. Hide join breakout room button when already automatically being moving to breakout room to prevent joining breakout room twice

# Why
Breakout rooms feature for beta

# How Tested
Local CallWithChat sample test:

https://github.com/user-attachments/assets/8b4eb5ae-9968-4d82-8c18-8b620a340acb


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->