### PR TITLE
temporary change to get coverage / bundle size updates to work again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       # Pull requests show details of coverage changes
       - name: Get jest tests coverage of main from gist
         if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.base.ref, 'release/') }}
-        run: curl -o temp/jest/base/coverage-report.json "https://gist.github.com/communication-ui-bot/${{ matrix.coverage_gist_id }}/raw/communication-react-jest-report-${{ matrix.flavor }}.json" --create-dirs -L
+        run: curl -o temp/jest/base/coverage-report.json "https://gist.github.com/alkwa-msft/${{ matrix.coverage_gist_id }}/raw/communication-react-jest-report-${{ matrix.flavor }}.json" --create-dirs -L
       - name: Calculate coverage change
         if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.base.ref, 'release/') }}
         id: coverage
@@ -787,11 +787,11 @@ jobs:
         include:
           # These are gist to track bundle sizes
           - app: Chat
-            gist: https://gist.github.com/communication-ui-bot/db13fa7067b083b7a91d7a95adf28be1
+            gist: https://gist.github.com/alkwa-msft/f19649d941b2739b13402ee4802aa851
           - app: Calling
-            gist: https://gist.github.com/communication-ui-bot/87d57b63bbbaee12273a9a901b67885c
+            gist: https://gist.github.com/alkwa-msft/8160c0362cb05b7b09f3dbf803007c73
           - app: CallWithChat
-            gist: https://gist.github.com/communication-ui-bot/72a7fca0af8a3c5b37f966bb6d4bcd11
+            gist: https://gist.github.com/alkwa-msft/c43393ae31b5b08215f3f49ed327d912
     steps:
       # checkout base bundle stats
       - name: Get bundle stats of main from gist
@@ -867,11 +867,11 @@ jobs:
         include:
           # These are gist to track bundle sizes
           - app: Chat
-            gist_id: db13fa7067b083b7a91d7a95adf28be1
+            gist_id: f19649d941b2739b13402ee4802aa851
           - app: Calling
-            gist_id: 87d57b63bbbaee12273a9a901b67885c
+            gist_id: 8160c0362cb05b7b09f3dbf803007c73
           - app: CallWithChat
-            gist_id: 72a7fca0af8a3c5b37f966bb6d4bcd11
+            gist_id: c43393ae31b5b08215f3f49ed327d912
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/change-beta/@azure-communication-react-a7e8be69-cfac-4bc0-99b4-883defecf226.json
+++ b/change-beta/@azure-communication-react-a7e8be69-cfac-4bc0-99b4-883defecf226.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "improvement",
+  "workstream": "Repairing Bundle Size Gist download/upload for CI",
+  "comment": "temporary change to get bundle size updates to work again",
+  "packageName": "@azure/communication-react",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/workflows/matrix.json
+++ b/common/config/workflows/matrix.json
@@ -2,11 +2,11 @@
     "include": [
         {
             "flavor": "stable",
-            "coverage_gist_id": "d1528e50153e6f7ea569040d7b437abb"
+            "coverage_gist_id": "19b238d46a84c28e44d689f0a8b57202"
         },
         {
             "flavor": "beta",
-            "coverage_gist_id": "67224b1799c92f0e1cd2da24798e4dd5"
+            "coverage_gist_id": "aadc866e05b5243846b1c15a79ec1779"
         }
 
     ]


### PR DESCRIPTION
We needed to create a new token since we don't have access to the communication-ui-bot. With the different user minting the token we needed to have a new set of gists that are accessible by the token. I am also making sure we include the last entry to each of these gists so we have consistency when this change goes to main and is ci.yml is run against main once again.

1. We need to create gists with the last entry 
2. We update the matrix.json for the communication-react-jest-beta/json  gist ids
3. We need to update the ci.yaml for how we are using the matrix.json as well as how we are dealing with the composite bundle sizes.

For handling the communication-react-jest-(beta/stable).json we

| Stable (Old) | Stable (New) |
|--------|--------|
| [communication-ui-bot/d1528e50153e6f7ea569040d7b437abb](https://gist.github.com/communication-ui-bot/d1528e50153e6f7ea569040d7b437abb/raw/communication-react-jest-report-stable.json)| [alkwa-msft/19b238d46a84c28e44d689f0a8b57202](https://gist.github.com/alkwa-msft/19b238d46a84c28e44d689f0a8b57202/raw/communication-react-jest-report-stable.json)|

| Beta (Old) | Beta (New) |
|--------|--------|
| [communication-ui-bot/67224b1799c92f0e1cd2da24798e4dd5](https://gist.github.com/communication-ui-bot/67224b1799c92f0e1cd2da24798e4dd5/raw/communication-react-jest-report-beta.json)| [alkwa-msft/aadc866e05b5243846b1c15a79ec1779](https://gist.github.com/alkwa-msft/aadc866e05b5243846b1c15a79ec1779/raw/communication-react-jest-report-beta.json)| 


For handling the bundle sizes by Chat, Calling, CallWithChat

| **App**          | **Old Gist**                                                                 | **New Gist**                                                                 |
|------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|
| **Chat**         | [communication-ui-bot/db13fa7067b083b7a91d7a95adf28be1](https://gist.github.com/communication-ui-bot/db13fa7067b083b7a91d7a95adf28be1)| [alkwa-msft/f19649d941b2739b13402ee4802aa851](https://gist.github.com/alkwa-msft/f19649d941b2739b13402ee4802aa851) |
| **Calling**      | [communication-ui-bot/87d57b63bbbaee12273a9a901b67885c](https://gist.github.com/communication-ui-bot/87d57b63bbbaee12273a9a901b67885c) | [alkwa-msft/8160c0362cb05b7b09f3dbf803007c73](https://gist.github.com/alkwa-msft/8160c0362cb05b7b09f3dbf803007c73) |
| **CallWithChat** | [communication-ui-bot/72a7fca0af8a3c5b37f966bb6d4bcd11](https://gist.github.com/communication-ui-bot/72a7fca0af8a3c5b37f966bb6d4bcd11) | [alkwa-msft/c43393ae31b5b08215f3f49ed327d912](https://gist.github.com/alkwa-msft/c43393ae31b5b08215f3f49ed327d912) |




