### PR TITLE
Remove HMR causing codespace to not load samples correctly

### DIFF
--- a/common/config/webpack/sampleapp.webpack.config.js
+++ b/common/config/webpack/sampleapp.webpack.config.js
@@ -6,12 +6,6 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 const CopyPlugin = require("copy-webpack-plugin");
-const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
-const ReactRefreshTypeScript = require('react-refresh-typescript');
-
-// Detect if running in GitHub Codespaces environment through environment variable set by codespace.
-// More details: https://docs.github.com/en/codespaces/developing-in-a-codespace/default-environment-variables-for-your-codespace#list-of-default-environment-variables
-const RUNNING_IN_GH_CODESPACES = !!process.env.CODESPACES;
 
 const webpackConfig = (sampleAppDir, env, babelConfig) => {
   const config = {
@@ -52,12 +46,7 @@ const webpackConfig = (sampleAppDir, env, babelConfig) => {
           test: /\.tsx?$/,
           loader: 'ts-loader',
           options: {
-            transpileOnly: true,
-
-            // Enable HRML for GH codespaces devlopment (this was found to not work on MacOS so enabling for GH Codespaces only)
-            getCustomTransformers: () => ({
-              before: [!env.production && RUNNING_IN_GH_CODESPACES && ReactRefreshTypeScript()].filter(Boolean),
-            })
+            transpileOnly: true
           },
           exclude: /dist/,
           sideEffects: false
@@ -77,9 +66,6 @@ const webpackConfig = (sampleAppDir, env, babelConfig) => {
       ]
     },
     plugins: [
-      // Enable HRML for GH codespaces devlopment (this was found to not work on MacOS so enabling for GH Codespaces only)
-      !env.production && RUNNING_IN_GH_CODESPACES && new ReactRefreshWebpackPlugin(),
-
       new HtmlWebpackPlugin({ template: './public/index.html' }),
       new webpack.DefinePlugin({
         'process.env.PRODUCTION': env.production || !env.development,
@@ -100,19 +86,12 @@ const webpackConfig = (sampleAppDir, env, babelConfig) => {
           { from: path.resolve(sampleAppDir, "public/assets"), to: "assets",  noErrorOnMissing: true },
         ]
       })
-    ].filter(Boolean),
+    ],
     devServer: {
       port: 3000,
       hot: true,
       open: true,
       static: { directory: path.resolve(sampleAppDir, 'public') },
-      // To support hot reloading in GitHub Codespaces, we need to use the secure websocket URL
-      // For more details: https://github.com/orgs/community/discussions/11524#discussioncomment-2176952
-      client: RUNNING_IN_GH_CODESPACES ? {
-        webSocketURL: {
-          port: '443'
-        }
-      } : undefined,
       proxy: [
         {
           path: '/token',

--- a/samples/Server/package.json
+++ b/samples/Server/package.json
@@ -40,7 +40,6 @@
     "@azure/communication-rooms": "1.1.0-beta.1 || ^1.1.0"
   },
   "devDependencies": {
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.13",
     "@types/copy-webpack-plugin": "^6.4.0",
     "@types/express": "^4.17.8",
     "@types/http-errors": "^1.8.0",
@@ -63,8 +62,6 @@
     "jest-junit": "^16.0.0",
     "prettier": "3.3.2",
     "pretty-quick": "^4.0.0",
-    "react-refresh": "^0.14.2",
-    "react-refresh-typescript": "^2.0.9",
     "rimraf": "^2.6.2",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.5",


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Undo PR https://github.com/Azure/communication-ui-library/pull/4567 as it's causing codespace to not load samples correctly. 
Temporary fix while we try to understand this issue further.
Believe issue occurred after node and webpack update. Have not pinpointed exactly when yet. Will dive deeper into this when time allows. In the meantime this pr is to help unblock others using codespace.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->