### PR TITLE
Use a github repo variable to dictate the ubuntu version runners run on

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build and publish alpha package
     environment:
       name: npm-alpha
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -19,7 +19,7 @@ jobs:
   # get matrix for ci-jobs
   get_matrix:
     name: Load CI Matrix Details
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
@@ -39,7 +39,7 @@ jobs:
   check_breaking_changes:
     needs: get_matrix
     name: 'Check Breaking Changes (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   # get matrix for ci-jobs
   get_matrix:
     name: Load CI Matrix Details
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
     steps:
@@ -43,7 +43,7 @@ jobs:
   build_packages:
     needs: get_matrix
     name: 'Build Packages (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
     steps:
@@ -123,7 +123,7 @@ jobs:
   jest-test-coverage:
     needs: [get_matrix, build_packages]
     name: 'Jest Test Coverage (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       pull-requests: write
     strategy:
@@ -220,7 +220,7 @@ jobs:
     name: Check if in progress feature can be removed separately (${{ matrix.flavor }})
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE so job can access it
       - uses: actions/checkout@v4
@@ -269,7 +269,7 @@ jobs:
   call_composite_automation_test:
     needs: get_matrix
     name: 'Call Composite automation test (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       pull-requests: write
     strategy:
@@ -336,7 +336,7 @@ jobs:
   chat_composite_automation_test:
     needs: get_matrix
     name: 'Chat Composite automation test (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       pull-requests: write
     strategy:
@@ -403,7 +403,7 @@ jobs:
   call_with_chat_composite_automation_test:
     needs: get_matrix
     name: 'Call With Chat Composite automation test (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       pull-requests: write
     strategy:
@@ -469,7 +469,7 @@ jobs:
   components_automation_test:
     needs: get_matrix
     name: 'Components automation test (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       pull-requests: write
     strategy:
@@ -527,7 +527,7 @@ jobs:
     name: Build Storybook v8 (${{ matrix.flavor }})
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -556,7 +556,7 @@ jobs:
   build_calling_sample:
     needs: get_matrix
     name: 'Build Calling Sample (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
     steps:
@@ -588,7 +588,7 @@ jobs:
   build_chat_sample:
     needs: get_matrix
     name: 'Build Chat Sample (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
     steps:
@@ -620,7 +620,7 @@ jobs:
   build_call_with_chat_sample:
     needs: get_matrix
     name: 'Build CallWithChat Sample (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
     steps:
@@ -652,7 +652,7 @@ jobs:
   build_calling_stateful_samples:
     needs: get_matrix
     name: 'Build Calling Stateful Samples (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
     steps:
@@ -678,7 +678,7 @@ jobs:
   build_static_html_composites_sample:
     needs: get_matrix
     name: 'Build And Test Static HTML Composites Sample (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       pull-requests: write
     strategy:
@@ -728,7 +728,7 @@ jobs:
   build_component_examples:
     needs: get_matrix
     name: 'Build And Test Component+Binding Examples (${{ matrix.flavor }})'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       pull-requests: write
     strategy:
@@ -776,7 +776,7 @@ jobs:
             })
 
   compare_base_bundle_stats:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       pull-requests: write
     if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.base.ref, 'release/') }}
@@ -858,7 +858,7 @@ jobs:
           fi
           echo "Bundle size diff for $app is below the threshold of $significantBundleSizeThreshold. All is good!"
   update_base_bundle_report:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     name: Upload bundle size report to gist - ${{ matrix.app }}
     needs: [build_calling_sample, build_chat_sample, build_call_with_chat_sample]
     if: github.ref == 'refs/heads/main'
@@ -886,7 +886,7 @@ jobs:
           file_path: report.json
 
   check_failure:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       issues: write
     needs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/create-api-view-feature-level.yml
+++ b/.github/workflows/create-api-view-feature-level.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE so job can access it

--- a/.github/workflows/create-prerelease-branch.yml
+++ b/.github/workflows/create-prerelease-branch.yml
@@ -31,7 +31,7 @@ jobs:
   # create pre-release branch for beta releases
   create_pre-release:
     name: Bump versions and make changelog for release
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     steps:
       # Check-out repo

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -18,7 +18,7 @@ jobs:
   create_release:
     if: ${{ startsWith(github.event.inputs.branch, 'prerelease') }}
     name: Create release branch
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     steps:
       # Check-out repo

--- a/.github/workflows/deploy-azure-webapps.yml
+++ b/.github/workflows/deploy-azure-webapps.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   build-and-deploy-samples:
     name: Build and Deploy samples
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       # Needed for Azure login
       id-token: write
@@ -95,7 +95,7 @@ jobs:
           package: ./samples/CallWithChat/dist
 
   check_failure:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       issues: write
     needs: [build-and-deploy-samples]

--- a/.github/workflows/deploy-feature-azure-webapps.yml
+++ b/.github/workflows/deploy-feature-azure-webapps.yml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   calling:
     name: Build and Deploy Calling App
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       # Needed for Azure login
       id-token: write
@@ -56,7 +56,7 @@ jobs:
 
   chat:
     name: Build and Deploy Chat App
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       # Needed for Azure login
       id-token: write
@@ -98,7 +98,7 @@ jobs:
 
   callwithchat:
     name: Build and Deploy CallWithChat App
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       # Needed for Azure login
       id-token: write

--- a/.github/workflows/deploy-release-azure-webapps.yml
+++ b/.github/workflows/deploy-release-azure-webapps.yml
@@ -18,7 +18,7 @@ permissions: read-all
 jobs:
   calling:
     name: Build and Deploy Calling App
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       # Needed for Azure login
       id-token: write
@@ -66,7 +66,7 @@ jobs:
 
   chat:
     name: Build and Deploy Chat App
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       # Needed for Azure login
       id-token: write
@@ -114,7 +114,7 @@ jobs:
 
   callwithchat:
     name: Build and Deploy CallWithChat App
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       # Needed for Azure login
       id-token: write

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build-and-deploy-storybook:
     name: Build and Deploy Storybook
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: # permissions needed for the deploy-storybook script
       pages: write
       id-token: write

--- a/.github/workflows/nightly-cd.yml
+++ b/.github/workflows/nightly-cd.yml
@@ -20,7 +20,7 @@ jobs:
     name: Check for new changes
     outputs:
       hasChanged: ${{ steps.checkChange.outputs.hasChanged }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     steps:
       # Check-out repo
@@ -61,7 +61,7 @@ jobs:
     environment:
       name: npm-alpha
     if: needs.checkForChanges.outputs.hasChanged == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       contents: write
       id-token: write
@@ -187,7 +187,7 @@ jobs:
           exit 1
 
   check_failure:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       issues: write
     needs: release

--- a/.github/workflows/npm-release-publish.yml
+++ b/.github/workflows/npm-release-publish.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   job-inputs:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     steps:
       - name: Set branch name
@@ -45,7 +45,7 @@ jobs:
       name: npm
       url: https://www.npmjs.com/package/@azure/communication-react
     name: Publish release
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       packages: write
       contents: write

--- a/.github/workflows/publish-chromatic.yml
+++ b/.github/workflows/publish-chromatic.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   chromatic_deployment:
     name: Publish Chromatic Storybook 8
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       packages: write
       pull-requests: write

--- a/.github/workflows/stress-test-ui-tests.yml
+++ b/.github/workflows/stress-test-ui-tests.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   stress_test_ui_tests:
     name: Stress test UI tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-api-files.yml
+++ b/.github/workflows/update-api-files.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   update_composite_snapshot:
     name: Update all API files
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/update-chat-snapshots.yml
+++ b/.github/workflows/update-chat-snapshots.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   precondition:
     name: Determine if this workflow is applicable
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       pull-requests: write
     outputs:
@@ -40,7 +40,7 @@ jobs:
     name: Set CI flavors
     needs: precondition
     if: needs.precondition.outputs.met
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
@@ -59,7 +59,7 @@ jobs:
     needs: [precondition, get_matrix]
     if: needs.precondition.outputs.met
     name: Update packages/react-composites ChatComposite browser test snapshots
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
@@ -150,7 +150,7 @@ jobs:
     needs: [chat_composite]
     if: needs.precondition.outputs.met
     name: Push all updated snapshots to branch
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   precondition:
     name: Determine if this workflow is applicable
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions:
       pull-requests: write
     outputs:
@@ -45,7 +45,7 @@ jobs:
     name: Set CI flavors
     needs: precondition
     if: needs.precondition.outputs.met
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
@@ -64,7 +64,7 @@ jobs:
     needs: [precondition, get_matrix]
     if: needs.precondition.outputs.met
     name: Update component examples snapshots
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
@@ -160,7 +160,7 @@ jobs:
     needs: [precondition, get_matrix]
     if: needs.precondition.outputs.met
     name: Update embed html bundle snapshots
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
@@ -256,7 +256,7 @@ jobs:
     needs: [precondition, get_matrix]
     if: needs.precondition.outputs.met
     name: Update packages/react-composites CallComposite browser test snapshots
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
@@ -352,7 +352,7 @@ jobs:
     needs: [precondition, get_matrix]
     if: needs.precondition.outputs.met
     name: Update packages/react-composites ChatComposite browser test snapshots
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
@@ -448,7 +448,7 @@ jobs:
     needs: [precondition, get_matrix]
     if: needs.precondition.outputs.met
     name: Update packages/react-composites CallWithChatComposite browser test snapshots
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
@@ -544,7 +544,7 @@ jobs:
     needs: [precondition, get_matrix]
     if: needs.precondition.outputs.met
     name: Update packages/react-components browser test snapshots
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     strategy:
       matrix: ${{ fromJSON(needs.get_matrix.outputs.matrix) }}
@@ -637,7 +637,7 @@ jobs:
     needs: [component_examples, html_bundle, call_composite, chat_composite, callwithchat_composite]
     if: needs.precondition.outputs.met
     name: Push all updated snapshots to branch
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNS_ON }}
     permissions: read-all
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# What

Use a github repo variable (https://github.com/Azure/communication-ui-library/settings/variables/actions) `RUNS_ON` to dictate the ubuntu version runners run on.

This has been set to `ubuntu-22.04`

# Why

Runners are about to be slowly updated to `ubuntu-24.04` December 5th -> January 25th. Our build fails on this new version: https://github.com/Azure/communication-ui-library/actions/runs/12055450770/job/33615831319
