### PR TITLE
[js-loaders] fix beta-release build

### DIFF
--- a/packages/communication-react/tsconfig.preprocess.json
+++ b/packages/communication-react/tsconfig.preprocess.json
@@ -10,7 +10,7 @@
       "@internal/calling-stateful-client": ["calling-stateful-client/src"],
       "@internal/chat-stateful-client": ["chat-stateful-client/src"],
       "@internal/react-components": ["react-components/src"],
-      "@internal/react-composites": ["react-composites/src"]
+      "@internal/react-composites": ["react-composites/src/index-public"]
     },
     "plugins": [
       { "transform": "typescript-transform-paths" },


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
fix build issues with beta-release build
# Why
<!--- What problem does this change solve? -->
enforces that when we pull the react composites package we make sure that we are only pulling in the public deps to communication react. otherwise the test packages will be included as a result of the new deps from acs-ui-javascript-loaders package
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Built locally