### PR TITLE
[a11y][bugfix] Add announcements to hold screen and attempting to reconnect screen

### DIFF
--- a/change-beta/@azure-communication-react-6c93277e-53fd-4565-bfd7-09aa7c8c10e1.json
+++ b/change-beta/@azure-communication-react-6c93277e-53fd-4565-bfd7-09aa7c8c10e1.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "a11y",
+  "comment": "Add announcements to hold screen and attempting to reconnect screen",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-6c93277e-53fd-4565-bfd7-09aa7c8c10e1.json
+++ b/change/@azure-communication-react-6c93277e-53fd-4565-bfd7-09aa7c8c10e1.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "a11y",
+  "comment": "Add announcements to hold screen and attempting to reconnect screen",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/HoldPane.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/HoldPane.tsx
@@ -60,7 +60,7 @@ export const HoldPane = (): JSX.Element => {
     <Stack styles={paneStyles}>
       <Stack horizontal styles={holdPaneContentStyles}>
         <Text styles={holdPaneTimerStyles}>{elapsedTime}</Text>
-        <Text styles={holdPaneLabelStyles} role="status" aria-live="assertive">
+        <Text styles={holdPaneLabelStyles} role="alert" aria-live="assertive">
           {strings.holdScreenLabel}
         </Text>
         <PrimaryButton

--- a/packages/react-composites/src/composites/CallComposite/components/NetworkReconnectTile.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/NetworkReconnectTile.tsx
@@ -68,18 +68,24 @@ export const NetworkReconnectTile = (props: NetworkReconnectTileProps): JSX.Elem
           className={mergeStyles(containerStyle)}
           aria-atomic
         >
-          <Stack horizontal className={mergeStyles(titleContainerStyle)}>
-            <CallCompositeIcon
-              iconName="NetworkReconnectIcon"
-              className={mergeStyles(titleStyle(palette, isVideoReady))}
-            />
-            <Text className={mergeStyles(titleStyle(palette, isVideoReady))} aria-live={'assertive'}>
-              {strings.networkReconnectTitle}
+          <Stack
+            role="alert"
+            verticalFill
+            horizontalAlign="center"
+            verticalAlign="center"
+            className={mergeStyles(containerStyle)}
+          >
+            <Stack horizontal className={mergeStyles(titleContainerStyle)}>
+              <CallCompositeIcon
+                iconName="NetworkReconnectIcon"
+                className={mergeStyles(titleStyle(palette, isVideoReady))}
+              />
+              <Text className={mergeStyles(titleStyle(palette, isVideoReady))}>{strings.networkReconnectTitle}</Text>
+            </Stack>
+            <Text className={mergeStyles(moreDetailsStyle(palette, isVideoReady))}>
+              {strings.networkReconnectMoreDetails}
             </Text>
           </Stack>
-          <Text className={mergeStyles(moreDetailsStyle(palette, isVideoReady))} aria-live={'assertive'}>
-            {strings.networkReconnectMoreDetails}
-          </Text>
           {isTeamsMeeting && meetingCoordinates && meetingCoordinates[0] && (
             <Stack>
               <Stack horizontal horizontalAlign="center" verticalAlign="center" className={titleContainerClassName}>

--- a/packages/react-composites/src/composites/CallComposite/components/NetworkReconnectTile.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/NetworkReconnectTile.tsx
@@ -10,6 +10,7 @@ import { Icon } from '@fluentui/react';
 import { useLocale } from '../../localization';
 import {
   containerStyle,
+  headerContainerStyle,
   moreDetailsStyle,
   titleContainerStyle,
   titleStyle
@@ -73,7 +74,7 @@ export const NetworkReconnectTile = (props: NetworkReconnectTileProps): JSX.Elem
             verticalFill
             horizontalAlign="center"
             verticalAlign="center"
-            className={mergeStyles({ gap: `1.5rem` })}
+            className={mergeStyles(headerContainerStyle)}
           >
             <Stack horizontal className={mergeStyles(titleContainerStyle)}>
               <CallCompositeIcon

--- a/packages/react-composites/src/composites/CallComposite/components/NetworkReconnectTile.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/NetworkReconnectTile.tsx
@@ -73,7 +73,7 @@ export const NetworkReconnectTile = (props: NetworkReconnectTileProps): JSX.Elem
             verticalFill
             horizontalAlign="center"
             verticalAlign="center"
-            className={mergeStyles(containerStyle)}
+            className={mergeStyles({ gap: `1.5rem` })}
           >
             <Stack horizontal className={mergeStyles(titleContainerStyle)}>
               <CallCompositeIcon

--- a/packages/react-composites/src/composites/CallComposite/styles/NetworkReconnectTile.styles.ts
+++ b/packages/react-composites/src/composites/CallComposite/styles/NetworkReconnectTile.styles.ts
@@ -15,6 +15,14 @@ export const containerStyle: IStyle = {
 /**
  * @private
  */
+export const headerContainerStyle: IStyle = {
+  gap: `1.5rem`,
+  height: `auto`
+};
+
+/**
+ * @private
+ */
 export const titleContainerStyle: IStyle = {
   gap: `1rem`
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add announcements to these two screens for accessibility reasons

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->