### PR TITLE
[Bugfix] update to use interface

### DIFF
--- a/packages/acs-ui-javascript-loaders/src/callCompositeLoader.ts
+++ b/packages/acs-ui-javascript-loaders/src/callCompositeLoader.ts
@@ -30,16 +30,15 @@ import { initializeIcons } from '@fluentui/react';
  *
  * @public
  */
-export type CallCompositeLoaderProps = {
+export interface CallCompositeLoaderProps extends Partial<BaseCompositeProps<CallCompositeIcons>> {
   userId: CommunicationUserIdentifier;
   credential: CommunicationTokenCredential;
   displayName: string;
   locator: CallAdapterLocator;
   callAdapterOptions?: AzureCommunicationCallAdapterOptions;
   callCompositeOptions?: CallCompositeOptions;
-  baseCompositeProps?: BaseCompositeProps<CallCompositeIcons>;
   formFactor?: 'mobile' | 'desktop';
-};
+}
 
 /**
  * Loader function for the CallComposite that you can use in your application. This
@@ -60,8 +59,13 @@ export const loadCallComposite = async function (
     locator,
     callAdapterOptions,
     callCompositeOptions,
-    baseCompositeProps,
-    formFactor
+    formFactor,
+    fluentTheme,
+    icons,
+    onFetchAvatarPersonaData,
+    onFetchParticipantMenuItems,
+    rtl,
+    locale
   } = loaderArgs;
   const adapter = await createAzureCommunicationCallAdapter({
     userId,
@@ -78,7 +82,17 @@ export const loadCallComposite = async function (
   createRoot(htmlElement).render(
     React.createElement(
       CallComposite,
-      { ...baseCompositeProps, options: callCompositeOptions, adapter, formFactor },
+      {
+        options: callCompositeOptions,
+        adapter,
+        formFactor,
+        fluentTheme,
+        icons,
+        locale,
+        onFetchAvatarPersonaData,
+        onFetchParticipantMenuItems,
+        rtl
+      },
       null
     )
   );

--- a/packages/acs-ui-javascript-loaders/src/callWithChatCompositeLoader.ts
+++ b/packages/acs-ui-javascript-loaders/src/callWithChatCompositeLoader.ts
@@ -29,7 +29,7 @@ import { initializeIcons } from '@fluentui/react';
  * - callCompositeOptions: Options for the {@link CallWithChatComposite} {@link CallWithChatCompositeOptions}
  * @public
  */
-export type CallWithChatCompositeLoaderProps = {
+export interface CallWithChatCompositeLoaderProps extends Partial<BaseCompositeProps<CallWithChatCompositeIcons>> {
   userId: CommunicationUserIdentifier;
   credential: CommunicationTokenCredential;
   displayName: string;
@@ -37,9 +37,8 @@ export type CallWithChatCompositeLoaderProps = {
   locator: CallAndChatLocator;
   callAdapterOptions?: AzureCommunicationCallAdapterOptions;
   callWithChatCompositeOptions?: CallWithChatCompositeOptions;
-  baseCompositeProps?: BaseCompositeProps<CallWithChatCompositeIcons>;
   formFactor?: 'mobile' | 'desktop';
-};
+}
 
 /**
  * Props for the CallWithChatComposite that you can use in your application. This
@@ -61,8 +60,13 @@ export const loadCallWithChatComposite = async function (
     locator,
     callAdapterOptions,
     callWithChatCompositeOptions,
-    baseCompositeProps,
-    formFactor
+    formFactor,
+    fluentTheme,
+    locale,
+    icons,
+    onFetchAvatarPersonaData,
+    onFetchParticipantMenuItems,
+    rtl
   } = loaderArgs;
   const adapter = await createAzureCommunicationCallWithChatAdapter({
     userId,
@@ -80,7 +84,17 @@ export const loadCallWithChatComposite = async function (
   createRoot(htmlElement).render(
     React.createElement(
       CallWithChatComposite,
-      { ...baseCompositeProps, options: callWithChatCompositeOptions, adapter, formFactor },
+      {
+        options: callWithChatCompositeOptions,
+        adapter,
+        formFactor,
+        fluentTheme,
+        icons,
+        locale,
+        onFetchAvatarPersonaData,
+        onFetchParticipantMenuItems,
+        rtl
+      },
       null
     )
   );

--- a/packages/acs-ui-javascript-loaders/src/chatCompositeLoader.ts
+++ b/packages/acs-ui-javascript-loaders/src/chatCompositeLoader.ts
@@ -24,15 +24,14 @@ import { initializeIcons } from '@fluentui/react';
  * options for the {@link ChatComposite} {@link ChatCompositeOptions}.
  * @public
  */
-export type ChatCompositeLoaderProps = {
+export interface ChatCompositeLoaderProps extends Partial<BaseCompositeProps<ChatCompositeIcons>> {
   userId: CommunicationUserIdentifier;
   credential: CommunicationTokenCredential;
   displayName?: string;
   endpoint: string;
   threadId: string;
   chatCompositeOptions?: ChatCompositeOptions;
-  baseCompositeProps?: BaseCompositeProps<ChatCompositeIcons>;
-};
+}
 
 /**
  * Loader function for the ChatComposite that you can use in your application. This
@@ -46,7 +45,20 @@ export const loadChatComposite = async function (
   htmlElement: HTMLElement
 ): Promise<ChatAdapter | undefined> {
   initializeIcons();
-  const { userId, credential, endpoint, threadId, displayName, chatCompositeOptions, baseCompositeProps } = loaderArgs;
+  const {
+    userId,
+    credential,
+    endpoint,
+    threadId,
+    displayName,
+    chatCompositeOptions,
+    fluentTheme,
+    locale,
+    icons,
+    onFetchAvatarPersonaData,
+    onFetchParticipantMenuItems,
+    rtl
+  } = loaderArgs;
   const adapter = await createAzureCommunicationChatAdapter({
     endpoint,
     userId,
@@ -60,7 +72,20 @@ export const loadChatComposite = async function (
   }
 
   createRoot(htmlElement).render(
-    React.createElement(ChatComposite, { ...baseCompositeProps, options: chatCompositeOptions, adapter }, null)
+    React.createElement(
+      ChatComposite,
+      {
+        options: chatCompositeOptions,
+        adapter,
+        fluentTheme,
+        icons,
+        locale,
+        onFetchAvatarPersonaData,
+        onFetchParticipantMenuItems,
+        rtl
+      },
+      null
+    )
   );
   return adapter;
 };

--- a/packages/acs-ui-javascript-loaders/src/outboundCallCompositeLoader.ts
+++ b/packages/acs-ui-javascript-loaders/src/outboundCallCompositeLoader.ts
@@ -31,15 +31,15 @@ import { initializeIcons } from '@fluentui/react';
  *
  * @public
  */
-export type OutboundCallCompositeLoaderProps = {
+export interface OutboundCallCompositeLoaderProps extends Partial<BaseCompositeProps<CallCompositeIcons>> {
   userId: CommunicationUserIdentifier;
   credential: CommunicationTokenCredential;
   displayName: string;
   targetCallees: string[] | StartCallIdentifier[];
   callAdapterOptions?: AzureCommunicationCallAdapterOptions;
-  baseCompositeProps?: BaseCompositeProps<CallCompositeIcons>;
   callCompositeOptions?: CallCompositeOptions;
-};
+  formFactor?: 'mobile' | 'desktop';
+}
 
 /**
  * Loader function for the OutboundCallComposite that you can use in your application. This

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -746,16 +746,22 @@ export type CallCompositeIcons = {
 };
 
 // @public
-export type CallCompositeLoaderProps = {
-    userId: CommunicationUserIdentifier;
-    credential: CommunicationTokenCredential;
-    displayName: string;
-    locator: CallAdapterLocator;
+export interface CallCompositeLoaderProps extends Partial<BaseCompositeProps<CallCompositeIcons>> {
+    // (undocumented)
     callAdapterOptions?: AzureCommunicationCallAdapterOptions;
+    // (undocumented)
     callCompositeOptions?: CallCompositeOptions;
-    baseCompositeProps?: BaseCompositeProps<CallCompositeIcons>;
+    // (undocumented)
+    credential: CommunicationTokenCredential;
+    // (undocumented)
+    displayName: string;
+    // (undocumented)
     formFactor?: 'mobile' | 'desktop';
-};
+    // (undocumented)
+    locator: CallAdapterLocator;
+    // (undocumented)
+    userId: CommunicationUserIdentifier;
+}
 
 // @public
 export type CallCompositeOptions = {
@@ -1592,17 +1598,24 @@ export type CallWithChatCompositeIcons = {
 };
 
 // @public
-export type CallWithChatCompositeLoaderProps = {
-    userId: CommunicationUserIdentifier;
-    credential: CommunicationTokenCredential;
-    displayName: string;
-    endpoint: string;
-    locator: CallAndChatLocator;
+export interface CallWithChatCompositeLoaderProps extends Partial<BaseCompositeProps<CallWithChatCompositeIcons>> {
+    // (undocumented)
     callAdapterOptions?: AzureCommunicationCallAdapterOptions;
+    // (undocumented)
     callWithChatCompositeOptions?: CallWithChatCompositeOptions;
-    baseCompositeProps?: BaseCompositeProps<CallWithChatCompositeIcons>;
+    // (undocumented)
+    credential: CommunicationTokenCredential;
+    // (undocumented)
+    displayName: string;
+    // (undocumented)
+    endpoint: string;
+    // (undocumented)
     formFactor?: 'mobile' | 'desktop';
-};
+    // (undocumented)
+    locator: CallAndChatLocator;
+    // (undocumented)
+    userId: CommunicationUserIdentifier;
+}
 
 // @public
 export type CallWithChatCompositeOptions = {
@@ -2144,15 +2157,20 @@ export type ChatCompositeIcons = {
 };
 
 // @public
-export type ChatCompositeLoaderProps = {
-    userId: CommunicationUserIdentifier;
-    credential: CommunicationTokenCredential;
-    displayName?: string;
-    endpoint: string;
-    threadId: string;
+export interface ChatCompositeLoaderProps extends Partial<BaseCompositeProps<ChatCompositeIcons>> {
+    // (undocumented)
     chatCompositeOptions?: ChatCompositeOptions;
-    baseCompositeProps?: BaseCompositeProps<ChatCompositeIcons>;
-};
+    // (undocumented)
+    credential: CommunicationTokenCredential;
+    // (undocumented)
+    displayName?: string;
+    // (undocumented)
+    endpoint: string;
+    // (undocumented)
+    threadId: string;
+    // (undocumented)
+    userId: CommunicationUserIdentifier;
+}
 
 // @public
 export type ChatCompositeOptions = {
@@ -4337,15 +4355,22 @@ export interface OptionsDevice {
 }
 
 // @public
-export type OutboundCallCompositeLoaderProps = {
-    userId: CommunicationUserIdentifier;
-    credential: CommunicationTokenCredential;
-    displayName: string;
-    targetCallees: string[] | StartCallIdentifier[];
+export interface OutboundCallCompositeLoaderProps extends Partial<BaseCompositeProps<CallCompositeIcons>> {
+    // (undocumented)
     callAdapterOptions?: AzureCommunicationCallAdapterOptions;
-    baseCompositeProps?: BaseCompositeProps<CallCompositeIcons>;
+    // (undocumented)
     callCompositeOptions?: CallCompositeOptions;
-};
+    // (undocumented)
+    credential: CommunicationTokenCredential;
+    // (undocumented)
+    displayName: string;
+    // (undocumented)
+    formFactor?: 'mobile' | 'desktop';
+    // (undocumented)
+    targetCallees: string[] | StartCallIdentifier[];
+    // (undocumented)
+    userId: CommunicationUserIdentifier;
+}
 
 // @public
 export type OverflowGalleryPosition = 'horizontalBottom' | 'verticalRight' | 'horizontalTop';

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -601,16 +601,22 @@ export type CallCompositeIcons = {
 };
 
 // @public
-export type CallCompositeLoaderProps = {
-    userId: CommunicationUserIdentifier;
-    credential: CommunicationTokenCredential;
-    displayName: string;
-    locator: CallAdapterLocator;
+export interface CallCompositeLoaderProps extends Partial<BaseCompositeProps<CallCompositeIcons>> {
+    // (undocumented)
     callAdapterOptions?: AzureCommunicationCallAdapterOptions;
+    // (undocumented)
     callCompositeOptions?: CallCompositeOptions;
-    baseCompositeProps?: BaseCompositeProps<CallCompositeIcons>;
+    // (undocumented)
+    credential: CommunicationTokenCredential;
+    // (undocumented)
+    displayName: string;
+    // (undocumented)
     formFactor?: 'mobile' | 'desktop';
-};
+    // (undocumented)
+    locator: CallAdapterLocator;
+    // (undocumented)
+    userId: CommunicationUserIdentifier;
+}
 
 // @public
 export type CallCompositeOptions = {
@@ -1426,17 +1432,24 @@ export type CallWithChatCompositeIcons = {
 };
 
 // @public
-export type CallWithChatCompositeLoaderProps = {
-    userId: CommunicationUserIdentifier;
-    credential: CommunicationTokenCredential;
-    displayName: string;
-    endpoint: string;
-    locator: CallAndChatLocator;
+export interface CallWithChatCompositeLoaderProps extends Partial<BaseCompositeProps<CallWithChatCompositeIcons>> {
+    // (undocumented)
     callAdapterOptions?: AzureCommunicationCallAdapterOptions;
+    // (undocumented)
     callWithChatCompositeOptions?: CallWithChatCompositeOptions;
-    baseCompositeProps?: BaseCompositeProps<CallWithChatCompositeIcons>;
+    // (undocumented)
+    credential: CommunicationTokenCredential;
+    // (undocumented)
+    displayName: string;
+    // (undocumented)
+    endpoint: string;
+    // (undocumented)
     formFactor?: 'mobile' | 'desktop';
-};
+    // (undocumented)
+    locator: CallAndChatLocator;
+    // (undocumented)
+    userId: CommunicationUserIdentifier;
+}
 
 // @public
 export type CallWithChatCompositeOptions = {
@@ -1940,15 +1953,20 @@ export type ChatCompositeIcons = {
 };
 
 // @public
-export type ChatCompositeLoaderProps = {
-    userId: CommunicationUserIdentifier;
-    credential: CommunicationTokenCredential;
-    displayName?: string;
-    endpoint: string;
-    threadId: string;
+export interface ChatCompositeLoaderProps extends Partial<BaseCompositeProps<ChatCompositeIcons>> {
+    // (undocumented)
     chatCompositeOptions?: ChatCompositeOptions;
-    baseCompositeProps?: BaseCompositeProps<ChatCompositeIcons>;
-};
+    // (undocumented)
+    credential: CommunicationTokenCredential;
+    // (undocumented)
+    displayName?: string;
+    // (undocumented)
+    endpoint: string;
+    // (undocumented)
+    threadId: string;
+    // (undocumented)
+    userId: CommunicationUserIdentifier;
+}
 
 // @public
 export type ChatCompositeOptions = {
@@ -3948,15 +3966,22 @@ export interface OptionsDevice {
 }
 
 // @public
-export type OutboundCallCompositeLoaderProps = {
-    userId: CommunicationUserIdentifier;
-    credential: CommunicationTokenCredential;
-    displayName: string;
-    targetCallees: string[] | StartCallIdentifier[];
+export interface OutboundCallCompositeLoaderProps extends Partial<BaseCompositeProps<CallCompositeIcons>> {
+    // (undocumented)
     callAdapterOptions?: AzureCommunicationCallAdapterOptions;
-    baseCompositeProps?: BaseCompositeProps<CallCompositeIcons>;
+    // (undocumented)
     callCompositeOptions?: CallCompositeOptions;
-};
+    // (undocumented)
+    credential: CommunicationTokenCredential;
+    // (undocumented)
+    displayName: string;
+    // (undocumented)
+    formFactor?: 'mobile' | 'desktop';
+    // (undocumented)
+    targetCallees: string[] | StartCallIdentifier[];
+    // (undocumented)
+    userId: CommunicationUserIdentifier;
+}
 
 // @public
 export type OverflowGalleryPosition = 'horizontalBottom' | 'verticalRight' | 'horizontalTop';


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
updates the composite props to extend off the base composite like when using the composite
# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->
Validated in Angular app
![image](https://github.com/user-attachments/assets/fe1b8638-c3c4-4381-9722-b83798d0c34c)
usage:
```typescript
this.adapter = await communicationreact
            .loadCallComposite(
              {
                userId: identifier as CommunicationUserIdentifier,
                credential: credential,
                displayName: this.displayName,
                locator: {
                  groupId: this.groupId,
                },
                callCompositeOptions: compositeOptions,
                fluentTheme: theme, locale: COMPOSITE_LOCALE_FR_CA,
                formFactor: 'mobile'
              },
              compositeContainer
            )
            .then((adapter: CallAdapter | undefined) => {
              if (adapter) {
                adapter.on('callEnded', () => {
                  console.log('Call ended');
                });
              }
            });
```