### PR TITLE
Fix deploy command for storybook 8 prod deploy

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -39,10 +39,10 @@ jobs:
         run: rush install --max-install-attempts 3
 
       - name: Build Storybook
-        run: rush build -o storybook
+        run: rush build -o storybook8
 
       - name: Run Storybook tests
-        run: rush test -o storybook
+        run: rush test -o storybook8
 
       - name: Copy .env values
         # storybook requires the env vars to be in a .env file for access in the manager.ts


### PR DESCRIPTION
## What

Ensure storybook8 is built instead of storybook6

## Why

We are migrating to s8, this is just a fix that was missed

## How tested

Cannot test e2e, that'll happen right after beta release