### PR TITLE
fixing documentation issues during video gallery migration around content sharing

### DIFF
--- a/packages/storybook8/stories/Components/VideoGallery/Docs.mdx
+++ b/packages/storybook8/stories/Components/VideoGallery/Docs.mdx
@@ -178,16 +178,16 @@ The vertical gallery can be most useful when the application is running a very w
 
 ## Content Sharing Experience
 
-Our VideoGallery component is designed for optimal content sharing, incorporating both screen sharing and PowerPoint Live functionalities. The screen shared is the sole element placed in the Grid Layout, with all remote participants positioned in the horizontal gallery at the lower section. For effective screen sharing or PowerPoint Live, ensure the sharing participant has their isScreenSharingOn prop set to true, along with a defined screenShareStream prop (refer to localParticipant and remoteParticipants props).
+Our VideoGallery component is designed for optimal content sharing, incorporating both screen sharing and PowerPoint Live functionalities. The screen shared is the sole element placed in the [Grid Layout](./?path=/docs/ui-components-gridlayout--grid-layout), with all remote participants positioned in the horizontal gallery at the lower section. For effective screen sharing or PowerPoint Live, ensure the sharing participant has their `isScreenSharingOn` prop set to true, along with a defined `screenShareStream` prop (refer to `localParticipant` and `remoteParticipants` props).
 
 ### Supported Features
 
 Currently, the VideoGallery component supports two primary features to enhance collaboration and presentation quality: screen sharing and PowerPoint Live.
 
-- <strong>Screen Sharing:</strong> Share your local screen with participants in real-time or view remote screen
-shares. For more details, see the sections below.
+- <strong>Screen Sharing:</strong> Share your local screen with participants in real-time or view remote screen shares.
+  For more details, see the sections below.
 - <strong>PowerPoint Live:</strong> Exclusively view remote PowerPoint presentations.
-<a href="?path=/docs/ppt-live--page">Learn more about PowerPoint Live</a>.
+  <a href="?path=/docs/ppt-live--page">Learn more about PowerPoint Live</a>.
 
 ### From a presenter point of view
 


### PR DESCRIPTION
- added Grid Layout link
- added additional backtick characters to highlight specific types 
Before:
![image](https://github.com/user-attachments/assets/f37ecb54-edce-4f2e-a878-a9b7fba9914b)

After:
![image](https://github.com/user-attachments/assets/ed9602dc-13b2-48ce-8343-8774aa8a2064)
