### PR TITLE
[A11y bugfix] config heading aria level

### DIFF
--- a/change-beta/@azure-communication-react-6e9ffc1d-2c5a-4cab-ae81-766d581dc33b.json
+++ b/change-beta/@azure-communication-react-6e9ffc1d-2c5a-4cab-ae81-766d581dc33b.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Update aria-level for heading on the config screen",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-6e9ffc1d-2c5a-4cab-ae81-766d581dc33b.json
+++ b/change/@azure-communication-react-6e9ffc1d-2c5a-4cab-ae81-766d581dc33b.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "A11y",
+  "comment": "Update aria-level for heading on the config screen",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/SvgWithWordWrapping.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/SvgWithWordWrapping.tsx
@@ -39,7 +39,14 @@ export const SvgWithWordWrapping = (props: {
   }, [width, lineHeightPx, text]);
 
   return (
-    <svg role={role} width={width} height={height + bufferHeightPx} ref={svgRef} xmlns="http://www.w3.org/2000/svg">
+    <svg
+      aria-level={1}
+      role={role}
+      width={width}
+      height={height + bufferHeightPx}
+      ref={svgRef}
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <text height={0} ref={calculationTextElement} style={{ visibility: 'hidden' }}>
         {text}
       </text>


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Update the aria level for the heading SVG on the config screen
# Why
<!--- What problem does this change solve? -->
Makes sure our elements are the correct level for screen readers
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/4031933
# How Tested
<!--- How did you test your change. What tests have you added. -->
![image](https://github.com/user-attachments/assets/91c3a876-427f-4f20-85fe-c51a11e81618)
Validated locally with A11y insights
# Process & policy checklist