### PR TITLE
[bugfix] call with chat listeners fix

### DIFF
--- a/change-beta/@azure-communication-react-a6582b31-bc20-4f03-9520-efd5fb814b21.json
+++ b/change-beta/@azure-communication-react-a6582b31-bc20-4f03-9520-efd5fb814b21.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Bugs",
+  "comment": "update the max number of listeners that the CallWIthChat adapter has",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-a6582b31-bc20-4f03-9520-efd5fb814b21.json
+++ b/change/@azure-communication-react-a6582b31-bc20-4f03-9520-efd5fb814b21.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Bugs",
+  "comment": "update the max number of listeners that the CallWIthChat adapter has",
+  "packageName": "@azure/communication-react",
+  "email": "dmceachern@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -113,12 +113,21 @@ import { busyWait } from '../../common/utils';
 
 type CallWithChatAdapterStateChangedHandler = (newState: CallWithChatAdapterState) => void;
 
+/**
+ * For each time that we use the hook {@link useSelector} in the {@link CallWithChatComposite} we add another listener
+ * to the `stateChanged` event on the this adapter. This number is set in relation to the number of
+ * times that we are using the hook useSelector in the CallComposite.
+ *
+ * We will need to update this as the threshold is reached with more usages of useSelector.
+ */
+const MAX_EVENT_LISTENERS = 125;
+
 /** Context of Call with Chat, which is a centralized context for all state updates */
 class CallWithChatContext {
   private emitter = new EventEmitter();
   private state: CallWithChatAdapterState;
 
-  constructor(clientState: CallWithChatAdapterState, maxListeners = 50) {
+  constructor(clientState: CallWithChatAdapterState, maxListeners = MAX_EVENT_LISTENERS) {
     this.state = clientState;
     this.emitter.setMaxListeners(maxListeners);
   }


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Update the max number of event listeners that the CallWithChatAdapter can have
# Why
<!--- What problem does this change solve? -->
We are subscribing to `'stateChanged'` event on the adapter when we use the `useSelector` hook to fetch the data we need from the adapter. We had this issue in the CallAdapter as well but the CallWithChat adapter manages its own max listeners since it has to manage both Adapters; Call and Chat.
<!--- Provide a link if you are addressing an open issue. -->
https://github.com/Azure/communication-ui-library/issues/5688
# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated locally