### PR TITLE
Update axios to 1.7.5 with a security fix

### DIFF
--- a/change-beta/@azure-communication-react-1109da55-934d-4ff6-be59-5b3ef01e4d27.json
+++ b/change-beta/@azure-communication-react-1109da55-934d-4ff6-be59-5b3ef01e4d27.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "Dependency update",
+  "comment": "Update axios to 1.7.5 with a security fix",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-1109da55-934d-4ff6-be59-5b3ef01e4d27.json
+++ b/change/@azure-communication-react-1109da55-934d-4ff6-be59-5b3ef01e4d27.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "Dependency update",
+  "comment": "Update axios to 1.7.5 with a security fix",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -11088,6 +11088,16 @@ packages:
       - debug
     dev: false
 
+  /axios@1.7.7:
+    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
+    dependencies:
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
     dependencies:
@@ -25352,7 +25362,7 @@ packages:
     dev: false
 
   file:projects/acs-ui-common.tgz:
-    resolution: {integrity: sha512-TuRhKrM8hjrXoXfAqJCZiJMbji42ktTBVBZO1r7XY6XWSZXjqmYhwbrCbDBd5t5fVc7/tr3QT012PfBUVZ0OOA==, tarball: file:projects/acs-ui-common.tgz}
+    resolution: {integrity: sha512-LzcSIW5SiMAUxkmpwEIUu2bmQMfxO3sD9nXSGHXok2lNsH73HCewwPDIMBxduPhDXk+hlruZY2HIz9qniKiMxg==, tarball: file:projects/acs-ui-common.tgz}
     name: '@rush-temp/acs-ui-common'
     version: 0.0.0
     dependencies:
@@ -25398,7 +25408,7 @@ packages:
     dev: false
 
   file:projects/acs-ui-javascript-loaders.tgz:
-    resolution: {integrity: sha512-jCwWWVUeiLLX49A5nlctZgTtsxVjlT+6wZul6XCZnfTFD2dVDL9AFxtV7hGdS94ZlMekaqcLNaSZuiia7R66AQ==, tarball: file:projects/acs-ui-javascript-loaders.tgz}
+    resolution: {integrity: sha512-anYbR+LJh1B2fgHuTObZ17XfPU51gjbbYJ4Kuzpg7zV/t+4BEAx0ybr9QzLuOvk5HJCHTPOJahIDQOwFNPdwcA==, tarball: file:projects/acs-ui-javascript-loaders.tgz}
     name: '@rush-temp/acs-ui-javascript-loaders'
     version: 0.0.0
     dependencies:
@@ -25445,7 +25455,7 @@ packages:
     dev: false
 
   file:projects/calling-component-bindings.tgz:
-    resolution: {integrity: sha512-jKW6RqXvR7bOCKjVG/RHhEUWBKc0W8GPQBy7VRr5ZfY1jyzCcbUkEAbSr8+7NilRFvCShkwd9uFkRd+pDyEUlA==, tarball: file:projects/calling-component-bindings.tgz}
+    resolution: {integrity: sha512-GNF6YgVOqe0L3joVzAwFQeBBWWNtP/iYk+57iYeMuoAvFyrxTd89uaofKRgaEGpHWWtOXio5idaU7wwL5fxG5Q==, tarball: file:projects/calling-component-bindings.tgz}
     name: '@rush-temp/calling-component-bindings'
     version: 0.0.0
     dependencies:
@@ -25494,7 +25504,7 @@ packages:
     dev: false
 
   file:projects/calling-stateful-client.tgz:
-    resolution: {integrity: sha512-753IAKA/tl1wYCb54+XlmSXgRSz4kHk1wKBxQs8+y9u23uwiNWGoykMrrt7BV0p3IKx8Ky3o2akIpIL/MK8NCA==, tarball: file:projects/calling-stateful-client.tgz}
+    resolution: {integrity: sha512-IZtKWR81PFH7txB05dA/qSyPkkLFz0wCAgK07xa3dVMvGNEN2TopnJyyOTcu+uDpZCCJioaKtdyDc0Lh5sRVNw==, tarball: file:projects/calling-stateful-client.tgz}
     name: '@rush-temp/calling-stateful-client'
     version: 0.0.0
     dependencies:
@@ -25543,7 +25553,7 @@ packages:
     dev: false
 
   file:projects/calling.tgz:
-    resolution: {integrity: sha512-QwzaobyZW74aS26HPjWEZBLaI2k2AOdCncTACoWIqXuaB0exRvAb4AXB5fOAykiivVIDgftU7FXB1TmLB/zSaA==, tarball: file:projects/calling.tgz}
+    resolution: {integrity: sha512-PkNyPSucvMVuHO+ANoVoap+7iSV9slVfpJEzWjsagVknPiy3k+hjiSMJJYjDUkZ7KObj44BXnu73CvvNhbZp/A==, tarball: file:projects/calling.tgz}
     name: '@rush-temp/calling'
     version: 0.0.0
     dependencies:
@@ -25637,7 +25647,7 @@ packages:
     dev: false
 
   file:projects/callingstateful.tgz:
-    resolution: {integrity: sha512-/gvCSe1eHKBv+UX2/LJFfH2A59rNZvFHgbsmhx1eoFt+aIdmG3E7S1fd8xfdF6OoZGBD8XSxJ7Mj6NLg3J0z9g==, tarball: file:projects/callingstateful.tgz}
+    resolution: {integrity: sha512-rXM31Vov+Fl/Y+i1lWGJMoOggd+qcYkN40HclWiPunt+a6tRAhffmhp7r4m0up+fZw8fkX7b+76XNKaC0GDcfg==, tarball: file:projects/callingstateful.tgz}
     name: '@rush-temp/callingstateful'
     version: 0.0.0
     dependencies:
@@ -25731,7 +25741,7 @@ packages:
     dev: false
 
   file:projects/callwithchat.tgz:
-    resolution: {integrity: sha512-FcJePy/NIeE78qqq+4zWIncNjrkXRG2IL9eJxxmkYXoHzbxjhMPCXARgkueaeKaAuUjpW5hyIyWmlZcqS0J4lg==, tarball: file:projects/callwithchat.tgz}
+    resolution: {integrity: sha512-+ca+CreC1jiR1MZqoUiQGJanRkkTLFZMtybj8/SYssqeqd1OGGT+Isca9iBY/P1qcW4Yb7gVT3Ae2X0hrc4u/Q==, tarball: file:projects/callwithchat.tgz}
     name: '@rush-temp/callwithchat'
     version: 0.0.0
     dependencies:
@@ -25824,7 +25834,7 @@ packages:
     dev: false
 
   file:projects/chat-component-bindings.tgz:
-    resolution: {integrity: sha512-Tkk8hJMfchMsVsS1zKSy+JrPBb1Ia7vAxO9Wfv3PhvIPWKqu7z2bWLnvRZap6hmhQ/fTywP3Zft5hR4ZjqoBRg==, tarball: file:projects/chat-component-bindings.tgz}
+    resolution: {integrity: sha512-aCx+/RQc//YLORG+1EovLa5trWymhObsPpQaOk5niClMkZK8g4fC5P+KvgJcoXSwG+MYmJMnIqcpkagG+brmxA==, tarball: file:projects/chat-component-bindings.tgz}
     name: '@rush-temp/chat-component-bindings'
     version: 0.0.0
     dependencies:
@@ -25867,7 +25877,7 @@ packages:
     dev: false
 
   file:projects/chat-stateful-client.tgz:
-    resolution: {integrity: sha512-+U4YeYKmCOPp/2QfttFL1eEpOZA3w4n92CRdCNSmMSPba1eEV820I9Jf/3/zMHCWqbk49pBXMsVqEzj8XNvHcA==, tarball: file:projects/chat-stateful-client.tgz}
+    resolution: {integrity: sha512-dGDuwP2C8tvUu8iW5dQDfxBvdi8EFqHpR2ayRq38g8i0HQ0vmf8NMLlW6bVb+F76cN2udp0bsUwbo6pK0/BhgQ==, tarball: file:projects/chat-stateful-client.tgz}
     name: '@rush-temp/chat-stateful-client'
     version: 0.0.0
     dependencies:
@@ -25919,7 +25929,7 @@ packages:
     dev: false
 
   file:projects/chat.tgz:
-    resolution: {integrity: sha512-PANT8cx7h2NeUmFZlQmfotB0L9je8F2PH2qivMjJmvdUsrmR11vjF/lLtwCQkgGsfy8hHBsmpqlViMwIPWn6ng==, tarball: file:projects/chat.tgz}
+    resolution: {integrity: sha512-BcBLAZ80K0yuMHQ0PUkQ+Wvsc0u3bEJOkHqWGnXjjvA0jRCghCKfzWK7jntQoRnztmux6wqlHL7vWLV+lqcsqg==, tarball: file:projects/chat.tgz}
     name: '@rush-temp/chat'
     version: 0.0.0
     dependencies:
@@ -25941,7 +25951,7 @@ packages:
       '@types/react-linkify': 1.0.4
       '@typescript-eslint/eslint-plugin': 7.14.1(@typescript-eslint/parser@7.14.1)(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/parser': 7.14.1(eslint@8.57.0)(typescript@5.4.5)
-      axios: 1.6.8
+      axios: 1.7.7
       babel-loader: 8.1.0(@babel/core@7.25.2)(webpack@5.89.0)
       concurrently: 5.3.0
       copyfiles: 2.4.1
@@ -26008,7 +26018,7 @@ packages:
     dev: false
 
   file:projects/check-treeshaking.tgz:
-    resolution: {integrity: sha512-J8hX3/ulTmqSz6Qc2FlVU3hutESIe30HPcCYFEhjDSbQ8P9Ng9I4xj0/RNQ77cALsNo0KsMcrmeExDbewQDAuA==, tarball: file:projects/check-treeshaking.tgz}
+    resolution: {integrity: sha512-fUI2b70JyTU3UFWEXVh/j7dz7LRjFvfnRVOdAbWCGihi8+8sTm+6Lps0dKbfZUd0a2nDNfxF747CiSxJlZoi2g==, tarball: file:projects/check-treeshaking.tgz}
     name: '@rush-temp/check-treeshaking'
     version: 0.0.0
     dependencies:
@@ -26036,7 +26046,7 @@ packages:
     dev: false
 
   file:projects/check-typescript-regression.tgz:
-    resolution: {integrity: sha512-u4+0gd5F6w/kh0W8e5tc2wuDxqoCZ9m+ovlUmrF6WFfvEOH/IzbMztyX0CD0BbC+irKu4NnEtx1VMcoyAejJUw==, tarball: file:projects/check-typescript-regression.tgz}
+    resolution: {integrity: sha512-uwo1unneYCAo7FqGpLjjwj34Od3plnuGvJl4ZLd4TLc4N3ClIcJQYVje+O/KvfgVZ5uPngvEHwjxNcAbW9uGtA==, tarball: file:projects/check-typescript-regression.tgz}
     name: '@rush-temp/check-typescript-regression'
     version: 0.0.0
     dependencies:
@@ -26054,7 +26064,7 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-7UZbQb5t5K89SS6krm0jXe2gvqUBCOSBlhimVm2cSGebH2xASFnJ29D4Hdm3vzyXQVr51bS26thCZ3k6J99TlA==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-MoGX1qiEaVXcn1mV6YMkPCFX99BZn7D7H9757zbWM3sMkkgiFjJCODLGBCR2+K46mGTVri/5cTh0Pe7PbTmeng==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
@@ -26167,7 +26177,7 @@ packages:
     dev: false
 
   file:projects/component-examples.tgz:
-    resolution: {integrity: sha512-fcJqjoMg62/43M4S+XDp/FTT4M6VakQVIbjEQDKxEkRDsqdgHuqoIBF67s2STNt5IggrItd5d3Q3fOrfKNtO/w==, tarball: file:projects/component-examples.tgz}
+    resolution: {integrity: sha512-XlToCDqhGU3BMfnn7SwrAUca4PeVHBeoqUSWg0MeygOe8j/uUu3HOomYZQffczs4Ie09GJ4cmmjJM0dV68C1LA==, tarball: file:projects/component-examples.tgz}
     name: '@rush-temp/component-examples'
     version: 0.0.0
     dependencies:
@@ -26234,7 +26244,7 @@ packages:
     dev: false
 
   file:projects/config.tgz:
-    resolution: {integrity: sha512-K+G3IjrQOzuz1Dv/AWkMaty4XkgsLeDVgs4N08asKNpcvfKf2PtQl3W6RXR2iALjzh/ayAiJSs97fLOwCio4AA==, tarball: file:projects/config.tgz}
+    resolution: {integrity: sha512-hIUFe93w/Ke6JNeA/eR20MwlshoXgITfwwQREnJ21INvh34lDavLtbXHb5+aDjPWdxyQ78wjFX29yz/5+sHpMA==, tarball: file:projects/config.tgz}
     name: '@rush-temp/config'
     version: 0.0.0
     dependencies:
@@ -26257,7 +26267,7 @@ packages:
     dev: false
 
   file:projects/fake-backends.tgz:
-    resolution: {integrity: sha512-c+unzHeQ+tKksfwC76OVdOTYj6pR1i4JOazqeO7JZKz/uJRyQbVmaG6v3Y1rqMiHx7e5OZGfKjhDC/4V6EQBMg==, tarball: file:projects/fake-backends.tgz}
+    resolution: {integrity: sha512-GUiQuIHOTElmykkvK1b9oOLBrCc+/+wjQ8/x9Rp1xDZ8ecytG9/4zUvfb6BES5xOL+NOclzditZSIs9vVET5fw==, tarball: file:projects/fake-backends.tgz}
     name: '@rush-temp/fake-backends'
     version: 0.0.0
     dependencies:
@@ -26313,7 +26323,7 @@ packages:
     dev: false
 
   file:projects/react-components.tgz:
-    resolution: {integrity: sha512-JDYahl95XpQT13LdadAA9ojLOLOvUEKnTmc7Dq0nrEzvQQpTkff4JqjGZhnAbcpX5LgnB3FjTnyghwmwFs4mMg==, tarball: file:projects/react-components.tgz}
+    resolution: {integrity: sha512-CxpngDFYxOOf/jyAYAniVtzWdOMmh6S3uOp796pIsVCLikDnNzCVCwKIiHYuWnmoYokhVHLbtJ0+mPiRREwS0g==, tarball: file:projects/react-components.tgz}
     name: '@rush-temp/react-components'
     version: 0.0.0
     dependencies:
@@ -26436,7 +26446,7 @@ packages:
     dev: false
 
   file:projects/react-composites.tgz:
-    resolution: {integrity: sha512-/DS0TL1+s9o1Vo7aHUaXWdcoIOHIahQD05KKKlISqH2X0gTM4gpVYl4q2P6xVO4VSkqtYVR0g5rIBYIH2FSBBg==, tarball: file:projects/react-composites.tgz}
+    resolution: {integrity: sha512-o5usqX2rLEktDSOIm9oywbtSvVYJj/lXoS3RUvKNv1meCMIjfrswLNM+/q/cTF0dcgZrogEtNTwsoNHCrS8rYg==, tarball: file:projects/react-composites.tgz}
     name: '@rush-temp/react-composites'
     version: 0.0.0
     dependencies:
@@ -26555,7 +26565,7 @@ packages:
     dev: false
 
   file:projects/sample-automation-tests.tgz:
-    resolution: {integrity: sha512-BOD3fdLz4jH59zyD0erJICbXR9zq7uKs1YpuT/TzCim/KMy3SxtW33Zb5T7myUF+uTLG8cd5ZVYZAKRtzvbHCg==, tarball: file:projects/sample-automation-tests.tgz}
+    resolution: {integrity: sha512-y+7Jo/MK9knZq8rKxOsUAocIa2kgSZiqYhhYe3sZeg4XkvDkYRoz0oxHeM98UfZ9/FU254tXLyHvV7h/UaIzXg==, tarball: file:projects/sample-automation-tests.tgz}
     name: '@rush-temp/sample-automation-tests'
     version: 0.0.0
     dependencies:
@@ -26580,7 +26590,7 @@ packages:
     dev: false
 
   file:projects/sample-static-html-composites.tgz:
-    resolution: {integrity: sha512-Dg0GXC9foNgeFEdXoBv1rErFzDlf+jfV1Xkxyl+A/JLYWHftCCu+EPlAXPA6Dp7UDEKHV8EYT3WGNDLaO5o0kg==, tarball: file:projects/sample-static-html-composites.tgz}
+    resolution: {integrity: sha512-x8LZfndQrFK4t1KU/aIJtyQ3v7WO1fLpRMPfTJqNg8l9xkwMEIUGtbSeLbRM4VI06PE5wMCIpXNiNUBxET01bA==, tarball: file:projects/sample-static-html-composites.tgz}
     name: '@rush-temp/sample-static-html-composites'
     version: 0.0.0
     dependencies:
@@ -26631,7 +26641,7 @@ packages:
     dev: false
 
   file:projects/scripts.tgz:
-    resolution: {integrity: sha512-etEablx5ljVhADQIRE5hIW0rcgMt2K8eQ1iTjXlDmK7izoFSCbcR8pBD5KRmNGqg47isbtKuNdcjEps6HJrRHg==, tarball: file:projects/scripts.tgz}
+    resolution: {integrity: sha512-bDw92ULh79UtEB3X5e+FZGr0fNIUev0GGLu7uBEQIVgJjigYJGIp6bz01+cVUcNqkP6zKjqrafhWXBkB43ckYw==, tarball: file:projects/scripts.tgz}
     name: '@rush-temp/scripts'
     version: 0.0.0
     dependencies:
@@ -26640,7 +26650,7 @@ packages:
     dev: false
 
   file:projects/server.tgz:
-    resolution: {integrity: sha512-LpEeSn9Vp4mg8JHQtX6OadeYae8nMk33TA8ME/ey5b3hMZ7LTPsi3LZLW3ctt8KsOQdmw/nXQft2zBaHdTQMWA==, tarball: file:projects/server.tgz}
+    resolution: {integrity: sha512-Bhj9m3xEzkkAifQGrOd2bLYsZXj8I276i6nKYUV2EArXEqQ0K9KO+MMta5WIgTcRZdraKHdcy43iGLzpXSa8dA==, tarball: file:projects/server.tgz}
     name: '@rush-temp/server'
     version: 0.0.0
     dependencies:
@@ -26723,7 +26733,7 @@ packages:
     dev: false
 
   file:projects/storybook.tgz:
-    resolution: {integrity: sha512-pjk8nK++tBzVxfiz5nUu68658pkt5DLAQ3GCq0iblMpnyhxZalNtZsEWpuRlmI99A98tKMnQ3oLulIk62J4b6Q==, tarball: file:projects/storybook.tgz}
+    resolution: {integrity: sha512-3dOPX4970752Z13eEfiH2hoCHdH0UQQ8t3gjF81SifI9AbmW6WcamZImj7HERuSL+XgW5Nz9a0ksHydicfOl3g==, tarball: file:projects/storybook.tgz}
     name: '@rush-temp/storybook'
     version: 0.0.0
     dependencies:
@@ -26867,7 +26877,7 @@ packages:
     dev: false
 
   file:projects/storybook8.tgz:
-    resolution: {integrity: sha512-ln49LnjrDhsoNIQWImvn7EQTarQo7+9Sz3uMd4tYtEZ8w5IxmsWMvHRtiIEZPLUkBsweamgWUQUT6VqNHpswiA==, tarball: file:projects/storybook8.tgz}
+    resolution: {integrity: sha512-oRtvBumvA+5N8Ynm0UX0QjAw9o1F67OfFOCHlB2P8JGHS3WNfSGJwOifCAV2z2gs5cb+Aq9K4sH6LrAJoAikDw==, tarball: file:projects/storybook8.tgz}
     name: '@rush-temp/storybook8'
     version: 0.0.0
     dependencies:

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -11114,6 +11114,16 @@ packages:
       - debug
     dev: false
 
+  /axios@1.7.7:
+    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
+    dependencies:
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
     dependencies:
@@ -25383,7 +25393,7 @@ packages:
     dev: false
 
   file:projects/acs-ui-javascript-loaders.tgz:
-    resolution: {integrity: sha512-jCwWWVUeiLLX49A5nlctZgTtsxVjlT+6wZul6XCZnfTFD2dVDL9AFxtV7hGdS94ZlMekaqcLNaSZuiia7R66AQ==, tarball: file:projects/acs-ui-javascript-loaders.tgz}
+    resolution: {integrity: sha512-riKBTA2JPdqTDZkRD7uts0m9qYqhP0NFl7/gJD6ntehL6jrfumskvrRzGzVLSQYNPVL01Kgx0mz7vXKakHqoDw==, tarball: file:projects/acs-ui-javascript-loaders.tgz}
     name: '@rush-temp/acs-ui-javascript-loaders'
     version: 0.0.0
     dependencies:
@@ -25430,7 +25440,7 @@ packages:
     dev: false
 
   file:projects/calling-component-bindings.tgz:
-    resolution: {integrity: sha512-8QIpnXqIa4GN5wf2Y1TEjQKo/eM7S8mrmLbXU8ZCFxIXDELiJlQ45rvl02dKfcf9f+t+lOTCW6XM6usD0NtyCg==, tarball: file:projects/calling-component-bindings.tgz}
+    resolution: {integrity: sha512-XT7BuQjwD3jgXxYilXI76IyYRBJhG+D5FaIdP2C03vLQOFlmRGph/qHS2Xjr7wHHI3M8I3/EHHjo4AnIKV+Jew==, tarball: file:projects/calling-component-bindings.tgz}
     name: '@rush-temp/calling-component-bindings'
     version: 0.0.0
     dependencies:
@@ -25479,7 +25489,7 @@ packages:
     dev: false
 
   file:projects/calling-stateful-client.tgz:
-    resolution: {integrity: sha512-SNLv3eWTlR7/AoUW8dfPwaLhkpleX8RYxmI3Xm82Zw+MFhFFmFQP+PzC0DL6le/rkM3EkHIsoPWLi+vtUL0c7Q==, tarball: file:projects/calling-stateful-client.tgz}
+    resolution: {integrity: sha512-vDaj25Qe+0nXHjexrMxpK88NfH0H06GZHuwMuhExUcaG5LexTSCnv4T/1YIWZseqF+Q9xxlrCagRZqIAhKe+JQ==, tarball: file:projects/calling-stateful-client.tgz}
     name: '@rush-temp/calling-stateful-client'
     version: 0.0.0
     dependencies:
@@ -25528,7 +25538,7 @@ packages:
     dev: false
 
   file:projects/calling.tgz:
-    resolution: {integrity: sha512-2jh6rL+BYFQ8iiQYse0AwNP7WkOdOKS5ZHrR47gX2cQKAejygvyKBMWQcuMX7JKTpiJAT5VgZytpAujdc/t44A==, tarball: file:projects/calling.tgz}
+    resolution: {integrity: sha512-MDq6qcH1EPesgwsIAme/EJAB92VqNnHc1wqvZzmTtZ/xAGoPAf4Jhgg4hq5qoHLfCWUr8jxBBPW5u+1SYwa/yw==, tarball: file:projects/calling.tgz}
     name: '@rush-temp/calling'
     version: 0.0.0
     dependencies:
@@ -25622,7 +25632,7 @@ packages:
     dev: false
 
   file:projects/callingstateful.tgz:
-    resolution: {integrity: sha512-nfRq2AB+LsG3qqakd5+KDI5V7UhkS+4jMN4fIZhYofgoCS9U1L5X3h81p+gAC6m0pMAvvFeQx48DGPanStCxdA==, tarball: file:projects/callingstateful.tgz}
+    resolution: {integrity: sha512-1eemv9/+He2jfUqu9dCgAtzWJDvQU3/XzRpA564fLKOdKgQXnApRLyX1MLkT1ORu4DS3w1642BEjXyXrDGRitg==, tarball: file:projects/callingstateful.tgz}
     name: '@rush-temp/callingstateful'
     version: 0.0.0
     dependencies:
@@ -25716,7 +25726,7 @@ packages:
     dev: false
 
   file:projects/callwithchat.tgz:
-    resolution: {integrity: sha512-bGsvJUvewWVdPpu++6fFvp1OnQKNuMym/4Vhu3Qvqs2ByVxsTyVhYbselB2jmjICu1IZtnXAwNYXUlGhTE852Q==, tarball: file:projects/callwithchat.tgz}
+    resolution: {integrity: sha512-os6LAym6jWL9zddicQwyJsGTYYEbL+FsENVdQZc7BtvGUJv/um7oXJPkbn90rYhJR4zHX1zmYvy9YZr55al97A==, tarball: file:projects/callwithchat.tgz}
     name: '@rush-temp/callwithchat'
     version: 0.0.0
     dependencies:
@@ -25809,7 +25819,7 @@ packages:
     dev: false
 
   file:projects/chat-component-bindings.tgz:
-    resolution: {integrity: sha512-Tkk8hJMfchMsVsS1zKSy+JrPBb1Ia7vAxO9Wfv3PhvIPWKqu7z2bWLnvRZap6hmhQ/fTywP3Zft5hR4ZjqoBRg==, tarball: file:projects/chat-component-bindings.tgz}
+    resolution: {integrity: sha512-f4N9CqEaLr0IsNYrHkAVp5WP49GZg4vFnp4sTChvX6dXTPU4y5wJzs8RwyEoUpPhV5/trOrSb0Lb6zLDWTiTtA==, tarball: file:projects/chat-component-bindings.tgz}
     name: '@rush-temp/chat-component-bindings'
     version: 0.0.0
     dependencies:
@@ -25852,7 +25862,7 @@ packages:
     dev: false
 
   file:projects/chat-stateful-client.tgz:
-    resolution: {integrity: sha512-+U4YeYKmCOPp/2QfttFL1eEpOZA3w4n92CRdCNSmMSPba1eEV820I9Jf/3/zMHCWqbk49pBXMsVqEzj8XNvHcA==, tarball: file:projects/chat-stateful-client.tgz}
+    resolution: {integrity: sha512-DpPhkzM1nE2LxOAMfAI6yN+5+TO3CjL/kuM75pRKrymAKD0FSYaJo7LcEsQ7K//lmy430p2rIvD3igqgtM/4ag==, tarball: file:projects/chat-stateful-client.tgz}
     name: '@rush-temp/chat-stateful-client'
     version: 0.0.0
     dependencies:
@@ -25904,7 +25914,7 @@ packages:
     dev: false
 
   file:projects/chat.tgz:
-    resolution: {integrity: sha512-PANT8cx7h2NeUmFZlQmfotB0L9je8F2PH2qivMjJmvdUsrmR11vjF/lLtwCQkgGsfy8hHBsmpqlViMwIPWn6ng==, tarball: file:projects/chat.tgz}
+    resolution: {integrity: sha512-5NPwHAkVqPSK0VOQHI2tgskc5Uf3g8di80usz4uOy57sglOyH6DUg/RsvO+Y34RjwwBmFGg+LFbRhPmSrKOKHQ==, tarball: file:projects/chat.tgz}
     name: '@rush-temp/chat'
     version: 0.0.0
     dependencies:
@@ -25926,7 +25936,7 @@ packages:
       '@types/react-linkify': 1.0.4
       '@typescript-eslint/eslint-plugin': 7.14.1(@typescript-eslint/parser@7.14.1)(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/parser': 7.14.1(eslint@8.57.0)(typescript@5.4.5)
-      axios: 1.6.8
+      axios: 1.7.7
       babel-loader: 8.1.0(@babel/core@7.25.2)(webpack@5.89.0)
       concurrently: 5.3.0
       copyfiles: 2.4.1
@@ -25993,7 +26003,7 @@ packages:
     dev: false
 
   file:projects/check-treeshaking.tgz:
-    resolution: {integrity: sha512-J8hX3/ulTmqSz6Qc2FlVU3hutESIe30HPcCYFEhjDSbQ8P9Ng9I4xj0/RNQ77cALsNo0KsMcrmeExDbewQDAuA==, tarball: file:projects/check-treeshaking.tgz}
+    resolution: {integrity: sha512-rHoBFz3KTs+6OQhePKMpRiOyH2DJLbe02ia2O5omYJqNJw2SifLeohD3F2XL4OnrTJSrLIYATvJiKUODSIED/A==, tarball: file:projects/check-treeshaking.tgz}
     name: '@rush-temp/check-treeshaking'
     version: 0.0.0
     dependencies:
@@ -26021,7 +26031,7 @@ packages:
     dev: false
 
   file:projects/check-typescript-regression.tgz:
-    resolution: {integrity: sha512-u4+0gd5F6w/kh0W8e5tc2wuDxqoCZ9m+ovlUmrF6WFfvEOH/IzbMztyX0CD0BbC+irKu4NnEtx1VMcoyAejJUw==, tarball: file:projects/check-typescript-regression.tgz}
+    resolution: {integrity: sha512-tpd5S9C3ZbWdgrxfS127RpSgKvtqnoGAxheiWp66ghDdL9Y1nN1PXnw+q/wJqWQ1H/cQ6WfdkbwGlpSz8j8pBA==, tarball: file:projects/check-typescript-regression.tgz}
     name: '@rush-temp/check-typescript-regression'
     version: 0.0.0
     dependencies:
@@ -26039,7 +26049,7 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-G4XQKSy1K0LdATTDgvxC8xH8d8go67oGU+UhR7J/T6KVkocWpkL8fFjacpmAN/Xuw0xerSO8Zv5yyyX8OFTq+g==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-JhnmouU82GsRd4s2JCJV1V2CqaFBKzyKmId8QmEFOma+H8PIvpLNWgBkAjvvkgqLjIdk/EC/2iRtxpgELVSOZA==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
@@ -26152,7 +26162,7 @@ packages:
     dev: false
 
   file:projects/component-examples.tgz:
-    resolution: {integrity: sha512-qXopDZnvTpIkLR8EnOUqzhbn4sefBytB83Sn7vJnSx4phAN5vFAhlCGkNuzVXzTG2Wc0J47M9+2DrVzJmWN01w==, tarball: file:projects/component-examples.tgz}
+    resolution: {integrity: sha512-rY9C/dwQFj5V8cTJ1mrpeWktbNppr6QsjHoBH3ezaF3FoQEELi85tg9ZP3VFald+DwmfqOIUvby5Rk9YXMgFrw==, tarball: file:projects/component-examples.tgz}
     name: '@rush-temp/component-examples'
     version: 0.0.0
     dependencies:
@@ -26242,7 +26252,7 @@ packages:
     dev: false
 
   file:projects/fake-backends.tgz:
-    resolution: {integrity: sha512-c+unzHeQ+tKksfwC76OVdOTYj6pR1i4JOazqeO7JZKz/uJRyQbVmaG6v3Y1rqMiHx7e5OZGfKjhDC/4V6EQBMg==, tarball: file:projects/fake-backends.tgz}
+    resolution: {integrity: sha512-sojVIvNFsmgu0grLqwhcb4k1A+AtcqLPZNNR9euKlbR/5jar5eub6o2r89Vi9qApUiMLIkYHbWNsIFdwszyWHA==, tarball: file:projects/fake-backends.tgz}
     name: '@rush-temp/fake-backends'
     version: 0.0.0
     dependencies:
@@ -26298,7 +26308,7 @@ packages:
     dev: false
 
   file:projects/react-components.tgz:
-    resolution: {integrity: sha512-JDYahl95XpQT13LdadAA9ojLOLOvUEKnTmc7Dq0nrEzvQQpTkff4JqjGZhnAbcpX5LgnB3FjTnyghwmwFs4mMg==, tarball: file:projects/react-components.tgz}
+    resolution: {integrity: sha512-g1E9lPS7zeJhkKG2/prsLxPyVBWkIBJffDR1ob5bXq+HXqReryYOymUlXLwDPguQtoyrYEbtx7DqBX7kRdi34Q==, tarball: file:projects/react-components.tgz}
     name: '@rush-temp/react-components'
     version: 0.0.0
     dependencies:
@@ -26421,7 +26431,7 @@ packages:
     dev: false
 
   file:projects/react-composites.tgz:
-    resolution: {integrity: sha512-/R8EHh8AVW5Fxnd5XTqrpUj7OJGlPI8vs5wFRx5NOzZUmbPi2HHhSTFZ1Vu420zfHHKhmBCqTxJz8ycu62i+mA==, tarball: file:projects/react-composites.tgz}
+    resolution: {integrity: sha512-ofjVFjaS9jq//1omV5sl51rs25Boe6IUBmA6+bGkxEslBKQr5OtK+gbim0G7I/z2qkyiSW9HQWIUGMME17nonw==, tarball: file:projects/react-composites.tgz}
     name: '@rush-temp/react-composites'
     version: 0.0.0
     dependencies:
@@ -26565,7 +26575,7 @@ packages:
     dev: false
 
   file:projects/sample-static-html-composites.tgz:
-    resolution: {integrity: sha512-wg7e0pnNZKMnailOjDXLWNkJZWz+52dQISZClge9viM1Rg2B1s+6MokP+vS+sqhfzTTB+DIdOrua+dkKDe6F8A==, tarball: file:projects/sample-static-html-composites.tgz}
+    resolution: {integrity: sha512-ro9o1T5hHR8kO9GIA2M4LGpFz6YvS7ENstpsiUrk7pQTts859zKlMwUunfoXJTw5BB3pNM0sekdQq8R4tG58eA==, tarball: file:projects/sample-static-html-composites.tgz}
     name: '@rush-temp/sample-static-html-composites'
     version: 0.0.0
     dependencies:
@@ -26709,7 +26719,7 @@ packages:
     dev: false
 
   file:projects/storybook.tgz:
-    resolution: {integrity: sha512-+bSKlnLrfFjAVkZ2WeI5gNYvAg3a/1wGd7FVUaRIgjKN0JBdHJPkYynhiPOtgh0dkOJgKsFAVifZc6xjF8k4CQ==, tarball: file:projects/storybook.tgz}
+    resolution: {integrity: sha512-RvkG/2GQDV5mRCLE4Xv7EO9A1HFe3DPdUjVAa90pT+lGF3jB+vIGy/0LvXfzTmf+IVyHPMDTQE22B8cIVi2cKQ==, tarball: file:projects/storybook.tgz}
     name: '@rush-temp/storybook'
     version: 0.0.0
     dependencies:
@@ -26853,7 +26863,7 @@ packages:
     dev: false
 
   file:projects/storybook8.tgz:
-    resolution: {integrity: sha512-+5zYxOZEfxUWVCHFE/9UjWt1mSwWnT1J45LkR8LL4qcd+R7Bx2JdhryYrPx+z8jt1TXb7CydhNZxmL1jixcppQ==, tarball: file:projects/storybook8.tgz}
+    resolution: {integrity: sha512-ysZ/xyoMK1dLveQjlXNY9yff5ZzuK6sM9/9R8wYJInlecvvwUjuRrcvfVcT5VdUnZIVe9oFx+fXcL3vgYlJjLQ==, tarball: file:projects/storybook8.tgz}
     name: '@rush-temp/storybook8'
     version: 0.0.0
     dependencies:

--- a/samples/Chat/package.json
+++ b/samples/Chat/package.json
@@ -53,7 +53,7 @@
     "react-linkify": "^1.0.0-alpha",
     "reselect": "^4.0.0",
     "shake.js": "1.2.2",
-    "axios": "^1.6.7",
+    "axios": "^1.7.5",
     "form-data": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
There's still another sub-dependency that's using axios <1.7.4. I've submitted a Github issue on their repo:
https://github.com/playwright-community/jest-process-manager/issues/41 and a Github issue on the Storybook/test-runner side: https://github.com/storybookjs/test-runner/issues/510

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->