### PR TITLE
[Storybook] Fixing alignment and betabanner padding

### DIFF
--- a/packages/storybook8/stories/BetaBanners/ImportantBannerHeading.tsx
+++ b/packages/storybook8/stories/BetaBanners/ImportantBannerHeading.tsx
@@ -19,7 +19,7 @@ export const ImportantHeading = (props: { color: string }): JSX.Element => (
 const importantIconStyles = {
   // Ensure icon aligns with text by setting to the height to the same as the font size (1rem)
   // And aligning the icon with the bottom of the text
-  height: '1rem',
+  height: '1.5rem',
   verticalAlign: 'text-bottom',
 
   // display must be block or inline-block for verticalAlign to work

--- a/packages/storybook8/stories/Composites/ChatComposite/Docs.mdx
+++ b/packages/storybook8/stories/Composites/ChatComposite/Docs.mdx
@@ -140,8 +140,9 @@ You can pass in a function that formats the datetime displayed in chat messages 
 
 ## Adding file sharing
 
-<SingleLineBetaBanner />
 ### In Azure Communication Service Chat Thread
+
+<SingleLineBetaBanner />
 
 The Chat Composite supports file sharing capabilities in conjunction with your choice of a storage solution.
 Please refer to our


### PR DESCRIPTION
# What
Beta banner i icon alignment was off
Extra padding between the title was incorrect

![image](https://github.com/user-attachments/assets/b73077c7-0432-4342-a99d-bcfdb01b437f)

