### PR TITLE
Fix error when listening to spotlight and capabilities events for call with chat adapter

### DIFF
--- a/change-beta/@azure-communication-react-338b3032-95c2-4539-9187-37939d37c21e.json
+++ b/change-beta/@azure-communication-react-338b3032-95c2-4539-9187-37939d37c21e.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "CallWithChatAdapter events",
-  "comment": "Fix event subscriptions to capabilitiesChanged and spotlightChanged events for AzureCommunicationCallWithChatAdapter",
+  "comment": "Fix error when listening to capabilitiesChanged and spotlightChanged events from AzureCommunicationCallWithChatAdapter",
   "packageName": "@azure/communication-react",
   "email": "79475487+mgamis-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change-beta/@azure-communication-react-338b3032-95c2-4539-9187-37939d37c21e.json
+++ b/change-beta/@azure-communication-react-338b3032-95c2-4539-9187-37939d37c21e.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "CallWithChatAdapter events",
+  "comment": "Fix event subscriptions to capabilitiesChanged and spotlightChanged events for AzureCommunicationCallWithChatAdapter",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-338b3032-95c2-4539-9187-37939d37c21e.json
+++ b/change/@azure-communication-react-338b3032-95c2-4539-9187-37939d37c21e.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "CallWithChatAdapter events",
-  "comment": "Fix event subscriptions to capabilitiesChanged and spotlightChanged events for AzureCommunicationCallWithChatAdapter",
+  "comment": "Fix error when listening to capabilitiesChanged and spotlightChanged events from AzureCommunicationCallWithChatAdapter",
   "packageName": "@azure/communication-react",
   "email": "79475487+mgamis-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@azure-communication-react-338b3032-95c2-4539-9187-37939d37c21e.json
+++ b/change/@azure-communication-react-338b3032-95c2-4539-9187-37939d37c21e.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "CallWithChatAdapter events",
+  "comment": "Fix event subscriptions to capabilitiesChanged and spotlightChanged events for AzureCommunicationCallWithChatAdapter",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -818,6 +818,12 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
       case 'chatInitialized':
         this.emitter.on(event, listener);
         break;
+      case 'capabilitiesChanged':
+        this.callAdapter.on('capabilitiesChanged', listener);
+        break;
+      case 'spotlightChanged':
+        this.callAdapter.on('spotlightChanged', listener);
+        break;
       default:
         throw `Unknown AzureCommunicationCallWithChatAdapter Event: ${event}`;
     }
@@ -942,6 +948,12 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         break;
       case 'chatInitialized':
         this.emitter.off(event, listener);
+        break;
+      case 'capabilitiesChanged':
+        this.emitter.off('capabilitiesChanged', listener);
+        break;
+      case 'spotlightChanged':
+        this.emitter.off('spotlightChanged', listener);
         break;
       default:
         throw `Unknown AzureCommunicationCallWithChatAdapter Event: ${event}`;

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -950,10 +950,10 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         this.emitter.off(event, listener);
         break;
       case 'capabilitiesChanged':
-        this.emitter.off('capabilitiesChanged', listener);
+        this.callAdapter.off('capabilitiesChanged', listener);
         break;
       case 'spotlightChanged':
-        this.emitter.off('spotlightChanged', listener);
+        this.callAdapter.off('spotlightChanged', listener);
         break;
       default:
         throw `Unknown AzureCommunicationCallWithChatAdapter Event: ${event}`;


### PR DESCRIPTION
# What
Fix error when listening to spotlight and capabilities events for call with chat adapter

# Why
The following error shows when you subscribe to 'spotlightChanged' event of the AzureCommunicationCallWithChatAdapter
![image](https://github.com/user-attachments/assets/3a367885-25a0-4f29-b2d2-f5a77b6cd305)
Similar error is shown for 'capabilitiesChanged' event

# How Tested
Verified listening to 'spotlightChanged' and 'capabilitiesChanged' in local CallWithChat works in this video:
https://github.com/user-attachments/assets/c6d7984f-9435-4c74-8df3-7d5015ab57c8

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->