### PR TITLE
Fix undefined chat thread in main meeting when breakout room is immediately closed

### DIFF
--- a/change-beta/@azure-communication-react-6ebb0895-7f83-4c53-bb1b-a3dfaa10a46f.json
+++ b/change-beta/@azure-communication-react-6ebb0895-7f83-4c53-bb1b-a3dfaa10a46f.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Breakout rooms",
+  "comment": "Fix bug where chat thread is stuck on spinner when immediately returning to main meeting from breakout room",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-6ebb0895-7f83-4c53-bb1b-a3dfaa10a46f.json
+++ b/change/@azure-communication-react-6ebb0895-7f83-4c53-bb1b-a3dfaa10a46f.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Breakout rooms",
+  "comment": "Fix bug where chat thread is stuck on spinner when immediately returning to main meeting from breakout room",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -222,8 +222,9 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         this.chatAdapter?.offStateChange(this.onChatStateChange);
         // Unassign chat adapter
         this.chatAdapter = undefined;
-        // Set chat state to undefined to prevent showing chat thread of origin call
+        // Set chat state to undefined to ensure that the chat thread of the breakout room is not shown
         this.context.unsetChatState();
+        // Update chat state to the origin call chat adapter
         if (this.originCallChatAdapter) {
           this.updateChatAdapter(this.originCallChatAdapter);
         }

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -206,7 +206,7 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         if (!eventData.data || eventData.data.state === 'closed') {
           if (
             this.originCallChatAdapter &&
-            this.originCallChatAdapter?.getState().thread.threadId !== this.chatAdapter?.getState().thread.threadId
+            this.originCallChatAdapter?.getState().thread.threadId !== this.context.getState().chat?.threadId
           ) {
             this.updateChatAdapter(this.originCallChatAdapter);
           }


### PR DESCRIPTION
# What
Fix undefined chat thread in main meeting when breakout room is immediately closed. 
The chat state in context is set to undefined when joining a breakout room so as to not show the main meeting chat thread.
The chat state will continue to be undefined until the local user is added to the breakout room chat thread. But when the breakout room is closed immediately the chat state will be stuck as undefined. So when the breakout room is closed we should compare the thread id from the chat state context (which is undefined) to the thread id of the origin call chat adapter.

# Why
Bug found during bug bash where we see the chat thread is stuck on spinner when immediately returning to main meeting from a closed breakout room.

# How Tested
Tested locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->