### PR TITLE
[A11y][Chat sample] Add tooltip for Leave Chat button in Chat sample

### DIFF
--- a/samples/Chat/src/app/ChatHeader.tsx
+++ b/samples/Chat/src/app/ChatHeader.tsx
@@ -64,6 +64,7 @@ export const ChatHeader = (props: ChatHeaderProps): JSX.Element => {
         onClick={() => props.onEndChat()}
         ariaLabel={leaveString}
         aria-live={'polite'}
+        title={leaveString}
       />
     </Stack>
   );


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Add tooltip for Leave Chat button in Chat sample
<img width="698" alt="image" src="https://github.com/user-attachments/assets/bd2f388f-e334-4d98-9c10-0f0383829d26" />

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
- In narrower window there's no text to indicate what the button does, adding a tooltip

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->