### PR TITLE
Update video gallery logic to show desktop view always when on Desktop

### DIFF
--- a/change-beta/@azure-communication-react-876f80cc-fe37-43ca-8af5-93b7118ab9fa.json
+++ b/change-beta/@azure-communication-react-876f80cc-fe37-43ca-8af5-93b7118ab9fa.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Video Gallery",
+  "comment": "Video Gallery should still show desktop view with name plate and 16:9 layout at 400% zoom",
+  "packageName": "@azure/communication-react",
+  "email": "96077406+carocao-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-876f80cc-fe37-43ca-8af5-93b7118ab9fa.json
+++ b/change/@azure-communication-react-876f80cc-fe37-43ca-8af5-93b7118ab9fa.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Video Gallery",
+  "comment": "Video Gallery should still show desktop view with name plate and 16:9 layout at 400% zoom",
+  "packageName": "@azure/communication-react",
+  "email": "96077406+carocao-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -583,7 +583,11 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
     const initialsName = !localParticipant.displayName ? '' : localParticipant.displayName;
 
     const showDisplayNameTrampoline = (): string => {
-      return layout === 'default' ? strings.localVideoLabel : isNarrow ? '' : strings.localVideoLabel;
+      return layout === 'default'
+        ? strings.localVideoLabel
+        : isNarrow && localVideoTileSize !== '16:9'
+          ? ''
+          : strings.localVideoLabel;
     };
 
     return (

--- a/packages/react-components/src/components/VideoGallery.tsx
+++ b/packages/react-components/src/components/VideoGallery.tsx
@@ -558,7 +558,8 @@ export const VideoGallery = (props: VideoGalleryProps): JSX.Element => {
   );
 
   const showLocalVideoTileLabel =
-    !((localTileNotInGrid && isNarrow) || localVideoTileSize === '9:16') || layout === 'default';
+    !((localTileNotInGrid && isNarrow && localVideoTileSize !== '16:9') || localVideoTileSize === '9:16') ||
+    layout === 'default';
   /**
    * Utility function for memoized rendering of LocalParticipant.
    */

--- a/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
+++ b/packages/react-components/src/components/VideoGallery/FloatingLocalVideoLayout.tsx
@@ -125,7 +125,7 @@ export const FloatingLocalVideoLayout = (props: FloatingLocalVideoLayoutProps): 
   const layerHostId = useId('layerhost');
 
   const localVideoSizeRem = useMemo(() => {
-    if (isNarrow || localVideoTileSize === '9:16') {
+    if ((isNarrow && localVideoTileSize !== '16:9') || localVideoTileSize === '9:16') {
       return SMALL_FLOATING_MODAL_SIZE_REM;
     }
     if ((overflowGalleryTiles.length > 0 || screenShareComponent) && overflowGalleryPosition === 'verticalRight') {


### PR DESCRIPTION
# What
Update video gallery logic to use localVideoTileSize to make sure when on desktop, we are always showing the desktop video gallery view 

# Why
fix bug https://skype.visualstudio.com/SPOOL/_workitems/edit/4035618

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->