### PR TITLE
Sanitize branch names before checkout

### DIFF
--- a/.github/workflows/update-chat-snapshots.yml
+++ b/.github/workflows/update-chat-snapshots.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Push new snapshots, if any
         if: ${{ steps.changescheck.outputs.hasChanged == 'true' }}
         env:
-          TARGET_BRANCH: ${{ needs.get_target_branch.outputs.target }}
+          SAFE_BRANCH: ${{ needs.precondition.outputs.active_branch_name_sanitized }}
         # Before pushing changes to origin, merge any intervening changes on the upstream branch.
         # This allows multiple snapshot update jobs in this action to run concurrently.
         # - The only files updated locally are UI snapshots
@@ -174,7 +174,7 @@ jobs:
         run: |
           git add packages/react-composites/*.png
           git commit -m 'Update packages/react-composites ChatComposite browser test snapshots'
-          git pull origin "$TARGET_BRANCH" --no-rebase --no-edit
+          git pull origin "$SAFE_BRANCH" --no-rebase --no-edit
           git push
 
   push_updated_snapshots:

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -164,12 +164,11 @@ jobs:
             echo "hasChanged=false" >> $GITHUB_OUTPUT
           else
             echo "hasChanged=true" >> $GITHUB_OUTPUT
-            exit
           fi
       - name: Push new snapshots, if any
         if: ${{ steps.changescheck.outputs.hasChanged == 'true' }}
         env:
-          TARGET_BRANCH: ${{ needs.get_target_branch.outputs.target }}
+          SAFE_BRANCH: ${{ needs.precondition.outputs.active_branch_name_sanitized }}
         # Before pushing changes to origin, merge any intervening changes on the upstream branch
         # This allows multiple snapshot update jobs in this action to run concurrently.
         # - The only files updated locally are UI snapshots
@@ -183,7 +182,7 @@ jobs:
         run: |
           git add samples/tests/*.png
           git commit -m 'Update component examples snapshots'
-          git pull origin "$TARGET_BRANCH" --no-rebase --no-edit
+          git pull origin "$SAFE_BRANCH" --no-rebase --no-edit
           git push
 
   html_bundle:
@@ -264,12 +263,11 @@ jobs:
             echo "hasChanged=false" >> $GITHUB_OUTPUT
           else
             echo "hasChanged=true" >> $GITHUB_OUTPUT
-            exit
           fi
       - name: Push new snapshots, if any
         if: ${{ steps.changescheck.outputs.hasChanged == 'true' }}
         env:
-          TARGET_BRANCH: ${{ needs.get_target_branch.outputs.target }}
+          SAFE_BRANCH: ${{ needs.precondition.outputs.active_branch_name_sanitized }}
         # Before pushing changes to origin, merge any intervening changes on the upstream branch
         # This allows multiple snapshot update jobs in this action to run concurrently.
         # - The only files updated locally are UI snapshots
@@ -283,7 +281,7 @@ jobs:
         run: |
           git add samples/tests/*.png
           git commit -m 'Update embed html bundle snapshots'
-          git pull origin "$TARGET_BRANCH" --no-rebase --no-edit
+          git pull origin "$SAFE_BRANCH" --no-rebase --no-edit
           git push
 
   call_composite:
@@ -369,7 +367,7 @@ jobs:
       - name: Push new snapshots, if any
         if: ${{ steps.changescheck.outputs.hasChanged == 'true' }}
         env:
-          TARGET_BRANCH: ${{ needs.get_target_branch.outputs.target }}
+          SAFE_BRANCH: ${{ needs.precondition.outputs.active_branch_name_sanitized }}
         # Before pushing changes to origin, merge any intervening changes on the upstream branch
         # This allows multiple snapshot update jobs in this action to run concurrently.
         # - The only files updated locally are UI snapshots
@@ -383,7 +381,7 @@ jobs:
         run: |
           git add packages/react-composites/*.png
           git commit -m 'Update packages/react-composites CallComposite browser test snapshots'
-          git pull origin "$TARGET_BRANCH" --no-rebase --no-edit
+          git pull origin "$SAFE_BRANCH" --no-rebase --no-edit
           git push
 
   chat_composite:
@@ -469,7 +467,7 @@ jobs:
       - name: Push new snapshots, if any
         if: ${{ steps.changescheck.outputs.hasChanged == 'true' }}
         env:
-          TARGET_BRANCH: ${{ needs.get_target_branch.outputs.target }}
+          SAFE_BRANCH: ${{ needs.precondition.outputs.active_branch_name_sanitized }}
         # Before pushing changes to origin, merge any intervening changes on the upstream branch
         # This allows multiple snapshot update jobs in this action to run concurrently.
         # - The only files updated locally are UI snapshots
@@ -483,7 +481,7 @@ jobs:
         run: |
           git add packages/react-composites/*.png
           git commit -m 'Update packages/react-composites ChatComposite browser test snapshots'
-          git pull origin "$TARGET_BRANCH" --no-rebase --no-edit
+          git pull origin "$SAFE_BRANCH" --no-rebase --no-edit
           git push
 
   callwithchat_composite:
@@ -569,7 +567,7 @@ jobs:
       - name: Push new snapshots, if any
         if: ${{ steps.changescheck.outputs.hasChanged == 'true' }}
         env:
-          TARGET_BRANCH: ${{ needs.get_target_branch.outputs.target }}
+          SAFE_BRANCH: ${{ needs.precondition.outputs.active_branch_name_sanitized }}
         # Before pushing changes to origin, merge any intervening changes on the upstream branch
         # This allows multiple snapshot update jobs in this action to run concurrently.
         # - The only files updated locally are UI snapshots
@@ -583,7 +581,7 @@ jobs:
         run: |
           git add packages/react-composites/*.png
           git commit -m 'Update packages/react-composites CallWithChatComposite browser test snapshots'
-          git pull origin "$TARGET_BRANCH" --no-rebase --no-edit
+          git pull origin "$SAFE_BRANCH" --no-rebase --no-edit
           git push
 
   components:
@@ -666,7 +664,7 @@ jobs:
       - name: Push new snapshots, if any
         if: ${{ steps.changescheck.outputs.hasChanged == 'true' }}
         env:
-          TARGET_BRANCH: ${{ needs.get_target_branch.outputs.target }}
+          SAFE_BRANCH: ${{ needs.precondition.outputs.active_branch_name_sanitized }}
         # Before pushing changes to origin, merge any intervening changes on the upstream branch
         # This allows multiple snapshot update jobs in this action to run concurrently.
         # - The only files updated locally are UI snapshots
@@ -680,7 +678,7 @@ jobs:
         run: |
           git add packages/react-components/*.png
           git commit -m 'Update packages/react-components browser test snapshots'
-          git pull origin "$TARGET_BRANCH" --no-rebase --no-edit
+          git pull origin "$SAFE_BRANCH" --no-rebase --no-edit
           git push
 
   push_updated_snapshots:


### PR DESCRIPTION
# What

Better security practices around using untrusted inputs (e.g. branchname)

# Why

Prevent potential branchname exploit in `git checkout <branchname>`

# How Tested

Verified updating snapshots working in test branch `jaburnsi/rce-fix-tests` (and merged in fixes from that branch)