### PR TITLE
[a11y][bugfix] Remove unnecessary disabled prop from label for contrast requirement

### DIFF
--- a/change-beta/@azure-communication-react-0a7c2e93-9abf-4776-879f-87c5f9fd9271.json
+++ b/change-beta/@azure-communication-react-0a7c2e93-9abf-4776-879f-87c5f9fd9271.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Remove unnecessary disabled prop from label",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-0a7c2e93-9abf-4776-879f-87c5f9fd9271.json
+++ b/change/@azure-communication-react-0a7c2e93-9abf-4776-879f-87c5f9fd9271.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Remove unnecessary disabled prop from label",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
@@ -248,7 +248,6 @@ export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element
             <Label
               id={'call-composite-local-camera-settings-label'}
               className={mergeStyles(dropDownStyles(theme).label)}
-              disabled={!cameraPermissionGranted} // follows dropdown disabled state
             >
               {cameraLabel}
             </Label>
@@ -278,7 +277,6 @@ export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element
         <Label
           id={'call-composite-local-sound-settings-label'}
           className={mergeStyles(dropDownStyles(theme).label)}
-          disabled={!micPermissionGranted} // follows Start button disabled state in ConfigurationPage
         >
           {soundLabel}
         </Label>

--- a/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
@@ -274,10 +274,7 @@ export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element
         </Stack>
       )}
       <Stack>
-        <Label
-          id={'call-composite-local-sound-settings-label'}
-          className={mergeStyles(dropDownStyles(theme).label)}
-        >
+        <Label id={'call-composite-local-sound-settings-label'} className={mergeStyles(dropDownStyles(theme).label)}>
           {soundLabel}
         </Label>
         <Stack data-ui-id="call-composite-sound-settings" tokens={soundStackTokens}>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Removed disabled prop for proper contrasted labels
<img width="795" alt="image" src="https://github.com/user-attachments/assets/25928ec6-157e-432c-b3a4-7ea3f7c4da62">


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Labels did not meet required contrast requirements
![image](https://github.com/user-attachments/assets/b75a8a7c-0a30-4e0e-aa26-0817c62e7995)
https://skype.visualstudio.com/SPOOL/_workitems/edit/3911558 

# How Tested
<!--- How did you test your change. What tests have you added. -->
Calling sample, macOS Chrome

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->