### PR TITLE
Add rush update:beta

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -85,6 +85,14 @@
     },
     {
       "commandKind": "global",
+      "name": "update:beta",
+      "summary": "Update dependencies to beta versions.",
+      "description": "Update dependencies to beta versions.",
+      "shellCommand": "rush update",
+      "safeForSimultaneousRushProcesses": true
+    },
+    {
+      "commandKind": "global",
       "name": "update:all-flavors",
       "summary": "Update dependencies for all flavors",
       "description": "Update dependencies for all flavors.",
@@ -113,6 +121,14 @@
       "summary": "SHORTNAME: update:stable",
       "description": "SHORTNAME: update:stable",
       "shellCommand": "rush update:stable",
+      "safeForSimultaneousRushProcesses": true
+    },
+    {
+      "commandKind": "global",
+      "name": "ub",
+      "summary": "SHORTNAME: update:beta",
+      "description": "SHORTNAME: update:beta",
+      "shellCommand": "rush update:beta",
       "safeForSimultaneousRushProcesses": true
     },
     {

--- a/docs/contributing-guide/1. getting-set-up.md
+++ b/docs/contributing-guide/1. getting-set-up.md
@@ -34,17 +34,21 @@ git clone git@github.com:Azure/communication-ui-library.git
 
 ### Installing dependencies
 
-Navigate to your cloned repo and install dependencies for all packages and samples:
+Navigate to your cloned repo and install dependencies for all packages and samples. This may take a long time the first time it runs.
 
 ```bash
 # navigate to the repository
 cd communication-ui-library/
 
 # install dependencies
-rush update
+rush update:beta
 ```
 
-> note: this may take a long time the first time it runs
+This repository uses two build flavors: `beta` and `stable`. These correspond to the `beta` and `stable` npm packages we release. To switch between the two, you can run `rush switch-flavor:stable` or `rush switch-flavor:beta`. These `switch-flavor` commands will perform the appropriate `rush update:stable` or `rush update:beta`.
+
+`rush update` command is also available as this is a default rush command we cannot remove. We recommend using `rush update:beta` or `rush update:stable` instead to be explicit about the flavor you are updating.
+
+> NOTE: When intaking new changes from main, you will often need to reupdate the installed packages. This should be done by running `rush update:beta` or `rush update:stable` depending on the flavor you are using.
 
 # FAQ
 If you are running into issues such as "Filename too long" when setting up the repo.

--- a/docs/contributing-guide/6. submitting-a-pr.md
+++ b/docs/contributing-guide/6. submitting-a-pr.md
@@ -23,14 +23,17 @@ If you are adding/updating dependencies in any package.json file, you will need 
 
 For beta:
 ```bash
-rush update
+rush update:beta
 ```
 
 For stable:
 ```bash
 rush update:stable
 ```
+
 These commands will update your dependencies locally and update the pnpm-lock.yaml. You may wish to install the correct dependencies for your current flavor (by default, run `rush switch-flavor:beta` again for switching back to beta flavor).
+
+> Note: `rush update` command is also available as this is a default rush command we cannot remove. We recommend using `rush update:beta` or `rush update:stable` instead to be explicit about the flavor you are updating.
 
 #### 2. Update package API files
 

--- a/docs/infrastructure/rush.md
+++ b/docs/infrastructure/rush.md
@@ -47,7 +47,7 @@ Ultimately with Rush we could get all the features we were looking for in our re
 
 For those familiar with running `npm` commands or `yarn` commands, we have a series of `rush` commands that replace most that should be run instead:
 
-* `npm install` --> `rush update`
+* `npm install` --> `rush update:beta` or `rush update:stable`
 * `npm install "package"` --> `rush add -p "package"` (add `--dev` to save to dev dependencies)
 * `npm run build` --> `rush build` (from anywhere), `rush build -t "package-name"` (from anywhere) or `rushx build` (from a package or sample directory)
 * `npm run start` --> `rushx start`
@@ -56,8 +56,8 @@ For those familiar with running `npm` commands or `yarn` commands, we have a ser
 
 Other useful commands
 
-* `rush update` -- run this anytime you pull new changes that have changed any package.json
-* `rush update -p` -- performs a purge before update
+* `rush update:beta` or `rush update:stable` -- run this anytime you pull new changes that have changed any package.json
+* `rush update:beta -p` -- performs a purge before update
 * `rush rebuild` -- performs a full build instead of an incremental build
 * `rush lint` -- perform lint across the whole repo
 * `rush changelog` -- generate change file for the changelog
@@ -67,7 +67,7 @@ Short commands
 * `rush sb` --> `rush switch-flavor:beta`
 * `rush sbr` --> `rush switch-flavor:beta-release`
 * `rush ss` --> `rush switch-flavor:stable`
-* `rush u` --> `rush update`
+* `rush ub` --> `rush update:beta`
 * `rush us` --> `rush update:stable`
 * `rush baf` --> `rush build:all-flavours`
 * `rush bapi` --> `rush build-api:all-flavors`

--- a/packages/react-composites/tests/README.md
+++ b/packages/react-composites/tests/README.md
@@ -36,7 +36,7 @@ PLAYWRIGHT_OUTPUT_DIR = "temp"
   ```sh
   rush update; rush build -t .
   ```
-  (if there were some build failures, run `rush update -p`)
+  (if there were some build failures, run `rush update:beta -p`)
 * Build the test applications.
   ```sh
   rushx build:e2e

--- a/samples/StaticHtmlComposites/README.md
+++ b/samples/StaticHtmlComposites/README.md
@@ -19,12 +19,14 @@ This sample shows how to embed the ready-to-use Calling, Chat, and CallWithChat 
 ## Commands
 
 ### Install dependencies
-```
-rush update
+
+```sh
+rush update:beta
 ```
 
 ### Bundle the app
-```
+
+```sh
 rushx build
 ```
 


### PR DESCRIPTION
# What

- Add rush update:beta
- Update documentation to use `update:beta` instead of `update`

# Why

We've had confusion from local development flavors. We are encouraging these explicit commands help ensure that developers do not update the wrong flavor.

Tried using `RUSH_VARIANT` as well to allow rush update to detect the flavor and update the current variant when `rush update` is called but there is no way to ensure that env var is set after switching flavor (in the case where someone opens a new terminal window) so this is not a good solution

# How Tested

Ran locally