### PR TITLE
Fix for dark text for raise hand button in dark theme

### DIFF
--- a/change-beta/@azure-communication-react-acd9ca3e-b6a3-45ae-be9e-3f99f4986602.json
+++ b/change-beta/@azure-communication-react-acd9ca3e-b6a3-45ae-be9e-3f99f4986602.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Dark text for raise hand button in dark theme",
+  "comment": "Dark text for raise hand button in dark theme",
+  "packageName": "@azure/communication-react",
+  "email": "97124699+prabhjot-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-acd9ca3e-b6a3-45ae-be9e-3f99f4986602.json
+++ b/change/@azure-communication-react-acd9ca3e-b6a3-45ae-be9e-3f99f4986602.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Dark text for raise hand button in dark theme",
+  "comment": "Dark text for raise hand button in dark theme",
+  "packageName": "@azure/communication-react",
+  "email": "97124699+prabhjot-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-components/src/components/RaiseHandButton.tsx
+++ b/packages/react-components/src/components/RaiseHandButton.tsx
@@ -82,14 +82,26 @@ export const RaiseHandButton = (props: RaiseHandButtonProps): JSX.Element => {
 
 const raiseHandButtonStyles = (theme: Theme): IButtonStyles => ({
   rootChecked: {
-    background: theme.palette.themePrimary,
-    color: DefaultPalette.white,
-    ':focus::after': { outlineColor: `${DefaultPalette.white}` }
+    background: theme.semanticColors.primaryButtonBackground,
+    color: theme.semanticColors.primaryButtonText,
+    ':focus::after': { outlineColor: `${DefaultPalette.white} !important` }, // added !important to avoid override by FluentUI button styles
+    '@media (forced-colors: active)': {
+      border: '1px solid',
+      borderColor: theme.palette.black
+    }
   },
   rootCheckedHovered: {
-    background: theme.palette.themePrimary,
-    color: DefaultPalette.white,
-    ':focus::after': { outlineColor: `${DefaultPalette.white}` }
+    background: theme.semanticColors.primaryButtonBackgroundHovered,
+    color: theme.semanticColors.primaryButtonTextHovered,
+    ':focus::after': { outlineColor: `${DefaultPalette.white} !important` }, // added !important to avoid override by FluentUI button styles
+    '@media (forced-colors: active)': {
+      border: '1px solid',
+      borderColor: theme.palette.black
+    }
   },
-  labelChecked: { color: DefaultPalette.white }
+  rootCheckedPressed: {
+    background: theme.semanticColors.primaryButtonBackgroundPressed,
+    color: theme.semanticColors.primaryButtonTextPressed
+  },
+  labelChecked: { color: theme.semanticColors.primaryButtonText }
 });


### PR DESCRIPTION
# What
Before:
<img width="892" alt="Screenshot 2025-06-04 at 2 11 05 PM" src="https://github.com/user-attachments/assets/eb34ccec-5948-4a85-b6c8-4efbf3918511" />

After:
<img width="933" alt="Screenshot 2025-06-04 at 2 09 13 PM" src="https://github.com/user-attachments/assets/ccb040eb-b6d7-42d7-9d2f-11aa730f2d27" />

# Why
https://skype.visualstudio.com/SPOOL/_workitems/edit/4045402

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->