### PR TITLE
[Ezra bug] Fix issue where end call button shifts to left

### DIFF
--- a/packages/react-composites/src/composites/CallComposite/components/buttons/EndCall.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/buttons/EndCall.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { concatStyleSets } from '@fluentui/react';
+import { concatStyleSets, Stack } from '@fluentui/react';
 /* @conditional-compile-remove(breakout-rooms) */
 import { IContextualMenuProps } from '@fluentui/react';
 import { ControlBarButtonStyles, EndCallButton } from '@internal/react-components';
@@ -132,18 +132,7 @@ export const EndCall = (props: {
   };
 
   return (
-    <>
-      {
-        /* @conditional-compile-remove(end-call-options) */
-        <Prompt
-          {...dialogLabels}
-          styles={{ main: { minWidth: '22.5rem', padding: '1.5rem' } }}
-          cancelButtonLabel={localeStrings.call.hangUpCancelButtonLabel}
-          onConfirm={() => onHangUpConfirm(props.enableEndCallMenu)} // if enableEndCallMenu is true, that means the dialog is triggered by hangUpForEveryone button
-          isOpen={showHangUpConfirm}
-          onCancel={toggleConfirm}
-        />
-      }
+    <Stack>
       <EndCallButton
         data-ui-id="call-composite-hangup-button"
         {...hangUpButtonProps}
@@ -156,6 +145,17 @@ export const EndCall = (props: {
         /* @conditional-compile-remove(breakout-rooms) */
         menuProps={enableBreakoutRoomMenu ? breakoutRoomMenuProps : undefined}
       />
-    </>
+      {
+        /* @conditional-compile-remove(end-call-options) */
+        <Prompt
+          {...dialogLabels}
+          styles={{ main: { minWidth: '22.5rem', padding: '1.5rem' } }}
+          cancelButtonLabel={localeStrings.call.hangUpCancelButtonLabel}
+          onConfirm={() => onHangUpConfirm(props.enableEndCallMenu)} // if enableEndCallMenu is true, that means the dialog is triggered by hangUpForEveryone button
+          isOpen={showHangUpConfirm}
+          onCancel={toggleConfirm}
+        />
+      }
+    </Stack>
   );
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Wrap the end call button and the prompt for the options in a stack so that the parent doesn't try to put space between them.
# Why
<!--- What problem does this change solve? -->
The parent Stack for the CommonControlBar was adding space between the 0 sized span for the prompt's modal-anchor. 
![image](https://github.com/user-attachments/assets/62225dd9-2a4d-4aa8-b7f5-792637b2e3bc)

<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3870948
# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated locally, snapshots to update