### PR TITLE
Fix to together mode view in meeting rejoin

### DIFF
--- a/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
+++ b/packages/react-composites/src/composites/CallComposite/CallComposite.tsx
@@ -473,6 +473,7 @@ const MainScreen = (props: MainScreenProps): JSX.Element => {
   useEffect(() => {
     const closeSidePane = (): void => {
       setSidePaneRenderer(undefined);
+      setUserSetGalleryLayout('floatingLocalVideo');
     };
     adapter.on('callEnded', closeSidePane);
     return () => {


### PR DESCRIPTION
# What
When participant rejoins  a meeting, the view needs to be re-setted back to the default (floatingLocalVideo)

# Why
When a participant rejoins a meeting after together mode stops. The view option needs to be resetted back

# How Tested
Locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?** No

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->