### PR TITLE
Only subscribe to breakoutrooms if capable. Resolves a bug where ecs disabled flag causes breakoutroom initialization to fail

### DIFF
--- a/packages/calling-stateful-client/src/CallSubscriber.ts
+++ b/packages/calling-stateful-client/src/CallSubscriber.ts
@@ -62,7 +62,7 @@ export class CallSubscriber {
 
   private _capabilitiesSubscriber: CapabilitiesSubscriber;
   private _spotlightSubscriber: SpotlightSubscriber;
-  private _breakoutRoomsSubscriber: BreakoutRoomsSubscriber;
+  private _breakoutRoomsSubscriber?: BreakoutRoomsSubscriber;
 
   private _togetherModeSubscriber: TogetherModeSubscriber;
   private _mediaAccessSubscriber: MediaAccessSubscriber;
@@ -120,13 +120,15 @@ export class CallSubscriber {
       this._call.feature(Features.Spotlight)
     );
 
-    // Clear assigned breakout room closed notification for this call.
-    this._context.deleteLatestNotification('assignedBreakoutRoomClosed');
-    this._breakoutRoomsSubscriber = new BreakoutRoomsSubscriber(
-      this._callIdRef,
-      this._context,
-      this._call.feature(Features.BreakoutRooms)
-    );
+    if (this._call.feature(Features.Capabilities).capabilities.joinBreakoutRooms.isPresent) {
+      // Clear assigned breakout room closed notification for this call.
+      this._context.deleteLatestNotification('assignedBreakoutRoomClosed');
+      this._breakoutRoomsSubscriber = new BreakoutRoomsSubscriber(
+        this._callIdRef,
+        this._context,
+        this._call.feature(Features.BreakoutRooms)
+      );
+    }
 
     this._togetherModeSubscriber = new TogetherModeSubscriber(
       this._callIdRef,
@@ -254,8 +256,9 @@ export class CallSubscriber {
     this._capabilitiesSubscriber.unsubscribe();
     this._reactionSubscriber?.unsubscribe();
     this._spotlightSubscriber.unsubscribe();
-    this._breakoutRoomsSubscriber.unsubscribe();
-
+    if (this._call.feature(Features.Capabilities).capabilities.joinBreakoutRooms.isPresent && this._breakoutRoomsSubscriber) {
+      this._breakoutRoomsSubscriber.unsubscribe();
+    }
     this._togetherModeSubscriber.unsubscribe();
     this._mediaAccessSubscriber.unsubscribe();
   };


### PR DESCRIPTION
# What
<!--- Describe your changes. -->
Subscribe to breakoutrooms only when the user has capabilities indicating it is able to

# Why
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
ICM related to an issue with subscribing to breakoutrooms when the call is not a breakoutrooms call.

ECS is throwing a disabled flag for breakoutrooms which causes the callsubscriber to fail to initialize on the breakoutroom subscription. However, the subscription is not needed for calls that are not capable of doing so. 
Doing a check before subscribing will prevent the communication react library from initializing a feature that is unable to be initialized.

In the Calling sdk there is a check in the breakoutrooms initialization which checks ECS flags. If the ECS flags is false, then the initialization will fail for breakoutrooms and throw an error up to whoever called the feature. Which in this case is our communication react library.

# How Tested
<!--- How did you test your change. What tests have you added. -->
Tested on macos chrome on the customers provided test-app using a locally packed tgz file of our communication-react library with the fix

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [ ] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->