### PR TITLE
Custom Button Injection auto dismiss drawer menu when actioned

### DIFF
--- a/change-beta/@azure-communication-react-d44320f8-4979-4572-87c6-b666454a9377.json
+++ b/change-beta/@azure-communication-react-d44320f8-4979-4572-87c6-b666454a9377.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "improvement",
+  "workstream": "CustomButtonInjection",
+  "comment": "Add custom button injection autohide in drawermenus",
+  "packageName": "@azure/communication-react",
+  "email": "edwardlee@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -2901,6 +2901,7 @@ export type CustomCallControlButtonPlacement = 'primary' | 'overflow' | 'seconda
 // @public
 export interface CustomCallControlButtonProps {
     disabled?: boolean;
+    dismissDrawer?: boolean;
     iconName?: string;
     id?: string;
     onItemClick?: () => void;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -2646,6 +2646,7 @@ export type CustomCallControlButtonPlacement = 'primary' | 'overflow' | 'seconda
 // @public
 export interface CustomCallControlButtonProps {
     disabled?: boolean;
+    dismissDrawer?: boolean;
     iconName?: string;
     id?: string;
     onItemClick?: () => void;

--- a/packages/react-components/src/components/Drawer/DrawerMenuItem.tsx
+++ b/packages/react-components/src/components/Drawer/DrawerMenuItem.tsx
@@ -62,6 +62,10 @@ export interface _DrawerMenuItemProps {
    * Aria label for the menu item
    */
   ariaLabel?: string;
+  /**
+   * Dismiss the drawer menu when the button is clicked
+   */ 
+  dismissDrawer?: boolean;
 }
 
 /**

--- a/packages/react-components/src/components/Drawer/DrawerMenuItem.tsx
+++ b/packages/react-components/src/components/Drawer/DrawerMenuItem.tsx
@@ -64,7 +64,7 @@ export interface _DrawerMenuItemProps {
   ariaLabel?: string;
   /**
    * Dismiss the drawer menu when the button is clicked
-   */ 
+   */
   dismissDrawer?: boolean;
 }
 

--- a/packages/react-composites/src/composites/common/ControlBar/CustomButton.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/CustomButton.tsx
@@ -85,9 +85,9 @@ export interface CustomCallControlButtonProps {
   strings?: CustomCallControlButtonStrings;
   /**
    * Dismiss the drawer menu when the button is clicked
-   * 
+   *
    * @defaultValue true
-   */ 
+   */
   dismissDrawer?: boolean;
 }
 

--- a/packages/react-composites/src/composites/common/ControlBar/CustomButton.tsx
+++ b/packages/react-composites/src/composites/common/ControlBar/CustomButton.tsx
@@ -83,6 +83,12 @@ export interface CustomCallControlButtonProps {
    * Optional strings to override in component
    */
   strings?: CustomCallControlButtonStrings;
+  /**
+   * Dismiss the drawer menu when the button is clicked
+   * 
+   * @defaultValue true
+   */ 
+  dismissDrawer?: boolean;
 }
 
 /**

--- a/packages/react-composites/src/composites/common/Drawer/MoreDrawer.tsx
+++ b/packages/react-composites/src/composites/common/Drawer/MoreDrawer.tsx
@@ -696,6 +696,11 @@ export const MoreDrawer = (props: MoreDrawerProps): JSX.Element => {
     drawerMenuItems.push(element);
   });
   customDrawerButtons['overflow'].forEach((element) => {
+    let customButtonProps = {...element};
+    // Default Auto dismiss drawer on click unless specified
+    if (customButtonProps.dismissDrawer || customButtonProps.dismissDrawer == null) {
+      element = {...customButtonProps, onItemClick: () => {customButtonProps.onItemClick?.(); onLightDismiss()} }
+    }
     drawerMenuItems.push(element);
   });
   return (

--- a/packages/react-composites/src/composites/common/Drawer/MoreDrawer.tsx
+++ b/packages/react-composites/src/composites/common/Drawer/MoreDrawer.tsx
@@ -696,10 +696,16 @@ export const MoreDrawer = (props: MoreDrawerProps): JSX.Element => {
     drawerMenuItems.push(element);
   });
   customDrawerButtons['overflow'].forEach((element) => {
-    let customButtonProps = {...element};
+    const customButtonProps = { ...element };
     // Default Auto dismiss drawer on click unless specified
     if (customButtonProps.dismissDrawer || customButtonProps.dismissDrawer == null) {
-      element = {...customButtonProps, onItemClick: () => {customButtonProps.onItemClick?.(); onLightDismiss()} }
+      element = {
+        ...customButtonProps,
+        onItemClick: () => {
+          customButtonProps.onItemClick?.();
+          onLightDismiss();
+        }
+      };
     }
     drawerMenuItems.push(element);
   });

--- a/packages/react-composites/src/composites/common/Drawer/MoreDrawer.tsx
+++ b/packages/react-composites/src/composites/common/Drawer/MoreDrawer.tsx
@@ -698,7 +698,7 @@ export const MoreDrawer = (props: MoreDrawerProps): JSX.Element => {
   customDrawerButtons['overflow'].forEach((element) => {
     const customButtonProps = { ...element };
     // Default Auto dismiss drawer on click unless specified
-    if (customButtonProps.dismissDrawer || customButtonProps.dismissDrawer == null) {
+    if (customButtonProps.dismissDrawer !== false) {
       element = {
         ...customButtonProps,
         onItemClick: () => {


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Add new prop to auto dismiss drawer menu for custom button injection

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Custom buttons clicked in overflow would not dismiss the drawermenu. Would cause issues when opening dialogs as drawermenu would overlay on top

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->