### PR TITLE
[Chat] White spaces handling update for text messages in message components

### DIFF
--- a/change-beta/@azure-communication-react-4a7eb3ab-7f30-4012-9a9a-d8813f2deaf0.json
+++ b/change-beta/@azure-communication-react-4a7eb3ab-7f30-4012-9a9a-d8813f2deaf0.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Chat",
+  "comment": "Update on how the white spaces are handled by message components for text messages",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-4a7eb3ab-7f30-4012-9a9a-d8813f2deaf0.json
+++ b/change-beta/@azure-communication-react-4a7eb3ab-7f30-4012-9a9a-d8813f2deaf0.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "Chat",
-  "comment": "Update on how the white spaces are handled by message components for text messages",
+  "comment": "White spaces handling update for text messages in message components",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@azure-communication-react-4a7eb3ab-7f30-4012-9a9a-d8813f2deaf0.json
+++ b/change/@azure-communication-react-4a7eb3ab-7f30-4012-9a9a-d8813f2deaf0.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Chat",
+  "comment": "Update on how the white spaces are handled by message components for text messages",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-4a7eb3ab-7f30-4012-9a9a-d8813f2deaf0.json
+++ b/change/@azure-communication-react-4a7eb3ab-7f30-4012-9a9a-d8813f2deaf0.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "area": "fix",
   "workstream": "Chat",
-  "comment": "Update on how the white spaces are handled by message components for text messages",
+  "comment": "White spaces handling update for text messages in message components",
   "packageName": "@azure/communication-react",
   "email": "98852890+vhuseinova-msft@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -25,6 +25,7 @@ import { _AttachmentDownloadCardsStrings } from '../Attachment/AttachmentDownloa
 import { AttachmentMetadata } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(data-loss-prevention) */
 import { dataLossIconStyle } from '../styles/MessageThread.styles';
+import { messageTextContentStyles } from '../styles/MessageThread.styles';
 
 type ChatMessageContentProps = {
   message: ChatMessage;
@@ -45,6 +46,7 @@ type MessageContentWithLiveAriaProps = {
   liveMessage: string;
   ariaLabel?: string;
   content: JSX.Element;
+  className?: string;
 };
 
 /**
@@ -91,7 +93,7 @@ export const ChatMessageContent = (props: ChatMessageContentProps): JSX.Element 
 
 const MessageContentWithLiveAria = (props: MessageContentWithLiveAriaProps): JSX.Element => {
   return (
-    <div data-ui-status={props.message.status} role="text" aria-label={props.ariaLabel}>
+    <div data-ui-status={props.message.status} role="text" aria-label={props.ariaLabel} className={props.className}>
       <LiveMessage message={props.liveMessage} ariaLive="polite" />
       {props.content}
     </div>
@@ -115,6 +117,7 @@ const MessageContentAsText = (props: ChatMessageContentProps): JSX.Element => {
       message={props.message}
       liveMessage={generateLiveMessage(props)}
       ariaLabel={messageContentAriaText(props)}
+      className={messageTextContentStyles}
       content={
         <Linkify
           componentDecorator={(decoratedHref: string, decoratedText: string, key: number) => {

--- a/packages/react-components/src/components/styles/MessageThread.styles.ts
+++ b/packages/react-components/src/components/styles/MessageThread.styles.ts
@@ -494,3 +494,8 @@ export const dataLossIconStyle = mergeStyles({
   width: '1.25rem',
   height: '1.25rem'
 });
+
+/** @private */
+export const messageTextContentStyles = mergeStyles({
+  whiteSpace: 'pre-wrap'
+});


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
| Messages | Before the update | After the update |
|------|--------|-------|
| ![image](https://github.com/user-attachments/assets/74324d43-efe0-4228-afc3-f03c05d249a3) | ![image](https://github.com/user-attachments/assets/145c15f2-1ac6-454a-ad15-a62dc66e6368) | ![image](https://github.com/user-attachments/assets/06bab2d5-ce0c-4032-9569-9f9f5bb01e79) |


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->