### PR TITLE
Fix listeners for chat events of AzureCommunicationCallWithChatAdapter when the threadId changes

### DIFF
--- a/change-beta/@azure-communication-react-8050440c-53e4-4704-8ede-16f4a0a6c0f8.json
+++ b/change-beta/@azure-communication-react-8050440c-53e4-4704-8ede-16f4a0a6c0f8.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "feature",
+  "workstream": "Breakout rooms",
+  "comment": "Fix listeners subscribed to chat events of AzureCallWithChatAdapter when the thread id is resolved late or is changed when moving to and from breakout rooms",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-8050440c-53e4-4704-8ede-16f4a0a6c0f8.json
+++ b/change/@azure-communication-react-8050440c-53e4-4704-8ede-16f4a0a6c0f8.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "feature",
+  "workstream": "Breakout rooms",
+  "comment": "Fix listeners subscribed to chat events of AzureCallWithChatAdapter when the thread id is resolved late or is changed when moving to and from breakout rooms",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -371,16 +371,22 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
       chatAdapter.on('messageDeleted', listener as MessageDeletedListener);
     }
 
-    const participantsAddedListeners = this.getListeners('participantsAdded');
+    const participantsAddedListeners = this.getListeners('chatParticipantsAdded');
     for (const listener of participantsAddedListeners) {
       this.chatAdapter?.off('participantsAdded', listener as ParticipantsAddedListener);
       chatAdapter.on('participantsAdded', listener as ParticipantsAddedListener);
     }
 
-    const participantsRemovedListeners = this.getListeners('participantsRemoved');
+    const participantsRemovedListeners = this.getListeners('chatParticipantsRemoved');
     for (const listener of participantsRemovedListeners) {
       this.chatAdapter?.off('participantsRemoved', listener as ParticipantsRemovedListener);
       chatAdapter.on('participantsRemoved', listener as ParticipantsRemovedListener);
+    }
+
+    const chatErrorListeners = this.getListeners('chatError');
+    for (const listener of chatErrorListeners) {
+      this.chatAdapter?.off('error', listener as (e: AdapterError) => void);
+      chatAdapter.on('error', listener as (e: AdapterError) => void);
     }
   }
 
@@ -941,13 +947,13 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         });
         break;
       case 'chatParticipantsAdded':
-        this.addListener('participantsAdded', listener);
+        this.addListener('chatParticipantsAdded', listener);
         this.executeWithResolvedChatAdapter((adapter) => {
           adapter.on('participantsAdded', listener);
         });
         break;
       case 'chatParticipantsRemoved':
-        this.addListener('participantsRemoved', listener);
+        this.addListener('chatParticipantsRemoved', listener);
         this.executeWithResolvedChatAdapter((adapter) => {
           adapter.on('participantsRemoved', listener);
         });
@@ -956,12 +962,12 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         this.callAdapter.on('error', listener);
         break;
       case 'chatError':
+        this.addListener('chatError', listener);
         this.executeWithResolvedChatAdapter((adapter) => {
           adapter.on('error', listener);
         });
         break;
       case 'chatInitialized':
-        this.addListener('chatInitialized', listener);
         this.emitter.on(event, listener);
         break;
       case 'capabilitiesChanged':
@@ -1087,13 +1093,13 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         });
         break;
       case 'chatParticipantsAdded':
-        this.removeListener('participantsAdded', listener);
+        this.removeListener('chatParticipantsAdded', listener);
         this.executeWithResolvedChatAdapter((adapter) => {
           adapter.off('participantsAdded', listener);
         });
         break;
       case 'chatParticipantsRemoved':
-        this.removeListener('participantsRemoved', listener);
+        this.removeListener('chatParticipantsRemoved', listener);
         this.executeWithResolvedChatAdapter((adapter) => {
           adapter.off('participantsRemoved', listener);
         });
@@ -1108,7 +1114,6 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
         });
         break;
       case 'chatInitialized':
-        this.removeListener('chatInitialized', listener);
         this.emitter.off(event, listener);
         break;
       case 'capabilitiesChanged':

--- a/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
+++ b/packages/react-composites/src/composites/CallWithChatComposite/adapter/AzureCommunicationCallWithChatAdapter.ts
@@ -472,6 +472,8 @@ export class AzureCommunicationCallWithChatAdapter implements CallWithChatAdapte
     }
     this.callAdapter.offStateChange(this.onCallStateChange);
     this.callAdapter.dispose();
+    // Clear chat event listeners
+    this.chatEventListeners.clear();
   }
   /** Remove a participant from the Call only. */
   public async removeParticipant(userId: string | CommunicationIdentifier): Promise<void> {

--- a/samples/CallWithChat/src/app/views/CallScreen.tsx
+++ b/samples/CallWithChat/src/app/views/CallScreen.tsx
@@ -17,14 +17,13 @@ import {
 } from '@azure/communication-react';
 /* @conditional-compile-remove(file-sharing-acs) */
 import { attachmentUploadOptions } from '../../../../Chat/src/app/utils/uploadHandler';
-import { DefaultButton, Spinner } from '@fluentui/react';
+import { Spinner } from '@fluentui/react';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSwitchableFluentTheme } from '../theming/SwitchableFluentThemeProvider';
 import { createAutoRefreshingCredential } from '../utils/credential';
 import { WEB_APP_TITLE } from '../utils/constants';
 import { useIsMobile } from '../utils/useIsMobile';
 import { isIOS } from '../utils/utils';
-import { ChatMessage } from '@azure/communication-chat';
 
 export interface CallScreenProps {
   token: string;
@@ -152,9 +151,6 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
         // add top-level error handling logic here (e.g. reporting telemetry).
         console.log('Adapter error event:', e);
       });
-      console.log('afterAdapterCreate...');
-      adapter.on('messageReceived', messageReceivedListener);
-      adapter.on('messageSent', messageSentListener);
       adapter.onStateChange((state: CallWithChatAdapterState) => {
         const pageTitle = convertPageStateToString(state);
         document.title = `${pageTitle} - ${WEB_APP_TITLE}`;
@@ -238,20 +234,14 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     callInvitationUrl = undefined;
   }
   return (
-    <>
-      <DefaultButton
-        text="Stop listening to received messages"
-        onClick={() => adapter.off('messageReceived', messageReceivedListener)}
-      />
-      <CallWithChatComposite
-        adapter={adapter}
-        fluentTheme={currentTheme.theme}
-        rtl={currentRtl}
-        joinInvitationURL={callInvitationUrl}
-        options={options}
-        formFactor={isMobileSession ? 'mobile' : 'desktop'}
-      />
-    </>
+    <CallWithChatComposite
+      adapter={adapter}
+      fluentTheme={currentTheme.theme}
+      rtl={currentRtl}
+      joinInvitationURL={callInvitationUrl}
+      options={options}
+      formFactor={isMobileSession ? 'mobile' : 'desktop'}
+    />
   );
 };
 
@@ -284,12 +274,4 @@ const isTeamsMeetingIdLocator = (
 
 const isGroupCallLocator = (locator: TeamsMeetingLinkLocator | CallAndChatLocator | TeamsMeetingIdLocator): boolean => {
   return 'callLocator' in locator && 'groupId' in locator.callLocator;
-};
-
-const messageReceivedListener = (e: { message: ChatMessage }): void => {
-  console.log('messageReceived: ', e);
-};
-
-const messageSentListener = (e: { message: ChatMessage }): void => {
-  console.log('messageSent: ', e);
 };

--- a/samples/CallWithChat/src/app/views/CallScreen.tsx
+++ b/samples/CallWithChat/src/app/views/CallScreen.tsx
@@ -17,13 +17,14 @@ import {
 } from '@azure/communication-react';
 /* @conditional-compile-remove(file-sharing-acs) */
 import { attachmentUploadOptions } from '../../../../Chat/src/app/utils/uploadHandler';
-import { Spinner } from '@fluentui/react';
+import { DefaultButton, Spinner } from '@fluentui/react';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSwitchableFluentTheme } from '../theming/SwitchableFluentThemeProvider';
 import { createAutoRefreshingCredential } from '../utils/credential';
 import { WEB_APP_TITLE } from '../utils/constants';
 import { useIsMobile } from '../utils/useIsMobile';
 import { isIOS } from '../utils/utils';
+import { ChatMessage } from '@azure/communication-chat';
 
 export interface CallScreenProps {
   token: string;
@@ -151,6 +152,9 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
         // add top-level error handling logic here (e.g. reporting telemetry).
         console.log('Adapter error event:', e);
       });
+      console.log('afterAdapterCreate...');
+      adapter.on('messageReceived', messageReceivedListener);
+      adapter.on('messageSent', messageSentListener);
       adapter.onStateChange((state: CallWithChatAdapterState) => {
         const pageTitle = convertPageStateToString(state);
         document.title = `${pageTitle} - ${WEB_APP_TITLE}`;
@@ -234,14 +238,20 @@ export const CallScreen = (props: CallScreenProps): JSX.Element => {
     callInvitationUrl = undefined;
   }
   return (
-    <CallWithChatComposite
-      adapter={adapter}
-      fluentTheme={currentTheme.theme}
-      rtl={currentRtl}
-      joinInvitationURL={callInvitationUrl}
-      options={options}
-      formFactor={isMobileSession ? 'mobile' : 'desktop'}
-    />
+    <>
+      <DefaultButton
+        text="Stop listening to received messages"
+        onClick={() => adapter.off('messageReceived', messageReceivedListener)}
+      />
+      <CallWithChatComposite
+        adapter={adapter}
+        fluentTheme={currentTheme.theme}
+        rtl={currentRtl}
+        joinInvitationURL={callInvitationUrl}
+        options={options}
+        formFactor={isMobileSession ? 'mobile' : 'desktop'}
+      />
+    </>
   );
 };
 
@@ -274,4 +284,12 @@ const isTeamsMeetingIdLocator = (
 
 const isGroupCallLocator = (locator: TeamsMeetingLinkLocator | CallAndChatLocator | TeamsMeetingIdLocator): boolean => {
   return 'callLocator' in locator && 'groupId' in locator.callLocator;
+};
+
+const messageReceivedListener = (e: { message: ChatMessage }): void => {
+  console.log('messageReceived: ', e);
+};
+
+const messageSentListener = (e: { message: ChatMessage }): void => {
+  console.log('messageSent: ', e);
 };


### PR DESCRIPTION
# What
Add map of listeners for chat events so that old chat adapter listeners can be propagated to newly created chat adapters. This will fix listeners for chat events when:
- the thread Id is resolved late in callInfo when joining a Teams meeting link 
- the thread Id is changed when moving to and from breakout rooms

# Why
Resolves one of the issue from #5755 regarding not being able chat event listeners not working when joining a breakout room

# How Tested
Tested with code from reverted [commit](https://github.com/Azure/communication-ui-library/commit/5e1c04305ce3314027d1636afd6ca17d370f3832) on this branch

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->