### PR TITLE
Cherry pick PR #5640

### DIFF
--- a/change-beta/@azure-communication-react-6ebb0895-7f83-4c53-bb1b-a3dfaa10a46f.json
+++ b/change-beta/@azure-communication-react-6ebb0895-7f83-4c53-bb1b-a3dfaa10a46f.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Breakout rooms",
+  "comment": "Fix bug where chat thread is stuck on spinner when immediately returning to main meeting from breakout room",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-6ebb0895-7f83-4c53-bb1b-a3dfaa10a46f.json
+++ b/change/@azure-communication-react-6ebb0895-7f83-4c53-bb1b-a3dfaa10a46f.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Breakout rooms",
+  "comment": "Fix bug where chat thread is stuck on spinner when immediately returning to main meeting from breakout room",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -206,7 +206,7 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         if (!eventData.data || eventData.data.state === 'closed') {
           if (
             this.originCallChatAdapter &&
-            this.originCallChatAdapter?.getState().thread.threadId !== this.chatAdapter?.getState().thread.threadId
+            this.originCallChatAdapter?.getState().thread.threadId !== this.context.getState().chat?.threadId
           ) {
             this.updateChatAdapter(this.originCallChatAdapter);
           }
@@ -222,8 +222,9 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         this.chatAdapter?.offStateChange(this.onChatStateChange);
         // Unassign chat adapter
         this.chatAdapter = undefined;
-        // Set chat state to undefined to prevent showing chat thread of origin call
+        // Set chat state to undefined to ensure that the chat thread of the breakout room is not shown
         this.context.unsetChatState();
+        // Update chat state to the origin call chat adapter
         if (this.originCallChatAdapter) {
           this.updateChatAdapter(this.originCallChatAdapter);
         }


### PR DESCRIPTION
# What
Cherry pick PR #5640 in to release/1.24.0

# Why
Bug found during bug bash where we see the chat thread is stuck on spinner when immediately returning to main meeting from a closed breakout room.

# How Tested
Local testing on CallWithChat composite

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->