### PR TITLE
RTT Feature: Change id to sequence id 

### DIFF
--- a/change-beta/@azure-communication-react-19209e7d-098c-4cfc-b0e5-40636320691b.json
+++ b/change-beta/@azure-communication-react-19209e7d-098c-4cfc-b0e5-40636320691b.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "feature",
+  "workstream": "RTT",
+  "comment": "Change id to sequenceId for RTT feature state",
+  "packageName": "@azure/communication-react",
+  "email": "96077406+carocao-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-component-bindings/src/captionsSelector.ts
+++ b/packages/calling-component-bindings/src/captionsSelector.ts
@@ -179,7 +179,7 @@ export const captionsBannerSelector: CaptionsBannerSelector = reselect.createSel
       .map((rtt) => {
         const userId = getRealTimeTextSpeakerIdentifier(rtt);
         return {
-          id: rtt.id,
+          id: rtt.sequenceId,
           displayName: getRealTimeTextDisplayName(rtt, identifier, remoteParticipants, displayName, userId),
           message: rtt.message,
           userId,
@@ -194,7 +194,7 @@ export const captionsBannerSelector: CaptionsBannerSelector = reselect.createSel
       .map((rtt) => {
         const userId = getRealTimeTextSpeakerIdentifier(rtt);
         return {
-          id: rtt.id,
+          id: rtt.sequenceId,
           displayName: getRealTimeTextDisplayName(rtt, identifier, remoteParticipants, displayName, userId),
           message: rtt.message,
           userId,
@@ -207,7 +207,7 @@ export const captionsBannerSelector: CaptionsBannerSelector = reselect.createSel
     const myInProgress =
       realTimeTexts?.myInProgress && realTimeTexts.myInProgress.message !== ''
         ? {
-            id: realTimeTexts.myInProgress.id,
+            id: realTimeTexts.myInProgress.sequenceId,
             displayName: displayName,
             message: realTimeTexts.myInProgress.message,
             userId: identifier,

--- a/packages/calling-stateful-client/src/CallClientState.ts
+++ b/packages/calling-stateful-client/src/CallClientState.ts
@@ -106,7 +106,7 @@ export interface RealTimeTextInfo {
   /**
    * The sequence id of the real time text.
    */
-  id: number;
+  sequenceId: number;
   /**
    * The sender of the real time text.
    */

--- a/packages/calling-stateful-client/src/CallContext.ts
+++ b/packages/calling-stateful-client/src/CallContext.ts
@@ -1200,7 +1200,7 @@ export class CallContext {
         realTimeTexts.myInProgress = undefined;
       } else {
         realTimeTexts.currentInProgress = realTimeTexts.currentInProgress?.filter(
-          (message) => message.id !== newRealTimeText.id
+          (message) => message.sequenceId !== newRealTimeText.sequenceId
         );
       }
     } else {
@@ -1219,7 +1219,7 @@ export class CallContext {
         // find the index of the existing in progress message
         // replace the existing in progress message with the new one
         const existingIndex = realTimeTexts.currentInProgress?.findIndex(
-          (message) => message.id === newRealTimeText.id
+          (message) => message.sequenceId === newRealTimeText.sequenceId
         );
         if (existingIndex === -1) {
           realTimeTexts.currentInProgress?.push(newRealTimeText);

--- a/packages/calling-stateful-client/src/Converter.ts
+++ b/packages/calling-stateful-client/src/Converter.ts
@@ -285,7 +285,6 @@ export function convertFromSDKToCaptionInfoState(caption: AcsCaptionsInfo): Capt
  */
 export function convertFromSDKRealTimeTextToRealTimeTextInfoState(realTimeText: ACSRealTimeTextInfo): RealTimeTextInfo {
   return {
-    id: realTimeText.sequenceId,
     message: realTimeText.text,
     isMe: realTimeText.isLocal,
     ...realTimeText

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -4633,12 +4633,12 @@ export interface RealTimeTextCallFeatureState {
 
 // @beta (undocumented)
 export interface RealTimeTextInfo {
-    id: number;
     isMe?: boolean;
     message: string;
     receivedTimestamp?: Date;
     resultType: RealTimeTextResultType;
     sender: ParticipantInfo;
+    sequenceId: number;
     updatedTimestamp?: Date;
 }
 

--- a/packages/react-components/src/components/CaptionsBanner.tsx
+++ b/packages/react-components/src/components/CaptionsBanner.tsx
@@ -69,7 +69,7 @@ export type CaptionsInformation = {
  */
 export type RealTimeTextInformation = {
   /**
-   * The sequence id of the real time text.
+   * The id of the real time text.
    */
   id: number;
   /**


### PR DESCRIPTION
# What
Change id to sequence id as this id is not unique. This id can be used to differentiate between partial messages from different origin, but the partial/final messages from the same origin all have the same sequence id. 

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->