### PR TITLE
Add more robust checks to composite javascript tests to fix flakey tests

### DIFF
--- a/samples/tests/StaticHtmlComposites/CompositeJavascriptTest.test.ts
+++ b/samples/tests/StaticHtmlComposites/CompositeJavascriptTest.test.ts
@@ -31,7 +31,6 @@ test.describe('JS Bundle Test', () => {
     const user = await createChatThreadAndUsers(PARTICIPANTS);
     const qs = encodeQueryData(user[0]);
     const getTestUrl = (subPageHtml) => `${SERVER_BASE_URL}${subPageHtml}?${qs}`;
-    console.log('TEST URL:', getTestUrl('chatComposite.html'));
     await page.goto(getTestUrl('chatComposite.html'));
 
     expect(await page.waitForSelector('text=Hello to you')).toBeTruthy();

--- a/samples/tests/StaticHtmlComposites/CompositeJavascriptTest.test.ts
+++ b/samples/tests/StaticHtmlComposites/CompositeJavascriptTest.test.ts
@@ -27,7 +27,7 @@ test.describe('JS Bundle Test', () => {
     expect(await page.screenshot()).toMatchSnapshot('callCompositeHtmlCheck.png');
   });
 
-  test.only('Whether html page is loaded correctly with chat composite', async ({ page }) => {
+  test('Whether html page is loaded correctly with chat composite', async ({ page }) => {
     const user = await createChatThreadAndUsers(PARTICIPANTS);
     const qs = encodeQueryData(user[0]);
     const getTestUrl = (subPageHtml) => `${SERVER_BASE_URL}${subPageHtml}?${qs}`;


### PR DESCRIPTION
# What

- Don't wait for 1s, instead wait for selectors

# Why

Fixes #5253 

# How Tested

Ran locally and tests were passing when they weren't, CI will be a better test however