### PR TITLE
[Notifications] fix naming typo with notification icon name

### DIFF
--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2984,7 +2984,7 @@ export const DEFAULT_COMPONENT_ICONS: {
     NotificationBarBreakoutRoomClosingSoon: React_2.JSX.Element;
     NotificationBarBreakoutRoomClosed: React_2.JSX.Element;
     NotificationBarTranscriptionError: React_2.JSX.Element;
-    NotificationBartranscriptionStartedByYou: React_2.JSX.Element;
+    NotificationBarTranscriptionStartedByYou: React_2.JSX.Element;
     HorizontalGalleryLeftButton: React_2.JSX.Element;
     HorizontalGalleryRightButton: React_2.JSX.Element;
     MessageDelivered: React_2.JSX.Element;
@@ -3193,7 +3193,7 @@ export const DEFAULT_COMPOSITE_ICONS: {
     NotificationBarBreakoutRoomClosingSoon: React_2.JSX.Element;
     NotificationBarBreakoutRoomClosed: React_2.JSX.Element;
     NotificationBarTranscriptionError: React_2.JSX.Element;
-    NotificationBartranscriptionStartedByYou: React_2.JSX.Element;
+    NotificationBarTranscriptionStartedByYou: React_2.JSX.Element;
     MessageResend: React_2.JSX.Element;
     ParticipantItemSpotlighted: React_2.JSX.Element;
     HoldCallContextualMenuItem: React_2.JSX.Element;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -2634,7 +2634,7 @@ export const DEFAULT_COMPONENT_ICONS: {
     NotificationBarBreakoutRoomClosingSoon: React_2.JSX.Element;
     NotificationBarBreakoutRoomClosed: React_2.JSX.Element;
     NotificationBarTranscriptionError: React_2.JSX.Element;
-    NotificationBartranscriptionStartedByYou: React_2.JSX.Element;
+    NotificationBarTranscriptionStartedByYou: React_2.JSX.Element;
     HorizontalGalleryLeftButton: React_2.JSX.Element;
     HorizontalGalleryRightButton: React_2.JSX.Element;
     MessageDelivered: React_2.JSX.Element;
@@ -2813,7 +2813,7 @@ export const DEFAULT_COMPOSITE_ICONS: {
     NotificationBarBreakoutRoomClosingSoon: React_2.JSX.Element;
     NotificationBarBreakoutRoomClosed: React_2.JSX.Element;
     NotificationBarTranscriptionError: React_2.JSX.Element;
-    NotificationBartranscriptionStartedByYou: React_2.JSX.Element;
+    NotificationBarTranscriptionStartedByYou: React_2.JSX.Element;
     MessageResend: React_2.JSX.Element;
     ParticipantItemSpotlighted: React_2.JSX.Element;
     HoldCallContextualMenuItem: React_2.JSX.Element;

--- a/packages/react-components/src/components/utils.ts
+++ b/packages/react-components/src/components/utils.ts
@@ -371,7 +371,7 @@ export const customNotificationIconName: Partial<{ [key in NotificationType]: st
   /* @conditional-compile-remove(together-mode) */
   togetherModeEnded: 'NotificationBarTogetherModeIcon',
   transcriptionError: 'NotificationBarTranscriptionError',
-  transcriptionStartedByYou: 'NotificationBartranscriptionStartedByYou'
+  transcriptionStartedByYou: 'NotificationBarTranscriptionStartedByYou'
 };
 
 /**

--- a/packages/react-components/src/theming/icons.tsx
+++ b/packages/react-components/src/theming/icons.tsx
@@ -315,7 +315,7 @@ export const DEFAULT_COMPONENT_ICONS = {
   /* @conditional-compile-remove(breakout-rooms) */
   NotificationBarBreakoutRoomClosed: <DoorArrowLeft16Regular />,
   NotificationBarTranscriptionError: <Warning16Regular />,
-  NotificationBartranscriptionStartedByYou: <SlideTextEdit16Regular />,
+  NotificationBarTranscriptionStartedByYou: <SlideTextEdit16Regular />,
   HorizontalGalleryLeftButton: <GalleryLeftButton />,
   HorizontalGalleryRightButton: <GalleryRightButton />,
   MessageDelivered: <CheckmarkCircle16Regular />,


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Fix casing in API icon name for notification type
# Why
<!--- What problem does this change solve? -->
fix the naming for the type
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Built API files