### PR TITLE
Fix RTE send button disabled after uploading is completed

### DIFF
--- a/change-beta/@azure-communication-react-866200b1-cae4-404a-b452-82a33f1cefb3.json
+++ b/change-beta/@azure-communication-react-866200b1-cae4-404a-b452-82a33f1cefb3.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Fix RichTextSendbox send button is disabled after file uploading is completed",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-866200b1-cae4-404a-b452-82a33f1cefb3.json
+++ b/change/@azure-communication-react-866200b1-cae4-404a-b452-82a33f1cefb3.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Fix RichTextSendbox send button is disabled after file uploading is completed",
+  "packageName": "@azure/communication-react",
+  "email": "107075081+Leah-Xia-Microsoft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+/* @conditional-compile-remove(file-sharing-acs) */
+import { useEffect } from 'react';
 import { RichTextInputBoxComponent } from './RichTextInputBoxComponent';
 import { Icon, Stack } from '@fluentui/react';
 import { useLocale } from '../../localization';

--- a/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RichTextInputBoxComponent } from './RichTextInputBoxComponent';
 import { Icon, Stack } from '@fluentui/react';
 import { useLocale } from '../../localization';
@@ -315,6 +315,13 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
     [contentValueOverflow, strings.textTooLong]
   );
 
+  /* @conditional-compile-remove(file-sharing-acs) */
+  useEffect(() => {
+    if (!hasIncompleteAttachmentUploads(attachments)) {
+      setAttachmentUploadsPendingError(undefined);
+    }
+  }, [attachments]);
+
   const setContent = useCallback((newValue?: string): void => {
     if (newValue === undefined) {
       return;
@@ -435,11 +442,6 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
 
   // ignore attachments error (errored attachment will not be added, shouldn't disable SendButton)
   const hasBlockingErrorMessages = useMemo(() => {
-    /* @conditional-compile-remove(file-sharing-acs) */
-    if (!hasIncompleteAttachmentUploads(attachments)) {
-      setAttachmentUploadsPendingError(undefined);
-    }
-
     return (
       !!systemMessage ||
       !!contentTooLongMessage ||
@@ -454,9 +456,7 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
     attachmentUploadsPendingError,
     systemMessage,
     /* @conditional-compile-remove(rich-text-editor-image-upload) */
-    inlineImagesWithProgress,
-    /* @conditional-compile-remove(file-sharing-acs) */
-    attachments
+    inlineImagesWithProgress
   ]);
 
   const isSendBoxButtonDisabledValue = useMemo(() => {

--- a/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
@@ -435,6 +435,11 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
 
   // ignore attachments error (errored attachment will not be added, shouldn't disable SendButton)
   const hasBlockingErrorMessages = useMemo(() => {
+    /* @conditional-compile-remove(file-sharing-acs) */
+    if (!hasIncompleteAttachmentUploads(attachments)) {
+      setAttachmentUploadsPendingError(undefined);
+    }
+
     return (
       !!systemMessage ||
       !!contentTooLongMessage ||
@@ -449,7 +454,9 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
     attachmentUploadsPendingError,
     systemMessage,
     /* @conditional-compile-remove(rich-text-editor-image-upload) */
-    inlineImagesWithProgress
+    inlineImagesWithProgress,
+    /* @conditional-compile-remove(file-sharing-acs) */
+    attachments
   ]);
 
   const isSendBoxButtonDisabledValue = useMemo(() => {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Repo steps:

1. Enable RTE
2. Upload a large file
3. While uploading, click on the send button
4. After file loaded, click on the send button and observe the issue
5. Remove the files and try to send a plain text message, fail to send the message as well


After the fix:
https://github.com/user-attachments/assets/f9a463c1-1c95-457b-9f4c-9b74876e1454


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->