### PR TITLE
Fix issue on Android WebView where there is no default audio device

### DIFF
--- a/packages/calling-component-bindings/src/callControlSelectors.ts
+++ b/packages/calling-component-bindings/src/callControlSelectors.ts
@@ -221,19 +221,15 @@ export const devicesButtonSelector: DevicesButtonSelector = reselect.createSelec
   [getDeviceManager],
   (deviceManager) => {
     return {
-      microphones: removeBlankNameDevices(deviceManager.microphones),
-      speakers: removeBlankNameDevices(deviceManager.speakers),
-      cameras: removeBlankNameDevices(deviceManager.cameras),
+      microphones: deviceManager.microphones,
+      speakers: deviceManager.speakers,
+      cameras: deviceManager.cameras,
       selectedMicrophone: deviceManager.selectedMicrophone,
       selectedSpeaker: deviceManager.selectedSpeaker,
       selectedCamera: deviceManager.selectedCamera
     };
   }
 );
-
-function removeBlankNameDevices<T extends { name: string }>(devices: T[]): T[] {
-  return devices.filter((device) => device.name !== '');
-}
 
 /**
  * Selector type for the {@link HoldButton} component.

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -156,6 +156,7 @@
     "onSplitButtonMicrophonePrimaryAction": "Mute mic",
     "microphonePrimaryActionSplitButtonTitle": "Use microphone",
     "microphoneAriaDescription": "Audio options",
+    "defaultMicrophoneLabelFallback": "Default",
     "deepNoiseSuppressionTitle": "Noise suppression",
     "deepNoiseSuppressionOnAnnouncement": "Deep noise suppression has been turned on",
     "deepNoiseSuppressionOffAnnouncement": "Deep noise suppression has been turned off"
@@ -169,6 +170,7 @@
     "audioDeviceMenuTooltip": "Choose audio device",
     "microphoneMenuTitle": "Microphone",
     "microphoneMenuTooltip": "Choose microphone",
+    "defaultMicrophoneLabelFallback": "Default",
     "speakerMenuTitle": "Speaker",
     "speakerMenuTooltip": "Choose speaker"
   },

--- a/packages/react-composites/src/composites/common/Drawer/PreparedMoreDrawer.tsx
+++ b/packages/react-composites/src/composites/common/Drawer/PreparedMoreDrawer.tsx
@@ -12,6 +12,7 @@ import { CommonCallControlOptions } from '../types/CommonCallControlOptions';
 import { VideoGalleryLayout } from '@internal/react-components';
 import { ReactionResources } from '@internal/react-components';
 import { DtmfDialPadOptions } from '../../CallComposite';
+import { useLocale } from '../../localization';
 
 /** @private */
 export interface PreparedMoreDrawerProps {
@@ -50,8 +51,37 @@ export const PreparedMoreDrawer = (props: PreparedMoreDrawerProps): JSX.Element 
     }),
     [strings]
   );
-  const deviceProps = useSelector(moreDrawerSelector);
+  const { microphones, selectedMicrophone, ...deviceProps } = useSelector(moreDrawerSelector);
   const callHandlers = useHandlers(MoreDrawer);
 
-  return <MoreDrawer {...props} {...deviceProps} {...callHandlers} strings={moreDrawerStrings} />;
+  const defaultMicrophoneLabelFallback =
+    useLocale().component.strings.devicesButton.defaultMicrophoneLabelFallback ?? 'Default';
+  const adjustedMicrophones = useMemo(() => {
+    return microphones?.map((microphone, i) => ({
+      id: microphone.id,
+      name: i === 0 && !microphone.name ? defaultMicrophoneLabelFallback : microphone.name
+    }));
+  }, [defaultMicrophoneLabelFallback, microphones]);
+
+  const adjustedSelectedMicrophone = useMemo(() => {
+    if (!selectedMicrophone) {
+      return undefined;
+    }
+    const selectedMicIsDefault = selectedMicrophone.id === microphones?.[0]?.id;
+    return {
+      id: selectedMicrophone.id,
+      name: selectedMicIsDefault && !selectedMicrophone.name ? defaultMicrophoneLabelFallback : selectedMicrophone.name
+    };
+  }, [defaultMicrophoneLabelFallback, selectedMicrophone]);
+
+  return (
+    <MoreDrawer
+      {...props}
+      {...deviceProps}
+      {...callHandlers}
+      strings={moreDrawerStrings}
+      microphones={adjustedMicrophones}
+      selectedMicrophone={adjustedSelectedMicrophone}
+    />
+  );
 };


### PR DESCRIPTION
# What

For config page and for call page, ensure we use a default fallback for the device name for microphone if the default microphone does not have one.

# Why

Fix issue on Android WebView where there is no default audio device. The default audio device on android webview has no label:

![image](https://github.com/user-attachments/assets/b97fb1da-0591-4ba9-a28a-f56634edf3db)


# How Tested

Verified on android web view

TODO: ensure no regression on macos from removing `removeBlankNameDevices`