### PR TITLE
Small GitHub action fixups for better supporting dual releases

### DIFF
--- a/.github/workflows/create-prerelease-branch.yml
+++ b/.github/workflows/create-prerelease-branch.yml
@@ -22,11 +22,6 @@ on:
           - beta-release-patch
           - beta-release-beta
 
-# cancel workflow when a newer version of the workflow is triggered on the same github ref
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   # create pre-release branch for beta releases
   create_pre-release:

--- a/.github/workflows/deploy-feature-azure-webapps.yml
+++ b/.github/workflows/deploy-feature-azure-webapps.yml
@@ -3,6 +3,15 @@ name: Deploy feature validation samples
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      flavor:
+        description: 'Build flavor to deploy (beta-release or stable)'
+        type: choice
+        required: true
+        default: beta-release
+        options:
+          - beta-release
+          - stable
 
 # cancel workflow when a newer version of the workflow is triggered on the same github ref
 concurrency:
@@ -31,8 +40,8 @@ jobs:
         run: npm install -g @microsoft/rush@$(jq -r '.rushVersion' "rush.json")
       - name: Install dependencies
         run: rush install
-      - name: Switch flavor for beta release build
-        run: rush switch-flavor:beta-release
+      - name: Switch flavor
+        run: rush switch-flavor:${{ inputs.flavor }}
       - name: Build Communication-react
         run: rush build -t @azure/communication-react
       - name: Build Server
@@ -73,8 +82,8 @@ jobs:
         run: npm install -g @microsoft/rush@$(jq -r '.rushVersion' "rush.json")
       - name: Install dependencies
         run: rush install
-      - name: Switch flavor for beta release build
-        run: rush switch-flavor:beta-release
+      - name: Switch flavor
+        run: rush switch-flavor:${{ inputs.flavor }}
       - name: Build Communication-react
         run: rush build -t @azure/communication-react
       - name: Build Server
@@ -115,8 +124,8 @@ jobs:
         run: npm install -g @microsoft/rush@$(jq -r '.rushVersion' "rush.json")
       - name: Install dependencies
         run: rush install
-      - name: Switch flavor for beta release build
-        run: rush switch-flavor:beta-release
+      - name: Switch flavor
+        run: rush switch-flavor:${{ inputs.flavor }}
       - name: Build Communication-react
         run: rush build -t @azure/communication-react
       - name: Build Server

--- a/.github/workflows/deploy-release-azure-webapps.yml
+++ b/.github/workflows/deploy-release-azure-webapps.yml
@@ -1,11 +1,6 @@
 name: Deploy release validation samples
 
 on:
-  push:
-    branches:
-      - 'release/**'
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # cancel workflow when a newer version of the workflow is triggered on the same github ref


### PR DESCRIPTION
# What

- Add option to choose beta vs stable in feature-deploy GH action
- Stop cancelling action in create-prerelease-branch if another one is triggered (to allow beta and stable to run at the same time)
- Remove auto deploy to beta-validation branch to stop cherry-picks clobbering deployments

# Why

Quick first step in better supporting dual releases

# How Tested
untested