### PR TITLE
Refactor logic to show join breakout room button

### DIFF
--- a/change-beta/@azure-communication-react-436f776c-1408-435c-88f8-4d864c2e0c95.json
+++ b/change-beta/@azure-communication-react-436f776c-1408-435c-88f8-4d864c2e0c95.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "Breakout rooms",
+  "comment": "Change logic of showing button to join breakout room when the breakout room call is available",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-436f776c-1408-435c-88f8-4d864c2e0c95.json
+++ b/change/@azure-communication-react-436f776c-1408-435c-88f8-4d864c2e0c95.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "Breakout rooms",
+  "comment": "Change logic of showing button to join breakout room when the breakout room call is available",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/BreakoutRoomsBanner.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/BreakoutRoomsBanner.tsx
@@ -4,8 +4,6 @@
 /* @conditional-compile-remove(breakout-rooms) */
 import { Stack } from '@fluentui/react';
 /* @conditional-compile-remove(breakout-rooms) */
-import { ActiveNotification } from '@internal/react-components';
-/* @conditional-compile-remove(breakout-rooms) */
 import React from 'react';
 /* @conditional-compile-remove(breakout-rooms) */
 import { bannerNotificationStyles } from '../styles/CallPage.styles';
@@ -25,23 +23,15 @@ import { Banner } from './Banner';
  * @private
  */
 export const BreakoutRoomsBanner = (props: {
-  latestNotifications: ActiveNotification[] | undefined;
   locale: CompositeLocale;
   adapter: CommonCallAdapter;
 }): JSX.Element | undefined => {
-  const { latestNotifications, locale, adapter } = props;
+  const { locale, adapter } = props;
 
   const assignedBreakoutRoom = useSelector(getAssignedBreakoutRoom);
   const breakoutRoomSettings = useSelector(getBreakoutRoomSettings);
 
-  const autoMoveToBreakoutRoomCurrentlyInEffect =
-    assignedBreakoutRoom?.autoMoveParticipantToBreakoutRoom &&
-    latestNotifications?.find(
-      (notification) =>
-        notification.type === 'assignedBreakoutRoomOpened' || notification.type === 'assignedBreakoutRoomChanged'
-    );
-
-  if (assignedBreakoutRoom && assignedBreakoutRoom.state === 'open' && !autoMoveToBreakoutRoomCurrentlyInEffect) {
+  if (assignedBreakoutRoom && assignedBreakoutRoom.state === 'open' && assignedBreakoutRoom.call) {
     return (
       <Stack styles={bannerNotificationStyles}>
         <Banner

--- a/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/CallArrangement.tsx
@@ -599,13 +599,7 @@ export const CallArrangement = (props: CallArrangementProps): JSX.Element => {
                   <Stack.Item styles={notificationsContainerStyles}>
                     {
                       /* @conditional-compile-remove(breakout-rooms) */
-                      props.mobileView && (
-                        <BreakoutRoomsBanner
-                          latestNotifications={latestNotifications}
-                          locale={locale}
-                          adapter={adapter}
-                        />
-                      )
+                      props.mobileView && <BreakoutRoomsBanner locale={locale} adapter={adapter} />
                     }
                     {props.showErrorNotifications && (
                       <Stack styles={notificationStackStyles} horizontalAlign="center" verticalAlign="center">

--- a/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/CommonCallControlBar.tsx
@@ -52,11 +52,7 @@ import { isBoolean } from '../utils';
 /* @conditional-compile-remove(end-call-options) */
 import { getIsTeamsCall } from '../../CallComposite/selectors/baseSelectors';
 /* @conditional-compile-remove(breakout-rooms) */
-import {
-  getAssignedBreakoutRoom,
-  getBreakoutRoomSettings,
-  getLatestNotifications
-} from '../../CallComposite/selectors/baseSelectors';
+import { getAssignedBreakoutRoom, getBreakoutRoomSettings } from '../../CallComposite/selectors/baseSelectors';
 import { callStatusSelector } from '../../CallComposite/selectors/callStatusSelector';
 /* @conditional-compile-remove(teams-meeting-conference) */
 import { MeetingConferencePhoneInfoModal } from '@internal/react-components';
@@ -149,13 +145,7 @@ export const CommonCallControlBar = (props: CommonCallControlBarProps & Containe
   /* @conditional-compile-remove(breakout-rooms) */
   const assignedBreakoutRoom = useSelector(getAssignedBreakoutRoom);
   /* @conditional-compile-remove(breakout-rooms) */
-  const latestNotifications = useSelector(getLatestNotifications);
-  /* @conditional-compile-remove(breakout-rooms) */
   const breakoutRoomSettings = useSelector(getBreakoutRoomSettings);
-  /* @conditional-compile-remove(breakout-rooms) */
-  const movingToBreakoutRoomAutomatically =
-    assignedBreakoutRoom?.autoMoveParticipantToBreakoutRoom &&
-    (latestNotifications['assignedBreakoutRoomOpened'] || latestNotifications['assignedBreakoutRoomChanged']);
 
   const handleResize = useCallback((): void => {
     setControlBarButtonsWidth(controlBarContainerRef.current ? controlBarContainerRef.current.offsetWidth : 0);
@@ -416,7 +406,7 @@ export const CommonCallControlBar = (props: CommonCallControlBarProps & Containe
                       !props.mobileView &&
                         assignedBreakoutRoom &&
                         assignedBreakoutRoom.state === 'open' &&
-                        !movingToBreakoutRoomAutomatically && (
+                        assignedBreakoutRoom.call && (
                           <PrimaryButton
                             text={callStrings.joinBreakoutRoomButtonLabel}
                             onClick={async (): Promise<void> => {


### PR DESCRIPTION
# What
Refactor logic of showing button to join breakout room when the breakout room call is available

# Why
The new logic is more correct and does not rely on notifications

# How Tested
Tested in local callwithchat app:
https://github.com/user-attachments/assets/dabc72ff-d80b-40cb-9afe-a5ba69b074ed

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->