### PR TITLE
[A11y]Change role to dialog to fix accessible name for effects pane

### DIFF
--- a/change-beta/@azure-communication-react-ccd05f12-b863-40d4-b7f5-a60988f4bdf6.json
+++ b/change-beta/@azure-communication-react-ccd05f12-b863-40d4-b7f5-a60988f4bdf6.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "[A11y]Change role to dialog to fix accessible name for effects pane",
+  "comment": "[A11y]Change role to dialog to fix accessible name for effects pane",
+  "packageName": "@azure/communication-react",
+  "email": "97124699+prabhjot-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-ccd05f12-b863-40d4-b7f5-a60988f4bdf6.json
+++ b/change/@azure-communication-react-ccd05f12-b863-40d4-b7f5-a60988f4bdf6.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "[A11y]Change role to dialog to fix accessible name for effects pane",
+  "comment": "[A11y]Change role to dialog to fix accessible name for effects pane",
+  "packageName": "@azure/communication-react",
+  "email": "97124699+prabhjot-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-composites/src/composites/CallComposite/components/SidePane/SidePane.tsx
+++ b/packages/react-composites/src/composites/CallComposite/components/SidePane/SidePane.tsx
@@ -110,7 +110,7 @@ export const SidePane = (props: SidePaneProps): JSX.Element => {
     <Stack
       aria-label={props.ariaLabel}
       data-is-focusable={!!props.ariaLabel}
-      role={props.ariaLabel ? 'navigation' : undefined}
+      role={props.ariaLabel ? 'dialog' : undefined}
       tabIndex={props.ariaLabel ? 0 : undefined}
       verticalFill
       grow


### PR DESCRIPTION
# What
[A11y]Change role to dialog to fix accessible name for effects pane

# Why
https://skype.visualstudio.com/SPOOL/_queries/edit/3832365/?queryId=b6ea9791-8605-4d46-840c-f240e55fd13d

# How Tested
<!--- How did you test your change. What tests have you added. -->

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->