### PR TITLE
[Storybook] Fix storybook Unsupported Browser canvas padding

### DIFF
--- a/packages/storybook8/stories/Components/UnsupportedBrowser/Docs.mdx
+++ b/packages/storybook8/stories/Components/UnsupportedBrowser/Docs.mdx
@@ -42,6 +42,7 @@ below to see the component
 <Canvas
   of={UnsupportedBrowserStories.UnsupportedEnvironmentModalsDocsOnly}
   source={{ code: UnsupportedEnvironmentModals }}
+  layout="padded"
 />
 
 ## Props


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Show code button is covering the UI in canvas
Before
<img width="1339" alt="image" src="https://github.com/user-attachments/assets/fe180745-ad43-4d0f-9628-6bc7d46a1149" />
After
<img width="1320" alt="image" src="https://github.com/user-attachments/assets/33e66043-5d0a-4ac3-9976-15fb29d7c85f" />

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->