### PR TITLE
Change link for release bug bash setup to use ADO test plan

### DIFF
--- a/docs/releases/creating-a-release.md
+++ b/docs/releases/creating-a-release.md
@@ -169,7 +169,7 @@ After finishing creating a release branch, follow these steps to create a UI sna
 
 Once the release branch has been created, we must make sure that the package we eventually off of the release branch is high quality. Towards this:
 
-- Set up a bug bash with the team to shake out any issues. See [internal documentation](https://skype.visualstudio.com/SPOOL/_wiki/wikis/SPOOL.wiki/31350/WebUI-Setting-up-a-bug-bash) for setting up a bug bash.
+- Set up a bug bash with the team to shake out any issues. See [internal documentation](https://skype.visualstudio.com/SPOOL/_wiki/wikis/SPOOL.wiki/59158/How-to-setup-a-release-bug-bash) for setting up a bug bash.
   - Triage bugs found via bug bash and manage merging of fixes into the release branch, as described in the section below.
 
 #### Cherry-picking Changes


### PR DESCRIPTION
# What
Change link for release bug bash setup to use ADO test plan

# Why
So that we can use ADO test plans for release bug bashes

# How Tested
New linked document test ran in small scale in previous releases

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->