### PR TITLE
[Storybook8] Storybook bugs V8

### DIFF
--- a/packages/storybook8/stories/Components/ControlBar/ControlBar/Docs.mdx
+++ b/packages/storybook8/stories/Components/ControlBar/ControlBar/Docs.mdx
@@ -23,11 +23,11 @@ import { DefaultButton } from '@fluentui/react';
 ## Example
 
 We recommend using our pre-defined buttons you can start find
-[here](./?path=/docs/ui-components-controlbar-buttons) or `DefaultButton`, a
+[here](./?path=/docs/components-controlbar-buttons-camera--docs) or `DefaultButton`, a
 [Button](https://developer.microsoft.com/fluentui#/controls/web/button) component from Fluent UI, as controls
 inside `ControlBar`. Pre-defined styles like `controlButtonStyles` or `controlButtonLabelStyles` can also be
 imported and used as `DefaultButton` styles for easy styling. `FluentThemeProvider` is needed around
-`ControlBar` to provide theming and icons. Learn more about theming [here](./?path=/docs/theming--page).
+`ControlBar` to provide theming and icons. Learn more about theming [here](./?path=/docs/concepts-theming--docs).
 
 <Canvas of={ControlBarStories.AllButtonsControlBarExampleDocsOnly} source={{ code: AllButtonsControlBarExampleText }} />
 
@@ -57,7 +57,7 @@ You can change the styles of the `ControlBar` by customizing its `styles` prop l
 You can also easily change the styles of included button components. They are built on Fluent UI `DefaultButton`
 and accept all the same props. In the example below we import `CameraButton` and `MicrophoneButton` for the 1st
 and 2nd buttons and style our own hang up button for the 3rd button. Learn more about styling
-[here](./?path=/docs/styling--page).
+[here](./?path=/docs/concepts-styling--docs).
 
 <Canvas of={ControlBarStories.CustomButtonsExampleDocsOnly} source={{ code: CustomButtonsExampleText }} />
 

--- a/packages/storybook8/stories/Components/UnsupportedBrowser/Docs.mdx
+++ b/packages/storybook8/stories/Components/UnsupportedBrowser/Docs.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Description, Meta, Source } from '@storybook/blocks';
+import { Canvas, Description, Meta, Source, ArgTypes } from '@storybook/blocks';
 import { UnsupportedBrowser as UnsupportedBrowserComponent } from '@azure/communication-react';
 import * as UnsupportedBrowserStories from './index.stories';
 import { SingleLineBetaBanner } from '../../BetaBanners/SingleLineBetaBanner';
@@ -43,3 +43,7 @@ below to see the component
   of={UnsupportedBrowserStories.UnsupportedEnvironmentModalsDocsOnly}
   source={{ code: UnsupportedEnvironmentModals }}
 />
+
+## Props
+
+<ArgTypes of={UnsupportedBrowserComponent} />

--- a/packages/storybook8/stories/Concepts/ClosedCaptions/Doc.mdx
+++ b/packages/storybook8/stories/Concepts/ClosedCaptions/Doc.mdx
@@ -12,7 +12,7 @@ Azure Communication Services UI Library is adding support for Closed Captions. C
 
 Closed Captions is supported by default and are automatically included within the CallComposite and CallWithChatComposite experiences.
 
-# Azure Communication Service Based Captions
+## Azure Communication Service Based Captions
 
 <SingleLineBetaBanner />
 
@@ -20,13 +20,13 @@ Azure Communication Service Closed Captions are supported by default and are aut
 
 For Azure Communication Service captions, users can enable captions in the menu and select the spoken language for the captions. Captions does not detect language automatically, so the spoken language selected needs to match the language that will be used in the call. Currently, Azure Communication Service captions does not support translation.
 
-# Teams Interop Closed Captions
+## Teams Interop Closed Captions
 
 Teams Interop Closed Captions is supported by default and are automatically included within the CallComposite and CallWithChatComposite experiences during a call including one or more teams users.
 
 The main difference between Azure Communication Service Closed Captions and Teams Interop Closed Captions is that Teams Interop Closed Captions supports translation. End users can choose to have captions translated to a different language by using captions settings.
 
-# How to use Captions
+## How to use Captions
 
 Captions is automatically included within the CallComposite and CallWithChatComposite experiences. To turn on captions, users need to navigate to the control bar after call is connected, and click on more button. Inside the menu pop up, click on Turn on captions.
 
@@ -74,7 +74,7 @@ The caption language (Teams Interop Closed Captions) is set to English by defaul
   />
 </Stack>
 
-# Disable captions
+## Disable captions
 
 The UI Library enables users to hide captions UI when they do not wish to use the captions service.
 

--- a/packages/storybook8/stories/Concepts/Survey/Doc.mdx
+++ b/packages/storybook8/stories/Concepts/Survey/Doc.mdx
@@ -4,7 +4,9 @@ import { Meta, Source } from '@storybook/addon-docs';
 
 import { exampleDisableSurvey, exampleOnSurveyClosed, exampleOnSurveySubmitted } from './utils/SurveyDocs';
 
-# End of Call Survey
+# Survey
+
+## End of Call Survey
 
 Azure Communication Services UI Library is adding support for End of Call Survey. With this new feature, call participants will be able to share feedback on the quality and reliability of Audio and Video calls.
 
@@ -17,7 +19,7 @@ Participants will be able to submit feedback based on four categories:
 
 They can rate their call experience on a star based numerical survey and provide additional detail as to the specifics of each category if they wish. The feedback feature will enable developers to collect subjective customer feedback on call quality and reliability and enable the creation of more definite metrics.
 
-# Handling Survey Results
+## Handling Survey Results
 
 Survey feedback is automatically sent to Azure Monitor. To send survey results to your own service, you can also gain access to the survey results by passing in a custom function utilizing the `onSurveySubmitted` prop inside `surveyOptions`.
 
@@ -27,13 +29,13 @@ With `onSurveySubmitted` populated, a free form text survey is available to the 
 
 <Source code={exampleOnSurveySubmitted} />
 
-# Disabling End of Call Survey
+## Disabling End of Call Survey
 
 The UI Library enables users to display surveys at end of call by providing the option to use end of call survey within the CallComposite and CallWithChatComposite experience. End of Call Survey are enabled by default both in Mobile Web sessions and in Desktop Web sessions. If you wish to disable the end of call survey, you have the option to remove this feature from the composites.
 
 <Source code={exampleDisableSurvey} />
 
-# Redirect to your own experience after end of call survey
+## Redirect to your own experience after end of call survey
 
 The UI Library enables users to redirect to their own experience when end of call survey is skipped, submitted, or has an issue sending. This is done by passing in a custom function utilizing the `onSurveyClosed` prop inside `surveyOptions`.
 

--- a/packages/storybook8/stories/Examples/Themes/Docs.mdx
+++ b/packages/storybook8/stories/Examples/Themes/Docs.mdx
@@ -8,7 +8,7 @@ import exampleTeamsTheme from '!!raw-loader!./snippets/TeamsTheme.snippet.tsx';
 
 Below is an example of a [Microsoft Teams](http://teams.microsoft.com/) Theme being applied to UI Components. In
 this example a color palette that resembles Teams is provided to the FluentThemeProvider. The
-FluentThemeProvider in turn styles the UI Components.\
+FluentThemeProvider in turn styles the UI Components.
 
 ## Teams-Like Theme
 

--- a/packages/storybook8/stories/StatefulClient/Call/Docs.mdx
+++ b/packages/storybook8/stories/StatefulClient/Call/Docs.mdx
@@ -13,7 +13,7 @@ Get started with Azure Communication Services by using the UI Library to quickly
 In this quickstart, you'll learn how to integrate UI Library stateful clients into your application to build communication experiences.
 To learn more about how to build applications with UI Library UI Components, see [Get started with UI Components](./?path=/docs/components-get-started--docs)
 Stateful clients make it easier for developers to build UI applications on top of Azure Communication Services by providing built-in state that UI components can use to render.
-Find more information about [Stateful client here.](./?path=/docs/stateful-client-overview--docs).
+Find more information about [Stateful client here](./?path=/docs/stateful-client-overview--docs).
 
 ## Download the code
 
@@ -90,8 +90,8 @@ The following classes and interfaces from the Azure Communication Services UI cl
 | [Call](https://docs.microsoft.com/javascript/api/azure-communication-services/@azure/communication-calling/call?view=azure-communication-services-js)             | Low-level call object for calling client                                               |
 | [createStatefulCallClient](./?path=/docs/stateful-client-overview--docs#calling-statefulclient)                                                                   | Method to translate low-level library client into a stateful client for the UI Library |
 | [CallClientProvider](./?path=/docs/stateful-client-react-hooks-setting-up--docs#calling)                                                                          | Provider allows access to the Stateful Call Client to the components inside of it      |
-| [CallAgentProvider](/?path=/docs/stateful-client-react-hooks-setting-up--docs#calling)                                                                            | Provider allows access to the Stateful Call Agent to the components inside of it       |
-| [CallProvider](/?path=/docs/stateful-client-react-hooks-setting-up--docs#calling)                                                                                 | Provider allows access to the Stateful Call object to the components inside of it      |
+| [CallAgentProvider](./?path=/docs/stateful-client-react-hooks-setting-up--docs#calling)                                                                           | Provider allows access to the Stateful Call Agent to the components inside of it       |
+| [CallProvider](./?path=/docs/stateful-client-react-hooks-setting-up--docs#calling)                                                                                | Provider allows access to the Stateful Call object to the components inside of it      |
 | [usePropsFor](./?path=/docs/stateful-client-react-hooks-usepropsfor--docs#usepropsfor-calling-app-example)                                                        | Hook to generate required props to enable UI Components                                |
 
 ## Instantiate Stateful Call Client, Call Agent and Call


### PR DESCRIPTION
# What
1. Themes Example- Random backslash at the end of the first paragraph
2. Survey Docs - All headings are h1. Title should be H1, then other headings on this page should be h2. 
3. Stateful client get started call -  Double full stop at the end of the first paragraph. CallAgentProvider and CaallProvider links in the Object model table do not work
4. Unsupported Browser page - Missing props table 
5. Control bar -  2 links saying "here" are not working. Icons in story not showing initially
6. Closed Captions - No sections navigation on the right side like v6 page(all headings are H1)

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/3856220
https://skype.visualstudio.com/SPOOL/_workitems/edit/3856211
https://skype.visualstudio.com/SPOOL/_workitems/edit/3856224
https://skype.visualstudio.com/SPOOL/_workitems/edit/3855063
https://skype.visualstudio.com/SPOOL/_workitems/edit/3856204
https://skype.visualstudio.com/SPOOL/_workitems/edit/3856208

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->