### PR TITLE
Update isNarrow value so when at 400% zoom, isNarrow is not triggered

### DIFF
--- a/change-beta/@azure-communication-react-c30180f7-6213-4e22-99ca-63a46a104e16.json
+++ b/change-beta/@azure-communication-react-c30180f7-6213-4e22-99ca-63a46a104e16.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Bug fix",
+  "comment": "Update isNarrow width so it does not get triggered when at 400% zoom",
+  "packageName": "@azure/communication-react",
+  "email": "96077406+carocao-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-c30180f7-6213-4e22-99ca-63a46a104e16.json
+++ b/change/@azure-communication-react-c30180f7-6213-4e22-99ca-63a46a104e16.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Bug fix",
+  "comment": "Update isNarrow width so it does not get triggered when at 400% zoom",
+  "packageName": "@azure/communication-react",
+  "email": "96077406+carocao-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/utils/responsive.ts
+++ b/packages/react-components/src/components/utils/responsive.ts
@@ -78,7 +78,7 @@ export const _useContainerHeight = (containerRef: RefObject<HTMLElement>): numbe
   return height;
 };
 
-const NARROW_WIDTH_REM = 30;
+const NARROW_WIDTH_REM = 27.5;
 
 const SHORT_HEIGHT_REM = 23.75;
 


### PR DESCRIPTION
# What
https://skype.visualstudio.com/SPOOL/_workitems/edit/4035618

<img width="1727" alt="Screenshot 2025-02-11 at 5 29 12 PM" src="https://github.com/user-attachments/assets/619ed854-5e0a-4bc7-9a41-473405f72c6a" />


# Why
when at 400% zoom, the width reduced to go under the isNarrow value.
Reduced isNarrow value so it does not go under. 
Common phone viewport width is under 440 px which is 27.5 rem

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->