### PR TITLE
[Bugfix A11y] Add aria descriptions to react, and raise buttons

### DIFF
--- a/change-beta/@azure-communication-react-9d8a539c-35da-4ba2-b3a5-7737dd5a08c2.json
+++ b/change-beta/@azure-communication-react-9d8a539c-35da-4ba2-b3a5-7737dd5a08c2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "add aria descriptions to reaction and raise buttons",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-9d8a539c-35da-4ba2-b3a5-7737dd5a08c2.json
+++ b/change/@azure-communication-react-9d8a539c-35da-4ba2-b3a5-7737dd5a08c2.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "add aria descriptions to reaction and raise buttons",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/RaiseHandButton.tsx
+++ b/packages/react-components/src/components/RaiseHandButton.tsx
@@ -73,6 +73,8 @@ export const RaiseHandButton = (props: RaiseHandButtonProps): JSX.Element => {
       onRenderOffIcon={props.onRenderOffIcon ?? onRenderRaiseHandIcon}
       strings={strings}
       labelKey={props.labelKey ?? 'raiseHandButtonLabel'}
+      aria-label={props.checked ? strings.onLabel : strings.offLabel}
+      aria-description={props.checked ? strings.tooltipOnContent : strings.tooltipOffContent}
       disabled={props.disabled}
     />
   );

--- a/packages/react-components/src/components/ReactionButton.tsx
+++ b/packages/react-components/src/components/ReactionButton.tsx
@@ -164,6 +164,7 @@ export const ReactionButton = (props: ReactionButtonProps): JSX.Element => {
                       className={classname}
                       styles={reactionItemButtonStyles}
                       aria-label={emojiButtonTooltip.get(emoji)}
+                      aria-description={strings.tooltipContent}
                     ></DefaultButton>
                   </TooltipHost>
                 );


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
add aria descriptions to reaction and raise buttons
# Why
<!--- What problem does this change solve? -->
announces more information about what the buttons do based on their tooltip information
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3905978
# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated locally