### PR TITLE
Maintain muted state when joining and leaving breakout rooms

### DIFF
--- a/change-beta/@azure-communication-react-5f000923-3c90-41f7-a76b-5e3ba071d9fc.json
+++ b/change-beta/@azure-communication-react-5f000923-3c90-41f7-a76b-5e3ba071d9fc.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Breakout rooms",
+  "comment": "Maintain muted state when joining and leaving breakout rooms",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-5f000923-3c90-41f7-a76b-5e3ba071d9fc.json
+++ b/change/@azure-communication-react-5f000923-3c90-41f7-a76b-5e3ba071d9fc.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Breakout rooms",
+  "comment": "Maintain muted state when joining and leaving breakout rooms",
+  "packageName": "@azure/communication-react",
+  "email": "79475487+mgamis-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
+++ b/packages/react-composites/src/composites/CallComposite/adapter/AzureCommunicationCallAdapter.ts
@@ -1247,6 +1247,10 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | TeamsCa
     this.context.setIsReturningFromBreakoutRoom(true);
 
     const mainMeeting = await assignedBreakoutRoom.returnToMainMeeting();
+    // Mute main meeting if the breakout room was muted
+    if (this.call?.isMuted) {
+      mainMeeting.mute();
+    }
     this.originCall = mainMeeting;
     this.processNewCall(mainMeeting);
   }
@@ -1518,6 +1522,10 @@ export class AzureCommunicationCallAdapter<AgentType extends CallAgent | TeamsCa
 
   private breakoutRoomJoined(call: Call | TeamsCall): void {
     if (this.call?.id !== call.id) {
+      // Mute the breakout room call if the main call was muted
+      if (this.call?.isMuted) {
+        call.mute();
+      }
       this.processNewCall(call);
     }
     // Hang up other breakout room calls in case we are joining a new breakout room while already in one


### PR DESCRIPTION
# What
Maintain muted state when joining and leaving breakout rooms

# Why
Resolves one of the issues from #5755 regarding not maintaining the muted state when joining and leaving breakout rooms.

# How Tested
Tested locally.

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->