### PR TITLE
Fix console error that requested teams conference details in unsupported calls

### DIFF
--- a/change-beta/@azure-communication-react-6705e3b1-5b5a-424e-831b-0c4dbd341e8c.json
+++ b/change-beta/@azure-communication-react-6705e3b1-5b5a-424e-831b-0c4dbd341e8c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Fix console error that requested teams conference details in unsupported calls",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-6705e3b1-5b5a-424e-831b-0c4dbd341e8c.json
+++ b/change/@azure-communication-react-6705e3b1-5b5a-424e-831b-0c4dbd341e8c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Fix console error that requested teams conference details in unsupported calls",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/src/CallSubscriber.ts
+++ b/packages/calling-stateful-client/src/CallSubscriber.ts
@@ -34,6 +34,7 @@ import { BreakoutRoomsSubscriber } from './BreakoutRoomsSubscriber';
 import { TogetherModeSubscriber } from './TogetherModeSubscriber';
 /* @conditional-compile-remove(media-access) */
 import { MediaAccessSubscriber } from './MediaAccessSubscriber';
+import { _isTeamsMeeting } from './TypeGuards';
 
 /**
  * Keeps track of the listeners assigned to a particular call because when we get an event from SDK, it doesn't tell us
@@ -301,7 +302,7 @@ export class CallSubscriber {
   };
 
   private initTeamsMeetingConference = (): void => {
-    if (this._call.state === 'Connected') {
+    if (this._call.state === 'Connected' && _isTeamsMeeting(this._call)) {
       this._call
         .feature(Features.TeamsMeetingAudioConferencing)
         .getTeamsMeetingAudioConferencingDetails()

--- a/packages/calling-stateful-client/src/TypeGuards.ts
+++ b/packages/calling-stateful-client/src/TypeGuards.ts
@@ -45,3 +45,10 @@ export const _isTeamsIncomingCall = (call: IncomingCallCommon): boolean => {
 export const _isACSIncomingCall = (call: IncomingCallCommon): boolean => {
   return call.kind === 'IncomingCall';
 };
+
+/**
+ * @internal
+ */
+export const _isTeamsMeeting = (call: CallCommon): boolean => {
+  return 'info' in call && !!call.info.threadId;
+};


### PR DESCRIPTION
# What

Check if the call is a teams call when trying to get the conference details

# Why

Fix console error that requested teams conference details in unsupported calls

# How Tested

Ran locally, no error in ACS group calls, Teams meeting conference details still work

![image](https://github.com/user-attachments/assets/4f7bd567-79fa-4f83-8dd2-e69baee06e80)
