### PR TITLE
Support joining an existing call in the CallComposite & CallWithChatComposite

### DIFF
--- a/change-beta/@azure-communication-react-424e27fb-3ea9-4505-8fb2-2d7c0c28cd2c.json
+++ b/change-beta/@azure-communication-react-424e27fb-3ea9-4505-8fb2-2d7c0c28cd2c.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "feature",
+  "workstream": "",
+  "comment": "Support Composites joining existing calls by updating CallAdapter and CallWithChatAdapters to take an existing call as a contruction parameter instead of a locator.",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-424e27fb-3ea9-4505-8fb2-2d7c0c28cd2c.json
+++ b/change/@azure-communication-react-424e27fb-3ea9-4505-8fb2-2d7c0c28cd2c.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "feature",
+  "workstream": "",
+  "comment": "Support Composites joining existing calls by updating CallAdapter and CallWithChatAdapters to take an existing call as a contruction parameter instead of a locator.",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2550,10 +2550,23 @@ export function createAzureCommunicationCallAdapterFromClient(callClient: Statef
 export function createAzureCommunicationCallAdapterFromClient(callClient: StatefulCallClient, callAgent: CallAgent, locator: CallAdapterLocator, options?: AzureCommunicationCallAdapterOptions): Promise<CallAdapter>;
 
 // @public
+export function createAzureCommunicationCallAdapterFromClient(callClient: StatefulCallClient, callAgent: CallAgent, call: Call, options?: AzureCommunicationCallAdapterOptions): Promise<CallAdapter>;
+
+// @public
 export const createAzureCommunicationCallWithChatAdapter: ({ userId, displayName, credential, endpoint, locator, alternateCallerId, callAdapterOptions }: AzureCommunicationCallWithChatAdapterArgs) => Promise<CallWithChatAdapter>;
 
 // @public
-export const createAzureCommunicationCallWithChatAdapterFromClients: ({ callClient, callAgent, callLocator, chatClient, chatThreadClient, callAdapterOptions }: AzureCommunicationCallWithChatAdapterFromClientArgs) => Promise<CallWithChatAdapter>;
+export function createAzureCommunicationCallWithChatAdapterFromClients(args: AzureCommunicationCallWithChatAdapterFromClientArgs): Promise<CallWithChatAdapter>;
+
+// @public
+export function createAzureCommunicationCallWithChatAdapterFromClients(args: {
+    callClient: StatefulCallClient;
+    callAgent: CallAgent;
+    call: Call;
+    chatClient: StatefulChatClient;
+    chatThreadClient: ChatThreadClient;
+    callAdapterOptions?: AzureCommunicationCallAdapterOptions;
+}): Promise<CallWithChatAdapter>;
 
 // @public
 export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -2160,10 +2160,23 @@ export function createAzureCommunicationCallAdapterFromClient(callClient: Statef
 export function createAzureCommunicationCallAdapterFromClient(callClient: StatefulCallClient, callAgent: CallAgent, locator: CallAdapterLocator, options?: AzureCommunicationCallAdapterOptions): Promise<CallAdapter>;
 
 // @public
+export function createAzureCommunicationCallAdapterFromClient(callClient: StatefulCallClient, callAgent: CallAgent, call: Call, options?: AzureCommunicationCallAdapterOptions): Promise<CallAdapter>;
+
+// @public
 export const createAzureCommunicationCallWithChatAdapter: ({ userId, displayName, credential, endpoint, locator, alternateCallerId, callAdapterOptions }: AzureCommunicationCallWithChatAdapterArgs) => Promise<CallWithChatAdapter>;
 
 // @public
-export const createAzureCommunicationCallWithChatAdapterFromClients: ({ callClient, callAgent, callLocator, chatClient, chatThreadClient, callAdapterOptions }: AzureCommunicationCallWithChatAdapterFromClientArgs) => Promise<CallWithChatAdapter>;
+export function createAzureCommunicationCallWithChatAdapterFromClients(args: AzureCommunicationCallWithChatAdapterFromClientArgs): Promise<CallWithChatAdapter>;
+
+// @public
+export function createAzureCommunicationCallWithChatAdapterFromClients(args: {
+    callClient: StatefulCallClient;
+    callAgent: CallAgent;
+    call: Call;
+    chatClient: StatefulChatClient;
+    chatThreadClient: ChatThreadClient;
+    callAdapterOptions?: AzureCommunicationCallAdapterOptions;
+}): Promise<CallWithChatAdapter>;
 
 // @public
 export const createAzureCommunicationChatAdapter: ({ endpoint: endpointUrl, userId, displayName, credential, threadId }: AzureCommunicationChatAdapterArgs) => Promise<ChatAdapter>;

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -473,7 +473,12 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | TeamsCa
       }
     });
 
-    const isRoomsCall = this.locator ? 'roomId' in this.locator : !!overloadedParamAsCall?.info.roomId;
+    const isOverloadedParamARoomsCallTrampoline = (): boolean => {
+      /* @conditional-compile-remove(calling-beta-sdk) */
+      return !!overloadedParamAsCall?.info.roomId;
+      return false;
+    };
+    const isRoomsCall = this.locator ? 'roomId' in this.locator : isOverloadedParamARoomsCallTrampoline();
 
     this.onResolveVideoBackgroundEffectsDependency = options?.videoBackgroundOptions?.onResolveDependency;
     /* @conditional-compile-remove(DNS) */

--- a/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
+++ b/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
@@ -7,7 +7,7 @@ import { CallControlOptions } from '../types/CallControlOptions';
 import { CallState, RemoteParticipantState } from '@internal/calling-stateful-client';
 import { isPhoneNumberIdentifier } from '@azure/communication-common';
 /* @conditional-compile-remove(unsupported-browser) */
-import { Call, EnvironmentInfo } from '@azure/communication-calling';
+import { EnvironmentInfo } from '@azure/communication-calling';
 import { AdapterStateModifier, CallAdapterLocator } from '../adapter/AzureCommunicationCallAdapter';
 
 import { VideoBackgroundEffectsDependency } from '@internal/calling-component-bindings';
@@ -15,7 +15,7 @@ import { VideoBackgroundEffectsDependency } from '@internal/calling-component-bi
 import { VideoBackgroundEffect } from '../adapter/CallAdapter';
 import { VideoDeviceInfo } from '@azure/communication-calling';
 
-import { VideoEffectProcessor } from '@azure/communication-calling';
+import { Call, VideoEffectProcessor } from '@azure/communication-calling';
 import { CompositeLocale } from '../../localization';
 import { CallCompositeIcons } from '../../common/icons';
 

--- a/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
+++ b/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
@@ -7,7 +7,7 @@ import { CallControlOptions } from '../types/CallControlOptions';
 import { CallState, RemoteParticipantState } from '@internal/calling-stateful-client';
 import { isPhoneNumberIdentifier } from '@azure/communication-common';
 /* @conditional-compile-remove(unsupported-browser) */
-import { EnvironmentInfo } from '@azure/communication-calling';
+import { Call, EnvironmentInfo } from '@azure/communication-calling';
 import { AdapterStateModifier, CallAdapterLocator } from '../adapter/AzureCommunicationCallAdapter';
 
 import { VideoBackgroundEffectsDependency } from '@internal/calling-component-bindings';
@@ -587,14 +587,18 @@ export const getSelectedCameraFromAdapterState = (state: CallAdapterState): Vide
 
 /**
  * Helper to determine if the adapter has a locator or targetCallees
- * @param locatorOrTargetCallees
  * @returns boolean to determine if the adapter has a locator or targetCallees, true is locator, false is targetCallees
  * @private
  */
-export const getLocatorOrTargetCallees = (
-  locatorOrTargetCallees: CallAdapterLocator | StartCallIdentifier[]
-): locatorOrTargetCallees is StartCallIdentifier[] => {
-  return !!Array.isArray(locatorOrTargetCallees);
+export const isTargetCallees = (
+  overloadedParam: CallAdapterLocator | StartCallIdentifier[] | Call
+): overloadedParam is StartCallIdentifier[] => {
+  return !!Array.isArray(overloadedParam);
+};
+
+/** @private */
+export const isCall = (overloadedParam: CallAdapterLocator | StartCallIdentifier[] | Call): overloadedParam is Call => {
+  return 'kind' in overloadedParam && overloadedParam.kind === 'Call';
 };
 
 /**

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -1394,7 +1394,6 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
   callClient: StatefulCallClient;
   chatClient: StatefulChatClient;
   chatThreadClient: ChatThreadClient;
-
   callAdapterOptions?: AzureCommunicationCallAdapterOptions;
 };
 
@@ -1407,24 +1406,59 @@ export type AzureCommunicationCallWithChatAdapterFromClientArgs = {
  *
  * @public
  */
-export const createAzureCommunicationCallWithChatAdapterFromClients = async ({
-  callClient,
-  callAgent,
-  callLocator,
-  chatClient,
-  chatThreadClient,
-  callAdapterOptions
-}: AzureCommunicationCallWithChatAdapterFromClientArgs): Promise<CallWithChatAdapter> => {
-  const callAdapter = await createAzureCommunicationCallAdapterFromClient(
-    callClient,
-    callAgent,
-    callLocator,
+export async function createAzureCommunicationCallWithChatAdapterFromClients(
+  args: AzureCommunicationCallWithChatAdapterFromClientArgs
+): Promise<CallWithChatAdapter>;
 
-    callAdapterOptions
-  );
+/**
+ * Create a {@link CallWithChatAdapter} using the provided {@link StatefulChatClient} and {@link StatefulCallClient} and {@link Call}.
+ *
+ * Useful if you want to keep a reference to {@link StatefulChatClient} and {@link StatefulCallClient}.
+ * Please note that chatThreadClient has to be created by StatefulChatClient via chatClient.getChatThreadClient(chatThreadId) API.
+ * Consider using {@link createAzureCommunicationCallWithChatAdapter} for a simpler API.
+ *
+ * @public
+ */
+export async function createAzureCommunicationCallWithChatAdapterFromClients(args: {
+  callClient: StatefulCallClient;
+  callAgent: CallAgent;
+  call: Call;
+  chatClient: StatefulChatClient;
+  chatThreadClient: ChatThreadClient;
+  callAdapterOptions?: AzureCommunicationCallAdapterOptions;
+}): Promise<CallWithChatAdapter>;
+
+/**
+ * Implementation of {@link createAzureCommunicationCallWithChatAdapterFromClients} overloads.
+ * @private
+ */
+export async function createAzureCommunicationCallWithChatAdapterFromClients(
+  args:
+    | AzureCommunicationCallWithChatAdapterFromClientArgs
+    | {
+        call: Call;
+        callAgent: CallAgent;
+        callClient: StatefulCallClient;
+        chatClient: StatefulChatClient;
+        chatThreadClient: ChatThreadClient;
+        callAdapterOptions?: AzureCommunicationCallAdapterOptions;
+      }
+): Promise<CallWithChatAdapter> {
+  const { callAgent, callClient, chatClient, chatThreadClient, callAdapterOptions } = args;
+
+  const callAdapter =
+    'call' in args
+      ? await createAzureCommunicationCallAdapterFromClient(callClient, callAgent, args.call, callAdapterOptions)
+      : await createAzureCommunicationCallAdapterFromClient(
+          callClient,
+          callAgent,
+          args.callLocator,
+          callAdapterOptions
+        );
+
   const chatAdapter = await createAzureCommunicationChatAdapterFromClient(chatClient, chatThreadClient);
   return new AzureCommunicationCallWithChatAdapter(callAdapter, chatAdapter);
-};
+}
 
 /**
  * Create a {@link CallWithChatAdapter} from the underlying adapters.


### PR DESCRIPTION
# What

- Update `createAzureCommunicationCallAdapterFromClients` and `createAzureCommunicationCallWithChatAdapterFromClients` to allow passing in a Call object instead of a locator

# Why

Supports scenarios such as CallAutomation or IncomingCalls were a call could be created outside of the regular adapter flow.

# How Tested

Verified in the Call sample and CallWithChat sample that I could join existing calls. Tried joining with&without unMute and cameraOn