### PR TITLE
Update touchdown build pipeline to resolve run errors and warning

### DIFF
--- a/.github/workflows/touchdown-pipeline/touchdown-build.yml
+++ b/.github/workflows/touchdown-pipeline/touchdown-build.yml
@@ -8,10 +8,10 @@ pr: none
 
 resources:
   repositories:
-    - repository: m365Pipelines
-      type: git
-      name: 1ESPipelineTemplates/M365GPT
-      ref: refs/tags/release
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
 parameters:
   # Parameter to control whether to only pass strings to touchdown (false) or to also create a PR with changes (true)
@@ -21,7 +21,7 @@ parameters:
     default: false
 
 extends:
-  template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
     pool:
       name: ess-1eshp-windows-latest
@@ -37,7 +37,7 @@ extends:
                 clean: true
                 persistCredentials: true
 
-              - task: TouchdownBuildTask@4
+              - task: TouchdownBuildTask@5
                 inputs:
                   environment: 'PRODEXT'
                   teamId: '35669'
@@ -49,7 +49,7 @@ extends:
                   cultureMappingType: 'None'
                 displayName: 'Call Touchdown build task for components and commit changes'
 
-              - task: TouchdownBuildTask@4
+              - task: TouchdownBuildTask@5
                 inputs:
                   environment: 'PRODEXT'
                   teamId: '35669'
@@ -99,7 +99,6 @@ extends:
                     git commit -m "TDBuild latest localization"
                     git push origin $newBranchName
 
-                    Write-Host "PR created successfully: $($response.url)"
     sdl:
       arrow:
         serviceConnection: Arrow_skype_PROD


### PR DESCRIPTION
# What
Update touchdown build pipeline to resolve run errors (will be blocking by the end of Mar 2025) by following this doc:
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/changemanagement/official-template-check
and update TouchdownBuild task version to latest

# Why
There are Touchdown build pipeline errors and a warning found in runs like in this run https://skype.visualstudio.com/SCC/_build/results?buildId=67822589&view=results
Errors: ![image](https://github.com/user-attachments/assets/f630f79f-e622-44ee-8527-badc85744538)
Warning: 
![image](https://github.com/user-attachments/assets/d618f8cf-3c81-4762-b750-3bdbc52623ae)

# How Tested
Test run here showing the above errors and warning are resolved:
https://skype.visualstudio.com/SCC/_build/results?buildId=67826845&view=results
(There is still a legal alert which I have to schedule a meeting with legal team to resolve)

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->