### PR TITLE
Add API to start captions in the background

### DIFF
--- a/change-beta/@azure-communication-react-67710a93-6800-43e9-a606-6e6ea98a2fbf.json
+++ b/change-beta/@azure-communication-react-67710a93-6800-43e9-a606-6e6ea98a2fbf.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "improvement",
+  "workstream": "Captions",
+  "comment": "Add CallAdapter API to start captions in the background",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-67710a93-6800-43e9-a606-6e6ea98a2fbf.json
+++ b/change/@azure-communication-react-67710a93-6800-43e9-a606-6e6ea98a2fbf.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "improvement",
+  "workstream": "Captions",
+  "comment": "Add CallAdapter API to start captions in the background",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1239,25 +1239,17 @@ export interface CallWithChatAdapterManagement {
     startCall(participants: string[], options?: StartCallOptions): Call | undefined;
     startCall(participants: (MicrosoftTeamsAppIdentifier | /* @conditional-compile-remove(PSTN-calls) */ PhoneNumberIdentifier | /* @conditional-compile-remove(one-to-n-calling) */ CommunicationUserIdentifier | /* @conditional-compile-remove(teams-adhoc-call) */ MicrosoftTeamsUserIdentifier | UnknownIdentifier)[], options?: StartCallOptions): Call | undefined;
     startCamera(options?: VideoStreamOptions): Promise<void>;
-<<<<<<< HEAD
     startCaptions(options?: StartCaptionsAdapterOptions): Promise<void>;
-=======
-    startCaptions(options?: StartCaptionsOptions): Promise<void>;
     // @beta
     startNoiseSuppressionEffect(): Promise<void>;
->>>>>>> origin/main
     startScreenShare(): Promise<void>;
     startSpotlight(userIds?: string[]): Promise<void>;
     startVideoBackgroundEffect(videoBackgroundEffect: VideoBackgroundEffect): Promise<void>;
     stopAllSpotlight(): Promise<void>;
     stopCamera(): Promise<void>;
-<<<<<<< HEAD
     stopCaptions(options?: StopCaptionsAdapterOptions): Promise<void>;
-=======
-    stopCaptions(): Promise<void>;
     // @beta
     stopNoiseSuppressionEffect(): Promise<void>;
->>>>>>> origin/main
     stopScreenShare(): Promise<void>;
     stopSpotlight(userIds?: string[]): Promise<void>;
     stopVideoBackgroundEffects(): Promise<void>;

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -478,13 +478,13 @@ export interface CallAdapterCallOperations {
     setCaptionLanguage(language: string): Promise<void>;
     setSpokenLanguage(language: string): Promise<void>;
     startCamera(options?: VideoStreamOptions): Promise<void>;
-    startCaptions(options?: StartCaptionsOptions): Promise<void>;
+    startCaptions(options?: StartCaptionsAdapterOptions): Promise<void>;
     startScreenShare(): Promise<void>;
     startSpotlight(userIds?: string[]): Promise<void>;
     startVideoBackgroundEffect(videoBackgroundEffect: VideoBackgroundEffect): Promise<void>;
     stopAllSpotlight(): Promise<void>;
     stopCamera(): Promise<void>;
-    stopCaptions(): Promise<void>;
+    stopCaptions(options?: StopCaptionsAdapterOptions): Promise<void>;
     stopScreenShare(): Promise<void>;
     stopSpotlight(userIds?: string[]): Promise<void>;
     stopVideoBackgroundEffects(): Promise<void>;
@@ -1244,13 +1244,13 @@ export interface CallWithChatAdapterManagement {
     startCall(participants: string[], options?: StartCallOptions): Call | undefined;
     startCall(participants: (MicrosoftTeamsAppIdentifier | /* @conditional-compile-remove(PSTN-calls) */ PhoneNumberIdentifier | /* @conditional-compile-remove(one-to-n-calling) */ CommunicationUserIdentifier | /* @conditional-compile-remove(teams-adhoc-call) */ MicrosoftTeamsUserIdentifier | UnknownIdentifier)[], options?: StartCallOptions): Call | undefined;
     startCamera(options?: VideoStreamOptions): Promise<void>;
-    startCaptions(options?: StartCaptionsOptions): Promise<void>;
+    startCaptions(options?: StartCaptionsAdapterOptions): Promise<void>;
     startScreenShare(): Promise<void>;
     startSpotlight(userIds?: string[]): Promise<void>;
     startVideoBackgroundEffect(videoBackgroundEffect: VideoBackgroundEffect): Promise<void>;
     stopAllSpotlight(): Promise<void>;
     stopCamera(): Promise<void>;
-    stopCaptions(): Promise<void>;
+    stopCaptions(options?: StopCaptionsAdapterOptions): Promise<void>;
     stopScreenShare(): Promise<void>;
     stopSpotlight(userIds?: string[]): Promise<void>;
     stopVideoBackgroundEffects(): Promise<void>;
@@ -4616,6 +4616,11 @@ export interface SpotlightState {
 // @public
 export type StartCallIdentifier = (MicrosoftTeamsAppIdentifier | /* @conditional-compile-remove(PSTN-calls) */ PhoneNumberIdentifier | /* @conditional-compile-remove(one-to-n-calling) */ CommunicationUserIdentifier | /* @conditional-compile-remove(teams-adhoc-call) */ MicrosoftTeamsUserIdentifier | UnknownIdentifier) | /* @conditional-compile-remove(start-call-beta) */ CommunicationIdentifier;
 
+// @public
+export interface StartCaptionsAdapterOptions extends StartCaptionsOptions {
+    startInBackground?: boolean;
+}
+
 // @beta
 export type StartTeamsCallIdentifier = MicrosoftTeamsUserIdentifier | PhoneNumberIdentifier | MicrosoftTeamsAppIdentifier | UnknownIdentifier;
 
@@ -4670,6 +4675,11 @@ export type StatefulChatClientOptions = {
 export interface StatefulDeviceManager extends DeviceManager {
     getUnparentedVideoStreams: () => LocalVideoStream[];
     selectCamera: (device: VideoDeviceInfo) => void;
+}
+
+// @public
+export interface StopCaptionsAdapterOptions {
+    stopInBackground?: boolean;
 }
 
 // @public

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -272,13 +272,13 @@ export interface CallAdapterCallOperations {
     setCaptionLanguage(language: string): Promise<void>;
     setSpokenLanguage(language: string): Promise<void>;
     startCamera(options?: VideoStreamOptions): Promise<void>;
-    startCaptions(options?: StartCaptionsOptions): Promise<void>;
+    startCaptions(options?: StartCaptionsAdapterOptions): Promise<void>;
     startScreenShare(): Promise<void>;
     startSpotlight(userIds?: string[]): Promise<void>;
     startVideoBackgroundEffect(videoBackgroundEffect: VideoBackgroundEffect): Promise<void>;
     stopAllSpotlight(): Promise<void>;
     stopCamera(): Promise<void>;
-    stopCaptions(): Promise<void>;
+    stopCaptions(options?: StopCaptionsAdapterOptions): Promise<void>;
     stopScreenShare(): Promise<void>;
     stopSpotlight(userIds?: string[]): Promise<void>;
     stopVideoBackgroundEffects(): Promise<void>;
@@ -931,13 +931,13 @@ export interface CallWithChatAdapterManagement {
     startCall(participants: string[], options?: StartCallOptions): Call | undefined;
     startCall(participants: (MicrosoftTeamsAppIdentifier | UnknownIdentifier)[], options?: StartCallOptions): Call | undefined;
     startCamera(options?: VideoStreamOptions): Promise<void>;
-    startCaptions(options?: StartCaptionsOptions): Promise<void>;
+    startCaptions(options?: StartCaptionsAdapterOptions): Promise<void>;
     startScreenShare(): Promise<void>;
     startSpotlight(userIds?: string[]): Promise<void>;
     startVideoBackgroundEffect(videoBackgroundEffect: VideoBackgroundEffect): Promise<void>;
     stopAllSpotlight(): Promise<void>;
     stopCamera(): Promise<void>;
-    stopCaptions(): Promise<void>;
+    stopCaptions(options?: StopCaptionsAdapterOptions): Promise<void>;
     stopScreenShare(): Promise<void>;
     stopSpotlight(userIds?: string[]): Promise<void>;
     stopVideoBackgroundEffects(): Promise<void>;
@@ -3722,6 +3722,11 @@ export interface SpotlightState {
 export type StartCallIdentifier = (MicrosoftTeamsAppIdentifier | UnknownIdentifier);
 
 // @public
+export interface StartCaptionsAdapterOptions extends StartCaptionsOptions {
+    startInBackground?: boolean;
+}
+
+// @public
 export interface StatefulCallClient extends CallClient {
     createTeamsCallAgent(...args: Parameters<CallClient['createTeamsCallAgent']>): Promise<DeclarativeTeamsCallAgent>;
     createView(callId: string | undefined, participantId: CommunicationIdentifier | undefined, stream: LocalVideoStreamState | RemoteVideoStreamState, options?: CreateViewOptions): Promise<CreateViewResult | undefined>;
@@ -3770,6 +3775,11 @@ export type StatefulChatClientOptions = {
 export interface StatefulDeviceManager extends DeviceManager {
     getUnparentedVideoStreams: () => LocalVideoStream[];
     selectCamera: (device: VideoDeviceInfo) => void;
+}
+
+// @public
+export interface StopCaptionsAdapterOptions {
+    stopInBackground?: boolean;
 }
 
 // @public

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -42,7 +42,7 @@ import { TeamsCaptions } from '@azure/communication-calling';
 /* @conditional-compile-remove(acs-close-captions) */
 import { Captions, CaptionsInfo } from '@azure/communication-calling';
 import { TransferEventArgs } from '@azure/communication-calling';
-import { StartCaptionsOptions, TeamsCaptionsInfo } from '@azure/communication-calling';
+import { TeamsCaptionsInfo } from '@azure/communication-calling';
 
 import type { BackgroundBlurConfig, BackgroundReplacementConfig } from '@azure/communication-calling';
 
@@ -71,7 +71,9 @@ import {
   CallAdapterCallEndedEvent,
   CallAdapter,
   JoinCallOptions,
-  StartCallIdentifier
+  StartCallIdentifier,
+  StartCaptionsAdapterOptions,
+  StopCaptionsAdapterOptions
 } from './CallAdapter';
 import { ReactionResources } from '@internal/react-components';
 import { TransferAcceptedListener } from './CallAdapter';
@@ -124,10 +126,23 @@ import { CallingSoundSubscriber } from './CallingSoundSubscriber';
 import { CallingSounds } from './CallAdapter';
 type CallTypeOf<AgentType extends CallAgent | TeamsCallAgent> = AgentType extends CallAgent ? Call : TeamsCall;
 
+/**
+ * State used by the CallAdapter to manage the call state that is not exposed to the public API.
+ */
+interface CallAdapterPrivateState {
+  /** Track how captions has been started to decide on showing UI or not */
+  captionsTriggers?: {
+    captionsStartedInBackground?: boolean;
+    captionsStartedWithUI?: boolean;
+  };
+}
+
+type CallContextState = CallAdapterState & CallAdapterPrivateState;
+
 /** Context of call, which is a centralized context for all state updates */
 class CallContext {
   private emitter: EventEmitter = new EventEmitter();
-  private state: CallAdapterState;
+  private state: CallContextState;
   private callId: string | undefined;
   private displayNameModifier: AdapterStateModifier | undefined;
 
@@ -187,20 +202,37 @@ class CallContext {
     this.setAllowedUnsupportedBrowser.bind(this);
   }
 
-  public onStateChange(handler: (_uiState: CallAdapterState) => void): void {
+  public onStateChange(handler: (_uiState: CallContextState) => void): void {
     this.emitter.on('stateChanged', handler);
   }
 
-  public offStateChange(handler: (_uiState: CallAdapterState) => void): void {
+  public offStateChange(handler: (_uiState: CallContextState) => void): void {
     this.emitter.off('stateChanged', handler);
   }
 
-  public setState(state: CallAdapterState): void {
+  public setState(state: CallContextState): void {
     this.state = this.displayNameModifier ? this.displayNameModifier(state) : state;
+
+    // This context privately tracks how captions was started to determine if captions is running only in the background.
+    // If so we should not show the UI.
+    this.state = captionsUIVisibilityModifier(this.state);
+
     this.emitter.emit('stateChanged', this.state);
   }
 
-  public getState(): CallAdapterState {
+  public updateCaptionsStartedInBackground(captionsStartedInBackground: boolean): void {
+    const captionsTriggers = this.state.captionsTriggers ?? {};
+    captionsTriggers.captionsStartedInBackground = captionsStartedInBackground;
+    this.setState({ ...this.state, captionsTriggers });
+  }
+
+  public updateCaptionsStartedWithUI(captionsStartedWithUI: boolean): void {
+    const captionsTriggers = this.state.captionsTriggers ?? {};
+    captionsTriggers.captionsStartedWithUI = captionsStartedWithUI;
+    this.setState({ ...this.state, captionsTriggers });
+  }
+
+  public getState(): CallContextState {
     return this.state;
   }
 
@@ -1014,12 +1046,26 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | TeamsCa
     this.handlers.onSendDtmfTone(dtmfTone);
   }
 
-  public async startCaptions(options?: StartCaptionsOptions): Promise<void> {
+  public async startCaptions(options?: StartCaptionsAdapterOptions): Promise<void> {
+    if (options?.startInBackground) {
+      this.context.updateCaptionsStartedInBackground(true);
+    } else {
+      this.context.updateCaptionsStartedWithUI(true);
+    }
     this.handlers.onStartCaptions(options);
   }
 
-  public async stopCaptions(): Promise<void> {
-    this.handlers.onStopCaptions();
+  public async stopCaptions(options?: StopCaptionsAdapterOptions): Promise<void> {
+    if (options?.stopInBackground) {
+      this.context.updateCaptionsStartedInBackground(false);
+    }
+
+    this.context.updateCaptionsStartedWithUI(false);
+
+    // Only stop captions if they are not still running in the background
+    if (!this.context.getState().captionsTriggers?.captionsStartedInBackground) {
+      this.handlers.onStopCaptions();
+    }
   }
 
   public async setCaptionLanguage(language: string): Promise<void> {
@@ -2156,6 +2202,28 @@ export const createTeamsCallAdapterFromClient = async (
   } else {
     return new AzureCommunicationCallAdapter(callClient, locator, callAgent, deviceManager, options);
   }
+};
+
+const captionsUIVisibilityModifier = (state: CallContextState): CallContextState => {
+  // To hide captions to the UI, set isCaptionsFeatureActive to false and startCaptionsInProgress to false
+  if (
+    state.call?.captionsFeature &&
+    state.captionsTriggers?.captionsStartedInBackground &&
+    !state.captionsTriggers?.captionsStartedWithUI
+  ) {
+    return {
+      ...state,
+      call: {
+        ...state.call,
+        captionsFeature: {
+          ...state.call.captionsFeature,
+          isCaptionsFeatureActive: false,
+          startCaptionsInProgress: false
+        }
+      }
+    };
+  }
+  return state;
 };
 
 const isCallError = (e: Error): e is CallError => {

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -474,6 +474,37 @@ export interface VideoBackgroundReplacementEffect extends BackgroundReplacementC
 }
 
 /**
+ * Options passed to adapter.startCaptions
+ *
+ * @public
+ */
+export interface StartCaptionsAdapterOptions extends StartCaptionsOptions {
+  /**
+   * Start captions in the background without showing the captions UI to the Composite user.
+   *
+   * @defaultValue false
+   */
+  startInBackground?: boolean;
+}
+
+/**
+ * Options passed to adapter.stopCaptions
+ *
+ * @public
+ */
+export interface StopCaptionsAdapterOptions {
+  /**
+   * Stop captions that have been started in the background.
+   *
+   * @remarks
+   * This option is only applicable when stopping captions that have been started using the `startInBackground` property of adpater.startCaptions.
+   *
+   * @defaultValue false
+   */
+  stopInBackground?: boolean;
+}
+
+/**
  * Functionality for managing the current call.
  *
  * @public
@@ -649,7 +680,7 @@ export interface CallAdapterCallOperations {
    * Function to Start captions
    * @param options - options for start captions
    */
-  startCaptions(options?: StartCaptionsOptions): Promise<void>;
+  startCaptions(options?: StartCaptionsAdapterOptions): Promise<void>;
   /**
    * Function to set caption language
    * @param language - language set for caption
@@ -663,7 +694,7 @@ export interface CallAdapterCallOperations {
   /**
    * Funtion to stop captions
    */
-  stopCaptions(): Promise<void>;
+  stopCaptions(options?: StopCaptionsAdapterOptions): Promise<void>;
 
   /**
    * Start the video background effect.

--- a/packages/react-composites/src/composites/CallComposite/adapter/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/index.ts
@@ -60,7 +60,9 @@ export type {
   ParticipantsJoinedListener,
   ParticipantsLeftListener,
   JoinCallOptions,
-  StartCallIdentifier
+  StartCallIdentifier,
+  StartCaptionsAdapterOptions,
+  StopCaptionsAdapterOptions
 } from './CallAdapter';
 
 export type {

--- a/packages/react-composites/src/composites/CallComposite/index.ts
+++ b/packages/react-composites/src/composites/CallComposite/index.ts
@@ -73,7 +73,9 @@ export type {
   ParticipantsJoinedListener,
   ParticipantsLeftListener,
   JoinCallOptions,
-  StartCallIdentifier
+  StartCallIdentifier,
+  StartCaptionsAdapterOptions,
+  StopCaptionsAdapterOptions
 } from './adapter';
 
 export type {

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -17,7 +17,6 @@ import {
 } from '@azure/communication-calling';
 import { TeamsMeetingIdLocator } from '@azure/communication-calling';
 import { Reaction } from '@azure/communication-calling';
-import { StartCaptionsOptions } from '@azure/communication-calling';
 /* @conditional-compile-remove(PSTN-calls) */
 import { AddPhoneNumberOptions } from '@azure/communication-calling';
 /* @conditional-compile-remove(breakout-rooms) */
@@ -90,7 +89,12 @@ import { ChatThreadClient } from '@azure/communication-chat';
 import { UploadChatImageResult } from '@internal/acs-ui-common';
 import { useEffect, useRef, useState } from 'react';
 import { _toCommunicationIdentifier, _TelemetryImplementationHint } from '@internal/acs-ui-common';
-import { JoinCallOptions, StartCallIdentifier } from '../../CallComposite/adapter/CallAdapter';
+import {
+  JoinCallOptions,
+  StartCallIdentifier,
+  StartCaptionsAdapterOptions,
+  StopCaptionsAdapterOptions
+} from '../../CallComposite/adapter/CallAdapter';
 
 import { AzureCommunicationCallAdapterOptions } from '../../CallComposite/adapter/AzureCommunicationCallAdapter';
 import {
@@ -630,12 +634,12 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
     return this.callAdapter.allowUnsupportedBrowserVersion();
   }
 
-  public async startCaptions(options?: StartCaptionsOptions): Promise<void> {
+  public async startCaptions(options?: StartCaptionsAdapterOptions): Promise<void> {
     await this.callAdapter.startCaptions(options);
   }
 
-  public async stopCaptions(): Promise<void> {
-    await this.callAdapter.stopCaptions();
+  public async stopCaptions(options?: StopCaptionsAdapterOptions): Promise<void> {
+    await this.callAdapter.stopCaptions(options);
   }
 
   public async setCaptionLanguage(language: string): Promise<void> {

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
@@ -35,7 +35,6 @@ import {
   VideoDeviceInfo
 } from '@azure/communication-calling';
 import { Reaction } from '@azure/communication-calling';
-import { StartCaptionsOptions } from '@azure/communication-calling';
 /* @conditional-compile-remove(PSTN-calls) */
 import { AddPhoneNumberOptions } from '@azure/communication-calling';
 /* @conditional-compile-remove(breakout-rooms) */
@@ -45,7 +44,11 @@ import { CreateVideoStreamViewResult, VideoStreamOptions } from '@internal/react
 import { SendMessageOptions } from '@azure/communication-chat';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { UploadChatImageResult } from '@internal/acs-ui-common';
-import { JoinCallOptions } from '../../CallComposite/adapter/CallAdapter';
+import {
+  JoinCallOptions,
+  StartCaptionsAdapterOptions,
+  StopCaptionsAdapterOptions
+} from '../../CallComposite/adapter/CallAdapter';
 /* @conditional-compile-remove(file-sharing-acs) */
 import { MessageOptions } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(PSTN-calls) */
@@ -435,7 +438,7 @@ export interface CallWithChatAdapterManagement {
    * Function to Start captions
    * @param options - options for start captions
    */
-  startCaptions(options?: StartCaptionsOptions): Promise<void>;
+  startCaptions(options?: StartCaptionsAdapterOptions): Promise<void>;
   /**
    * Function to set caption language
    * @param language - language set for caption
@@ -449,7 +452,7 @@ export interface CallWithChatAdapterManagement {
   /**
    * Funtion to stop captions
    */
-  stopCaptions(): Promise<void>;
+  stopCaptions(options?: StopCaptionsAdapterOptions): Promise<void>;
 
   /**
    * Start the video background effect.

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedCallAdapter.ts
@@ -14,7 +14,6 @@ import {
   StartCallOptions
 } from '@azure/communication-calling';
 import { Reaction } from '@azure/communication-calling';
-import { StartCaptionsOptions } from '@azure/communication-calling';
 /* @conditional-compile-remove(PSTN-calls) */
 import { AddPhoneNumberOptions } from '@azure/communication-calling';
 import { DtmfTone } from '@azure/communication-calling';
@@ -24,7 +23,12 @@ import { CommunicationIdentifier, isPhoneNumberIdentifier, PhoneNumberIdentifier
 /* @conditional-compile-remove(one-to-n-calling) */
 import { CommunicationUserIdentifier } from '@azure/communication-common';
 import { _toCommunicationIdentifier } from '@internal/acs-ui-common';
-import { JoinCallOptions, StartCallIdentifier } from '../../CallComposite/adapter/CallAdapter';
+import {
+  JoinCallOptions,
+  StartCallIdentifier,
+  StartCaptionsAdapterOptions,
+  StopCaptionsAdapterOptions
+} from '../../CallComposite/adapter/CallAdapter';
 import { CallSurvey, CallSurveyResponse } from '@azure/communication-calling';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -180,20 +184,20 @@ export class CallWithChatBackedCallAdapter implements CallAdapter {
     await this.callWithChatAdapter.sendDtmfTone(dtmfTone);
   };
 
-  public async startCaptions(options?: StartCaptionsOptions): Promise<void> {
-    this.callWithChatAdapter.startCaptions(options);
+  public async startCaptions(options?: StartCaptionsAdapterOptions): Promise<void> {
+    await this.callWithChatAdapter.startCaptions(options);
   }
 
-  public async stopCaptions(): Promise<void> {
-    this.callWithChatAdapter.stopCaptions();
+  public async stopCaptions(options?: StopCaptionsAdapterOptions): Promise<void> {
+    await this.callWithChatAdapter.stopCaptions(options);
   }
 
   public async setCaptionLanguage(language: string): Promise<void> {
-    this.callWithChatAdapter.setCaptionLanguage(language);
+    await this.callWithChatAdapter.setCaptionLanguage(language);
   }
 
   public async setSpokenLanguage(language: string): Promise<void> {
-    this.callWithChatAdapter.setSpokenLanguage(language);
+    await this.callWithChatAdapter.setSpokenLanguage(language);
   }
 
   public async startVideoBackgroundEffect(videoBackgroundEffect: VideoBackgroundEffect): Promise<void> {


### PR DESCRIPTION
# What

- Add new options to adapter.startCaptions and adapter.stopCaptions
- Options allow starting captions in the background without showing the UI
- Added captions start tracking properties to adapter callcontext
- Added a state modifier on setState of the callcontext to use the private captions start tracking properties to not show the captions UI in the composite

# Why

Customer request

# How Tested

Ran locally, tested:
- `adapter.startCaptions({ startInBackground: true })` starts captions silently and can listen to adapter state to track captions
- `adpater.startCaptions()` shows UI. As does starting captions from the UI
- `adapter.stopCaptions()` stops UI but keeps captions running only iff `adapter.startCaptions({ startInBackground: true })` has been previously called
- UI stop captions has the same behavior