### PR TITLE
Revert a11y dropdown group announcement

### DIFF
--- a/change-beta/@azure-communication-react-4b170639-a671-4920-b5d6-0f5348f02b5f.json
+++ b/change-beta/@azure-communication-react-4b170639-a671-4920-b5d6-0f5348f02b5f.json
@@ -1,9 +1,0 @@
-{
-  "type": "patch",
-  "area": "fix",
-  "workstream": "Accessibility",
-  "comment": "Add focus outline to buttons that maintain focus after being actioned",
-  "packageName": "@azure/communication-react",
-  "email": "edwardlee@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change-beta/@azure-communication-react-dddcb5df-0075-426b-8012-314e9c29ae97.json
+++ b/change-beta/@azure-communication-react-dddcb5df-0075-426b-8012-314e9c29ae97.json
@@ -1,9 +1,0 @@
-{
-  "type": "patch",
-  "area": "improvement",
-  "workstream": "PSTN",
-  "comment": "Enable ringing tone during connecting and ringing state",
-  "packageName": "@azure/communication-react",
-  "email": "edwardlee@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/LocalDeviceSettings.tsx
@@ -50,18 +50,6 @@ const getDropDownList = (list: Array<VideoDeviceInfo | AudioDeviceInfo>): IDropd
   return dropdownList;
 };
 
-// This helper function is used to prepend a header item to the dropdown list.
-// Allows Dropdowns to have a name for the list of options when first being actioned (a11y requirement).
-const prependHeaderDropdownItem = (list: IDropdownOption[], headerTitle: string): IDropdownOption[] => {
-  const headerItem: IDropdownOption = {
-    key: headerTitle,
-    text: headerTitle,
-    itemType: 2,
-    hidden: true
-  };
-  return [headerItem, ...list];
-};
-
 const getOptionIcon = (type: iconType): JSX.Element | undefined => {
   if (type === 'Camera') {
     return <CallCompositeIcon iconName="LocalDeviceSettingsCamera" className={optionIconStyles} />;
@@ -163,11 +151,7 @@ export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element
       data-ui-id="call-composite-local-camera-settings"
       aria-labelledby={cameraLabelId}
       placeholder={hasCameras ? defaultPlaceHolder : noCameraLabel}
-      options={
-        cameraPermissionGranted
-          ? prependHeaderDropdownItem(getDropDownList(props.cameras), cameraLabel)
-          : [{ key: 'deniedOrUnknown', text: '' }]
-      }
+      options={cameraPermissionGranted ? getDropDownList(props.cameras) : [{ key: 'deniedOrUnknown', text: '' }]}
       styles={dropDownStyles(theme)}
       disabled={!cameraPermissionGranted || !hasCameras}
       errorMessage={
@@ -209,11 +193,7 @@ export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element
               ? undefined
               : locale.strings.call.microphonePermissionDenied
           }
-          options={
-            micPermissionGranted
-              ? prependHeaderDropdownItem(getDropDownList(props.microphones), soundLabel)
-              : [{ key: 'deniedOrUnknown', text: '' }]
-          }
+          options={micPermissionGranted ? getDropDownList(props.microphones) : [{ key: 'deniedOrUnknown', text: '' }]}
           defaultSelectedKey={
             micPermissionGranted
               ? props.selectedMicrophone
@@ -245,7 +225,7 @@ export const LocalDeviceSettings = (props: LocalDeviceSettingsType): JSX.Element
       placeholder={hasSpeakers ? defaultPlaceHolder : noSpeakersLabel}
       styles={dropDownStyles(theme)}
       disabled={props.speakers.length === 0}
-      options={prependHeaderDropdownItem(getDropDownList(props.speakers), soundLabel)}
+      options={getDropDownList(props.speakers)}
       defaultSelectedKey={props.selectedSpeaker ? props.selectedSpeaker.id : defaultDeviceId(props.speakers)}
       onChange={(
         event: React.FormEvent<HTMLDivElement>,


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Revert a11y dropdown group announcement

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Causing a ghost element to take precedence when selecting a new item in the dropdown every other time.

# How Tested
<!--- How did you test your change. What tests have you added. -->
MacOS Chrome

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->