### PR TITLE
Read receipts selector fix

### DIFF
--- a/change-beta/@azure-communication-react-cc8ce792-335e-4d9c-a07a-84eedc869f5e.json
+++ b/change-beta/@azure-communication-react-cc8ce792-335e-4d9c-a07a-84eedc869f5e.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Read receipt selector",
+  "comment": "Fix chat selectors using read receipts from state",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-cc8ce792-335e-4d9c-a07a-84eedc869f5e.json
+++ b/change/@azure-communication-react-cc8ce792-335e-4d9c-a07a-84eedc869f5e.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Read receipt selector",
+  "comment": "Fix chat selectors using read receipts from state",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/chat-component-bindings/src/baseSelectors.ts
+++ b/packages/chat-component-bindings/src/baseSelectors.ts
@@ -44,7 +44,10 @@ export const getParticipants = (
 /**
  * @private
  */
-export const getReadReceipts = (state: ChatClientState, props: ChatBaseSelectorProps): ChatMessageReadReceipt[] => {
+export const getReadReceipts = (
+  state: ChatClientState,
+  props: ChatBaseSelectorProps
+): ChatMessageReadReceipt[] | undefined => {
   return state.threads[props?.threadId]?.readReceipts;
 };
 

--- a/packages/chat-component-bindings/src/messageThreadSelector.ts
+++ b/packages/chat-component-bindings/src/messageThreadSelector.ts
@@ -317,7 +317,7 @@ const hasValidParticipant = (chatMessage: ChatMessageWithStatus): boolean =>
 export const messageThreadSelectorWithThread: () => MessageThreadSelector = () =>
   createSelector(
     [getUserId, getChatMessages, getLatestReadTime, getIsLargeGroup, getReadReceipts, getParticipants],
-    (userId, chatMessages, latestReadTime, isLargeGroup, readReceipts, participants) => {
+    (userId, chatMessages, latestReadTime, isLargeGroup, readReceipts = [], participants) => {
       // We can't get displayName in teams meeting interop for now, disable rr feature when it is teams interop
       const isTeamsInterop = Object.values(participants).find((p) => 'microsoftTeamsUserId' in p.id) !== undefined;
 


### PR DESCRIPTION
# What
1. Change type return of getReadReceipt base selector
2. Avoid potentially calling filter when readReceipts is undefined

# Why
When I initialize a new chat adapter for my breakout rooms feature I get this error:
![image](https://github.com/user-attachments/assets/4c2c6ced-b981-4958-8acf-34ae0e3519e5)

# How Tested
Fixed the above error with fix.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->