### PR TITLE
[Chat] Flagging when the adapter is being created

### DIFF
--- a/change-beta/@azure-communication-react-3609656d-b6a9-4253-93ee-50eacf1719e2.json
+++ b/change-beta/@azure-communication-react-3609656d-b6a9-4253-93ee-50eacf1719e2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "AzureCommunicationChatAdapter",
+  "comment": "Adding logic to flag when the adapter is in the middle of creation",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-3609656d-b6a9-4253-93ee-50eacf1719e2.json
+++ b/change/@azure-communication-react-3609656d-b6a9-4253-93ee-50eacf1719e2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "AzureCommunicationChatAdapter",
+  "comment": "Adding logic to flag when the adapter is in the middle of creation",
+  "packageName": "@azure/communication-react",
+  "email": "9044372+JoshuaLai@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
+++ b/packages/react-composites/src/composites/ChatComposite/adapter/AzureCommunicationChatAdapter.ts
@@ -613,6 +613,7 @@ export const useAzureCommunicationChatAdapter = (
   const [adapter, setAdapter] = useState<ChatAdapter | undefined>(undefined);
   // Ref needed for cleanup to access the old adapter created asynchronously.
   const adapterRef = useRef<ChatAdapter | undefined>(undefined);
+  const creatingAdapterRef = useRef<boolean>(false);
 
   const afterCreateRef = useRef<((adapter: ChatAdapter) => Promise<ChatAdapter>) | undefined>(undefined);
   const beforeDisposeRef = useRef<((adapter: ChatAdapter) => Promise<void>) | undefined>(undefined);
@@ -641,7 +642,13 @@ export const useAzureCommunicationChatAdapter = (
           adapterRef.current.dispose();
           adapterRef.current = undefined;
         }
-
+        if (creatingAdapterRef.current) {
+          console.warn(
+            'Adapter is already being created, please see storybook for more information: https://azure.github.io/communication-ui-library/?path=/story/troubleshooting--page'
+          );
+          return;
+        }
+        creatingAdapterRef.current = true;
         let newAdapter = await createAzureCommunicationChatAdapter({
           credential,
           displayName,
@@ -653,6 +660,7 @@ export const useAzureCommunicationChatAdapter = (
           newAdapter = await afterCreateRef.current(newAdapter);
         }
         adapterRef.current = newAdapter;
+        creatingAdapterRef.current = false;
         setAdapter(newAdapter);
       })();
     },


### PR DESCRIPTION
# What
Issue found during OCE rotation! 
Today there is a race condition where `useAzureCommunicationChatAdapter` can be called twice, and if the second call happens before the adapter has been created by the first call, events can be missed / lost. 
The `AzureCommunicationCallAdapter` and `AzureCommunicationCallWithChatAdapter` already implement logic exactly like this one, so adding this missing logic to be consistent across all adapter methods. 

# Why
There is bug where:
- If user A joins an empty chat thread
- User B joins the chat thread 
- User A cannot see User B 
- User B can see User A

In this case, messages sent from User A are lost, but User A can still receive messages from User B 

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->