### PR TITLE
[A11y][Chat] Fix an issue where keyboard focus was lost after message is edited

### DIFF
--- a/change-beta/@azure-communication-react-57cd7723-5d5c-42b4-bbf0-c9c839448d49.json
+++ b/change-beta/@azure-communication-react-57cd7723-5d5c-42b4-bbf0-c9c839448d49.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Fix an issue where keyboard focus was lost after message is edited",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-57cd7723-5d5c-42b4-bbf0-c9c839448d49.json
+++ b/change/@azure-communication-react-57cd7723-5d5c-42b4-bbf0-c9c839448d49.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Fix an issue where keyboard focus was lost after message is edited",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ChatMessage/MyMessageComponents/FluentChatMyMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/MyMessageComponents/FluentChatMyMessageComponent.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { MessageStatus, _formatString } from '@internal/acs-ui-common';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { MessageProps, _ChatMessageProps } from '../../MessageThread';
 import { ChatMessage } from '../../../types';
 /* @conditional-compile-remove(data-loss-prevention) */
@@ -59,6 +59,11 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
     onInsertInlineImage
   } = props;
   const chatMessageRenderStyles = useChatMessageRenderStyles();
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const onEditComplete = useCallback(() => {
+    bodyRef.current?.focus();
+  }, []);
 
   // To rerender the defaultChatMessageRenderer if app running across days(every new day chat time stamp
   // needs to be regenerated), the dependency on "new Date().toDateString()"" is added.
@@ -71,6 +76,7 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
         return (
           <ChatMyMessageComponent
             {...messageProps}
+            onEditComplete={onEditComplete}
             onRenderAttachmentDownloads={onRenderAttachmentDownloads}
             strings={messageProps.strings}
             message={messageProps.message}
@@ -190,7 +196,8 @@ export const FluentChatMyMessageComponent = (props: FluentChatMessageComponentWr
 
   const myMessageBodyProps = useMemo(() => {
     return {
-      className: mergeClasses(chatMessageRenderStyles.bodyCommon, chatMessageRenderStyles.bodyMyMessage)
+      className: mergeClasses(chatMessageRenderStyles.bodyCommon, chatMessageRenderStyles.bodyMyMessage),
+      ref: bodyRef
     };
   }, [chatMessageRenderStyles.bodyCommon, chatMessageRenderStyles.bodyMyMessage]);
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
 Fix an issue where keyboard focus was lost after message is edited

Steps to reproduce:

1. Open chat sample app
2. Navigate to 'Start chat' button using tab key and activate it using enter key.
3. Navigate to 'Name' edit field using tab key and type a name.
4. Navigate to the 'Join chat' button using tab key and activate it using enter key.
5. 'Your chat sample' app opens.
6. Navigate to 'Enter a message' edit field and type some value.
7. Navigate to 'Send message' button using tab key and activate it using enter key.
8. Now navigate to the sent message group using shift + tab key.
9. Press tab key to navigate over the 'More options' button and activate it using enter key.
10. Navigate to 'Edit' item using tab key and activate it using enter key.
11. Edit the message and navigate to 'Done' button using tab key and activate it using enter key.
12. Observe where keyboard focus lands (should be on the same message)

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Chat sample app

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->