### PR TITLE
[FHL] Accessibility Provider

### DIFF
--- a/packages/react-composites/src/composites/Accessibility/AccessibilityProvider.tsx
+++ b/packages/react-composites/src/composites/Accessibility/AccessibilityProvider.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { IButton } from '@fluentui/react';
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+
+/**
+ * Type for reference to the last component used
+ */
+export type AccessibilityComponentRef = IButton | null;
+
+interface AccessibilityContextType {
+  /** function to set the reference to the last used control */
+  setComponentRef: (ref: AccessibilityComponentRef) => void;
+  /** reference to the last used control */
+  componentRef: AccessibilityComponentRef;
+}
+
+// Create the context with a default value
+const AccessibilityContext = createContext<AccessibilityContextType | null>(null);
+
+/**
+ * Hook to access the A11yContext content
+ * @returns The A11yContext
+ */
+export const useAccessibility = (): AccessibilityContextType => {
+  const context = useContext(AccessibilityContext);
+  if (!context) {
+    throw new Error('useAccessibility must be used within an AccessibilityProvider');
+  }
+  return context;
+};
+
+/**
+ * Props for the AccessibilityProvider
+ */
+export type AccessibilityProviderProps = {
+  children: ReactNode;
+};
+
+/**
+ * Provider to access the A11yContext
+ */
+export const AccessibilityProvider = (props: AccessibilityProviderProps): JSX.Element => {
+  const [componentRef, setComponentRef] = useState<AccessibilityComponentRef>(null);
+
+  const handleSetComponentRef = useCallback((ref: AccessibilityComponentRef) => {
+    console.log(ref);
+    setComponentRef(ref);
+  }, []);
+
+  return (
+    <AccessibilityContext.Provider value={{ setComponentRef: handleSetComponentRef, componentRef }}>
+      {props.children}
+    </AccessibilityContext.Provider>
+  );
+};

--- a/packages/react-composites/src/composites/Accessibility/index.ts
+++ b/packages/react-composites/src/composites/Accessibility/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export * from './AccessibilityProvider';

--- a/packages/react-composites/src/composites/CallComposite/components/buttons/Microphone.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/buttons/Microphone.tsx
@@ -17,6 +17,8 @@ import {
   getRole
 } from '../../selectors/baseSelectors';
 import { concatButtonBaseStyles } from '../../styles/Buttons.styles';
+import { useAccessibility } from '../../../Accessibility';
+import { IButton } from '@fluentui/react';
 
 /**
  * @private
@@ -37,6 +39,11 @@ export const Microphone = (props: {
   const isRoomsCall = useSelector(getIsRoomsCall);
   const role = useSelector(getRole);
   const unmuteMicCapability = useSelector(getCapabilites)?.unmuteMic;
+
+  // activate the context
+  const accessibility = useAccessibility();
+  // create a ref for the local component
+  const micButtonRef = React.useRef<IButton | null>(null);
 
   /**
    * When call is in connecting state, microphone button should be disabled.
@@ -59,6 +66,10 @@ export const Microphone = (props: {
       showLabel={props.displayType !== 'compact'}
       disableTooltip={props.disableTooltip}
       styles={styles}
+      // set the ref to the local component in the context
+      onBlur={() => accessibility.setComponentRef(micButtonRef.current)}
+      // set the ref for the local component to track
+      componentRef={micButtonRef}
       enableDeviceSelectionMenu={props.splitButtonsForDeviceSelection}
       disabled={microphoneButtonProps.disabled || props.disabled || !!(isRoomsCall && role === 'Unknown')}
       onRenderOffIcon={

--- a/samples/Calling/src/app/App.tsx
+++ b/samples/Calling/src/app/App.tsx
@@ -31,7 +31,7 @@ import { HomeScreen } from './views/HomeScreen';
 import { UnsupportedBrowserPage } from './views/UnsupportedBrowserPage';
 import { getMeetingIdFromUrl } from './utils/AppUtils';
 
-setLogLevel('error');
+setLogLevel('verbose');
 
 console.log(
   `ACS sample calling app. Last Updated ${buildTime} with CommitID:${commitID} using @azure/communication-calling:${callingSDKVersion} and @azure/communication-react:${communicationReactSDKVersion}`


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Adds a new A11y provider to the composites to use to track the last used control at all times so you can focus on the dismiss of a menu
# Why
<!--- What problem does this change solve? -->
Allows more control over where the focus goes when we dismiss temporary controls so we never accidentally lose focus on the page
<!--- Provide a link if you are addressing an open issue. -->
FHL - Lets see what happens...
# How Tested
<!--- How did you test your change. What tests have you added. -->
Testing locally, demo to come...