### PR TITLE
Fix screenshare button text to be black in dark mode 

### DIFF
--- a/change-beta/@azure-communication-react-30587b02-9f12-4a63-b4da-2233507bb692.json
+++ b/change-beta/@azure-communication-react-30587b02-9f12-4a63-b4da-2233507bb692.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Fix screenshare button text to be black in dark mode to match fluent dark mode primary button",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-30587b02-9f12-4a63-b4da-2233507bb692.json
+++ b/change/@azure-communication-react-30587b02-9f12-4a63-b4da-2233507bb692.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Fix screenshare button text to be black in dark mode to match fluent dark mode primary button",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/ScreenShareButton.tsx
+++ b/packages/react-components/src/components/ScreenShareButton.tsx
@@ -82,7 +82,7 @@ const screenshareButtonStyles = (theme: Theme): IButtonStyles => ({
   rootChecked: {
     background: theme.semanticColors.primaryButtonBackground,
     color: theme.semanticColors.primaryButtonText,
-    ':focus::after': { outlineColor: `${theme.palette.white} !important` }, // added !important to avoid override by FluentUI button styles
+    ':focus::after': { outlineColor: `${DefaultPalette.white} !important` }, // added !important to avoid override by FluentUI button styles
     '@media (forced-colors: active)': {
       border: '1px solid',
       borderColor: theme.palette.black
@@ -91,7 +91,7 @@ const screenshareButtonStyles = (theme: Theme): IButtonStyles => ({
   rootCheckedHovered: {
     background: theme.semanticColors.primaryButtonBackgroundHovered,
     color: theme.semanticColors.primaryButtonTextHovered,
-    ':focus::after': { outlineColor: `${theme.palette.white} !important` }, // added !important to avoid override by FluentUI button styles
+    ':focus::after': { outlineColor: `${DefaultPalette.white} !important` }, // added !important to avoid override by FluentUI button styles
     '@media (forced-colors: active)': {
       border: '1px solid',
       borderColor: theme.palette.black

--- a/packages/react-components/src/components/ScreenShareButton.tsx
+++ b/packages/react-components/src/components/ScreenShareButton.tsx
@@ -80,22 +80,26 @@ export const ScreenShareButton = (props: ScreenShareButtonProps): JSX.Element =>
 
 const screenshareButtonStyles = (theme: Theme): IButtonStyles => ({
   rootChecked: {
-    background: theme.palette.themePrimary,
-    color: DefaultPalette.white,
-    ':focus::after': { outlineColor: `${DefaultPalette.white} !important` }, // added !important to avoid override by FluentUI button styles
+    background: theme.semanticColors.primaryButtonBackground,
+    color: theme.semanticColors.primaryButtonText,
+    ':focus::after': { outlineColor: `${theme.palette.white} !important` }, // added !important to avoid override by FluentUI button styles
     '@media (forced-colors: active)': {
       border: '1px solid',
       borderColor: theme.palette.black
     }
   },
   rootCheckedHovered: {
-    background: theme.palette.themePrimary,
-    color: DefaultPalette.white,
-    ':focus::after': { outlineColor: `${DefaultPalette.white} !important` }, // added !important to avoid override by FluentUI button styles
+    background: theme.semanticColors.primaryButtonBackgroundHovered,
+    color: theme.semanticColors.primaryButtonTextHovered,
+    ':focus::after': { outlineColor: `${theme.palette.white} !important` }, // added !important to avoid override by FluentUI button styles
     '@media (forced-colors: active)': {
       border: '1px solid',
       borderColor: theme.palette.black
     }
   },
-  labelChecked: { color: DefaultPalette.white }
+  rootCheckedPressed: {
+    background: theme.semanticColors.primaryButtonBackgroundPressed,
+    color: theme.semanticColors.primaryButtonTextPressed
+  },
+  labelChecked: { color: theme.semanticColors.primaryButtonText }
 });


### PR DESCRIPTION
# What

Update screenshare button stylings to match a regular primary button

# Why

Screenshare button icon was black but text was white. Both should be black.

# How Tested

| before | after |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/1d3926da-013a-4629-a02c-d2b41ebfad61) |  ![image](https://github.com/user-attachments/assets/6b9591cf-d9c0-4908-b719-325b706e4b51) |

No impact to high contrast modes:
| aquatic | desert | dusk | night sky |
| -- | -- | -- | -- |
| ![image](https://github.com/user-attachments/assets/17da407f-62ff-40d4-bb55-03299101b116) | ![image](https://github.com/user-attachments/assets/ca8f2ab7-49e6-4dd2-9707-572253cd1c91) | ![image](https://github.com/user-attachments/assets/5b2ad41e-7224-45a8-854f-510db8f66d81) | ![image](https://github.com/user-attachments/assets/77015ac3-fc34-450e-a5b2-09f81a23c4e0) |