### PR TITLE
[bugfix] Add a filter to ensure only captions/rtt data is presented and no empty elements without keys

### DIFF
--- a/change-beta/@azure-communication-react-38bd8537-9167-4bee-818d-e0da918622dd.json
+++ b/change-beta/@azure-communication-react-38bd8537-9167-4bee-818d-e0da918622dd.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Captions",
+  "comment": "Ensure all Captions and RealTimeText messages contains key values",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-38bd8537-9167-4bee-818d-e0da918622dd.json
+++ b/change/@azure-communication-react-38bd8537-9167-4bee-818d-e0da918622dd.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Captions",
+  "comment": "Ensure all Captions and RealTimeText messages contains key values",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/CaptionsBanner.tsx
+++ b/packages/react-components/src/components/CaptionsBanner.tsx
@@ -348,8 +348,9 @@ export const CaptionsBanner = (props: CaptionsBannerProps): JSX.Element => {
     /* @conditional-compile-remove(rtt) */
     return (
       <>
-        {mergedCaptions.map((caption) => {
-          if (caption) {
+        {mergedCaptions
+          .filter((caption) => caption)
+          .map((caption) => {
             if ('message' in caption) {
               return (
                 <li key={`RealTimeText - ${caption.id}`} className={captionContainerClassName} data-is-focusable={true}>
@@ -362,9 +363,8 @@ export const CaptionsBanner = (props: CaptionsBannerProps): JSX.Element => {
                 <_Caption {...(caption as CaptionsInformation)} onRenderAvatar={onRenderAvatar} />
               </li>
             );
-          }
-          return <></>;
-        })}
+            return <></>;
+          })}
       </>
     );
 


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add a filter to ensure captions/rtt data is available to set a key to.

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Empty elements were being listed without key values. 
We should not be presenting empty elements at all.

# How Tested
<!--- How did you test your change. What tests have you added. -->
MacOS Chrome calling sample app

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->