### PR TITLE
[Storybook8] Hiding the onFetchParticipantsMenuItems control from the stories

### DIFF
--- a/packages/storybook8/stories/controlsUtils.ts
+++ b/packages/storybook8/stories/controlsUtils.ts
@@ -562,6 +562,7 @@ export const defaultChatCompositeHiddenControls = {
   identifiers: hiddenControl,
   locale: hiddenControl,
   onFetchAvatarPersonaData: hiddenControl,
+  onFetchParticipantMenuItems: hiddenControl,
   rtl: hiddenControl,
   formFactor: hiddenControl // formFactor is hidden by default and compositeFormFactor is used as a prop instead to workaround a bug where formFactor is not put in the correct order when the controls are generated
 };


### PR DESCRIPTION
# What
Hiding extra controls that cannot be interacted with. 
![image](https://github.com/user-attachments/assets/5b80f597-a101-48c3-a3c6-7a36ca66bba8)

# Why
Match controls in current prod storybook 
