### PR TITLE
[Bugfix] update text container width to cap text for longer locale strings

### DIFF
--- a/change-beta/@azure-communication-react-6b224443-1be4-4542-98c4-16d89f6842b4.json
+++ b/change-beta/@azure-communication-react-6b224443-1be4-4542-98c4-16d89f6842b4.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Video Effects",
+  "comment": "update text container width to cap text for longer locale strings",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-6b224443-1be4-4542-98c4-16d89f6842b4.json
+++ b/change/@azure-communication-react-6b224443-1be4-4542-98c4-16d89f6842b4.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Video Effects",
+  "comment": "update text container width to cap text for longer locale strings",
+  "packageName": "@azure/communication-react",
+  "email": "94866715+dmceachernmsft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/VideoEffects/VideoEffectsItem.tsx
+++ b/packages/react-components/src/components/VideoEffects/VideoEffectsItem.tsx
@@ -128,7 +128,7 @@ export const _VideoEffectsItem = (props: _VideoEffectsItemProps): JSX.Element =>
   const backgroundImage = props.backgroundProps?.url;
   const iconContainerStyles = mergeStyles({ height: '1.25rem' }, props.styles?.iconContainer);
   const textContainerStyles = mergeStyles(
-    { height: '1.25rem', maxWidth: '4.375rem', overflow: 'hidden' },
+    { height: '1.25rem', maxWidth: '4.5rem', overflow: 'hidden' },
     props.styles?.textContainer
   );
 

--- a/packages/react-components/src/components/VideoEffects/VideoEffectsItem.tsx
+++ b/packages/react-components/src/components/VideoEffects/VideoEffectsItem.tsx
@@ -128,7 +128,7 @@ export const _VideoEffectsItem = (props: _VideoEffectsItemProps): JSX.Element =>
   const backgroundImage = props.backgroundProps?.url;
   const iconContainerStyles = mergeStyles({ height: '1.25rem' }, props.styles?.iconContainer);
   const textContainerStyles = mergeStyles(
-    { height: '1.25rem', width: '100%', overflow: 'hidden' },
+    { height: '1.25rem', maxWidth: '4.375rem', overflow: 'hidden' },
     props.styles?.textContainer
   );
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Update the container width to match Teams when there are long strings in the locale for video effects.
# Why
<!--- What problem does this change solve? -->
without the cap in size the text runs off the button to the left and right
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3996876
# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated locally to match Teams 
![image](https://github.com/user-attachments/assets/b01b17eb-1442-4785-9d73-15c4fb015006)
