### PR TITLE
Update calling sdk versions

### DIFF
--- a/change-beta/@azure-communication-react-7723b22c-642d-4bff-878b-320062337d13.json
+++ b/change-beta/@azure-communication-react-7723b22c-642d-4bff-878b-320062337d13.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "feature",
+  "workstream": "Calling dependency",
+  "comment": "Update communication calling to 1.29.1-beta.1 and 1.28.1",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-7723b22c-642d-4bff-878b-320062337d13.json
+++ b/change/@azure-communication-react-7723b22c-642d-4bff-878b-320062337d13.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "feature",
+  "workstream": "Calling dependency",
+  "comment": "Update communication calling to 1.29.1-beta.1 and 1.28.1",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -24,7 +24,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "@azure/communication-calling": "1.28.1-beta.4",
+    "@azure/communication-calling": "1.29.1-beta.1",
     "@azure/communication-common": "2.3.0",
     "@azure/communication-chat": "1.6.0-beta.3",
     "@azure/communication-signaling": "1.0.0-beta.27",
@@ -55,7 +55,7 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
-    "@azure/communication-calling": ["1.28.1-beta.4"],
+    "@azure/communication-calling": ["1.29.1-beta.1"],
     "@azure/communication-common": ["2.3.0"],
     "@azure/communication-chat": ["1.6.0-beta.3"],
     "@azure/communication-signaling": ["1.0.0-beta.27"],

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@azure/communication-calling':
-    specifier: 1.28.1-beta.4
-    version: 1.28.1-beta.4
+    specifier: 1.29.1-beta.1
+    version: 1.29.1-beta.1
   '@azure/communication-chat':
     specifier: 1.6.0-beta.3
     version: 1.6.0-beta.3
@@ -144,8 +144,8 @@ packages:
       events: 3.3.0
     dev: false
 
-  /@azure/communication-calling@1.28.1-beta.4:
-    resolution: {integrity: sha512-JY0Jn/1Ws7YFkCDilvIMeVdRedPrpU3v9q8lx2c7ggIAa1LXiHagauvsHpmwegTEF3n+hywxpIqPCbSDGgXkrQ==}
+  /@azure/communication-calling@1.29.1-beta.1:
+    resolution: {integrity: sha512-JgRXK56cSAESV2ZhAFYL3482PQcF5LnqWl5AD10iv5REEG6Kz+k7bqp4fsYXgVN7ZCEChGdGg9Fz0cy/hT4d+Q==}
     dependencies:
       '@azure/communication-common': 2.3.0
       '@azure/logger': 1.0.4
@@ -25387,11 +25387,11 @@ packages:
     dev: false
 
   file:projects/calling-component-bindings.tgz:
-    resolution: {integrity: sha512-rs/6nO97F5ZHfy9nDr84g+SEPsT2jaGR0rLb0OxuDQlyl0GgH8RGDRm7Lytq4yE8QSeyvKDHHQqcroS6Z/S9LA==, tarball: file:projects/calling-component-bindings.tgz}
+    resolution: {integrity: sha512-jKW6RqXvR7bOCKjVG/RHhEUWBKc0W8GPQBy7VRr5ZfY1jyzCcbUkEAbSr8+7NilRFvCShkwd9uFkRd+pDyEUlA==, tarball: file:projects/calling-component-bindings.tgz}
     name: '@rush-temp/calling-component-bindings'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-calling-effects': 1.1.1-beta.1
       '@azure/communication-common': 2.3.1
       '@babel/cli': 7.24.8(@babel/core@7.25.2)
@@ -25436,11 +25436,11 @@ packages:
     dev: false
 
   file:projects/calling-stateful-client.tgz:
-    resolution: {integrity: sha512-fnofZZFiPqW28iWkCN/7jLOEAVJLqIcx9rYAOWzv+FoSWqBakhePuHmUK2XXs2/fpbVwNX6BDpzlr65R2x+3bA==, tarball: file:projects/calling-stateful-client.tgz}
+    resolution: {integrity: sha512-753IAKA/tl1wYCb54+XlmSXgRSz4kHk1wKBxQs8+y9u23uwiNWGoykMrrt7BV0p3IKx8Ky3o2akIpIL/MK8NCA==, tarball: file:projects/calling-stateful-client.tgz}
     name: '@rush-temp/calling-stateful-client'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/core-auth': 1.6.0
       '@azure/logger': 1.0.4
@@ -25485,12 +25485,12 @@ packages:
     dev: false
 
   file:projects/calling.tgz:
-    resolution: {integrity: sha512-t1kwy2dHxAA1v1JzRLuPrQRBxSqnItFhMpGvD2wSOTLlUo9RFdhyGLTckPVT6VJNmxf2O5gspP4V1QjyD68NQQ==, tarball: file:projects/calling.tgz}
+    resolution: {integrity: sha512-QwzaobyZW74aS26HPjWEZBLaI2k2AOdCncTACoWIqXuaB0exRvAb4AXB5fOAykiivVIDgftU7FXB1TmLB/zSaA==, tarball: file:projects/calling.tgz}
     name: '@rush-temp/calling'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
       '@azure/logger': 1.0.4
@@ -25579,12 +25579,12 @@ packages:
     dev: false
 
   file:projects/callingstateful.tgz:
-    resolution: {integrity: sha512-ahKaVcWyKTunBvxUcwUYrQT9Yoob5WQjN0RLigyTxAMtUqUswZZz8d1qQGAjvv5Cv2xKiOLow8gioYdW4rGXiQ==, tarball: file:projects/callingstateful.tgz}
+    resolution: {integrity: sha512-/gvCSe1eHKBv+UX2/LJFfH2A59rNZvFHgbsmhx1eoFt+aIdmG3E7S1fd8xfdF6OoZGBD8XSxJ7Mj6NLg3J0z9g==, tarball: file:projects/callingstateful.tgz}
     name: '@rush-temp/callingstateful'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
       '@azure/logger': 1.0.4
@@ -25673,12 +25673,12 @@ packages:
     dev: false
 
   file:projects/callwithchat.tgz:
-    resolution: {integrity: sha512-zBkP5Qry6IQ7b4w+3RwnyiGkx7ISB8vcHIKvA62JZtkscl1E9buHcF7aSl0IjLnfNoMZZMsFNObNMFsNwNdzgA==, tarball: file:projects/callwithchat.tgz}
+    resolution: {integrity: sha512-FcJePy/NIeE78qqq+4zWIncNjrkXRG2IL9eJxxmkYXoHzbxjhMPCXARgkueaeKaAuUjpW5hyIyWmlZcqS0J4lg==, tarball: file:projects/callwithchat.tgz}
     name: '@rush-temp/callwithchat'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.3
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -25996,11 +25996,11 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-uuE38nrTdizIjIwJLuRP7LRlLoeYgfuupRq0V5/1ZOIaVoF0rXpTVnQJANFmMXYtd2/2EF+uN46QDGn8IDxznQ==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-7UZbQb5t5K89SS6krm0jXe2gvqUBCOSBlhimVm2cSGebH2xASFnJ29D4Hdm3vzyXQVr51bS26thCZ3k6J99TlA==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-calling-effects': 1.1.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.3
       '@azure/communication-common': 2.3.1
@@ -26109,11 +26109,11 @@ packages:
     dev: false
 
   file:projects/component-examples.tgz:
-    resolution: {integrity: sha512-kuLAH3EexZ/o/IBcq6CFMfL8fyrlgNn2wgVKqLVCA7NUh1mbFYNMYBizo1qDWIiBIYAgR/fWYCHMeuAJfxlKrA==, tarball: file:projects/component-examples.tgz}
+    resolution: {integrity: sha512-fcJqjoMg62/43M4S+XDp/FTT4M6VakQVIbjEQDKxEkRDsqdgHuqoIBF67s2STNt5IggrItd5d3Q3fOrfKNtO/w==, tarball: file:projects/component-examples.tgz}
     name: '@rush-temp/component-examples'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.3
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -26378,11 +26378,11 @@ packages:
     dev: false
 
   file:projects/react-composites.tgz:
-    resolution: {integrity: sha512-p5tLeTcXP277MFyztIhwj8G57I8TFntQDRv2jlReD5yaHxd9U54cH9GMAG45s/ogFwB2TXC5juSKBWwb70KyPg==, tarball: file:projects/react-composites.tgz}
+    resolution: {integrity: sha512-/DS0TL1+s9o1Vo7aHUaXWdcoIOHIahQD05KKKlISqH2X0gTM4gpVYl4q2P6xVO4VSkqtYVR0g5rIBYIH2FSBBg==, tarball: file:projects/react-composites.tgz}
     name: '@rush-temp/react-composites'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-calling-effects': 1.1.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.3
       '@azure/communication-common': 2.3.1
@@ -26497,11 +26497,11 @@ packages:
     dev: false
 
   file:projects/sample-automation-tests.tgz:
-    resolution: {integrity: sha512-gYr75vAG5AUb0nWoYBgkdAhTdbbJT8U9cN+VVTX2YfgYwGxwxX0DU+ApNC6vO8Xq5v8TV3E1x7ki9bFRVvBO0Q==, tarball: file:projects/sample-automation-tests.tgz}
+    resolution: {integrity: sha512-BOD3fdLz4jH59zyD0erJICbXR9zq7uKs1YpuT/TzCim/KMy3SxtW33Zb5T7myUF+uTLG8cd5ZVYZAKRtzvbHCg==, tarball: file:projects/sample-automation-tests.tgz}
     name: '@rush-temp/sample-automation-tests'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.3
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -26522,11 +26522,11 @@ packages:
     dev: false
 
   file:projects/sample-static-html-composites.tgz:
-    resolution: {integrity: sha512-UIgIUklCjWfH3y1DCPEPu/TjUg7LAlCZXNPT1hE5IhWk4pdPU+OiulVuT+5mwLpLfSA67j6UPCXNrTHOKDNa8g==, tarball: file:projects/sample-static-html-composites.tgz}
+    resolution: {integrity: sha512-Dg0GXC9foNgeFEdXoBv1rErFzDlf+jfV1Xkxyl+A/JLYWHftCCu+EPlAXPA6Dp7UDEKHV8EYT3WGNDLaO5o0kg==, tarball: file:projects/sample-static-html-composites.tgz}
     name: '@rush-temp/sample-static-html-composites'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.3
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -26657,11 +26657,11 @@ packages:
     dev: false
 
   file:projects/storybook.tgz:
-    resolution: {integrity: sha512-OV0kAb1EsFw3tcptxdUjJUtHB2h5B1VDk36K7xr9Oclan05Lsoz4TpZqP/ShmyHtoezLRw08XzqIn0pIQx6CwQ==, tarball: file:projects/storybook.tgz}
+    resolution: {integrity: sha512-pjk8nK++tBzVxfiz5nUu68658pkt5DLAQ3GCq0iblMpnyhxZalNtZsEWpuRlmI99A98tKMnQ3oLulIk62J4b6Q==, tarball: file:projects/storybook.tgz}
     name: '@rush-temp/storybook'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.3
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -26801,11 +26801,11 @@ packages:
     dev: false
 
   file:projects/storybook8.tgz:
-    resolution: {integrity: sha512-DU9dV/t3xXtSkNIzzINBrmpjc+r/6qqpc6QI9aaX+SlLRaKAHDFw8dULf5C6LuaVVnLQr2upZXQsIQsx01jVXg==, tarball: file:projects/storybook8.tgz}
+    resolution: {integrity: sha512-ln49LnjrDhsoNIQWImvn7EQTarQo7+9Sz3uMd4tYtEZ8w5IxmsWMvHRtiIEZPLUkBsweamgWUQUT6VqNHpswiA==, tarball: file:projects/storybook8.tgz}
     name: '@rush-temp/storybook8'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.28.1-beta.4
+      '@azure/communication-calling': 1.29.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.3
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0

--- a/common/config/rush/variants/stable/common-versions.json
+++ b/common/config/rush/variants/stable/common-versions.json
@@ -25,7 +25,7 @@
      */
     // "some-library": "1.2.3"
     // This is the version for stable build (please also update allowedAlternativeVersions below)
-    "@azure/communication-calling": "^1.27.5",
+    "@azure/communication-calling": "^1.28.1",
     "@azure/communication-common": "2.3.0",
     "@azure/communication-chat": "^1.5.1",
     "@azure/communication-signaling": "1.0.0-beta.26"
@@ -57,7 +57,7 @@
    */
   "allowedAlternativeVersions": {
     // This is the version for stable build (please also update preferredVersions above)
-    "@azure/communication-calling": ["^1.27.5"],
+    "@azure/communication-calling": ["^1.28.1"],
     "@azure/communication-common": ["2.3.0"],
     "@azure/communication-chat": ["^1.5.1"],
     "@azure/communication-signaling": ["1.0.0-beta.26"],

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@azure/communication-calling':
-    specifier: ^1.27.5
-    version: 1.27.5
+    specifier: ^1.28.1
+    version: 1.28.1
   '@azure/communication-chat':
     specifier: ^1.5.1
     version: 1.5.1
@@ -144,8 +144,8 @@ packages:
       events: 3.3.0
     dev: false
 
-  /@azure/communication-calling@1.27.5:
-    resolution: {integrity: sha512-cCprATHAZtlGhJ15RQ2GGcSX96GfDUX/I8Q+Y7xkhj4nJgrXjr+LSGgWd+xKeYz9nUAZesgPIuYZH9gyoLS3iw==}
+  /@azure/communication-calling@1.28.1:
+    resolution: {integrity: sha512-RmWKfOSpf4bsLOfGkDblOoDi9tJJfo5/1vUeUX6g/l/yNnvcl5KFBD8WxHqTIWkNga1WKs419cmpu/zL+bGs/g==}
     dependencies:
       '@azure/communication-common': 2.3.0
       '@azure/logger': 1.0.4
@@ -25372,11 +25372,11 @@ packages:
     dev: false
 
   file:projects/calling-component-bindings.tgz:
-    resolution: {integrity: sha512-rs/6nO97F5ZHfy9nDr84g+SEPsT2jaGR0rLb0OxuDQlyl0GgH8RGDRm7Lytq4yE8QSeyvKDHHQqcroS6Z/S9LA==, tarball: file:projects/calling-component-bindings.tgz}
+    resolution: {integrity: sha512-8QIpnXqIa4GN5wf2Y1TEjQKo/eM7S8mrmLbXU8ZCFxIXDELiJlQ45rvl02dKfcf9f+t+lOTCW6XM6usD0NtyCg==, tarball: file:projects/calling-component-bindings.tgz}
     name: '@rush-temp/calling-component-bindings'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-calling-effects': 1.1.1-beta.1
       '@azure/communication-common': 2.3.1
       '@babel/cli': 7.24.8(@babel/core@7.25.2)
@@ -25421,11 +25421,11 @@ packages:
     dev: false
 
   file:projects/calling-stateful-client.tgz:
-    resolution: {integrity: sha512-fnofZZFiPqW28iWkCN/7jLOEAVJLqIcx9rYAOWzv+FoSWqBakhePuHmUK2XXs2/fpbVwNX6BDpzlr65R2x+3bA==, tarball: file:projects/calling-stateful-client.tgz}
+    resolution: {integrity: sha512-SNLv3eWTlR7/AoUW8dfPwaLhkpleX8RYxmI3Xm82Zw+MFhFFmFQP+PzC0DL6le/rkM3EkHIsoPWLi+vtUL0c7Q==, tarball: file:projects/calling-stateful-client.tgz}
     name: '@rush-temp/calling-stateful-client'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-common': 2.3.1
       '@azure/core-auth': 1.6.0
       '@azure/logger': 1.0.4
@@ -25470,12 +25470,12 @@ packages:
     dev: false
 
   file:projects/calling.tgz:
-    resolution: {integrity: sha512-t1kwy2dHxAA1v1JzRLuPrQRBxSqnItFhMpGvD2wSOTLlUo9RFdhyGLTckPVT6VJNmxf2O5gspP4V1QjyD68NQQ==, tarball: file:projects/calling.tgz}
+    resolution: {integrity: sha512-2jh6rL+BYFQ8iiQYse0AwNP7WkOdOKS5ZHrR47gX2cQKAejygvyKBMWQcuMX7JKTpiJAT5VgZytpAujdc/t44A==, tarball: file:projects/calling.tgz}
     name: '@rush-temp/calling'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
       '@azure/logger': 1.0.4
@@ -25564,12 +25564,12 @@ packages:
     dev: false
 
   file:projects/callingstateful.tgz:
-    resolution: {integrity: sha512-ahKaVcWyKTunBvxUcwUYrQT9Yoob5WQjN0RLigyTxAMtUqUswZZz8d1qQGAjvv5Cv2xKiOLow8gioYdW4rGXiQ==, tarball: file:projects/callingstateful.tgz}
+    resolution: {integrity: sha512-nfRq2AB+LsG3qqakd5+KDI5V7UhkS+4jMN4fIZhYofgoCS9U1L5X3h81p+gAC6m0pMAvvFeQx48DGPanStCxdA==, tarball: file:projects/callingstateful.tgz}
     name: '@rush-temp/callingstateful'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
       '@azure/logger': 1.0.4
@@ -25658,12 +25658,12 @@ packages:
     dev: false
 
   file:projects/callwithchat.tgz:
-    resolution: {integrity: sha512-zBkP5Qry6IQ7b4w+3RwnyiGkx7ISB8vcHIKvA62JZtkscl1E9buHcF7aSl0IjLnfNoMZZMsFNObNMFsNwNdzgA==, tarball: file:projects/callwithchat.tgz}
+    resolution: {integrity: sha512-bGsvJUvewWVdPpu++6fFvp1OnQKNuMym/4Vhu3Qvqs2ByVxsTyVhYbselB2jmjICu1IZtnXAwNYXUlGhTE852Q==, tarball: file:projects/callwithchat.tgz}
     name: '@rush-temp/callwithchat'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-chat': 1.5.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -25981,11 +25981,11 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-uuE38nrTdizIjIwJLuRP7LRlLoeYgfuupRq0V5/1ZOIaVoF0rXpTVnQJANFmMXYtd2/2EF+uN46QDGn8IDxznQ==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-G4XQKSy1K0LdATTDgvxC8xH8d8go67oGU+UhR7J/T6KVkocWpkL8fFjacpmAN/Xuw0xerSO8Zv5yyyX8OFTq+g==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-calling-effects': 1.1.1-beta.1
       '@azure/communication-chat': 1.5.1
       '@azure/communication-common': 2.3.1
@@ -26094,11 +26094,11 @@ packages:
     dev: false
 
   file:projects/component-examples.tgz:
-    resolution: {integrity: sha512-kuLAH3EexZ/o/IBcq6CFMfL8fyrlgNn2wgVKqLVCA7NUh1mbFYNMYBizo1qDWIiBIYAgR/fWYCHMeuAJfxlKrA==, tarball: file:projects/component-examples.tgz}
+    resolution: {integrity: sha512-qXopDZnvTpIkLR8EnOUqzhbn4sefBytB83Sn7vJnSx4phAN5vFAhlCGkNuzVXzTG2Wc0J47M9+2DrVzJmWN01w==, tarball: file:projects/component-examples.tgz}
     name: '@rush-temp/component-examples'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-chat': 1.5.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -26363,11 +26363,11 @@ packages:
     dev: false
 
   file:projects/react-composites.tgz:
-    resolution: {integrity: sha512-p5tLeTcXP277MFyztIhwj8G57I8TFntQDRv2jlReD5yaHxd9U54cH9GMAG45s/ogFwB2TXC5juSKBWwb70KyPg==, tarball: file:projects/react-composites.tgz}
+    resolution: {integrity: sha512-/R8EHh8AVW5Fxnd5XTqrpUj7OJGlPI8vs5wFRx5NOzZUmbPi2HHhSTFZ1Vu420zfHHKhmBCqTxJz8ycu62i+mA==, tarball: file:projects/react-composites.tgz}
     name: '@rush-temp/react-composites'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-calling-effects': 1.1.1-beta.1
       '@azure/communication-chat': 1.5.1
       '@azure/communication-common': 2.3.1
@@ -26482,11 +26482,11 @@ packages:
     dev: false
 
   file:projects/sample-automation-tests.tgz:
-    resolution: {integrity: sha512-gYr75vAG5AUb0nWoYBgkdAhTdbbJT8U9cN+VVTX2YfgYwGxwxX0DU+ApNC6vO8Xq5v8TV3E1x7ki9bFRVvBO0Q==, tarball: file:projects/sample-automation-tests.tgz}
+    resolution: {integrity: sha512-jl8El2Hd1dvs8a8KaMr1d3U39zTzDJE5l7eJBjcetxh0yoszAERrhKhg9ck68orC8cwFipuSnlcWhJd0IfgFSg==, tarball: file:projects/sample-automation-tests.tgz}
     name: '@rush-temp/sample-automation-tests'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-chat': 1.5.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -26507,11 +26507,11 @@ packages:
     dev: false
 
   file:projects/sample-static-html-composites.tgz:
-    resolution: {integrity: sha512-UIgIUklCjWfH3y1DCPEPu/TjUg7LAlCZXNPT1hE5IhWk4pdPU+OiulVuT+5mwLpLfSA67j6UPCXNrTHOKDNa8g==, tarball: file:projects/sample-static-html-composites.tgz}
+    resolution: {integrity: sha512-wg7e0pnNZKMnailOjDXLWNkJZWz+52dQISZClge9viM1Rg2B1s+6MokP+vS+sqhfzTTB+DIdOrua+dkKDe6F8A==, tarball: file:projects/sample-static-html-composites.tgz}
     name: '@rush-temp/sample-static-html-composites'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-chat': 1.5.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -26643,11 +26643,11 @@ packages:
     dev: false
 
   file:projects/storybook.tgz:
-    resolution: {integrity: sha512-OV0kAb1EsFw3tcptxdUjJUtHB2h5B1VDk36K7xr9Oclan05Lsoz4TpZqP/ShmyHtoezLRw08XzqIn0pIQx6CwQ==, tarball: file:projects/storybook.tgz}
+    resolution: {integrity: sha512-+bSKlnLrfFjAVkZ2WeI5gNYvAg3a/1wGd7FVUaRIgjKN0JBdHJPkYynhiPOtgh0dkOJgKsFAVifZc6xjF8k4CQ==, tarball: file:projects/storybook.tgz}
     name: '@rush-temp/storybook'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-chat': 1.5.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0
@@ -26787,11 +26787,11 @@ packages:
     dev: false
 
   file:projects/storybook8.tgz:
-    resolution: {integrity: sha512-DU9dV/t3xXtSkNIzzINBrmpjc+r/6qqpc6QI9aaX+SlLRaKAHDFw8dULf5C6LuaVVnLQr2upZXQsIQsx01jVXg==, tarball: file:projects/storybook8.tgz}
+    resolution: {integrity: sha512-+5zYxOZEfxUWVCHFE/9UjWt1mSwWnT1J45LkR8LL4qcd+R7Bx2JdhryYrPx+z8jt1TXb7CydhNZxmL1jixcppQ==, tarball: file:projects/storybook8.tgz}
     name: '@rush-temp/storybook8'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.27.5
+      '@azure/communication-calling': 1.28.1
       '@azure/communication-chat': 1.5.1
       '@azure/communication-common': 2.3.1
       '@azure/communication-identity': 1.3.0

--- a/packages/calling-component-bindings/package.json
+++ b/packages/calling-component-bindings/package.json
@@ -38,13 +38,13 @@
     "reselect": "^4.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-calling-effects": "1.1.1-beta.1 || ^1.1.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-calling-effects": "1.1.1-beta.1 || ^1.1.0",
     "@babel/cli": "^7.24.8",
     "@babel/core": "^7.25.2",

--- a/packages/calling-component-bindings/package.json
+++ b/packages/calling-component-bindings/package.json
@@ -38,13 +38,13 @@
     "reselect": "^4.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-calling-effects": "1.1.1-beta.1 || ^1.1.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-calling-effects": "1.1.1-beta.1 || ^1.1.0",
     "@babel/cli": "^7.24.8",
     "@babel/core": "^7.25.2",

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -36,10 +36,10 @@
     "immer": "10.1.1"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5"
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/core-auth": "^1.4.0",
     "@babel/cli": "^7.24.8",
     "@babel/core": "^7.25.2",

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -36,10 +36,10 @@
     "immer": "10.1.1"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5"
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/core-auth": "^1.4.0",
     "@babel/cli": "^7.24.8",
     "@babel/core": "^7.25.2",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -54,8 +54,8 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
-    "@azure/communication-calling-effects": "1.1.1-beta.1 || ^1.1.0",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
+    "@azure/communication-calling-effects": "1.0.1",
     "@azure/communication-chat": "1.6.0-beta.3 || >=1.5.1",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
@@ -96,7 +96,7 @@
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-calling-effects": "1.1.1-beta.1 || ^1.1.0",
     "@azure/core-auth": "^1.4.0",
     "@babel/cli": "^7.24.8",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -54,7 +54,7 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-calling-effects": "1.1.1-beta.1 || ^1.1.0",
     "@azure/communication-chat": "1.6.0-beta.3 || >=1.5.1",
     "@types/react": ">=16.8.0 <19.0.0",
@@ -96,7 +96,7 @@
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-calling-effects": "1.1.1-beta.1 || ^1.1.0",
     "@azure/core-auth": "^1.4.0",
     "@babel/cli": "^7.24.8",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -71,7 +71,7 @@
     "nanoid": "3.3.6"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-calling-effects": "1.1.1-beta.1 || ^1.1.0",
     "@azure/communication-chat": "1.6.0-beta.3 || >=1.5.1",
     "@types/react": ">=16.8.0 <19.0.0",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -71,7 +71,7 @@
     "nanoid": "3.3.6"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-calling-effects": "1.1.1-beta.1 || ^1.1.0",
     "@azure/communication-chat": "1.6.0-beta.3 || >=1.5.1",
     "@types/react": ">=16.8.0 <19.0.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-identity": "^1.3.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-identity": "^1.3.0",

--- a/packages/storybook8/package.json
+++ b/packages/storybook8/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-identity": "^1.3.0",

--- a/packages/storybook8/package.json
+++ b/packages/storybook8/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-identity": "^1.3.0",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@azure/communication-react": "1.19.0-beta.1",
     "@azure/communication-common": "^2.3.1",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@azure/communication-react": "1.19.0-beta.1",
     "@azure/communication-common": "^2.3.1",

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -34,7 +34,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.19.0-beta.1",
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-common": "^2.3.1",
     "@azure/logger": "^1.0.4",
     "@babel/preset-react": "^7.12.7",

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -34,7 +34,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.19.0-beta.1",
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-common": "^2.3.1",
     "@azure/logger": "^1.0.4",
     "@babel/preset-react": "^7.12.7",

--- a/samples/CallingStateful/package.json
+++ b/samples/CallingStateful/package.json
@@ -34,7 +34,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.19.0-beta.1",
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-common": "^2.3.1",
     "@azure/logger": "^1.0.4",
     "@babel/preset-react": "^7.12.7",

--- a/samples/CallingStateful/package.json
+++ b/samples/CallingStateful/package.json
@@ -34,7 +34,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.19.0-beta.1",
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-common": "^2.3.1",
     "@azure/logger": "^1.0.4",
     "@babel/preset-react": "^7.12.7",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-identity": "^1.3.0",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "@azure/communication-identity": "^1.3.0",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@azure/communication-react": "1.19.0-beta.1",
     "@azure/communication-common": "^2.3.1",
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@fluentui/react": "^8.120.0",
     "react": "18.3.1",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@azure/communication-react": "1.19.0-beta.1",
     "@azure/communication-common": "^2.3.1",
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@fluentui/react": "^8.120.0",
     "react": "18.3.1",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.28.1-beta.4 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "uuid": "^9.0.0",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -20,7 +20,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.29.1-beta.1 || ^1.27.5",
+    "@azure/communication-calling": "1.29.1-beta.1 || ^1.28.1",
     "@azure/communication-chat": "1.6.0-beta.3 || ^1.5.0",
     "@azure/communication-common": "^2.3.1",
     "uuid": "^9.0.0",


### PR DESCRIPTION
# What
Update communication calling to 1.29.1-beta.1 and 1.28.1

# Why
OCE task to ensure we have the latest from calling SDK

# How Tested
Smoke tested CallWithChat sample app for beta and stable in group and teams meetings

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->