### PR TITLE
Update configuration page local preview to show 'Video is loading'

### DIFF
--- a/change-beta/@azure-communication-react-39a1ed7f-9d32-4307-bd13-abfd4dfd65ae.json
+++ b/change-beta/@azure-communication-react-39a1ed7f-9d32-4307-bd13-abfd4dfd65ae.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Update configuration page local preview to show 'Video is loading' while camera is switching on or switching source. Also disable camera button while swiching source.",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-39a1ed7f-9d32-4307-bd13-abfd4dfd65ae.json
+++ b/change/@azure-communication-react-39a1ed7f-9d32-4307-bd13-abfd4dfd65ae.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Update configuration page local preview to show 'Video is loading' while camera is switching on or switching source. Also disable camera button while swiching source.",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -843,6 +843,7 @@ export interface CallCompositeStrings {
     complianceBannerTranscriptionStarted: string;
     complianceBannerTranscriptionStopped: string;
     configurationPageCallDetails?: string;
+    configurationPageCameraIsLoadingLabel?: string;
     configurationPageTitle: string;
     configurationPageVideoEffectsButtonLabel?: string;
     copyInviteLinkActionedAriaLabel: string;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -651,6 +651,7 @@ export interface CallCompositeStrings {
     complianceBannerTranscriptionStarted: string;
     complianceBannerTranscriptionStopped: string;
     configurationPageCallDetails?: string;
+    configurationPageCameraIsLoadingLabel?: string;
     configurationPageTitle: string;
     configurationPageVideoEffectsButtonLabel?: string;
     copyInviteLinkActionedAriaLabel: string;

--- a/packages/react-composites/src/composites/CallComposite/Strings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/Strings.tsx
@@ -369,6 +369,11 @@ export interface CallCompositeStrings {
   /**
    * Label for the button to open effects
    */
+  configurationPageCameraIsLoadingLabel?: string;
+
+  /**
+   * Label for the button to open effects
+   */
   configurationPageVideoEffectsButtonLabel?: string;
 
   /**

--- a/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
@@ -168,10 +168,10 @@ export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element
               : ''
           : 'deniedOrUnknown'
       }
-      onChange={(event, option, index) => {
+      onChange={async (event, option, index) => {
         const camera = props.cameras[index ?? 0];
         if (camera) {
-          props.onSelectCamera(camera, localVideoViewOptions);
+          await props.onSelectCamera(camera, localVideoViewOptions);
         } else {
           console.error('No cameras available');
         }

--- a/packages/react-composites/src/composites/CallComposite/components/LocalPreview.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LocalPreview.tsx
@@ -9,7 +9,8 @@ import {
   DevicesButton,
   StreamMedia,
   useTheme,
-  VideoTile
+  VideoTile,
+  VideoStreamOptions
 } from '@internal/react-components';
 import React, { useCallback } from 'react';
 import { CallCompositeIcon } from '../../common/icons';
@@ -35,6 +36,8 @@ import {
 export interface LocalPreviewProps {
   mobileView: boolean;
   showDevicesButton: boolean;
+  onToggleCamera: (options?: VideoStreamOptions | undefined) => Promise<void>;
+  cameraLoading?: boolean;
 }
 
 /**
@@ -63,6 +66,10 @@ export const LocalPreview = (props: LocalPreviewProps): JSX.Element => {
   const hasCameras = devicesButtonProps.cameras.length > 0;
   const hasMicrophones = devicesButtonProps.microphones.length > 0;
 
+  const cameraLoadingString =
+    locale.strings.call.configurationPageCameraIsLoadingLabel ?? locale.strings.call.cameraTurnedOff;
+  const previewCameraString = props.cameraLoading ? cameraLoadingString : locale.strings.call.cameraTurnedOff;
+
   const theme = useTheme();
   const onRenderPlaceholder = useCallback((): JSX.Element => {
     return (
@@ -85,12 +92,12 @@ export const LocalPreview = (props: LocalPreviewProps): JSX.Element => {
         </Stack.Item>
         <Stack.Item align="center">
           <Text className={mergeStyles(cameraOffLabelStyle, { color: theme.palette.neutralSecondary })}>
-            {locale.strings.call.cameraTurnedOff}
+            {previewCameraString}
           </Text>
         </Stack.Item>
       </Stack>
     );
-  }, [theme, locale.strings.call.cameraTurnedOff]);
+  }, [theme, previewCameraString]);
 
   const devicesButtonStyles = props.mobileView
     ? {
@@ -130,8 +137,9 @@ export const LocalPreview = (props: LocalPreviewProps): JSX.Element => {
           <CameraButton
             data-ui-id="call-composite-local-device-settings-camera-button"
             {...cameraButtonProps}
+            onToggleCamera={props.onToggleCamera}
             showLabel={true}
-            disabled={!cameraPermissionGranted || !hasCameras}
+            disabled={!cameraPermissionGranted || !hasCameras || props.cameraLoading}
             // disable tooltip as it obscures list of devices on mobile
             strings={
               props.mobileView

--- a/packages/react-composites/src/composites/localization/locales/en-US/strings.json
+++ b/packages/react-composites/src/composites/localization/locales/en-US/strings.json
@@ -27,6 +27,7 @@
     "videoEffectsPaneTitle": "Effects",
     "videoEffectsPaneBackgroundSelectionTitle": "Background",
     "videoEffectsPaneAriaLabel": "Video effects pane",
+    "configurationPageCameraIsLoadingLabel": "Video is loading...",
     "configurationPageVideoEffectsButtonLabel": "Effects",
     "unableToStartVideoEffect": "Unable to apply video effect.",
     "blurBackgroundEffectButtonLabel": "Blur",


### PR DESCRIPTION
# What

Update configuration page local preview to show 'Video is loading' while camera is switching on or switching source. Also disable camera button while swiching source.

# Why

Bug. When it takes a while to turn on camera or switch source, its confusing to just see camera is off and no disabled button

# How Tested

https://github.com/user-attachments/assets/83fb6cd0-c759-42f1-aace-22a632bda147


