### PR TITLE
Alkwa/add agent md2

### DIFF
--- a/change-beta/@azure-communication-react-8de4a637-f198-4902-8d55-41a7414c395a.json
+++ b/change-beta/@azure-communication-react-8de4a637-f198-4902-8d55-41a7414c395a.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "improvement",
+  "workstream": "adding agent.md so we can update all dependencies",
+  "comment": "adding in an agent.md for future OCE tasks to update all dependencies",
+  "packageName": "@azure/communication-react",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change-beta/@azure-communication-react-cd478bbe-e90f-4f5f-a9f8-2921f0c66189.json
+++ b/change-beta/@azure-communication-react-cd478bbe-e90f-4f5f-a9f8-2921f0c66189.json
@@ -1,0 +1,9 @@
+{
+  "type": "prerelease",
+  "area": "improvement",
+  "workstream": "updating calling sdk versions",
+  "comment": "updated calling sdk",
+  "packageName": "@azure/communication-react",
+  "email": "79329532+alkwa-msft@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -24,7 +24,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "@azure/communication-calling": "1.37.1-beta.1",
+    "@azure/communication-calling": "1.38.1-beta.1",
     "@azure/communication-common": "2.3.2-beta.1",
     "@azure/communication-chat": "1.6.0-beta.7",
     "@azure/communication-signaling": "1.0.0-beta.33",
@@ -56,7 +56,7 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
-    "@azure/communication-calling": ["1.37.1-beta.1"],
+    "@azure/communication-calling": ["1.38.1-beta.1"],
     "@azure/communication-common": ["2.3.2-beta.1"],
     "@azure/communication-chat": ["1.6.0-beta.7"],
     "@azure/communication-signaling": ["1.0.0-beta.33"],

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@azure/communication-calling':
-    specifier: 1.37.1-beta.1
-    version: 1.37.1-beta.1
+    specifier: 1.38.1-beta.1
+    version: 1.38.1-beta.1
   '@azure/communication-calling-effects':
     specifier: 1.1.4
     version: 1.1.4
@@ -168,10 +168,10 @@ packages:
       - supports-color
     dev: false
 
-  /@azure/communication-calling@1.37.1-beta.1:
-    resolution: {integrity: sha512-M9UdieOnNRny7WzXr76FB3eIvTjObLez4Q0cQHa2ek44YWIpdFDwLRCfQyhGhq8YVh0RyuTNYRlsjA/lOhCfyw==}
+  /@azure/communication-calling@1.38.1-beta.1:
+    resolution: {integrity: sha512-7x+SDFOartQRHPP9/AxvKTCGLK1VyWJ/rptFxZlLDGuuMLYVUCpwe15mjKULHxK8I2+ZaU0zpD2M3+PAb7NTDw==}
     dependencies:
-      '@azure/communication-common': 2.3.2-beta.1
+      '@azure/communication-common': 2.4.0
       '@azure/logger': 1.3.0
     transitivePeerDependencies:
       - supports-color
@@ -17807,11 +17807,11 @@ packages:
     dev: false
 
   file:projects/calling-component-bindings.tgz:
-    resolution: {integrity: sha512-h05NJwRBzOawIjjcVK+q+Ll/CnjV5GveHyD19P6q9ltj/JZxONzaP/zCVBwPb0ZpYEZqiEH2PnmO9IZneS/MQA==, tarball: file:projects/calling-component-bindings.tgz}
+    resolution: {integrity: sha512-9tuO5/rkZda+8j5lmVnDLcDkKAxXXs53J3IpWLsDZx0oxlZAYjekyciQoXy7x6C4+z2D2TmeDl8KPEQP8eZSmA==, tarball: file:projects/calling-component-bindings.tgz}
     name: '@rush-temp/calling-component-bindings'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-calling-effects': 1.1.4
       '@azure/communication-common': 2.3.2-beta.1
       '@babel/cli': 7.28.0(@babel/core@7.28.0)
@@ -17858,11 +17858,11 @@ packages:
     dev: false
 
   file:projects/calling-stateful-client.tgz:
-    resolution: {integrity: sha512-P5iPL3qbBt+MeBjWkpe/d5nDXBytQPh3cdGBmaMMAuk+OU2ZOo5GySyu1+gmiI5XqNlDnPCjJ5QIyfqQtJJrbg==, tarball: file:projects/calling-stateful-client.tgz}
+    resolution: {integrity: sha512-el1CYdvSd6+QWyEaDUw049iFqIMYzQeaKnHG0AzCmM06lTq73R4EiZW3VUVoCkEWJOOVmOYvP4RvX/+hAFOGJg==, tarball: file:projects/calling-stateful-client.tgz}
     name: '@rush-temp/calling-stateful-client'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-common': 2.3.2-beta.1
       '@azure/core-auth': 1.10.0
       '@azure/logger': 1.3.0
@@ -17911,12 +17911,12 @@ packages:
     dev: false
 
   file:projects/calling-stateful-samples.tgz:
-    resolution: {integrity: sha512-gQBTgmBswwWEikqXFZRc3lCgJ4YxRTkzs8DlgIhQyRvCV4UQ8qwo0TXZjQwVflc9E9qhDLh54+vViQ9gz0fkGg==, tarball: file:projects/calling-stateful-samples.tgz}
+    resolution: {integrity: sha512-JWdeOTUkoA+e9kxUFPvM4b+N4UCeeGuniNR79R6EECOa/OiGLN+OgxJ08N1KmAYj2cgE7F5L9nC7Mjl+I6Imnw==, tarball: file:projects/calling-stateful-samples.tgz}
     name: '@rush-temp/calling-stateful-samples'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-common': 2.3.2-beta.1
       '@azure/communication-identity': 1.3.1
       '@azure/logger': 1.3.0
@@ -18010,12 +18010,12 @@ packages:
     dev: false
 
   file:projects/calling.tgz:
-    resolution: {integrity: sha512-GHWEhb/JBCD2vbUSy/aPELYqIz7UCs1vSnNAncC6Jmohi/xYyOPoaVO4FpZYYMENHo4Wt3Q557UcCUksk4UPEA==, tarball: file:projects/calling.tgz}
+    resolution: {integrity: sha512-V5pEN/CzvucSzzE8Gh28mXUrIve7YpvaBZbqj5+7NXbqf6zQ81gqH6oaQaFAEPZ4hidCLjmJKfs9B+Go/0YLbg==, tarball: file:projects/calling.tgz}
     name: '@rush-temp/calling'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-common': 2.3.2-beta.1
       '@azure/communication-identity': 1.3.1
       '@azure/logger': 1.3.0
@@ -18109,12 +18109,12 @@ packages:
     dev: false
 
   file:projects/callwithchat.tgz:
-    resolution: {integrity: sha512-4Se1iJAGbiL3UcjUIy899gByP+NmSMQ+KrUFhcmeVcOLkqhSCn/L1PB02td+3tcvFiW2urBVrJmoGNhKq/MzPQ==, tarball: file:projects/callwithchat.tgz}
+    resolution: {integrity: sha512-tEn0voYv0QSkAt8lPy7bt3QwgzBDLnn0IuO2/J8qM1E0yDvUoCzcV56wZptNoVdw31XvexESvhMBMB+yCm2NtA==, tarball: file:projects/callwithchat.tgz}
     name: '@rush-temp/callwithchat'
     version: 0.0.0
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.7
       '@azure/communication-common': 2.3.2-beta.1
       '@azure/communication-identity': 1.3.1
@@ -18461,11 +18461,11 @@ packages:
     dev: false
 
   file:projects/communication-react.tgz:
-    resolution: {integrity: sha512-JJWhp2jdE5l8jstQB08dMOG7/s02MQ5hIlSEmcqy2Kx2mdPMXxAzNKw5sCBN4rwFqmZkk46COahCg8Qjbz9GJg==, tarball: file:projects/communication-react.tgz}
+    resolution: {integrity: sha512-1bdUhr/Lb/ISTr2ayxHD2WPLZiv1Zx4No9a05urynHs13mln/2jeBUpqC/gwSNXQdI/3mn9kZfMCzI6rETL4Ug==, tarball: file:projects/communication-react.tgz}
     name: '@rush-temp/communication-react'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-calling-effects': 1.1.4
       '@azure/communication-chat': 1.6.0-beta.7
       '@azure/communication-common': 2.3.2-beta.1
@@ -18572,11 +18572,11 @@ packages:
     dev: false
 
   file:projects/component-examples.tgz:
-    resolution: {integrity: sha512-JfhoNxAzCJ4A1dNh10w9DS4DUD7tVFUvJX/vKbj8kN0YxQfUGAEwgqM0RHwMGA0+PXNVs8uacEU31vWu2hKqAA==, tarball: file:projects/component-examples.tgz}
+    resolution: {integrity: sha512-cyT9xd5XAJo6d4rK9ElEt8xbqiRA2ODrUF2UZ5pBcekwVrwCLC5urd37bX+fjLAKbVvzdwPL6znOv+w+FZX6/Q==, tarball: file:projects/component-examples.tgz}
     name: '@rush-temp/component-examples'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.7
       '@azure/communication-common': 2.3.2-beta.1
       '@azure/communication-identity': 1.3.1
@@ -18860,11 +18860,11 @@ packages:
     dev: false
 
   file:projects/react-composites.tgz:
-    resolution: {integrity: sha512-te8YrJREiuKRf9VkQ194VJ1FbhTX97CZaDEmIvJ569BZBl7Hv80gcGdNtUWpMcKJZAioAoqCWWWEXmnSScqyuA==, tarball: file:projects/react-composites.tgz}
+    resolution: {integrity: sha512-T7xyGimVWHl2peq+DXNy0PIHTf6xmFiw51VErV+Cv0CzJI7ACTwY5JnddTWZeP85UOO4KLTGth8NVHleB4pJ9Q==, tarball: file:projects/react-composites.tgz}
     name: '@rush-temp/react-composites'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-calling-effects': 1.1.4
       '@azure/communication-chat': 1.6.0-beta.7
       '@azure/communication-common': 2.3.2-beta.1
@@ -18985,11 +18985,11 @@ packages:
     dev: false
 
   file:projects/sample-automation-tests.tgz:
-    resolution: {integrity: sha512-OsvGe1ZW24nsSStXTfrHGbm4/DCHSboj1VPrR4ougmdyNI/aq4HY+RT6RTsaxluuW1HsqGWO8jev+vmNGJUZrQ==, tarball: file:projects/sample-automation-tests.tgz}
+    resolution: {integrity: sha512-XM4XHWClue8sZGL21fSCs4ijv6Fdgze4YesCuyEE86h50wqYdPuuo8K+nS8q/Qj4B0wODjya+QVt6PQem6/HLA==, tarball: file:projects/sample-automation-tests.tgz}
     name: '@rush-temp/sample-automation-tests'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.7
       '@azure/communication-common': 2.3.2-beta.1
       '@azure/communication-identity': 1.3.1
@@ -19009,11 +19009,11 @@ packages:
     dev: false
 
   file:projects/sample-static-html-composites.tgz:
-    resolution: {integrity: sha512-b4SCEcHaU1I7YWLdU4CW05bh0N753NKWvi3hj5h7og5XkwSfbfUlDdFtKHtWyKs+DRh55BRckR19bh0Yk2BWng==, tarball: file:projects/sample-static-html-composites.tgz}
+    resolution: {integrity: sha512-NV0bAcLZYdSaV5sBisyAA5a5ZEz6/b87miI1DmlyOaJmubSt7rQtXH2R7ApAg35R5UY0RydMjqRiWscVSLY28w==, tarball: file:projects/sample-static-html-composites.tgz}
     name: '@rush-temp/sample-static-html-composites'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.7
       '@azure/communication-common': 2.3.2-beta.1
       '@azure/communication-identity': 1.3.1
@@ -19155,11 +19155,11 @@ packages:
     dev: false
 
   file:projects/storybook8.tgz:
-    resolution: {integrity: sha512-AVsgrGRbnr1BYPeVFTWM+eHU34RRKRzW+aa5NzaQn6sdaEqarYWkdMy5plKifAPtutB+ANqZgWH6OYGZAYatoQ==, tarball: file:projects/storybook8.tgz}
+    resolution: {integrity: sha512-UTFdw1I0VsUSJs0Axh3fdfJcm7rxFxatTI63TnLOzatgp9rLWFk0Px1By18pMdKJfEhGoRX/+GV+hvNe73jYag==, tarball: file:projects/storybook8.tgz}
     name: '@rush-temp/storybook8'
     version: 0.0.0
     dependencies:
-      '@azure/communication-calling': 1.37.1-beta.1
+      '@azure/communication-calling': 1.38.1-beta.1
       '@azure/communication-chat': 1.6.0-beta.7
       '@azure/communication-common': 2.3.2-beta.1
       '@azure/communication-identity': 1.3.1

--- a/common/config/rush/variants/stable/common-versions.json
+++ b/common/config/rush/variants/stable/common-versions.json
@@ -25,7 +25,7 @@
      */
     // "some-library": "1.2.3"
     // This is the version for stable build (please also update allowedAlternativeVersions below)
-    "@azure/communication-calling": "^1.37.1",
+    "@azure/communication-calling": "^1.37.2",
     "@azure/communication-common": "2.4.0",
     "@azure/communication-chat": "^1.6.0",
     "@azure/communication-signaling": "1.0.0-beta.34",
@@ -58,7 +58,7 @@
    */
   "allowedAlternativeVersions": {
     // This is the version for stable build (please also update preferredVersions above)
-    "@azure/communication-calling": ["^1.37.1"],
+    "@azure/communication-calling": ["^1.37.2"],
     "@azure/communication-common": ["2.4.0"],
     "@azure/communication-chat": ["^1.6.0"],
     "@azure/communication-signaling": ["1.0.0-beta.34"],

--- a/docs/agent/agent.md
+++ b/docs/agent/agent.md
@@ -1,0 +1,367 @@
+# Instructions for Switching to Beta Flavor
+
+> **Note:** Version numbers shown in this document are for demonstration purposes only and may not reflect the latest available versions. Always check npm for the most current version information.
+
+To switch to the "beta" flavor of the `@azure/communication-calling` package and ensure everything is set up correctly, follow these steps in your terminal:
+
+**Estimated Time:** ~8-10 minutes total
+
+1. **Switch to Beta Flavor:**
+   Run the following command to switch to the beta flavor:
+   ```bash
+   rush switch-flavor:beta
+   ```
+   *Estimated time: ~30 seconds*
+
+2. **Update Packages:**
+   After switching to the beta flavor, update the packages to ensure that the version of `@azure/communication-calling` is pointed to the beta version:
+   ```bash
+   rush update
+   ```
+   *Estimated time: ~2 seconds (usually already up-to-date from step 1)*
+
+3. **Verify Beta Version:**
+   To confirm you're using the beta version, check the installed package:
+   ```bash
+   cat common/temp/node_modules/@azure/communication-calling/package.json
+   ```
+   You should see `"version": "1.37.1-beta.1"` (or similar beta version) and `"types": "types/communication-calling-beta.d.ts"`
+
+4. **Build the Project:**
+   Finally, run the build command to ensure everything is compiled and ready to use:
+   ```bash
+   rush build
+   ```
+   *Estimated time: ~8 minutes*
+
+# Instructions for Switching to Stable Flavor
+
+To switch to the "stable" flavor of the `@azure/communication-calling` package and ensure everything is set up correctly, follow these steps in your terminal:
+
+**Estimated Time:** ~12-15 minutes total
+
+1. **Update to Stable Variants:**
+  Run the following command to update packages using the stable variant:
+  ```bash
+  rush update:stable
+  ```
+  *Estimated time: ~8 seconds*
+
+2. **Switch to Stable Flavor:**
+  Run the following command to switch to the stable flavor:
+  ```bash
+  rush switch-flavor:stable
+  ```
+  *Estimated time: ~7 seconds*
+
+3. **Update Packages:**
+  After switching to the stable flavor, update the packages to ensure everything is in sync:
+  ```bash
+  rush update
+  ```
+  *Estimated time: ~2 seconds (usually already up-to-date from step 2)*
+
+4. **Verify Stable Version:**
+  To confirm you're using the stable version, check the installed package:
+  ```bash
+  cat common/temp/node_modules/@azure/communication-calling/package.json
+  ```
+  You should see `"version": "1.37.1"` (without `-beta` suffix) and `"types": "types/communication-calling.d.ts"`
+
+5. **Build the Project:**
+  Finally, run the build command to ensure everything is compiled and ready to use:
+  ```bash
+  rush build
+  ```
+  *Estimated time: ~4.5 minutes*
+
+# Instructions for Updating Beta Version
+
+To update the `@azure/communication-calling` package to the latest beta version while already in beta flavor, follow these steps:
+
+**Estimated Time:** ~15-20 minutes total
+
+1. **Verify Beta Flavor:**
+   Confirm you're currently in beta flavor by checking the environment:
+   ```bash
+   echo $COMMUNICATION_REACT_FLAVOR
+   ```
+   Should return `beta`. If not, run `rush switch-flavor:beta` first.
+
+2. **Check Current Beta Version:**
+   Check the currently installed beta version:
+   ```bash
+   cat common/temp/node_modules/@azure/communication-calling/package.json | grep version
+   ```
+   Note the current version (e.g., `"version": "1.37.1-beta.1"`)
+
+3. **Find Latest Beta Version:**
+   Check npm for the latest beta version:
+   ```bash
+   npm view @azure/communication-calling versions --beta --json
+   ```
+   This will show all available beta versions. Use the latest one.
+
+4. **Update Version in Configuration Files:**
+   If a newer beta version is available, update the following files:
+   
+   **a. Update common-versions.json:**
+   ```bash
+   # Edit common/config/rush/common-versions.json
+   # Update both "preferredVersions" and "allowedAlternativeVersions" sections
+   # Replace old beta version with new beta version
+   ```
+   
+   **b. Update package.json files:**
+   The following files typically contain `@azure/communication-calling` dependencies:
+   - `samples/CallWithChat/package.json`
+   - `samples/CallingStateful/package.json`
+   - `packages/calling-stateful-client/package.json`
+   - `packages/communication-react/package.json`
+   - `packages/react-composites/package.json`
+   - `packages/storybook8/package.json`
+   - `samples/ComponentExamples/package.json`
+   - `samples/StaticHtmlComposites/package.json`
+   - `samples/tests/package.json`
+   - `samples/Calling/package.json`
+   - `packages/calling-component-bindings/package.json`
+   
+   *Use search tools to find all files containing the old beta version and replace with the new version.*
+
+5. **Rebuild Project:**
+   After updating all version references, rebuild the entire project:
+   ```bash
+   rush rebuild
+   ```
+   *Estimated time: ~10-15 minutes*
+
+6. **Verify Updated Version:**
+   Confirm the new beta version is installed:
+   ```bash
+   cat common/temp/node_modules/@azure/communication-calling/package.json | grep version
+   ```
+   Should show the new beta version you specified.
+
+## Notes:
+- Always ensure all references to the old beta version are updated consistently across all files
+- The `rush rebuild` command is necessary to ensure all packages are rebuilt with the new version
+
+# Instructions for Updating Stable Version
+
+To update the `@azure/communication-calling` package to the latest stable version while already in stable flavor, follow these steps:
+
+**Estimated Time:** ~15-20 minutes total
+
+1. **Verify Stable Flavor:**
+   Confirm you're currently in stable flavor by checking the environment:
+   ```bash
+   echo $COMMUNICATION_REACT_FLAVOR
+   ```
+   Should return `stable`. If not, follow the "Instructions for Switching to Stable Flavor" section first.
+
+2. **Check Current Stable Version:**
+   Check the currently installed stable version:
+   ```bash
+   cat common/temp/node_modules/@azure/communication-calling/package.json | grep version
+   ```
+   Note the current version (e.g., `"version": "1.37.1"`)
+
+3. **Find Latest Stable Version:**
+   Check npm for the latest stable version (without -beta suffix):
+   ```bash
+   npm view @azure/communication-calling versions --json
+   ```
+   Look for the highest version number without `-beta`, `-alpha`, or `-rc` suffixes.
+
+4. **Update Version in Configuration Files:**
+   If a newer stable version is available, update the following files:
+   
+   **a. Update stable common-versions.json:**
+   ```bash
+   # Edit common/config/rush/variants/stable/common-versions.json
+   # Update both "preferredVersions" and "allowedAlternativeVersions" sections
+   # Replace old stable version with new stable version (e.g., ^1.37.1 -> ^1.37.2)
+   ```
+   
+   **b. Update package.json files:**
+   The following files typically contain `@azure/communication-calling` dependencies with patterns like `"1.38.1-beta.1 || ^1.37.1"`:
+   - `samples/CallWithChat/package.json`
+   - `samples/CallingStateful/package.json`
+   - `packages/calling-stateful-client/package.json`
+   - `packages/communication-react/package.json`
+   - `packages/react-composites/package.json`
+   - `packages/storybook8/package.json`
+   - `samples/ComponentExamples/package.json`
+   - `samples/StaticHtmlComposites/package.json`
+   - `samples/tests/package.json`
+   - `samples/Calling/package.json`
+   - `packages/calling-component-bindings/package.json`
+   
+   *Update the stable version part (after `||`) in each file. For example, change `"1.38.1-beta.1 || ^1.37.1"` to `"1.38.1-beta.1 || ^1.37.2"`*
+
+5. **Rebuild Project:**
+   After updating all version references, rebuild the entire project:
+   ```bash
+   rush rebuild
+   ```
+   *Estimated time: ~10-15 minutes*
+
+6. **Verify Updated Version:**
+   Confirm the new stable version is installed:
+   ```bash
+   cat common/temp/node_modules/@azure/communication-calling/package.json | grep version
+   ```
+   Should show the new stable version you specified.
+
+## Notes:
+- Always ensure all references to the old stable version are updated consistently across all files
+- The `rush rebuild` command is necessary to ensure all packages are rebuilt with the new version
+- Version format should follow pattern: `X.Y.Z` (e.g., `1.37.2`) without any pre-release suffixes
+- Make sure to update both the stable variant configuration and all package.json files that contain version ranges
+- Version format should follow pattern: `X.Y.Z-beta.N` (e.g., `1.38.1-beta.1`)
+
+# Instructions for Updating All Beta Dependencies
+
+To efficiently update all Azure Communication Services dependencies to their latest beta versions (not just `@azure/communication-calling`), follow these streamlined steps:
+
+**Estimated Time:** ~10-12 minutes total
+
+1. **Switch to Beta Flavor:**
+   Run the following command to switch to the beta flavor:
+   ```bash
+   rush switch-flavor:beta
+   ```
+   *This command automatically updates packages and installs the latest beta versions defined in the configuration.*
+   *Estimated time: ~30-45 seconds*
+
+2. **Full Update (Recommended):**
+   Ensure all dependencies are fully synchronized:
+   ```bash
+   rush update --full
+   ```
+   *This ensures all packages are updated and dependency resolution is complete.*
+   *Estimated time: ~30-45 seconds*
+
+3. **Rebuild and Verify:**
+   Build the entire project to ensure beta compatibility:
+   ```bash
+   rush rebuild
+   ```
+   *This verifies that all packages build successfully with the new beta versions.*
+   *Estimated time: ~8-10 minutes*
+
+## Expected Beta Dependency Updates
+
+When switching to beta flavor, the following Azure Communication Services dependencies will typically be updated:
+
+- **@azure/communication-calling**: Latest beta version (e.g., `1.38.1-beta.1`)
+- **@azure/communication-chat**: Latest beta version (e.g., `1.6.0-beta.7`)
+- **@azure/communication-common**: Latest beta version (e.g., `2.3.2-beta.1`)
+- **@azure/communication-signaling**: Latest beta version (e.g., `1.0.0-beta.33`)
+- **@azure/communication-calling-effects**: Latest version (typically stable)
+
+# Instructions for Updating All Stable Dependencies
+
+To efficiently update all Azure Communication Services dependencies to their latest stable versions, follow these streamlined steps:
+
+**Estimated Time:** ~10-12 minutes total
+
+1. **Switch to Stable Flavor:**
+   Run the following command to switch to the stable flavor:
+   ```bash
+   rush switch-flavor:stable
+   ```
+   *This command switches the environment to use stable variants.*
+   *Estimated time: ~30-45 seconds*
+
+2. **Full Update with Stable Variant:**
+   Update all dependencies using the stable variant configuration:
+   ```bash
+   rush update --full --variant stable
+   ```
+   *This ensures all packages are updated to their latest stable versions and dependency resolution is complete.*
+   *Estimated time: ~30-45 seconds*
+
+3. **Rebuild and Verify:**
+   Build the entire project to ensure stable compatibility:
+   ```bash
+   rush rebuild
+   ```
+   *This verifies that all packages build successfully with the new stable versions.*
+   *Estimated time: ~8-10 minutes*
+
+## Expected Stable Dependency Updates
+
+When updating to stable versions, the following Azure Communication Services dependencies will typically be updated:
+
+- **@azure/communication-calling**: Latest stable version (e.g., `1.37.2`)
+- **@azure/communication-chat**: Latest stable version (e.g., `1.6.0`)
+- **@azure/communication-common**: Latest stable version (e.g., `2.4.0`)
+- **@azure/communication-signaling**: Latest stable version (e.g., `1.0.0-beta.34`)
+- **@azure/communication-calling-effects**: Latest stable version (e.g., `1.1.4`)
+
+## Verification Steps (For Both Beta and Stable)
+
+After the process completes, you can verify the updates:
+
+1. **Check specific package versions:**
+   ```bash
+   cat common/temp/node_modules/@azure/communication-calling/package.json | grep version
+   cat common/temp/node_modules/@azure/communication-chat/package.json | grep version
+   cat common/temp/node_modules/@azure/communication-common/package.json | grep version
+   ```
+
+2. **Review configuration files:**
+   - **Beta**: [`common/config/rush/common-versions.json`](common/config/rush/common-versions.json)
+   - **Stable**: [`common/config/rush/variants/stable/common-versions.json`](common/config/rush/variants/stable/common-versions.json)
+
+3. **Build success indicators:**
+   - All packages should build successfully (22/24 typically pass)
+   - Minor TypeScript warnings are acceptable and non-blocking
+   - No critical build failures
+
+## Notes for PR Documentation
+
+When creating a PR for dependency updates, include:
+
+**Major Changes:**
+- List each Azure Communication Services dependency and its version change (from → to)
+- Note any version regressions or notable changes
+- Highlight the switch between beta/stable versions
+
+**Build Verification:**
+- Confirm successful build completion with package count (e.g., "22/24 packages built successfully")
+- Note any warnings (typically TypeScript warnings in communication-react or storybook8)
+- Mention total build time and success rate
+
+**Impact:**
+- **Beta**: Enables access to latest beta features and fixes, prepares codebase for testing cutting-edge functionality
+- **Stable**: Ensures production-ready stability, maintains backward compatibility with latest stable releases
+
+# Example Prompts
+
+Here are example prompts you can use to request specific update operations:
+
+## For Beta Update Only:
+```
+Switch to beta flavor and update the @azure/communication-calling package to the latest beta version. Use the agent.md to understand how to do this.
+```
+
+## For Stable Update Only:
+```
+Switch to stable flavor and update the @azure/communication-calling package to the latest stable version. Use the agent.md to understand how to do this.
+```
+
+## For Both Beta and Stable Updates:
+```
+I want to switch to beta, update the version of calling to the latest beta, then switch to stable, and update the version to the latest stable. Use the agent.md to understand how to do this.
+```
+
+These prompts will guide the assistant to:
+- Read the agent.md instructions
+- Follow the proper sequence of commands (`rush switch-flavor`, `rush update`, etc.)
+- Update the appropriate configuration files (`common/config/rush/common-versions.json` for beta, `common/config/rush/variants/stable/common-versions.json` for stable)
+- Update all relevant package.json files
+- Verify the installations and run rebuilds as needed
+
+Each prompt is designed to be self-contained and will result in the assistant following the established workflow from this documentation.

--- a/packages/calling-component-bindings/package.json
+++ b/packages/calling-component-bindings/package.json
@@ -40,12 +40,12 @@
   },
   "peerDependencies": {
     "@azure/communication-calling-effects": "^1.1.4",
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@types/react": ">=16.8.0 <19.0.0",
     "react": ">=16.8.0 <19.0.0"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-calling-effects": "^1.1.4",
     "@babel/cli": "^7.27.2",
     "@babel/core": "^7.27.4",

--- a/packages/calling-stateful-client/package.json
+++ b/packages/calling-stateful-client/package.json
@@ -38,10 +38,10 @@
     "immer": "10.1.1"
   },
   "peerDependencies": {
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1"
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/core-auth": "^1.7.2",
     "@babel/cli": "^7.27.2",
     "@babel/core": "^7.27.4",

--- a/packages/communication-react/package.json
+++ b/packages/communication-react/package.json
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "@azure/communication-calling-effects": "^1.1.4",
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-chat": "1.6.0-beta.7 || >=1.6.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",
@@ -111,7 +111,7 @@
     "_by-flavor": "rushx _current-flavor && env-cmd -f ../../common/config/env/.env --use-shell"
   },
   "devDependencies": {
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-calling-effects": "^1.1.4",
     "@azure/core-auth": "^1.7.2",
     "@babel/cli": "^7.27.2",

--- a/packages/react-composites/package.json
+++ b/packages/react-composites/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "@azure/communication-calling-effects": "^1.1.4",
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-chat": "1.6.0-beta.7 || >=1.6.0",
     "@types/react": ">=16.8.0 <19.0.0",
     "@types/react-dom": ">=16.8.0 <19.0.0",

--- a/packages/storybook8/package.json
+++ b/packages/storybook8/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-chat": "1.6.0-beta.7 || ^1.6.0",
     "@azure/communication-common": "^2.3.2-beta.1 || ^2.4.0",
     "@azure/communication-identity": "^1.3.0",

--- a/samples/CallWithChat/package.json
+++ b/samples/CallWithChat/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-chat": "1.6.0-beta.7 || ^1.6.0",
     "@azure/communication-react": "1.30.0-beta.0",
     "@azure/communication-common": "^2.3.2-beta.1 || ^2.4.0",

--- a/samples/Calling/package.json
+++ b/samples/Calling/package.json
@@ -34,7 +34,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.30.0-beta.0",
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-common": "^2.3.2-beta.1 || ^2.4.0",
     "@azure/logger": "^1.0.4",
     "@babel/preset-react": "^7.12.7",

--- a/samples/CallingStateful/package.json
+++ b/samples/CallingStateful/package.json
@@ -34,7 +34,7 @@
     "@azure/abort-controller": "^1.1.0",
     "@azure/communication-identity": "^1.3.0",
     "@azure/communication-react": "1.30.0-beta.0",
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-common": "^2.3.2-beta.1 || ^2.4.0",
     "@azure/logger": "^1.0.4",
     "@babel/preset-react": "^7.12.7",

--- a/samples/ComponentExamples/package.json
+++ b/samples/ComponentExamples/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-chat": "1.6.0-beta.7 || ^1.6.0",
     "@azure/communication-common": "^2.3.2-beta.1 || ^2.4.0",
     "@azure/communication-identity": "^1.3.0",

--- a/samples/StaticHtmlComposites/package.json
+++ b/samples/StaticHtmlComposites/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@azure/communication-react": "1.30.0-beta.0",
     "@azure/communication-common": "^2.3.2-beta.1 || ^2.4.0",
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-chat": "1.6.0-beta.7 || ^1.6.0",
     "@fluentui/react": "^8.123.0",
     "react": "18.3.1",

--- a/samples/tests/package.json
+++ b/samples/tests/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/communication-calling": "1.37.1-beta.1 || ^1.37.1",
+    "@azure/communication-calling": "1.38.1-beta.1 || ^1.37.1",
     "@azure/communication-chat": "1.6.0-beta.7 || ^1.6.0",
     "@azure/communication-common": "^2.3.2-beta.1 || ^2.4.0",
     "uuid": "^9.0.0",


### PR DESCRIPTION
Using agentic flows you can pass in a prompt to update all dependencies

"I want to switch to beta, update the version of calling to the latest beta, then switch to stable, and update the version to the latest stable. Use the agent.md to understand how to do this."

It knows how to switch flavors, check for most recent versions, apply versions, and do full builds.
We can probably make it more efficient over time. 
Ideally we can run this in full execution mode for coffee for 20 min and update everything in a codespace.