### PR TITLE
Fix createAzureCommunicationCallWithChatAdapterFromClients for breakout rooms

### DIFF
--- a/change-beta/@azure-communication-react-ae4dd794-8396-42ec-b246-234e9dfc7214.json
+++ b/change-beta/@azure-communication-react-ae4dd794-8396-42ec-b246-234e9dfc7214.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Breakout rooms",
+  "comment": "Ensure createChatAdapterCallback is set for AzureCommunicationCallWithChatAdapter in createAzureCommunicationCallWithChatAdapterFromClients so that a new ChatAdapter can be created when joining a breakout room",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-ae4dd794-8396-42ec-b246-234e9dfc7214.json
+++ b/change/@azure-communication-react-ae4dd794-8396-42ec-b246-234e9dfc7214.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Breakout rooms",
+  "comment": "Ensure createChatAdapterCallback is set for AzureCommunicationCallWithChatAdapter in createAzureCommunicationCallWithChatAdapterFromClients so that a new ChatAdapter can be created when joining a breakout room",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -1471,7 +1471,6 @@ export const createAzureCommunicationCallWithChatAdapterFromClients = async ({
     callAdapterOptions
   );
   const chatAdapter = await createAzureCommunicationChatAdapterFromClient(chatClient, chatThreadClient);
-  /* @conditional-compile-remove(breakout-rooms) */
   const callWithChatAdapter = new AzureCommunicationCallWithChatAdapter(callAdapter, chatAdapter);
   /* @conditional-compile-remove(breakout-rooms) */
   callWithChatAdapter.setCreateChatAdapterCallback((threadId: string) =>

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -1471,7 +1471,13 @@ export const createAzureCommunicationCallWithChatAdapterFromClients = async ({
     callAdapterOptions
   );
   const chatAdapter = await createAzureCommunicationChatAdapterFromClient(chatClient, chatThreadClient);
-  return new AzureCommunicationCallWithChatAdapter(callAdapter, chatAdapter);
+  /* @conditional-compile-remove(breakout-rooms) */
+  const callWithChatAdapter = new AzureCommunicationCallWithChatAdapter(callAdapter, chatAdapter);
+  /* @conditional-compile-remove(breakout-rooms) */
+  callWithChatAdapter.setCreateChatAdapterCallback((threadId: string) =>
+    createAzureCommunicationChatAdapterFromClient(chatClient, chatClient.getChatThreadClient(threadId))
+  );
+  return callWithChatAdapter;
 };
 
 /**


### PR DESCRIPTION
# What
Ensure createChatAdapterCallback is set for AzureCommunicationCallWithChatAdapter in `createAzureCommunicationCallWithChatAdapterFromClients`  so that a new ChatAdapter can be created when joining a breakout room

# Why
To resolve #5675

# How Tested
I tested using `createAzureCommunicationCallWithChatAdapterFromClients` to create a CallWithChatAdapter for a CallWithChatComposite in the quickstarts repo and first verified I got the same error in the issue above:
`Unable to create chat adapter for thread because createChatAdapterCallback is not set
    at AzureCommunicationCallWithChatAdapter.createNewChatAdapterForThread`
I then tested this branch by packaging the communication-react package for the quickstarts repo and verified that the error was resolved and a new ChatAdapter was created when joining a breakout room
# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->