### PR TITLE
[A11y][bugfix] Add Role to SvgWithWordWrapping 

### DIFF
--- a/change-beta/@azure-communication-react-e5231fa5-bfbb-4fde-8f01-2e9938d30f30.json
+++ b/change-beta/@azure-communication-react-e5231fa5-bfbb-4fde-8f01-2e9938d30f30.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Add role to SvgWithWorkWrapping and set as a heading in the configuration page on use",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-e5231fa5-bfbb-4fde-8f01-2e9938d30f30.json
+++ b/change/@azure-communication-react-e5231fa5-bfbb-4fde-8f01-2e9938d30f30.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Add role to SvgWithWorkWrapping and set as a heading in the configuration page on use",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/SvgWithWordWrapping.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/SvgWithWordWrapping.tsx
@@ -13,8 +13,9 @@ export const SvgWithWordWrapping = (props: {
   text: string;
   lineHeightPx: number;
   bufferHeightPx: number;
+  role?: string;
 }): JSX.Element => {
-  const { width, text, lineHeightPx, bufferHeightPx } = props;
+  const { width, text, lineHeightPx, bufferHeightPx, role } = props;
   const svgRef = useRef<SVGSVGElement>(null);
   const calculationTextElement = useRef<SVGTextElement>(null);
   const visibleTextElement = useRef<SVGTextElement>(null);
@@ -38,7 +39,7 @@ export const SvgWithWordWrapping = (props: {
   }, [width, lineHeightPx, text]);
 
   return (
-    <svg width={width} height={height + bufferHeightPx} ref={svgRef} xmlns="http://www.w3.org/2000/svg">
+    <svg role={role} width={width} height={height + bufferHeightPx} ref={svgRef} xmlns="http://www.w3.org/2000/svg">
       <text height={0} ref={calculationTextElement} style={{ visibility: 'hidden' }}>
         {text}
       </text>

--- a/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
+++ b/packages/react-composites/src/composites/CallComposite/pages/ConfigurationPage.tsx
@@ -171,6 +171,7 @@ export const ConfigurationPage = (props: ConfigurationPageProps): JSX.Element =>
           lineHeightPx={16 * 1.5}
           bufferHeightPx={16}
           text={locale.strings.call.configurationPageTitle}
+          role="heading"
         />
       </Stack.Item>
     ) : (


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
* Add Role to SvgWithWordWrapping
* Add heading role in ConfigurationPage use
Video of the Fix in action. Turn up audio to hear. Go to the Why section to see the original problem in video.

https://github.com/user-attachments/assets/69d2a14d-b8c7-400a-9976-69cf3a7a5d2c



# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
* A11y bug where when using Windows narrator the SvgWithWordWrapping announces "Graphic" when focused. Should not announce Graphic and should announce heading. 
Graphic announced. Turn up audio to hear it in the video:

https://github.com/user-attachments/assets/c6eb1df0-5de4-4baa-856f-ae33599374e0



# How Tested
<!--- How did you test your change. What tests have you added. -->
Window 11 Devbox


# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->