### PR TITLE
Avoid permissions API on Android WebView

### DIFF
--- a/packages/calling-stateful-client/src/DeviceManagerDeclarative.ts
+++ b/packages/calling-stateful-client/src/DeviceManagerDeclarative.ts
@@ -179,8 +179,11 @@ class ProxyDeviceManager implements ProxyHandler<DeviceManager> {
           navigator.permissions.query({ name: 'microphone' as PermissionName })
         ]);
 
-        hasCameraPermission = cameraPermissions.state === 'granted';
-        hasMicPermission = micPermissions.state === 'granted';
+        // Use logical OR to combine the SDK state with the Permissions API state.
+        // This way we can get a more accurate picture of the device permission state.
+        // If the SDK state is 'granted', we don't need to check the Permissions API state.
+        hasCameraPermission ||= cameraPermissions.state === 'granted';
+        hasMicPermission ||= micPermissions.state === 'granted';
       } catch (e) {
         console.info('Permissions API is not supported by browser', e);
       }

--- a/samples/CallWithChat/src/app/utils/localStorage.ts
+++ b/samples/CallWithChat/src/app/utils/localStorage.ts
@@ -12,22 +12,22 @@ export enum LocalStorageKeys {
  * Get display name from local storage.
  */
 export const getDisplayNameFromLocalStorage = (): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.DisplayName);
+  window.localStorage?.getItem(LocalStorageKeys.DisplayName);
 
 /**
  * Save display name into local storage.
  */
 export const saveDisplayNameToLocalStorage = (displayName: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.DisplayName, displayName);
+  window.localStorage?.setItem(LocalStorageKeys.DisplayName, displayName);
 
 /**
  * Get theme from local storage.
  */
 export const getThemeFromLocalStorage = (scopeId: string): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.Theme + '_' + scopeId);
+  window.localStorage?.getItem(LocalStorageKeys.Theme + '_' + scopeId);
 
 /**
  * Save theme into local storage.
  */
 export const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);
+  window.localStorage?.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);

--- a/samples/Calling/src/app/utils/localStorage.ts
+++ b/samples/Calling/src/app/utils/localStorage.ts
@@ -12,22 +12,22 @@ export enum LocalStorageKeys {
  * Get display name from local storage.
  */
 export const getDisplayNameFromLocalStorage = (): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.DisplayName);
+  window.localStorage?.getItem(LocalStorageKeys.DisplayName);
 
 /**
  * Save display name into local storage.
  */
 export const saveDisplayNameToLocalStorage = (displayName: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.DisplayName, displayName);
+  window.localStorage?.setItem(LocalStorageKeys.DisplayName, displayName);
 
 /**
  * Get theme from local storage.
  */
 export const getThemeFromLocalStorage = (scopeId: string): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.Theme + '_' + scopeId);
+  window.localStorage?.getItem(LocalStorageKeys.Theme + '_' + scopeId);
 
 /**
  * Save theme into local storage.
  */
 export const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);
+  window.localStorage?.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);

--- a/samples/Chat/src/app/utils/localStorage.ts
+++ b/samples/Chat/src/app/utils/localStorage.ts
@@ -12,22 +12,22 @@ export enum LocalStorageKeys {
  * Get display name from local storage.
  */
 export const getDisplayNameFromLocalStorage = (): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.DisplayName);
+  window.localStorage?.getItem(LocalStorageKeys.DisplayName);
 
 /**
  * Save display name into local storage.
  */
 export const saveDisplayNameToLocalStorage = (displayName: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.DisplayName, displayName);
+  window.localStorage?.setItem(LocalStorageKeys.DisplayName, displayName);
 
 /**
  * Get theme from local storage.
  */
 export const getThemeFromLocalStorage = (scopeId: string): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.Theme + '_' + scopeId);
+  window.localStorage?.getItem(LocalStorageKeys.Theme + '_' + scopeId);
 
 /**
  * Save theme into local storage.
  */
 export const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);
+  window.localStorage?.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);


### PR DESCRIPTION
# What

- In Stateful layer, if the calling SDK says granted, use the SDK value (avoiding permissions API badness on Android WebView)
- In Composite layer, do a explicit check for Android WebView to avoid permissions API usage there
- Improve some memoization on the config page

# Why

Fix #5875

# How Tested

Locally in Android web view.