### PR TITLE
Add hideAvatar to onFetchAvatarPersonaData API

### DIFF
--- a/packages/react-components/src/components/ChatMessage/MessageComponents/FluentChatMessageComponent.tsx
+++ b/packages/react-components/src/components/ChatMessage/MessageComponents/FluentChatMessageComponent.tsx
@@ -136,11 +136,12 @@ export const FluentChatMessageComponent = (props: FluentChatMessageComponentWrap
         renderedAvatar = avatarComponent;
       }
     }
-    return (
+    return !renderedAvatar?.props ? (
       <div className={mergeStyles(chatAvatarStyle)}>
         {renderedAvatar ? renderedAvatar : <Persona {...personaOptions} />}
       </div>
-    );
+    ) : // When pass undefined to FluentChatMessage component, it will remove the unnecessary left margin
+    undefined;
   }, [message.senderDisplayName, message.senderId, onRenderAvatar, shouldShowAvatar]);
 
   const setMessageContainerRef = useCallback((node: HTMLDivElement | null) => {

--- a/packages/react-composites/src/composites/common/AvatarPersona.tsx
+++ b/packages/react-composites/src/composites/common/AvatarPersona.tsx
@@ -39,6 +39,10 @@ export type AvatarPersonaData = {
    * It has '?' in place of initials, with static font and background colors
    */
   showUnknownPersonaCoin?: boolean;
+  /**
+   * If true, hide the entire avatar avatar element.
+   */
+  hideAvatar?: boolean;
 };
 
 /**
@@ -107,7 +111,7 @@ export const AvatarPersona = (props: AvatarPersonaProps): JSX.Element => {
     mergeStyles(activePersona, props.styles);
   }
 
-  return (
+  return !data?.hideAvatar ? (
     <Persona
       {...props}
       className={activePersona}
@@ -120,6 +124,8 @@ export const AvatarPersona = (props: AvatarPersonaProps): JSX.Element => {
       showOverflowTooltip={showOverflowTooltip ?? false}
       showUnknownPersonaCoin={data?.showUnknownPersonaCoin ?? props.showUnknownPersonaCoin ?? false}
     />
+  ) : (
+    <></>
   );
 };
 

--- a/samples/Chat/src/app/ChatScreen.tsx
+++ b/samples/Chat/src/app/ChatScreen.tsx
@@ -105,7 +105,8 @@ export const ChatScreen = (props: ChatScreenProps): JSX.Element => {
           new Promise((resolve) => {
             return resolve({
               imageInitials: emoji,
-              initialsColor: emoji ? getBackgroundColor(emoji)?.backgroundColor : undefined
+              initialsColor: emoji ? getBackgroundColor(emoji)?.backgroundColor : undefined,
+              hideAvatar: true
             });
           })
       );


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- This PR is to add the ability to hide the entire avatar element in the composite level.
- Also at the component level, if Contoso developer passes in an empty element <></> to the onRenderAvatar, this PR removes the unnecessary left margin
- Since we're only adding a new optional prop to the onFetchAvatarPersonaData API, it won't be a breaking change

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->