### PR TITLE
Updated together mode types

### DIFF
--- a/change-beta/@azure-communication-react-d907f4b1-65ab-4f14-a725-3090ce2d3130.json
+++ b/change-beta/@azure-communication-react-d907f4b1-65ab-4f14-a725-3090ce2d3130.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "feature",
+  "workstream": "together-mode",
+  "comment": "Updated together mode types",
+  "packageName": "@azure/communication-react",
+  "email": "nwankwojustin93@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-d907f4b1-65ab-4f14-a725-3090ce2d3130.json
+++ b/change-beta/@azure-communication-react-d907f4b1-65ab-4f14-a725-3090ce2d3130.json
@@ -4,6 +4,5 @@
   "workstream": "together-mode",
   "comment": "Updated together mode types",
   "packageName": "@azure/communication-react",
-  "email": "nwankwojustin93@gmail.com",
   "dependentChangeType": "patch"
 }

--- a/packages/react-components/src/types/TogetherModeTypes.ts
+++ b/packages/react-components/src/types/TogetherModeTypes.ts
@@ -2,8 +2,16 @@
 // Licensed under the MIT License.
 
 /* @conditional-compile-remove(together-mode) */
-import { CreateVideoStreamViewResult, ViewScalingMode } from './VideoGalleryParticipant';
+import { CreateVideoStreamViewResult, VideoGalleryStream, VideoStreamOptions } from './VideoGalleryParticipant';
 
+/* @conditional-compile-remove(together-mode) */
+/**
+ * Interface representing the result of a Together Mode stream view.
+ * @beta
+ */
+export interface TogetherModeStreamOptions extends VideoStreamOptions {
+  viewKind?: 'main' | 'panoramic';
+}
 /* @conditional-compile-remove(together-mode) */
 /**
  * Interface representing the result of a Together Mode stream view.
@@ -15,41 +23,11 @@ export interface TogetherModeStreamViewResult {
 
 /* @conditional-compile-remove(together-mode) */
 /**
- * Represents a video stream in Together Mode.
- * @beta
- */
-export interface TogetherModeStream {
-  /**
-   * Flag indicating whether the video stream is available for rendering
-   */
-  isAvailable?: boolean;
-  /**
-   * Flag indicating whether the together mode stream is packets are being received.
-   */
-  isReceiving?: boolean;
-  /**
-   * The HTML element used to render the video stream.
-   *
-   */
-  renderElement?: HTMLElement;
-  /**
-   * Scaling mode of the video stream
-   */
-  scalingMode?: ViewScalingMode;
-  /**
-   * The size of the video stream.
-   *
-   */
-  streamSize?: { width: number; height: number };
-}
-
-/* @conditional-compile-remove(together-mode) */
-/**
  * Interface representing the streams in Together Mode.
  * @beta
  */
 export interface VideoGalleryTogetherModeStreams {
-  mainVideoStream?: TogetherModeStream;
+  mainVideoStream?: VideoGalleryStream;
 }
 
 /* @conditional-compile-remove(together-mode) */


### PR DESCRIPTION
# What
Updated the API by removing redundant interface

# Why
- Created a new interface TogetherModeStreamOptions. This options interface will be used to select what kind of together mode to be created
-  Removed duplicate interface TogetherModeStream  and used VideoGalleryStream since they both have similar properties


# How Tested
locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->