### PR TITLE
Fix vscode not showing live linting errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,10 @@
   "before-after-diff-checker.compileCommand": "rushx _by-flavor \"rushx preprocess\" && (npx eslint $PROCESSED_FILE --fix || true)",
   "before-after-diff-checker.srcPath": "src",
   "before-after-diff-checker.enableOnSave": false,
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ],
   "typescript.tsdk": "common/config/node_modules/typescript/lib"
 }

--- a/common/config/package.json
+++ b/common/config/package.json
@@ -17,16 +17,24 @@
   },
   "devDependencies": {
     "@actions/core": "^1.10.1",
+    "@eslint/js": "~9.28.0",
     "@octokit/rest": "~21.1.1",
     "@playwright/test": "~1.52.0",
     "@rollup/plugin-commonjs": "~25.0.7",
     "@rollup/plugin-json": "^6.0.1",
     "@types/node": "^22.15.18",
+    "@typescript-eslint/parser": "^8.34.0",
     "beachball": "^2.44.0",
-    "rollup": "^4.40.2",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-headers": "~1.3.3",
+    "eslint-plugin-jsdoc": "^50.6.17",
+    "eslint": "^9.28.0",
+    "globals": "~16.2.0",
     "rollup-plugin-sourcemaps": "~0.6.3",
     "rollup-plugin-svg": "~2.0.0",
+    "rollup": "^4.40.2",
     "ts-node": "^10.9.2",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "typescript-eslint": "~8.33.0"
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6578,8 +6578,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.33.1(typescript@5.4.5)
-      '@typescript-eslint/types': 8.33.1
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.4.5)
+      '@typescript-eslint/types': 8.39.0
       debug: 4.4.1(supports-color@5.5.0)
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -18731,25 +18731,35 @@ packages:
     dev: false
 
   file:projects/config.tgz:
-    resolution: {integrity: sha512-JZEJt0Gf/UtyINOyGicWK57DWGwf4nylcGFQaiJ9+3MdIekpVREHddtpQQ0UKJMzt89t9fiQ7fX02mJUFvCoHg==, tarball: file:projects/config.tgz}
+    resolution: {integrity: sha512-loSgVAPRcqsnUXF7R5iEi3OOytvu/3EvCMeLS4cwtBgTQoJcv0U6dSZed7H3SGrurvxVRyFeCc42PSnpJhJivg==, tarball: file:projects/config.tgz}
     name: '@rush-temp/config'
     version: 0.0.0
     dependencies:
       '@actions/core': 1.11.1
+      '@eslint/js': 9.28.0
       '@octokit/rest': 21.1.1
       '@playwright/test': 1.52.0
       '@rollup/plugin-commonjs': 25.0.8(rollup@4.46.2)
       '@rollup/plugin-json': 6.1.0(rollup@4.46.2)
       '@types/node': 22.17.0
+      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0)(typescript@5.4.5)
       beachball: 2.54.0(typescript@5.4.5)
+      eslint: 9.32.0(jiti@2.4.2)
+      eslint-config-prettier: 10.1.8(eslint@9.32.0)
+      eslint-plugin-headers: 1.3.3(eslint@9.32.0)
+      eslint-plugin-jsdoc: 50.8.0(eslint@9.32.0)
+      globals: 16.2.0
       rollup: 4.46.2
       rollup-plugin-sourcemaps: 0.6.3(@types/node@22.17.0)(rollup@4.46.2)
       rollup-plugin-svg: 2.0.0
       ts-node: 10.9.2(@types/node@22.17.0)(typescript@5.4.5)
       typescript: 5.4.5
+      typescript-eslint: 8.33.1(eslint@9.32.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
+      - jiti
+      - supports-color
     dev: false
 
   file:projects/eslint-plugin-custom-rules.tgz:

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -18714,25 +18714,35 @@ packages:
     dev: false
 
   file:projects/config.tgz:
-    resolution: {integrity: sha512-JZEJt0Gf/UtyINOyGicWK57DWGwf4nylcGFQaiJ9+3MdIekpVREHddtpQQ0UKJMzt89t9fiQ7fX02mJUFvCoHg==, tarball: file:projects/config.tgz}
+    resolution: {integrity: sha512-loSgVAPRcqsnUXF7R5iEi3OOytvu/3EvCMeLS4cwtBgTQoJcv0U6dSZed7H3SGrurvxVRyFeCc42PSnpJhJivg==, tarball: file:projects/config.tgz}
     name: '@rush-temp/config'
     version: 0.0.0
     dependencies:
       '@actions/core': 1.11.1
+      '@eslint/js': 9.28.0
       '@octokit/rest': 21.1.1
       '@playwright/test': 1.52.0
       '@rollup/plugin-commonjs': 25.0.8(rollup@4.46.2)
       '@rollup/plugin-json': 6.1.0(rollup@4.46.2)
       '@types/node': 22.17.0
+      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0)(typescript@5.4.5)
       beachball: 2.54.0(typescript@5.4.5)
+      eslint: 9.32.0(jiti@2.4.2)
+      eslint-config-prettier: 10.1.8(eslint@9.32.0)
+      eslint-plugin-headers: 1.3.3(eslint@9.32.0)
+      eslint-plugin-jsdoc: 50.8.0(eslint@9.32.0)
+      globals: 16.2.0
       rollup: 4.46.2
       rollup-plugin-sourcemaps: 0.6.3(@types/node@22.17.0)(rollup@4.46.2)
       rollup-plugin-svg: 2.0.0
       ts-node: 10.9.2(@types/node@22.17.0)(typescript@5.4.5)
       typescript: 5.4.5
+      typescript-eslint: 8.33.1(eslint@9.32.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
+      - jiti
+      - supports-color
     dev: false
 
   file:projects/eslint-plugin-custom-rules.tgz:


### PR DESCRIPTION
# What

Update eslint settings to correctly show linting red squigglies, update the node modules in the common folder to have access to required deps

# Why

Currently the vscode eslint extension is not working, it fails internally with: `Error: Config file could not be found`. (under the hood this is because it is searching for the config in the root of the repo, and not crawling up from the current file)

Setting this setting seems to fix it.

# How Tested
On testing seems to be working now:
<img width="1116" height="442" alt="image" src="https://github.com/user-attachments/assets/ba2e059e-2b2f-47ee-a5e6-357744ed9da8" />
