### PR TITLE
Fixed an issue with types for usePropsFor

### DIFF
--- a/change-beta/@azure-communication-react-364a17bc-d253-45ca-8155-63469c3e5c64.json
+++ b/change-beta/@azure-communication-react-364a17bc-d253-45ca-8155-63469c3e5c64.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Fix returned types for useChatPropsFor and useCallingPropsFor",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-364a17bc-d253-45ca-8155-63469c3e5c64.json
+++ b/change/@azure-communication-react-364a17bc-d253-45ca-8155-63469c3e5c64.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "improvement",
+  "workstream": "",
+  "comment": "Fix returned types for useChatPropsFor and useCallingPropsFor",
+  "packageName": "@azure/communication-react",
+  "email": "98852890+vhuseinova-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -5495,13 +5495,13 @@ export const useCallAgent: () => CallAgent | undefined;
 export const useCallClient: () => StatefulCallClient;
 
 // @public
-export const useCallingPropsFor: <Component extends (props: any) => JSX.Element>(component: Component) => ComponentProps<Component>;
+export const useCallingPropsFor: <Component extends (props: any) => JSX.Element>(component: Component) => CallingReturnProps<Component>;
 
 // @public
 export const useChatClient: () => StatefulChatClient;
 
 // @public
-export const useChatPropsFor: <Component extends (props: any) => JSX.Element>(component: Component) => ComponentProps<Component>;
+export const useChatPropsFor: <Component extends (props: any) => JSX.Element>(component: Component) => ChatReturnProps<Component>;
 
 // @public
 export const useChatThreadClient: () => ChatThreadClient;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -4744,13 +4744,13 @@ export const useCallAgent: () => CallAgent | undefined;
 export const useCallClient: () => StatefulCallClient;
 
 // @public
-export const useCallingPropsFor: <Component extends (props: any) => JSX.Element>(component: Component) => ComponentProps<Component>;
+export const useCallingPropsFor: <Component extends (props: any) => JSX.Element>(component: Component) => CallingReturnProps<Component>;
 
 // @public
 export const useChatClient: () => StatefulChatClient;
 
 // @public
-export const useChatPropsFor: <Component extends (props: any) => JSX.Element>(component: Component) => ComponentProps<Component>;
+export const useChatPropsFor: <Component extends (props: any) => JSX.Element>(component: Component) => ChatReturnProps<Component>;
 
 // @public
 export const useChatThreadClient: () => ChatThreadClient;

--- a/packages/communication-react/src/mergedHooks.ts
+++ b/packages/communication-react/src/mergedHooks.ts
@@ -159,14 +159,14 @@ export const usePropsFor = <Component extends (props: any) => JSX.Element>(
  */
 export const useChatPropsFor = <Component extends (props: any) => JSX.Element>(
   component: Component
-): ComponentProps<Component> => {
+): ChatReturnProps<Component> => {
   const props = useChatPropsForInternal(component);
   if (props === undefined) {
     throw new Error(
       'Could not find props for this component, ensure the component is wrapped by appropriate providers.'
     );
   }
-  return props as ComponentProps<Component>;
+  return props as ChatReturnProps<Component>;
 };
 
 /**
@@ -178,12 +178,12 @@ export const useChatPropsFor = <Component extends (props: any) => JSX.Element>(
  */
 export const useCallingPropsFor = <Component extends (props: any) => JSX.Element>(
   component: Component
-): ComponentProps<Component> => {
+): CallingReturnProps<Component> => {
   const props = useCallingPropsForInternal(component);
   if (props === undefined) {
     throw new Error(
       'Could not find props for this component, ensure the component is wrapped by appropriate providers.'
     );
   }
-  return props as ComponentProps<Component>;
+  return props as CallingReturnProps<Component>;
 };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
With the previous implementation Typescript couldn't correctly infer the return type of the `useCallingPropsFor` and `useChatPropsFor` hooks. Change the return type to fix the issue

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->