### PR TITLE
[Bugfix] Update max number of listeners on stateChange event for CallAdapter

### DIFF
--- a/change-beta/@azure-communication-react-f3a7790e-0c51-4994-852a-e636b2cfd18b.json
+++ b/change-beta/@azure-communication-react-f3a7790e-0c51-4994-852a-e636b2cfd18b.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "CallAdapter",
+  "comment": "Update the Max number of event listeners on a event in the CallAdapter",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-f3a7790e-0c51-4994-852a-e636b2cfd18b.json
+++ b/change/@azure-communication-react-f3a7790e-0c51-4994-852a-e636b2cfd18b.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "CallAdapter",
+  "comment": "Update the Max number of event listeners on a event in the CallAdapter",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -196,7 +196,7 @@ class CallContext {
       sounds: options?.callingSounds,
       reactions: options?.reactionResources
     };
-    this.emitter.setMaxListeners(options?.maxListeners ?? 50);
+    this.emitter.setMaxListeners(options?.maxListeners ?? 125);
     this.bindPublicMethods();
     this.displayNameModifier = options?.onFetchProfile
       ? createProfileStateModifier(options.onFetchProfile, () => {

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -136,6 +136,15 @@ interface CallAdapterPrivateState {
   };
 }
 
+/**
+ * For each time that we use the hook {@link useSelector} in the {@link CallComposite} we add another listener
+ * to the `stateChanged` event on the this adapter. This number is set in relation to the number of
+ * times that we are using the hook useSelector in the CallComposite.
+ *
+ * We will need to update this as the threshold is reached with more usages of useSelector.
+ */
+const EVENT_LISTENER_WARNING_WARNING_LIMIT = 125;
+
 type CallContextState = CallAdapterState & CallAdapterPrivateState;
 
 /** Context of call, which is a centralized context for all state updates */
@@ -196,7 +205,7 @@ class CallContext {
       sounds: options?.callingSounds,
       reactions: options?.reactionResources
     };
-    this.emitter.setMaxListeners(options?.maxListeners ?? 125);
+    this.emitter.setMaxListeners(options?.maxListeners ?? EVENT_LISTENER_WARNING_WARNING_LIMIT);
     this.bindPublicMethods();
     this.displayNameModifier = options?.onFetchProfile
       ? createProfileStateModifier(options.onFetchProfile, () => {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Updates the max number of event listeners that can be applied to an event.
# Why
<!--- What problem does this change solve? -->
The warning that we were seeing was sepcifically caused by the max number of event subscriptions on the `'stateChanged'` event for the adapter. This was previously set to `50` as the max.

Recently we started making changes to how we were getting data from the state of the adapter by writing selectors for all of the data that we would be retrieving. This is what sent us over the limit. when we call `useSelector` like so 
![image](https://github.com/user-attachments/assets/28f48974-90ce-49a2-b442-1126f34d3449)
this under the hood calls a special hook for the adapter called `useAdaptedSelector`. in this hook we have a useEffect defined as follows 
![image](https://github.com/user-attachments/assets/cfca95a3-8703-491f-8ec5-902362318cfe)
for every render that would go by all of the different selectors would unmount, removing listeners from the event. Then when the components of the composite would all go requesting their data again if the state changed causing the count of subscriptions to go up.

From testing the cap that we would see for the listeners on this event would be just over 100. ivestigating into the usage of `useSelector` in the CallComposite the number is `94` usages of the hook.
![image](https://github.com/user-attachments/assets/d087a83e-4ed6-407a-91c6-774fddff5d4d)
Since Typescript is linear we would see subscriptions to the event from different selectors around the composite before they were all cleaned up so we see the number of subscriptions going a little higher than 100 but they are always cleaned up down to a much smaller number.

Suggesting we bump the number of subscriptions here to give us a little more room to write more selectors in the CallComposite without causing the warning to come back.
<!--- Provide a link if you are addressing an open issue. -->
https://skype.visualstudio.com/SPOOL/_workitems/edit/3964503
# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated and investigated locally