### PR TITLE
[A11y] Add aria-label for upload progress

### DIFF
--- a/change-beta/@azure-communication-react-a9d5fe68-a874-4d68-bef5-a3a814c33298.json
+++ b/change-beta/@azure-communication-react-a9d5fe68-a874-4d68-bef5-a3a814c33298.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "a11y",
+  "comment": "Add aria label for upload progress",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-a9d5fe68-a874-4d68-bef5-a3a814c33298.json
+++ b/change/@azure-communication-react-a9d5fe68-a874-4d68-bef5-a3a814c33298.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "a11y",
+  "comment": "Add aria label for upload progress",
+  "packageName": "@azure/communication-react",
+  "email": "77021369+jimchou-dev@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -4956,6 +4956,7 @@ export interface SendBoxStrings {
     textTooLong: string;
     uploadCompleted: string;
     uploading: string;
+    uploadProgress: string;
 }
 
 // @public

--- a/packages/react-components/src/components/Attachment/AttachmentCard.tsx
+++ b/packages/react-components/src/components/Attachment/AttachmentCard.tsx
@@ -19,7 +19,7 @@ import {
 } from '@fluentui/react-components';
 import { getFileTypeIconProps } from '@fluentui/react-file-type-icons';
 import React from 'react';
-import { _pxToRem } from '@internal/acs-ui-common';
+import { _pxToRem, _formatString } from '@internal/acs-ui-common';
 import { Announcer } from '../Announcer';
 import { useEffect, useState, useMemo } from 'react';
 import { _AttachmentUploadCardsStrings } from './AttachmentUploadCards';
@@ -164,6 +164,9 @@ export const _AttachmentCard = (props: _AttachmentCardProps): JSX.Element => {
             thickness="medium"
             value={Math.max(progress ?? 0, ATTACHMENT_CARD_MIN_PROGRESS)}
             shape="rounded"
+            aria-label={progress
+              ? _formatString(localeStrings.uploadProgress, { progress: `${Math.round(progress * 100)}` })
+              : undefined}
           />
         </CardFooter>
       ) : (

--- a/packages/react-components/src/components/Attachment/AttachmentUploadCards.tsx
+++ b/packages/react-components/src/components/Attachment/AttachmentUploadCards.tsx
@@ -18,6 +18,8 @@ export interface _AttachmentUploadCardsStrings {
   removeAttachment: string;
   /** Aria label to notify user attachment uploading starts. */
   uploading: string;
+  /** Aria label to notify user attachment upload progress. */
+  uploadProgress: string
   /** Aria label to notify user attachment is uploaded. */
   uploadCompleted: string;
   /** Aria label to notify user more attachment action menu. */

--- a/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
@@ -541,6 +541,7 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
             strings={{
               removeAttachment: strings.removeAttachment,
               uploading: strings.uploading,
+              uploadProgress: strings.uploadProgress,
               uploadCompleted: strings.uploadCompleted,
               attachmentMoreMenu: strings.attachmentMoreMenu
             }}

--- a/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
+++ b/packages/react-components/src/components/RichTextEditor/RichTextSendBox.tsx
@@ -557,6 +557,7 @@ export const RichTextSendBox = (props: RichTextSendBoxProps): JSX.Element => {
     onCancelAttachmentUpload,
     strings.removeAttachment,
     strings.uploading,
+    strings.uploadProgress,
     strings.uploadCompleted,
     strings.attachmentMoreMenu,
     disabled

--- a/packages/react-components/src/components/SendBox.tsx
+++ b/packages/react-components/src/components/SendBox.tsx
@@ -92,6 +92,11 @@ export interface SendBoxStrings {
   uploading: string;
   /* @conditional-compile-remove(file-sharing-acs) */
   /**
+   * Aria label to notify user attachment upload progress.
+   */
+  uploadProgress: string;
+  /* @conditional-compile-remove(file-sharing-acs) */
+  /**
    * Aria label to notify user attachment is uploaded.
    */
   uploadCompleted: string;
@@ -360,6 +365,7 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
             strings={{
               removeAttachment: props.strings?.removeAttachment ?? localeStrings.removeAttachment,
               uploading: props.strings?.uploading ?? localeStrings.uploading,
+              uploadProgress: props.strings?.uploadProgress ?? localeStrings.uploadProgress,
               uploadCompleted: props.strings?.uploadCompleted ?? localeStrings.uploadCompleted,
               attachmentMoreMenu: props.strings?.attachmentMoreMenu ?? localeStrings.attachmentMoreMenu
             }}
@@ -375,6 +381,7 @@ export const SendBox = (props: SendBoxProps): JSX.Element => {
     customV9Styles.clearBackground,
     localeStrings.removeAttachment,
     localeStrings.uploading,
+    localeStrings.uploadProgress,
     localeStrings.uploadCompleted,
     localeStrings.attachmentMoreMenu,
     disabled

--- a/packages/react-components/src/components/utils/common.ts
+++ b/packages/react-components/src/components/utils/common.ts
@@ -17,6 +17,7 @@ export const useLocaleAttachmentCardStringsTrampoline = (): _AttachmentUploadCar
     removeAttachment: '',
     uploadCompleted: '',
     uploading: '',
+    uploadProgress: '',
     attachmentMoreMenu: ''
   };
 };

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -32,6 +32,7 @@
     "attachmentUploadsPendingError": "File is uploading, please wait.",
     "removeAttachment": "Remove file",
     "uploading": "Uploading",
+    "uploadProgress": "Upload progress {progress}%",
     "uploadCompleted": "Upload completed",
     "attachmentMoreMenu": "More Options"
   },
@@ -43,6 +44,7 @@
     "imageUploadsPendingError": "Image is uploading, please wait.",
     "removeAttachment": "Remove file",
     "uploading": "Uploading",
+    "uploadProgress": "Upload progress {progress}%",
     "uploadCompleted": "Upload completed",
     "richTextBoldTooltip": "Bold",
     "richTextItalicTooltip": "Italic",


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
- Add aria-label for upload progress
<img width="696" alt="image" src="https://github.com/user-attachments/assets/cc066501-7360-44e6-b8f9-fc48b29713ac" />

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->