### PR TITLE
Avoid permissions API on Android WebView 

### DIFF
--- a/change-beta/@azure-communication-react-59be0ba8-2007-4ade-bf4f-6edeb0f7ce4c.json
+++ b/change-beta/@azure-communication-react-59be0ba8-2007-4ade-bf4f-6edeb0f7ce4c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Improve device permission checks on Android WebViews",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-59be0ba8-2007-4ade-bf4f-6edeb0f7ce4c.json
+++ b/change/@azure-communication-react-59be0ba8-2007-4ade-bf4f-6edeb0f7ce4c.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "",
+  "comment": "Improve device permission checks on Android WebViews",
+  "packageName": "@azure/communication-react",
+  "email": "2684369+JamesBurnside@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/calling-stateful-client/src/DeviceManagerDeclarative.ts
+++ b/packages/calling-stateful-client/src/DeviceManagerDeclarative.ts
@@ -179,8 +179,11 @@ class ProxyDeviceManager implements ProxyHandler<DeviceManager> {
           navigator.permissions.query({ name: 'microphone' as PermissionName })
         ]);
 
-        hasCameraPermission = cameraPermissions.state === 'granted';
-        hasMicPermission = micPermissions.state === 'granted';
+        // Use logical OR to combine the SDK state with the Permissions API state.
+        // This way we can get a more accurate picture of the device permission state.
+        // If the SDK state is 'granted', we don't need to check the Permissions API state.
+        hasCameraPermission ||= cameraPermissions.state === 'granted';
+        hasMicPermission ||= micPermissions.state === 'granted';
       } catch (e) {
         console.info('Permissions API is not supported by browser', e);
       }

--- a/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
+++ b/packages/react-composites/src/composites/CallComposite/utils/Utils.ts
@@ -431,14 +431,31 @@ export const isDisabled = (option: boolean | { disabled: boolean } | undefined):
 };
 
 /* @conditional-compile-remove(call-readiness) */
+const isAndroidWebView = (environmentInfo?: EnvironmentInfo): boolean => {
+  const ua = navigator.userAgent || '';
+  return (
+    environmentInfo?.environment?.browser?.toLowerCase() === 'chrome webview' ||
+    (/Android/.test(ua) && /Version\/[\d.]+/.test(ua) && /wv/.test(ua))
+  );
+};
+
+/* @conditional-compile-remove(call-readiness) */
 /**
  * @returns Permissions state for the camera.
  */
-const queryCameraPermissionFromPermissionsAPI = async (): Promise<PermissionState | 'unsupported'> => {
+const queryCameraPermissionFromPermissionsAPI = async (
+  environmentInfo?: EnvironmentInfo
+): Promise<PermissionState | 'unsupported'> => {
+  // Android WebView does not support permissions API, nor does it throw an error when trying to access it,
+  // in actuality the API always returns 'prompt' which is not correct.
+  if (isAndroidWebView(environmentInfo)) {
+    return 'unsupported';
+  }
+
   try {
     return (await navigator.permissions.query({ name: 'camera' as PermissionName })).state;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (e) {
-    console.info('permissions API is not supported by browser', e);
     return 'unsupported';
   }
 };
@@ -447,11 +464,19 @@ const queryCameraPermissionFromPermissionsAPI = async (): Promise<PermissionStat
 /**
  * @returns Permissions state for the microphone.
  */
-const queryMicrophonePermissionFromPermissionsAPI = async (): Promise<PermissionState | 'unsupported'> => {
+const queryMicrophonePermissionFromPermissionsAPI = async (
+  environmentInfo?: EnvironmentInfo
+): Promise<PermissionState | 'unsupported'> => {
+  // Android WebView does not support permissions API, nor does it throw an error when trying to access it,
+  // in actuality the API always returns 'prompt' which is not correct.
+  if (isAndroidWebView(environmentInfo)) {
+    return 'unsupported';
+  }
+
   try {
     return (await navigator.permissions.query({ name: 'microphone' as PermissionName })).state;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (e) {
-    console.info('permissions API is not supported by browser', e);
     return 'unsupported';
   }
 };
@@ -465,15 +490,24 @@ const queryMicrophonePermissionFromPermissionsAPI = async (): Promise<Permission
  * @private
  */
 export const getDevicePermissionState = async (
+  environmentInfo: undefined | EnvironmentInfo,
   setVideoState: (state: PermissionState | 'unsupported') => void,
-  setAudioState: (state: PermissionState | 'unsupported') => void
+  setAudioState: (state: PermissionState | 'unsupported') => void,
+  previousVideoState: PermissionState | 'unsupported' | undefined,
+  previousAudioState: PermissionState | 'unsupported' | undefined
 ): Promise<void> => {
   const [cameraResult, microphoneResult] = await Promise.all([
-    queryCameraPermissionFromPermissionsAPI(),
-    queryMicrophonePermissionFromPermissionsAPI()
+    queryCameraPermissionFromPermissionsAPI(environmentInfo),
+    queryMicrophonePermissionFromPermissionsAPI(environmentInfo)
   ]);
-  setVideoState(cameraResult);
-  setAudioState(microphoneResult);
+
+  if (cameraResult !== previousVideoState) {
+    setVideoState(cameraResult);
+  }
+
+  if (microphoneResult !== previousAudioState) {
+    setAudioState(microphoneResult);
+  }
 };
 /* @conditional-compile-remove(unsupported-browser) */
 const isUnsupportedEnvironment = (

--- a/samples/CallWithChat/src/app/utils/localStorage.ts
+++ b/samples/CallWithChat/src/app/utils/localStorage.ts
@@ -12,22 +12,22 @@ export enum LocalStorageKeys {
  * Get display name from local storage.
  */
 export const getDisplayNameFromLocalStorage = (): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.DisplayName);
+  window.localStorage?.getItem(LocalStorageKeys.DisplayName);
 
 /**
  * Save display name into local storage.
  */
 export const saveDisplayNameToLocalStorage = (displayName: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.DisplayName, displayName);
+  window.localStorage?.setItem(LocalStorageKeys.DisplayName, displayName);
 
 /**
  * Get theme from local storage.
  */
 export const getThemeFromLocalStorage = (scopeId: string): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.Theme + '_' + scopeId);
+  window.localStorage?.getItem(LocalStorageKeys.Theme + '_' + scopeId);
 
 /**
  * Save theme into local storage.
  */
 export const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);
+  window.localStorage?.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);

--- a/samples/Calling/src/app/utils/localStorage.ts
+++ b/samples/Calling/src/app/utils/localStorage.ts
@@ -12,22 +12,22 @@ export enum LocalStorageKeys {
  * Get display name from local storage.
  */
 export const getDisplayNameFromLocalStorage = (): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.DisplayName);
+  window.localStorage?.getItem(LocalStorageKeys.DisplayName);
 
 /**
  * Save display name into local storage.
  */
 export const saveDisplayNameToLocalStorage = (displayName: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.DisplayName, displayName);
+  window.localStorage?.setItem(LocalStorageKeys.DisplayName, displayName);
 
 /**
  * Get theme from local storage.
  */
 export const getThemeFromLocalStorage = (scopeId: string): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.Theme + '_' + scopeId);
+  window.localStorage?.getItem(LocalStorageKeys.Theme + '_' + scopeId);
 
 /**
  * Save theme into local storage.
  */
 export const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);
+  window.localStorage?.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);

--- a/samples/Chat/src/app/utils/localStorage.ts
+++ b/samples/Chat/src/app/utils/localStorage.ts
@@ -12,22 +12,22 @@ export enum LocalStorageKeys {
  * Get display name from local storage.
  */
 export const getDisplayNameFromLocalStorage = (): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.DisplayName);
+  window.localStorage?.getItem(LocalStorageKeys.DisplayName);
 
 /**
  * Save display name into local storage.
  */
 export const saveDisplayNameToLocalStorage = (displayName: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.DisplayName, displayName);
+  window.localStorage?.setItem(LocalStorageKeys.DisplayName, displayName);
 
 /**
  * Get theme from local storage.
  */
 export const getThemeFromLocalStorage = (scopeId: string): string | null =>
-  window.localStorage.getItem(LocalStorageKeys.Theme + '_' + scopeId);
+  window.localStorage?.getItem(LocalStorageKeys.Theme + '_' + scopeId);
 
 /**
  * Save theme into local storage.
  */
 export const saveThemeToLocalStorage = (theme: string, scopeId: string): void =>
-  window.localStorage.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);
+  window.localStorage?.setItem(LocalStorageKeys.Theme + '_' + scopeId, theme);


### PR DESCRIPTION
# What
In Stateful layer, if the calling SDK says granted, use the SDK value (avoiding permissions API badness on Android WebView)
In Composite layer, do a explicit check for Android WebView to avoid permissions API usage there
Improve some memoization on the config page
Add local storage check as that is not available on android webview


# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->