### PR TITLE
Mark adapter.dispose as async, Add dispose option to ignore disposing of the callAgent

### DIFF
--- a/change-beta/@azure-communication-react-0f94f856-0d7e-4f92-9e16-2c58149052ac.json
+++ b/change-beta/@azure-communication-react-0f94f856-0d7e-4f92-9e16-2c58149052ac.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Add option to callAdapter and callWithChatAdapter dispose methods to not dispose of the callAgent",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-7c38ebea-7a13-4fee-8d1d-0cfca4f07642.json
+++ b/change-beta/@azure-communication-react-7c38ebea-7a13-4fee-8d1d-0cfca4f07642.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Update callAdapter.dispose and callWithChatAdapter.dispose to be async to match underlying behavior",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-0f94f856-0d7e-4f92-9e16-2c58149052ac.json
+++ b/change/@azure-communication-react-0f94f856-0d7e-4f92-9e16-2c58149052ac.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Add option to callAdapter and callWithChatAdapter dispose methods to not dispose of the callAgent",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-7c38ebea-7a13-4fee-8d1d-0cfca4f07642.json
+++ b/change/@azure-communication-react-7c38ebea-7a13-4fee-8d1d-0cfca4f07642.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Update callAdapter.dispose and callWithChatAdapter.dispose to be async to match underlying behavior",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1183,7 +1183,10 @@ export interface CallSurveyImprovementSuggestions {
 }
 
 // @public
-export interface CallWithChatAdapter extends CallWithChatAdapterManagement, AdapterState<CallWithChatAdapterState>, Disposable_2, CallWithChatAdapterSubscriptions {
+export interface CallWithChatAdapter extends CallWithChatAdapterManagement, AdapterState<CallWithChatAdapterState>, CallWithChatAdapterSubscriptions {
+    dispose(options?: {
+        doNotDisposeCallAgent?: boolean;
+    }): Promise<void>;
 }
 
 // @public
@@ -2087,7 +2090,10 @@ export type ClientState = CallClientState & ChatClientState;
 export type Common<A, B> = Pick<A, CommonProperties<A, B>>;
 
 // @public
-export interface CommonCallAdapter extends AdapterState<CallAdapterState>, Disposable_2, CallAdapterCallOperations, CallAdapterDeviceManagement, CallAdapterSubscribers {
+export interface CommonCallAdapter extends AdapterState<CallAdapterState>, CallAdapterCallOperations, CallAdapterDeviceManagement, CallAdapterSubscribers {
+    dispose(options?: {
+        doNotDisposeCallAgent?: boolean;
+    }): Promise<void>;
     // @deprecated
     joinCall(microphoneOn?: boolean): void;
     joinCall(options?: JoinCallOptions): void;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -967,7 +967,10 @@ export interface CallSurveyImprovementSuggestions {
 }
 
 // @public
-export interface CallWithChatAdapter extends CallWithChatAdapterManagement, AdapterState<CallWithChatAdapterState>, Disposable_2, CallWithChatAdapterSubscriptions {
+export interface CallWithChatAdapter extends CallWithChatAdapterManagement, AdapterState<CallWithChatAdapterState>, CallWithChatAdapterSubscriptions {
+    dispose(options?: {
+        doNotDisposeCallAgent?: boolean;
+    }): Promise<void>;
 }
 
 // @public
@@ -1801,7 +1804,10 @@ export type ClientState = CallClientState & ChatClientState;
 export type Common<A, B> = Pick<A, CommonProperties<A, B>>;
 
 // @public
-export interface CommonCallAdapter extends AdapterState<CallAdapterState>, Disposable_2, CallAdapterCallOperations, CallAdapterDeviceManagement, CallAdapterSubscribers {
+export interface CommonCallAdapter extends AdapterState<CallAdapterState>, CallAdapterCallOperations, CallAdapterDeviceManagement, CallAdapterSubscribers {
+    dispose(options?: {
+        doNotDisposeCallAgent?: boolean;
+    }): Promise<void>;
     // @deprecated
     joinCall(microphoneOn?: boolean): void;
     joinCall(options?: JoinCallOptions): void;

--- a/packages/react-composites/src/composites/CallComposite/MockCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/MockCallAdapter.ts
@@ -60,7 +60,7 @@ export class _MockCallAdapter implements CallAdapter {
   getState(): CallAdapterState {
     return this.state;
   }
-  dispose(): void {
+  dispose(): Promise<void> {
     throw Error('dispose not implemented');
   }
   joinCall(): Call | undefined {

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -648,10 +648,12 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | TeamsCa
     this.muteAllRemoteParticipants.bind(this);
   }
 
-  public dispose(): void {
+  public async dispose(options?: { doNotDisposeCallAgent?: boolean }): Promise<void> {
     this.resetDiagnosticsForwarder();
     this.callClient.offStateChange(this.onClientStateChange);
-    this.callAgent.dispose();
+    if (!options?.doNotDisposeCallAgent) {
+      await this.callAgent.dispose();
+    }
   }
 
   public async queryCameras(): Promise<VideoDeviceInfo[]> {
@@ -1955,7 +1957,7 @@ function useAzureCommunicationCallAdapterGeneric<
           if (beforeDisposeRef.current) {
             await beforeDisposeRef.current(adapterRef.current);
           }
-          adapterRef.current.dispose();
+          await adapterRef.current.dispose();
           adapterRef.current = undefined;
         }
         let newAdapter: Adapter | undefined = undefined;
@@ -2050,7 +2052,7 @@ function useAzureCommunicationCallAdapterGeneric<
           if (beforeDisposeRef.current) {
             await beforeDisposeRef.current(adapterRef.current);
           }
-          adapterRef.current.dispose();
+          await adapterRef.current.dispose();
           adapterRef.current = undefined;
         }
       })();

--- a/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/CallAdapter.ts
@@ -38,7 +38,7 @@ import { AddPhoneNumberOptions } from '@azure/communication-calling';
 import { DtmfTone } from '@azure/communication-calling';
 import { CommunicationIdentifier } from '@azure/communication-common';
 import type { CommunicationUserIdentifier, PhoneNumberIdentifier } from '@azure/communication-common';
-import type { AdapterState, Disposable, AdapterError, AdapterErrors } from '../../common/adapters';
+import type { AdapterState, AdapterError, AdapterErrors } from '../../common/adapters';
 /* @conditional-compile-remove(breakout-rooms) */
 import type { AdapterNotifications } from '../../common/adapters';
 
@@ -1120,10 +1120,13 @@ export interface CallAdapterCallManagement extends CallAdapterCallOperations {
  */
 export interface CommonCallAdapter
   extends AdapterState<CallAdapterState>,
-    Disposable,
     CallAdapterCallOperations,
     CallAdapterDeviceManagement,
     CallAdapterSubscribers {
+  /**
+   * Dispose of the adapter. This performs cleanup of resources.
+   */
+  dispose(options?: { doNotDisposeCallAgent?: boolean }): Promise<void>;
   /**
    * Join the call with microphone initially on/off.
    * @deprecated Use joinCall(options?:JoinCallOptions) instead.

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -425,14 +425,14 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
     return this.context.getState();
   }
   /** Dispose of the current CallWithChatAdapter. */
-  public dispose(): void {
+  public async dispose(options?: { doNotDisposeCallAgent?: boolean }): Promise<void> {
     this.isAdapterDisposed = true;
     if (this.chatAdapter) {
       this.chatAdapter.offStateChange(this.onChatStateChange);
       this.chatAdapter.dispose();
     }
     this.callAdapter.offStateChange(this.onCallStateChange);
-    this.callAdapter.dispose();
+    await this.callAdapter.dispose(options);
   }
   /** Remove a participant from the Call only. */
   public async removeParticipant(userId: string | CommunicationIdentifier): Promise<void> {
@@ -1299,7 +1299,7 @@ export const useAzureCommunicationCallWithChatAdapter = (
           if (beforeDisposeRef.current) {
             await beforeDisposeRef.current(adapterRef.current);
           }
-          adapterRef.current.dispose();
+          await adapterRef.current.dispose();
           adapterRef.current = undefined;
         }
         if (creatingAdapterRef.current) {
@@ -1349,7 +1349,7 @@ export const useAzureCommunicationCallWithChatAdapter = (
           if (beforeDisposeRef.current) {
             await beforeDisposeRef.current(adapterRef.current);
           }
-          adapterRef.current.dispose();
+          await adapterRef.current.dispose();
           adapterRef.current = undefined;
         }
       })();

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatAdapter.ts
@@ -25,7 +25,7 @@ import {
 } from '../../ChatComposite';
 import { ResourceDetails } from '../../ChatComposite';
 import { CallWithChatAdapterState } from '../state/CallWithChatAdapterState';
-import type { AdapterError, AdapterState, Disposable } from '../../common/adapters';
+import type { AdapterError, AdapterState } from '../../common/adapters';
 import {
   AudioDeviceInfo,
   Call,
@@ -603,8 +603,12 @@ export type ChatInitializedListener = (event: { adapter: CallWithChatAdapter }) 
 export interface CallWithChatAdapter
   extends CallWithChatAdapterManagement,
     AdapterState<CallWithChatAdapterState>,
-    Disposable,
-    CallWithChatAdapterSubscriptions {}
+    CallWithChatAdapterSubscriptions {
+  /**
+   * Dispose of the adapter. This performs cleanup of resources.
+   */
+  dispose(options?: { doNotDisposeCallAgent?: boolean }): Promise<void>;
+}
 
 /**
  * Events fired off by the {@link CallWithChatAdapter}.

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedCallAdapter.ts
@@ -85,7 +85,8 @@ export class CallWithChatBackedCallAdapter implements CallAdapter {
   };
   public getState = (): CallAdapterState =>
     callAdapterStateFromCallWithChatAdapterState(this.callWithChatAdapter.getState());
-  public dispose = (): void => this.callWithChatAdapter.dispose();
+  public dispose = (options?: { doNotDisposeCallAgent?: boolean }): Promise<void> =>
+    this.callWithChatAdapter.dispose(options);
   public joinCall = (options?: boolean | JoinCallOptions): Call | undefined => {
     if (typeof options === 'boolean') {
       return this.callWithChatAdapter.joinCall(options);

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/CallWithChatBackedChatAdapter.ts
@@ -67,7 +67,7 @@ export class CallWithChatBackedChatAdapter implements ChatAdapter {
     await this.callWithChatAdapter.removeParticipant(userId);
   public loadPreviousChatMessages = async (messagesToLoad: number): Promise<boolean> =>
     await this.callWithChatAdapter.loadPreviousChatMessages(messagesToLoad);
-  public dispose = (): void => this.callWithChatAdapter.dispose();
+  public dispose = (): Promise<void> => this.callWithChatAdapter.dispose();
 
   public onStateChange = (handler: (state: ChatAdapterState) => void): void => {
     const convertedHandler = (state: CallWithChatAdapterState): void => {

--- a/packages/react-composites/tests/app/call/LiveApp.tsx
+++ b/packages/react-composites/tests/app/call/LiveApp.tsx
@@ -21,7 +21,9 @@ export function LiveApp(props: { queryArgs: QueryArgs }): JSX.Element {
       setCallAdapter(wrapAdapterForTests(await createCallAdapterWithCredentials(queryArgs)));
     })();
 
-    return () => callAdapter && callAdapter.dispose();
+    return () => {
+      callAdapter && callAdapter.dispose();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queryArgs]);
 


### PR DESCRIPTION
# What

- Mark adapter.dispose as async
- Add dispose option to ignore disposing of the callAgent
- Update useAdapter to await the dispose functions

# Why

If the adapter is created through createadapterWithDeps we should not be disposing of the callAgent. However to remove this would be a breaking change so adding an option to dispose instead.

Marking the dispose as async is a breaking change, but technically this is already performing async behavior so we just need ARB sign off on this. Keeping in draft until ARB sign off.

# How Tested
CI only