### PR TITLE
[Storybook] Fixing canvas padding in storybook components

### DIFF
--- a/packages/storybook8/stories/Components/ImageOverlay/Docs.mdx
+++ b/packages/storybook8/stories/Components/ImageOverlay/Docs.mdx
@@ -20,7 +20,11 @@ import { ImageOverlay } from '@azure/communication-react';
 
 Component will render a fullscreen modal using a set image source.
 
-<Canvas of={ImageOverlayStories.ImageOverlaySnippetDocsOnly} source={{ code: ImageOverlayStoriesExampleText }} />
+<Canvas
+  of={ImageOverlayStories.ImageOverlaySnippetDocsOnly}
+  source={{ code: ImageOverlayStoriesExampleText }}
+  layout="padded"
+/>
 
 ## Cover iOS safe area
 

--- a/packages/storybook8/stories/Components/MessageStatusIndicator/Docs.mdx
+++ b/packages/storybook8/stories/Components/MessageStatusIndicator/Docs.mdx
@@ -20,6 +20,7 @@ import { MessageStatus, MessageStatusIndicator } from '@azure/communication-reac
 <Canvas
   of={MessageStatusIndicatorStories.MessageStatusIndicatorSnippetDocsOnly}
   source={{ code: MessageStatusIndicatorStoriesExampleText }}
+  layout="padded"
 />
 
 ## Props

--- a/packages/storybook8/stories/Components/MessageThread/Docs.mdx
+++ b/packages/storybook8/stories/Components/MessageThread/Docs.mdx
@@ -59,17 +59,29 @@ into that file.
 By default, MessageThread displays Chat messages with display name of only for other users and creation time
 of message when available.
 
-<Canvas of={MessageThreadStories.DefaultMessageThreadDocsOnly} source={{ code: DefaultMessageThreadExampleText }} />
+<Canvas
+  of={MessageThreadStories.DefaultMessageThreadDocsOnly}
+  source={{ code: DefaultMessageThreadExampleText }}
+  layout="padded"
+/>
 
 ## MessageThread With Message Date
 
-<Canvas of={MessageThreadStories.DateExampleDocsOnly} source={{ code: MessageThreadWithMessageDateExampleText }} />
+<Canvas
+  of={MessageThreadStories.DateExampleDocsOnly}
+  source={{ code: MessageThreadWithMessageDateExampleText }}
+  layout="padded"
+/>
 
 ## System Message
 
 The example below shows a message thread with a system message.
 
-<Canvas of={MessageThreadStories.SystemMessageDocsOnly} source={{ code: MessageThreadWithSystemMessagesExampleText }} />
+<Canvas
+  of={MessageThreadStories.SystemMessageDocsOnly}
+  source={{ code: MessageThreadWithSystemMessagesExampleText }}
+  layout="padded"
+/>
 
 ## Blocked Message
 
@@ -80,6 +92,7 @@ The example below shows a message thread with a blocked message. If `link` is no
 <Canvas
   of={MessageThreadStories.BlockedMessagesDocsOnly}
   source={{ code: MessageThreadWithBlockedMessagesExampleText }}
+  layout="padded"
 />
 
 ## Custom Message
@@ -89,6 +102,7 @@ he example below shows how to render a `custom` message with `onRenderMessage` i
 <Canvas
   of={MessageThreadStories.CustomMessagesDocsOnly}
   source={{ code: MessageThreadWithCustomMessagesExampleText }}
+  layout="padded"
 />
 
 ## Messages with Customized Chat Container
@@ -98,6 +112,7 @@ The example below shows how to render a `custom` chat container with `styles.cha
 <Canvas
   of={MessageThreadStories.CustomChatContainerDocsOnly}
   source={{ code: MessageThreadWithCustomChatContainerExampleText }}
+  layout="padded"
 />
 
 ## Messages with Customized Message Container
@@ -111,6 +126,7 @@ malformed issue when loading the storybook snippets
 <Canvas
   of={MessageThreadStories.CustomMessageContainerDocsOnly}
   source={{ code: MessageThreadWithCustomMessageContainerExampleText }}
+  layout="padded"
 />
 
 ## Messages with Customized Blocked message Container
@@ -124,6 +140,7 @@ in `MessageThread`
 <Canvas
   of={MessageThreadStories.CustomBlockedMessageDocsOnly}
   source={{ code: MessageThreadWithCustomBlockedMessageContainerExampleText }}
+  layout="padded"
 />
 
 ## Default Message Status Indicator
@@ -131,6 +148,7 @@ in `MessageThread`
 <Canvas
   of={MessageThreadStories.MessageStatusIndicatorDocsOnly}
   source={{ code: MessageThreadWithMessageStatusIndicatorExampleText }}
+  layout="padded"
 />
 
 ## Custom Message Status Indicator
@@ -141,11 +159,16 @@ The example below shows how to render a `custom` message status indicator with `
 <Canvas
   of={MessageThreadStories.CustomStatusIndicatorDocsOnly}
   source={{ code: MessageThreadWithCustomMessageStatusIndicatorExampleText }}
+  layout="padded"
 />
 
 ## Custom Avatar
 
-<Canvas of={MessageThreadStories.CustomAvatarDocsOnly} source={{ code: MessageThreadWithCustomAvatarExampleText }} />
+<Canvas
+  of={MessageThreadStories.CustomAvatarDocsOnly}
+  source={{ code: MessageThreadWithCustomAvatarExampleText }}
+  layout="padded"
+/>
 
 Note: You can view the details of the
 [Persona](https://developer.microsoft.com/fluentui#/controls/web/persona) component
@@ -156,11 +179,16 @@ Note: You can view the details of the
 <Canvas
   of={MessageThreadStories.CustomTimestampExampleDocsOnly}
   source={{ code: MessageThreadWithCustomTimestampExampleText }}
+  layout="padded"
 />
 
 ## Tapping Inline Images on Messages
 
-<Canvas of={MessageThreadStories.InlineImageDocsOnly} source={{ code: MessageThreadWithInlineImageExampleText }} />
+<Canvas
+  of={MessageThreadStories.InlineImageDocsOnly}
+  source={{ code: MessageThreadWithInlineImageExampleText }}
+  layout="padded"
+/>
 
 ## Display Messages with Attachments
 
@@ -173,12 +201,16 @@ content along with associated attachments.
 By default, the button associated with the attachment card will open the attachment in a new tab.
 Specifically, `window.open` method will be called for target `URL` defined in `AttachmentMetadata`.
 
-<Canvas of={MessageThreadStories.AttachmentsDocsOnly} source={{ code: MessageWithAttachmentText }} />
+<Canvas of={MessageThreadStories.AttachmentsDocsOnly} source={{ code: MessageWithAttachmentText }} layout="padded" />
 
 If the identity of message sender is a Microsoft Teams user, the attachment will be rendered with an `open`
 icon shown below.
 
-<Canvas of={MessageThreadStories.AttachmentFromTeamsDocsOnly} source={{ code: MessageWithAttachmentFromTeamsText }} />
+<Canvas
+  of={MessageThreadStories.AttachmentFromTeamsDocsOnly}
+  source={{ code: MessageWithAttachmentFromTeamsText }}
+  layout="padded"
+/>
 
 ### Advanced Usage: Customizing Attachment Rendering
 
@@ -191,7 +223,11 @@ a static list for all scenarios.
 
 For example, the following code snippet demonstrates how to customize the download options for attachments.
 
-<Canvas of={MessageThreadStories.CustomAttachmentsDocsOnly} source={{ code: MessageWithCustomAttachmentText }} />
+<Canvas
+  of={MessageThreadStories.CustomAttachmentsDocsOnly}
+  source={{ code: MessageWithCustomAttachmentText }}
+  layout="padded"
+/>
 
 ## Mention of Users with a custom renderer within Message
 
@@ -207,7 +243,11 @@ further customization. The HTML Tag is defined:
 
 The MessageThread component also supports mentioning users when editing a message if the `lookupOptions` under the `mentionOptions` property is provided. However, if the `richTextEditorOptions` property is set, the `lookupOptions` will be ignored.
 
-<Canvas of={MessageThreadStories.CustomMentionsDocsOnly} source={{ code: MessageWithCustomMentionRendererText }} />
+<Canvas
+  of={MessageThreadStories.CustomMentionsDocsOnly}
+  source={{ code: MessageWithCustomMentionRendererText }}
+  layout="padded"
+/>
 
 ## Rich Text Editor Support for Editing Messages
 
@@ -220,6 +260,7 @@ Enabling the rich text editor for message editing, without customizing its behav
 <Canvas
   of={MessageThreadStories.RichTextEditorTextDocsOnly}
   source={{ code: MessageThreadWithRichTextEditorExampleText }}
+  layout="padded"
 />
 
 ## Rich Text Editor Support for Editing Messages with Inline Images
@@ -249,6 +290,7 @@ paste. Selecting from the clipboard view from keyboard may not be supported.
 <Canvas
   of={MessageThreadStories.RichTextEditorInlineImagesTextDocsOnly}
   source={{ code: MessageThreadWithRichTextEditorInlineImagesExampleText }}
+  layout="padded"
 />
 
 ## Process content on paste in Rich Text Editor during message editing
@@ -260,6 +302,7 @@ paste. Selecting from the clipboard view from keyboard may not be supported.
 <Canvas
   of={MessageThreadStories.RichTextEditorOnPasteTextDocsOnly}
   source={{ code: MessageThreadWithRichTextEditorOnPasteExampleText }}
+  layout="padded"
 />
 
 ## Props

--- a/packages/storybook8/stories/Components/SendBox/RichTextSendBox/Docs.mdx
+++ b/packages/storybook8/stories/Components/SendBox/RichTextSendBox/Docs.mdx
@@ -36,6 +36,7 @@ To add a system message, use the systemMessage property like in the example belo
 <Canvas
   of={RichTextSendBoxStories.RichTextSendBoxWithSystemMessageSnippetDocsOnly}
   source={{ code: RichTextSendBoxWithSystemMessageExampleText }}
+  layout="padded"
 />
 
 ## Display File Uploads
@@ -47,6 +48,7 @@ their own attachment upload logic and utilize the UI provided by RichTextSendBox
 <Canvas
   of={RichTextSendBoxStories.RichTextSendBoxAttachmentUploadsSnippetDocsOnly}
   source={{ code: RichTextSendBoxAttachmentUploadsExampleText }}
+  layout="padded"
 />
 
 ## Enable Inserting Inline Images
@@ -71,6 +73,7 @@ their own attachment upload logic and utilize the UI provided by RichTextSendBox
 <Canvas
   of={RichTextSendBoxStories.RichTextSendBoxWithInlineImagesSnippetDocsOnly}
   source={{ code: RichTextSendBoxWithInlineImagesExampleText }}
+  layout="padded"
 />
 
 ## Process pasted content
@@ -80,6 +83,7 @@ RichTextSendBox provides `onPaste` callback for custom processing of the pasted 
 <Canvas
   of={RichTextSendBoxStories.RichTextSendBoxOnPasteCallbackSnippetDocsOnly}
   source={{ code: RichTextSendBoxOnPasteCallbackExampleText }}
+  layout="padded"
 />
 
 ## Props

--- a/packages/storybook8/stories/Components/SendBox/SendBox/Docs.mdx
+++ b/packages/storybook8/stories/Components/SendBox/SendBox/Docs.mdx
@@ -26,7 +26,7 @@ import { SendBox } from '@azure/communication-react';
 
 ## Example
 
-<Canvas of={SendBoxStories.SendBoxExampleDocsOnly} source={{ code: SendBoxExampleText }} />
+<Canvas of={SendBoxStories.SendBoxExampleDocsOnly} source={{ code: SendBoxExampleText }} layout="padded" />
 
 ## Add a system message
 
@@ -35,18 +35,19 @@ To add a system message, use the `systemMessage` property like in the example be
 <Canvas
   of={SendBoxStories.SendBoxWithSystemMessageExampleDocsOnly}
   source={{ code: SendBoxWithSystemMessageExampleText }}
+  layout="padded"
 />
 
 ## Customize send icon
 
 To customize the send icon, use the `onRenderIcon` property like in the example below. A Fluent UI [Icon](https://developer.microsoft.com/fluentui#/controls/web/icon) is used in this example but you can use any `JSX.Element`.
 
-<Canvas of={SendBoxStories.CustomIconExampleDocsOnly} source={{ code: CustomIconExampleText }} />
+<Canvas of={SendBoxStories.CustomIconExampleDocsOnly} source={{ code: CustomIconExampleText }} layout="padded" />
 ## Customize styling
 
 To customize the style of SendBox, use the `styles` property like in the example below. Notice that the keys of the `styles` property are the root and sub-components of `SendBox`, each of which can be styled independently.
 
-<Canvas of={SendBoxStories.CustomStylingExampleDocsOnly} source={{ code: CustomStylingExampleText }} />
+<Canvas of={SendBoxStories.CustomStylingExampleDocsOnly} source={{ code: CustomStylingExampleText }} layout="padded" />
 
 ## Display Attachment Uploads
 
@@ -54,7 +55,11 @@ To customize the style of SendBox, use the `styles` property like in the example
 
 SendBox component provides UI for displaying `AttachmentMetadataInProgress` in the SendBox. This allows developers to implement a file-sharing feature using the pure UI component with minimal effort. Developers can write their own attachment upload logic and utilize the UI provided by SendBox.
 
-<Canvas of={SendBoxStories.AttachmentUploadsExampleDocsOnly} source={{ code: AttachmentUploadsExampleText }} />
+<Canvas
+  of={SendBoxStories.AttachmentUploadsExampleDocsOnly}
+  source={{ code: AttachmentUploadsExampleText }}
+  layout="padded"
+/>
 
 ## Mentioning Users
 
@@ -62,6 +67,6 @@ SendBox component provides UI for displaying `AttachmentMetadataInProgress` in t
 
 The SendBox component supports mentioning users in the chat. To enable this feature, set the `mentionLookupOptions` property to an object and implement the required functionality.
 
-<Canvas of={SendBoxStories.MentionsExampleDocsOnly} source={{ code: MentionsExampleText }} />
+<Canvas of={SendBoxStories.MentionsExampleDocsOnly} source={{ code: MentionsExampleText }} layout="padded" />
 ## Props
 <ArgTypes of={SendBox} />

--- a/packages/storybook8/stories/Components/TypingIndicator/Docs.mdx
+++ b/packages/storybook8/stories/Components/TypingIndicator/Docs.mdx
@@ -19,13 +19,21 @@ import { TypingIndicator } from '@azure/communication-react';
 
 ## Example
 
-<Canvas of={TypingIndicatorStories.TypingIndicatorExampleDocsOnly} source={{ code: TypingIndicatorExampleText }} />
+<Canvas
+  of={TypingIndicatorStories.TypingIndicatorExampleDocsOnly}
+  source={{ code: TypingIndicatorExampleText }}
+  layout="padded"
+/>
 
 ## Customize Style
 
 To customize the style of `TypingIndicator`, use the `styles` property like in the example below. Notice that the keys of `styles` property are the root and sub-components of `TypingIndicator`, each of which can be styled independently.
 
-<Canvas of={TypingIndicatorStories.CustomizeStyleExampleDocsOnly} source={{ code: CustomizeStyleExampleText }} />
+<Canvas
+  of={TypingIndicatorStories.CustomizeStyleExampleDocsOnly}
+  source={{ code: CustomizeStyleExampleText }}
+  layout="padded"
+/>
 
 ## Customize user rendering
 
@@ -34,6 +42,7 @@ To customize user rendering of `TypingIndicator`, use the `onRenderUsers` proper
 <Canvas
   of={TypingIndicatorStories.CustomizeUserRenderingExampleDocsOnly}
   source={{ code: CustomizeUserRenderingExampleText }}
+  layout="padded"
 />
 
 ## Props


### PR DESCRIPTION
# What
Fixing the padding around the canvas to match closer to storybook 6 
![image](https://github.com/user-attachments/assets/cf4f062d-8782-4074-8fb2-3fffc843cae4)
![image](https://github.com/user-attachments/assets/e2551cbd-fe87-4104-be06-82e78bd5244e)

# Why
Padding look and feel issue