### PR TITLE
Remove conditional-compile lines for file-sharing-teams-interop

### DIFF
--- a/common/config/babel/features.js
+++ b/common/config/babel/features.js
@@ -82,8 +82,6 @@ module.exports = {
     "stabilizedDemo",
     // Feature for end call options 
     'end-call-options',
-    // Feature to support file sharing in Teams interoperability chats
-    "file-sharing-teams-interop",
     // Feature for showing notifications
     "notifications",
     // Feature for tracking beta start call identifier

--- a/packages/acs-ui-common/src/common.ts
+++ b/packages/acs-ui-common/src/common.ts
@@ -55,7 +55,6 @@ export function _getKeys<T extends object>(obj: T): (keyof T)[] {
   return Object.keys(obj) as Array<keyof T>;
 }
 
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 /**
  * Data model that represents a chat message attachment
  * where it contains an ID to uniquely identify the attachment,

--- a/packages/chat-component-bindings/src/messageThreadSelector.ts
+++ b/packages/chat-component-bindings/src/messageThreadSelector.ts
@@ -28,11 +28,9 @@ import { createSelector } from 'reselect';
 import { DEFAULT_DATA_LOSS_PREVENTION_POLICY_URL } from './utils/constants';
 import { ACSKnownMessageType } from './utils/constants';
 import { updateMessagesWithAttached } from './utils/updateMessagesWithAttached';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentMetadata } from '@internal/acs-ui-common';
 import { ChatAttachment } from '@azure/communication-chat';
 import type { ChatParticipant } from '@azure/communication-chat';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { ChatAttachmentType } from '@internal/react-components';
 
 const memoizedAllConvertChatMessage = memoizeFnAll(
@@ -60,7 +58,6 @@ const memoizedAllConvertChatMessage = memoizeFnAll(
   }
 );
 
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 const extractAttachmentMetadata = (metadata: Record<string, string>): AttachmentMetadata[] => {
   const attachmentMetadata = metadata.fileSharingMetadata;
   if (!attachmentMetadata) {
@@ -73,7 +70,7 @@ const extractAttachmentMetadata = (metadata: Record<string, string>): Attachment
     return [];
   }
 };
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
+
 const extractTeamsAttachmentsMetadata = (
   rawAttachments: ChatAttachment[]
 ): {
@@ -117,10 +114,10 @@ const convertToUiBlockedMessage = (
   };
 };
 
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 const extractAttachmentUrl = (attachment: ChatAttachment): string => {
   return attachment.previewUrl ? attachment.previewUrl : attachment.url || '';
 };
+
 const processChatMessageContent = (message: ChatMessageWithStatus): string | undefined => {
   let content = message.content?.message;
   if (
@@ -219,7 +216,6 @@ const setImageWidthAndHeight = (img?: HTMLImageElement): void => {
   }
 };
 
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 const extractAttachmentsMetadata = (message: ChatMessageWithStatus): { attachments?: AttachmentMetadata[] } => {
   let attachments: AttachmentMetadata[] = [];
   if (message.metadata) {
@@ -231,6 +227,7 @@ const extractAttachmentsMetadata = (message: ChatMessageWithStatus): { attachmen
   }
   return { attachments: attachments.length > 0 ? attachments : undefined };
 };
+
 const convertToUiChatMessage = (
   message: ChatMessageWithStatus,
   userId: string,
@@ -238,7 +235,6 @@ const convertToUiChatMessage = (
   isLargeGroup: boolean
 ): ChatMessage => {
   const messageSenderId = message.sender !== undefined ? toFlatCommunicationIdentifier(message.sender) : userId;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   const { attachments } = extractAttachmentsMetadata(message);
   return {
     messageType: 'chat',
@@ -254,10 +250,10 @@ const convertToUiChatMessage = (
     deletedOn: message.deletedOn,
     mine: messageSenderId === userId,
     metadata: message.metadata,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
     attachments
   };
 };
+
 const convertToUiSystemMessage = (message: ChatMessageWithStatus): SystemMessage => {
   const systemMessageType = message.type;
   if (systemMessageType === 'participantAdded' || systemMessageType === 'participantRemoved') {

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -1867,7 +1867,7 @@ export type ChatAdapterUiState = {
 };
 
 // @public
-export type ChatAttachmentType = 'unknown' | 'image' | /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */ 'file';
+export type ChatAttachmentType = 'unknown' | 'image' | 'file';
 
 // @public
 export type ChatBaseSelectorProps = {

--- a/packages/communication-react/src/index.ts
+++ b/packages/communication-react/src/index.ts
@@ -349,7 +349,6 @@ export type {
   AttachmentUploadOptions,
   AttachmentUploadTask
 } from '../../react-components/src';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 export type { AttachmentMetadata } from '../../acs-ui-common/src';
 
 /* @conditional-compile-remove(file-sharing-acs) */

--- a/packages/react-components/src/components/Attachment/AttachmentDownloadCards.tsx
+++ b/packages/react-components/src/components/Attachment/AttachmentDownloadCards.tsx
@@ -66,7 +66,7 @@ export interface _AttachmentDownloadCardsProps {
  */
 export const _AttachmentDownloadCards = (props: _AttachmentDownloadCardsProps): JSX.Element => {
   const { attachments, message } = props;
-  const localeStrings = useLocaleStringsTrampoline();
+  const localeStrings = useLocale().strings.messageThread;
   const attachmentCardGroupStyles = useAttachmentCardGroupStyles();
 
   const getMenuActions = useCallback(
@@ -123,13 +123,6 @@ export const _AttachmentDownloadCards = (props: _AttachmentDownloadCardsProps): 
       </_AttachmentCardGroup>
     </div>
   );
-};
-
-/**
- * @private
- */
-const useLocaleStringsTrampoline = (): _AttachmentDownloadCardsStrings => {
-  return useLocale().strings.messageThread;
 };
 
 /**

--- a/packages/react-components/src/components/Attachment/AttachmentDownloadCards.tsx
+++ b/packages/react-components/src/components/Attachment/AttachmentDownloadCards.tsx
@@ -4,7 +4,6 @@
 import { Icon } from '@fluentui/react';
 import React, { useCallback } from 'react';
 import { useMemo } from 'react';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { useLocale } from '../../localization';
 import { _AttachmentCard } from './AttachmentCard';
 import { _AttachmentCardGroup, _AttachmentCardGroupLayout } from './AttachmentCardGroup';
@@ -20,10 +19,7 @@ import { useAttachmentCardGroupStyles } from '../styles/AttachmentCardGroup.styl
  * Represents the type of attachment
  * @public
  */
-export type ChatAttachmentType =
-  | 'unknown'
-  | 'image'
-  | /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */ 'file';
+export type ChatAttachmentType = 'unknown' | 'image' | 'file';
 
 /**
  * Strings of _AttachmentDownloadCards that can be overridden.
@@ -133,14 +129,7 @@ export const _AttachmentDownloadCards = (props: _AttachmentDownloadCardsProps): 
  * @private
  */
 const useLocaleStringsTrampoline = (): _AttachmentDownloadCardsStrings => {
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   return useLocale().strings.messageThread;
-  return {
-    /* @conditional-compile-remove(file-sharing-acs) */
-    downloadAttachment: '',
-    openAttachment: '',
-    attachmentCardGroupMessage: ''
-  };
 };
 
 /**

--- a/packages/react-components/src/components/ChatMessage/ChatMessageComponentWrapper.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageComponentWrapper.tsx
@@ -7,9 +7,7 @@ import { MessageProps, MessageRenderer, MessageThreadStyles, _ChatMessageProps }
 import { ChatMessage, OnRenderAvatarCallback } from '../../types';
 /* @conditional-compile-remove(data-loss-prevention) */
 import { BlockedMessage } from '../../types';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentMenuAction } from '../../types/Attachment';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentMetadata } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { AttachmentMetadataInProgress } from '@internal/acs-ui-common';
@@ -60,9 +58,7 @@ export type ChatMessageComponentWrapperProps = _ChatMessageProps & {
   inlineImageOptions?: InlineImageOptions;
   /* @conditional-compile-remove(mention) */
   mentionOptions?: MentionOptions;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   onRenderAttachmentDownloads?: (message: ChatMessage) => JSX.Element;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /**
    * Optional callback to define custom actions for attachments.
    */

--- a/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
+++ b/packages/react-components/src/components/ChatMessage/ChatMessageContent.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import React from 'react';
-import { _formatString } from '@internal/acs-ui-common';
+import { AttachmentMetadata, _formatString } from '@internal/acs-ui-common';
 import parse, { HTMLReactParserOptions, Element as DOMElement } from 'html-react-parser';
 import { attributesToProps } from 'html-react-parser';
 import Linkify from 'react-linkify';
@@ -21,8 +21,6 @@ import LiveMessage from '../Announcer/LiveMessage';
 import { defaultOnMentionRender } from './MentionRenderer';
 import DOMPurify from 'dompurify';
 import { _AttachmentDownloadCardsStrings } from '../Attachment/AttachmentDownloadCards';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-import { AttachmentMetadata } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(data-loss-prevention) */
 import { dataLossIconStyle } from '../styles/MessageThread.styles';
 import { messageTextContentStyles } from '../styles/MessageThread.styles';
@@ -172,10 +170,7 @@ export const BlockedMessageContent = (props: BlockedMessageContentProps): JSX.El
 };
 
 const extractContentForAllyMessage = (props: ChatMessageContentProps): string => {
-  let attachments = undefined;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-  attachments = props.message.attachments;
-  if (props.message.content || attachments) {
+  if (props.message.content || props.message.attachments) {
     // Replace all <img> tags with 'image' for aria.
     const parsedContent = DOMPurify.sanitize(props.message.content ?? '', {
       ALLOWED_TAGS: ['img'],
@@ -193,8 +188,7 @@ const extractContentForAllyMessage = (props: ChatMessageContentProps): string =>
 
     // Inject message attachment count for aria.
     // this is only applying to file attachments not for inline images.
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-    if (attachments && attachments.length > 0) {
+    if (props.message.attachments && props.message.attachments.length > 0) {
       const attachmentCardDescription = attachmentCardGroupDescription(props);
       const attachmentTextNode = document.createElement('div');
       attachmentTextNode.innerHTML = `${attachmentCardDescription}`;
@@ -232,13 +226,11 @@ const messageContentAriaText = (props: ChatMessageContentProps): string | undefi
       });
 };
 
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 const attachmentCardGroupDescription = (props: ChatMessageContentProps): string => {
   const attachments = props.message.attachments;
   return getAttachmentCountLiveMessage(attachments ?? [], props.strings.attachmentCardGroupMessage);
 };
 
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 /**
  * @private
  */

--- a/packages/react-components/src/components/ChatMessage/MessageComponents/ChatMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/MessageComponents/ChatMessageComponentAsMessageBubble.tsx
@@ -17,10 +17,7 @@ import { ChatMessage } from '../../../types/ChatMessage';
 /* @conditional-compile-remove(data-loss-prevention) */
 import { BlockedMessage } from '../../../types/ChatMessage';
 import { MessageThreadStrings } from '../../MessageThread';
-import { ComponentSlotStyle } from '../../../types';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-import { AttachmentMenuAction } from '../../../types';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
+import { AttachmentMenuAction, ComponentSlotStyle } from '../../../types';
 import { AttachmentMetadata } from '@internal/acs-ui-common';
 import { _AttachmentDownloadCards } from '../../Attachment/AttachmentDownloadCards';
 import { useLocale } from '../../../localization';
@@ -48,12 +45,10 @@ type ChatMessageComponentAsMessageBubbleProps = {
    * Whether to overlap avatar and message when the view is width constrained.
    */
   shouldOverlapAvatarAndMessage: boolean;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /**
    * Optional callback to render message attachments in the message component.
    */
   onRenderAttachmentDownloads?: (message: ChatMessage) => JSX.Element;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /**
    * Optional callback to define custom actions for attachments.
    */
@@ -88,11 +83,9 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
     showDate,
     messageContainerStyle,
     strings,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
     onRenderAttachmentDownloads,
     inlineImageOptions,
     shouldOverlapAvatarAndMessage,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
     actionsForAttachment,
     /* @conditional-compile-remove(mention) */
     mentionDisplayOptions,
@@ -123,17 +116,15 @@ const MessageBubble = (props: ChatMessageComponentAsMessageBubbleProps): JSX.Ele
       inlineImageOptions,
       /* @conditional-compile-remove(mention) */
       mentionDisplayOptions,
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
       onRenderAttachmentDownloads,
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
       actionsForAttachment
     );
   }, [
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */ actionsForAttachment,
+    actionsForAttachment,
     inlineImageOptions,
     /* @conditional-compile-remove(mention) */ mentionDisplayOptions,
     message,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */ onRenderAttachmentDownloads,
+    onRenderAttachmentDownloads,
     strings,
     userId
   ]);

--- a/packages/react-components/src/components/ChatMessage/MessageComponents/FluentChatMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/MessageComponents/FluentChatMessageComponent.tsx
@@ -47,21 +47,13 @@ export const FluentChatMessageComponent = (props: FluentChatMessageComponentWrap
     /* @conditional-compile-remove(date-time-customization) */
     onDisplayDateTimeString,
     inlineImageOptions,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
     actionsForAttachment,
     userId,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
     onRenderAttachmentDownloads,
     /* @conditional-compile-remove(mention) */
     mentionOptions
   } = props;
   const chatMessageRenderStyles = useChatMessageRenderStyles();
-
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-  const onRenderAttachmentDownloadsMemo = useMemo(() => {
-    return onRenderAttachmentDownloads;
-    return undefined;
-  }, [onRenderAttachmentDownloads]);
 
   // To rerender the defaultChatMessageRenderer if app running across days(every new day chat time stamp
   // needs to be regenerated), the dependency on "new Date().toDateString()"" is added.
@@ -74,8 +66,7 @@ export const FluentChatMessageComponent = (props: FluentChatMessageComponentWrap
         return (
           <ChatMessageComponentAsMessageBubble
             {...messageProps}
-            /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-            onRenderAttachmentDownloads={onRenderAttachmentDownloadsMemo}
+            onRenderAttachmentDownloads={onRenderAttachmentDownloads}
             strings={messageProps.strings}
             message={messageProps.message}
             userId={userId}
@@ -83,7 +74,6 @@ export const FluentChatMessageComponent = (props: FluentChatMessageComponentWrap
             /* @conditional-compile-remove(date-time-customization) */
             onDisplayDateTimeString={onDisplayDateTimeString}
             inlineImageOptions={inlineImageOptions}
-            /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
             actionsForAttachment={actionsForAttachment}
             /* @conditional-compile-remove(mention) */
             mentionDisplayOptions={mentionOptions?.displayOptions}
@@ -93,14 +83,12 @@ export const FluentChatMessageComponent = (props: FluentChatMessageComponentWrap
       return <></>;
     },
     [
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-      onRenderAttachmentDownloadsMemo,
+      onRenderAttachmentDownloads,
       userId,
       shouldOverlapAvatarAndMessage,
       /* @conditional-compile-remove(date-time-customization) */
       onDisplayDateTimeString,
       inlineImageOptions,
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
       actionsForAttachment,
       /* @conditional-compile-remove(mention) */
       mentionOptions?.displayOptions

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMessageComponentAsEditBoxPicker.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMessageComponentAsEditBoxPicker.tsx
@@ -5,7 +5,6 @@ import React, { useMemo } from 'react';
 /* @conditional-compile-remove(rich-text-editor) */
 import { Suspense } from 'react';
 import { ChatMessage } from '../../../types';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentMetadata } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(rich-text-editor-image-upload) */
 import { AttachmentMetadataInProgress } from '@internal/acs-ui-common';
@@ -37,11 +36,7 @@ export const loadChatMessageComponentAsRichTextEditBox = (): Promise<{
  */
 export type ChatMessageComponentAsEditBoxPickerProps = {
   onCancel?: (messageId: string) => void;
-  onSubmit: (
-    text: string,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-    attachmentMetadata?: AttachmentMetadata[]
-  ) => void;
+  onSubmit: (text: string, attachmentMetadata?: AttachmentMetadata[]) => void;
   message: ChatMessage;
   strings: MessageThreadStrings;
   /* @conditional-compile-remove(mention) */

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMyMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMyMessageComponent.tsx
@@ -7,9 +7,7 @@ import { MessageThreadStrings, UpdateMessageCallback } from '../../MessageThread
 import { ChatMessage, ComponentSlotStyle, OnRenderAvatarCallback } from '../../../types';
 /* @conditional-compile-remove(data-loss-prevention) */
 import { BlockedMessage } from '../../../types';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentMenuAction } from '../../../types/Attachment';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentMetadata } from '@internal/acs-ui-common';
 /* @conditional-compile-remove(file-sharing-acs) */
 import { MessageOptions } from '@internal/acs-ui-common';
@@ -90,13 +88,11 @@ export type ChatMyMessageComponentProps = {
    * @beta
    */
   inlineImageOptions?: InlineImageOptions;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /**
    * Optional callback to render message attachments in the message component.
    * @beta
    */
   onRenderAttachmentDownloads?: (message: ChatMessage) => JSX.Element;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /**
    * Optional callback to define custom actions for attachments.
    * @beta

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMyMessageComponentAsMessageBubble.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/ChatMyMessageComponentAsMessageBubble.tsx
@@ -20,9 +20,7 @@ import { BlockedMessage } from '../../../types/ChatMessage';
 import { MessageThreadStrings } from '../../MessageThread';
 import { chatMessageActionMenuProps } from '../ChatMessageActionMenu';
 import { ComponentSlotStyle, OnRenderAvatarCallback } from '../../../types';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentMenuAction } from '../../../types/Attachment';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentMetadata } from '@internal/acs-ui-common';
 import { _AttachmentDownloadCards } from '../../Attachment/AttachmentDownloadCards';
 import { useLocale } from '../../../localization';
@@ -83,12 +81,10 @@ type ChatMyMessageComponentAsMessageBubbleProps = {
    * @beta
    */
   inlineImageOptions?: InlineImageOptions;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /**
    * Optional callback to render message attachments in the message component.
    */
   onRenderAttachmentDownloads?: (message: ChatMessage) => JSX.Element;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /**
    * Optional callback to define custom actions for attachments.
    */
@@ -119,9 +115,7 @@ const MessageBubble = (props: ChatMyMessageComponentAsMessageBubbleProps): JSX.E
     /* @conditional-compile-remove(mention) */
     mentionDisplayOptions,
     onDisplayDateTimeString,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
     onRenderAttachmentDownloads,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
     actionsForAttachment
   } = props;
 
@@ -199,17 +193,15 @@ const MessageBubble = (props: ChatMyMessageComponentAsMessageBubbleProps): JSX.E
       inlineImageOptions,
       /* @conditional-compile-remove(mention) */
       mentionDisplayOptions,
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
       onRenderAttachmentDownloads,
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
       actionsForAttachment
     );
   }, [
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */ actionsForAttachment,
+    actionsForAttachment,
     inlineImageOptions,
     /* @conditional-compile-remove(mention) */ mentionDisplayOptions,
     message,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */ onRenderAttachmentDownloads,
+    onRenderAttachmentDownloads,
     strings,
     userId
   ]);

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/FluentChatMyMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/FluentChatMyMessageComponent.tsx
@@ -45,9 +45,7 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
     userId,
     defaultStatusRenderer,
     statusToRender,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
     actionsForAttachment,
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
     onRenderAttachmentDownloads,
     /* @conditional-compile-remove(rich-text-editor) */
     isRichTextEditorEnabled,
@@ -61,14 +59,6 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
     onInsertInlineImage
   } = props;
   const chatMessageRenderStyles = useChatMessageRenderStyles();
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-  const onRenderAttachmentDownloadsMemo = useMemo(() => {
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-    return onRenderAttachmentDownloads;
-    return undefined;
-  }, [
-    /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */ onRenderAttachmentDownloads
-  ]);
 
   // To rerender the defaultChatMessageRenderer if app running across days(every new day chat time stamp
   // needs to be regenerated), the dependency on "new Date().toDateString()"" is added.
@@ -81,9 +71,7 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
         return (
           <ChatMyMessageComponent
             {...messageProps}
-            /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-            onRenderAttachmentDownloads={onRenderAttachmentDownloadsMemo}
-            /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
+            onRenderAttachmentDownloads={onRenderAttachmentDownloads}
             strings={messageProps.strings}
             message={messageProps.message}
             userId={userId}
@@ -98,7 +86,6 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
             inlineImageOptions={inlineImageOptions}
             /* @conditional-compile-remove(mention) */
             mentionOptions={mentionOptions}
-            /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
             actionsForAttachment={actionsForAttachment}
             /* @conditional-compile-remove(rich-text-editor) */
             isRichTextEditorEnabled={isRichTextEditorEnabled}
@@ -127,9 +114,7 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
       inlineImageOptions,
       /* @conditional-compile-remove(mention) */
       mentionOptions,
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-      onRenderAttachmentDownloadsMemo,
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
+      onRenderAttachmentDownloads,
       actionsForAttachment,
       // eslint-disable-next-line react-hooks/exhaustive-deps
       new Date().toDateString(),

--- a/packages/react-components/src/components/MessageThread.tsx
+++ b/packages/react-components/src/components/MessageThread.tsx
@@ -221,7 +221,6 @@ export interface MessageThreadStrings {
   /* @conditional-compile-remove(file-sharing-acs) */
   /** String for download attachment button in attachment card */
   downloadAttachment: string;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /** String for open attachment button in attachment card */
   openAttachment: string;
   /* @conditional-compile-remove(data-loss-prevention) */
@@ -230,7 +229,6 @@ export interface MessageThreadStrings {
   /* @conditional-compile-remove(data-loss-prevention) */
   /** String for policy violation message removal details link */
   blockedWarningLinkText: string;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /** String for aria text in attachment card group*/
   attachmentCardGroupMessage: string;
   /* @conditional-compile-remove(rich-text-editor-image-upload) */

--- a/packages/react-components/src/components/utils/ChatMessageComponentUtils.tsx
+++ b/packages/react-components/src/components/utils/ChatMessageComponentUtils.tsx
@@ -13,9 +13,7 @@ import { MessageThreadStrings } from '../MessageThread';
 /* @conditional-compile-remove(mention) */
 import { MentionDisplayOptions } from '../MentionPopover';
 import { _AttachmentDownloadCards } from '../Attachment/AttachmentDownloadCards';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentMenuAction } from '../../types/Attachment';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 import { AttachmentMetadata } from '@internal/acs-ui-common';
 import { formatTimeForChatMessage, formatTimestampForChatMessage } from './Datetime';
 import { ComponentLocale } from '../../localization/LocalizationProvider';
@@ -43,12 +41,10 @@ export function getMessageBubbleContent(
   inlineImageOptions: InlineImageOptions | undefined,
   /* @conditional-compile-remove(mention) */
   mentionDisplayOptions?: MentionDisplayOptions,
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /**
    * Optional callback to render message attachments in the message component.
    */
   onRenderAttachmentDownloads?: (message: ChatMessage) => JSX.Element,
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /**
    * Optional callback to define custom actions for attachments.
    */
@@ -71,16 +67,14 @@ export function getMessageBubbleContent(
         mentionDisplayOptions={mentionDisplayOptions}
         inlineImageOptions={inlineImageOptions}
       />
-      {
-        /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */ onRenderAttachmentDownloads
-          ? onRenderAttachmentDownloads(message)
-          : defaultOnRenderAttachmentDownloads(
-              message,
-              strings,
-              /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-              actionsForAttachment
-            )
-      }
+      {onRenderAttachmentDownloads
+        ? onRenderAttachmentDownloads(message)
+        : defaultOnRenderAttachmentDownloads(
+            message,
+            strings,
+
+            actionsForAttachment
+          )}
     </div>
   );
 }
@@ -88,22 +82,17 @@ export function getMessageBubbleContent(
 /**
  * Default component for rendering attachment downloads.
  */
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
 const defaultOnRenderAttachmentDownloads = (
   message: ChatMessage | /* @conditional-compile-remove(data-loss-prevention) */ BlockedMessage,
   strings: MessageThreadStrings,
   actionsForAttachment?: (attachment: AttachmentMetadata, message?: ChatMessage) => AttachmentMenuAction[]
 ): JSX.Element | undefined => {
   const attachments = 'attachments' in message ? message.attachments : undefined;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   return (attachments?.length ?? 0) > 0 ? (
     <_AttachmentDownloadCards
       message={message as ChatMessage}
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
       attachments={attachments}
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
       actionsForAttachment={actionsForAttachment}
-      /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
       strings={{
         /* @conditional-compile-remove(file-sharing-acs) */
         downloadAttachment: strings.downloadAttachment,

--- a/packages/react-components/src/theming/icons.tsx
+++ b/packages/react-components/src/theming/icons.tsx
@@ -6,50 +6,72 @@ import { mergeStyles } from '@fluentui/react';
 import { Stack } from '@fluentui/react';
 import {
   ArrowClockwise16Regular,
+  Backspace20Regular,
+  Call20Filled,
   CallEnd20Filled,
+  CallPause20Filled,
+  CallPause20Regular,
   Checkmark20Regular,
   CheckmarkCircle16Regular,
+  ChevronLeft20Regular,
+  ChevronRight20Regular,
   Circle16Regular,
+  ClosedCaption20Regular,
+  ClosedCaptionOff20Regular,
   Delete20Regular,
-  Dismiss20Regular,
   Dismiss16Regular,
+  Dismiss20Regular,
   Edit20Regular,
+  Emoji20Regular,
   ErrorCircle16Regular,
   Eye16Regular,
-  MicOff16Filled,
-  MicOff20Regular,
-  MicOff20Filled,
+  HandRight20Regular,
+  HandRightOff20Regular,
   Mic16Filled,
   Mic20Filled,
   Mic20Regular,
+  MicOff16Filled,
+  MicOff16Regular,
+  MicOff20Filled,
+  MicOff20Regular,
+  MicProhibited16Filled,
   MoreHorizontal20Filled,
   MoreHorizontal20Regular,
+  Open20Regular,
   People20Filled,
-  Settings20Filled,
-  Send20Filled,
-  Send20Regular,
-  ShareScreenStart20Filled,
-  ShareScreenStop20Filled,
-  Speaker220Regular,
-  Video16Filled,
-  Video20Filled,
-  Video20Regular,
-  VideoOff20Filled,
-  ChevronLeft20Regular,
-  ChevronRight20Regular,
-  WifiWarning20Filled,
-  SpeakerMute16Filled,
-  MicProhibited16Filled,
-  VideoProhibited16Filled,
+  People20Regular,
+  PersonDelete20Regular,
+  PersonVoice20Regular,
   Pin16Filled,
   Pin20Filled,
   Pin20Regular,
   PinOff20Regular,
-  ScaleFit20Regular,
+  Play20Regular,
+  Record16Regular,
   ScaleFill20Regular,
-  PersonDelete20Regular
+  ScaleFit20Regular,
+  Send20Filled,
+  Send20Regular,
+  Settings20Filled,
+  Settings20Regular,
+  ShareScreenStart20Filled,
+  ShareScreenStop20Filled,
+  Speaker220Regular,
+  SpeakerMute16Filled,
+  Star28Filled,
+  Star28Regular,
+  Translate20Regular,
+  Video16Filled,
+  Video20Filled,
+  Video20Regular,
+  VideoBackgroundEffect20Filled,
+  VideoBackgroundEffect20Regular,
+  VideoOff20Filled,
+  VideoPersonStar20Filled,
+  VideoPersonStarOff20Filled,
+  VideoProhibited16Filled,
+  WifiWarning20Filled
 } from '@fluentui/react-icons';
-import { MicOff16Regular } from '@fluentui/react-icons';
 /* @conditional-compile-remove(rich-text-editor) */
 import {
   TextBold20Regular,
@@ -67,52 +89,26 @@ import {
   TableAdd20Regular,
   TableDismiss20Regular
 } from '@fluentui/react-icons';
-import { Emoji20Regular } from '@fluentui/react-icons';
-import { Star28Regular, Star28Filled } from '@fluentui/react-icons';
-import { HandRight20Regular, HandRightOff20Regular } from '@fluentui/react-icons';
-import {
-  ClosedCaption20Regular,
-  ClosedCaptionOff20Regular,
-  Settings20Regular,
-  PersonVoice20Regular,
-  Translate20Regular
-} from '@fluentui/react-icons';
 /* @conditional-compile-remove(call-readiness) */
-import { Important20Filled } from '@fluentui/react-icons';
-
-import { Record16Regular } from '@fluentui/react-icons';
+import {
+  Important20Filled,
+  Sparkle20Filled,
+  VideoProhibited20Filled,
+  MicProhibited20Filled
+} from '@fluentui/react-icons';
 /* @conditional-compile-remove(breakout-rooms) */
 import { ConferenceRoom16Regular, DoorArrowLeft16Regular, DoorArrowRight16Regular } from '@fluentui/react-icons';
-
-import { VideoBackgroundEffect20Filled, VideoBackgroundEffect20Regular } from '@fluentui/react-icons';
-
-import { Backspace20Regular } from '@fluentui/react-icons';
-
-/* @conditional-compile-remove(call-readiness) */
-import { Sparkle20Filled, VideoProhibited20Filled, MicProhibited20Filled } from '@fluentui/react-icons';
-
-/* @conditional-compile-remove(file-sharing-teams-interop) */
-import { Open20Regular } from '@fluentui/react-icons';
 /* @conditional-compile-remove(file-sharing-acs) */
 import { ArrowDownload20Regular } from '@fluentui/react-icons';
-import { CallPause20Regular, CallPause20Filled, Play20Regular } from '@fluentui/react-icons';
-import { People20Regular } from '@fluentui/react-icons';
-
 /* @conditional-compile-remove(data-loss-prevention) */
 import { Prohibited16Regular } from '@fluentui/react-icons';
-
 /* @conditional-compile-remove(unsupported-browser) */
 import { Warning20Filled } from '@fluentui/react-icons';
-
-import { VideoPersonStar20Filled, VideoPersonStarOff20Filled } from '@fluentui/react-icons';
-
 import { _pxToRem } from '@internal/acs-ui-common';
-
 import React from 'react';
 import { useTheme } from './FluentThemeProvider';
 /* @conditional-compile-remove(call-readiness) */
 import { sitePermissionIconBackgroundStyle, scaledIconStyles } from './icons.styles';
-import { Call20Filled } from '@fluentui/react-icons';
 
 /**
  * Icons used by the React components exported from this library.
@@ -280,7 +276,6 @@ export const DEFAULT_COMPONENT_ICONS = {
   CancelAttachmentUpload: <Dismiss16Regular />,
   /* @conditional-compile-remove(file-sharing-acs) */
   DownloadAttachment: <ArrowDownload20Regular />,
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   OpenAttachment: <Open20Regular />,
   /* @conditional-compile-remove(file-sharing-acs) */
   AttachmentMoreMenu: <MoreHorizontal20Filled />,

--- a/packages/react-components/src/types/ChatMessage.ts
+++ b/packages/react-components/src/types/ChatMessage.ts
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { MessageStatus } from '@internal/acs-ui-common';
+import { AttachmentMetadata, MessageStatus } from '@internal/acs-ui-common';
 import { CommunicationParticipant } from './CommunicationParticipant';
-/* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
-import { AttachmentMetadata } from '@internal/acs-ui-common';
 
 /**
  * Indicate whether a chat message should be displayed merged with the message before / after it.
@@ -71,7 +69,6 @@ export interface ChatMessage extends MessageCommon {
    * {@link @azure/communication-chat#ChatMessage.metadata}
    */
   metadata?: Record<string, string>;
-  /* @conditional-compile-remove(file-sharing-teams-interop) @conditional-compile-remove(file-sharing-acs) */
   /**
    * A list of attachments in the message.
    * {@link AttachmentMetadata}


### PR DESCRIPTION
# What

Remove conditional-compile lines for file-sharing-teams-interop

# Why

Housekeeping. Cleaning up lines now that feature is in stable release

# How Tested

CI only