### PR TITLE
Resolve issue where link color was incorrect in dark mode

### DIFF
--- a/change-beta/@azure-communication-react-2486d3fd-5b86-4ae4-ada4-bca3f53046fb.json
+++ b/change-beta/@azure-communication-react-2486d3fd-5b86-4ae4-ada4-bca3f53046fb.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Resolve issue where link color was incorrect in dark mode",
+  "packageName": "@azure/communication-react",
+  "email": "palatter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-2486d3fd-5b86-4ae4-ada4-bca3f53046fb.json
+++ b/change/@azure-communication-react-2486d3fd-5b86-4ae4-ada4-bca3f53046fb.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Resolve issue where link color was incorrect in dark mode",
+  "packageName": "@azure/communication-react",
+  "email": "palatter@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/styles/RichTextEditor.styles.ts
+++ b/packages/react-components/src/components/styles/RichTextEditor.styles.ts
@@ -52,6 +52,10 @@ export const richTextEditorWrapperStyle = (theme: Theme): string => {
           verticalAlign: 'top'
         }
       }
+    },
+    '& a': {
+      color: theme.palette.themePrimary,
+      textDecoration: 'underline'
     }
   });
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->

<img width="1060" alt="image" src="https://github.com/user-attachments/assets/cbaae369-93ed-4b0b-a613-18af25bdc7d7" />

Force link to be primary, this matches the message thread itself and teams.

Correct behaviour:

<img width="704" alt="image" src="https://github.com/user-attachments/assets/5804fa60-cb75-43fe-a464-07a042c55e6e" />


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->