### PR TITLE
Update Chat sample usage of axios to 1.12.2

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7502,6 +7502,16 @@ packages:
       - debug
     dev: false
 
+  /axios@1.12.2:
+    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -18429,7 +18439,7 @@ packages:
     dev: false
 
   file:projects/chat.tgz:
-    resolution: {integrity: sha512-IVQ8swVCikC7ytUZN0ad7oHBVVEbp0MjpTNkdOks2Nt4MTFscfJAJD57JLZXnNXArlUuNeRBVKCuQoBcVXZiXw==, tarball: file:projects/chat.tgz}
+    resolution: {integrity: sha512-GlACbScCgbbi90lUvT1qG0p6YpgPZ7JVgYaP4dBew/1vkewUMDLJyfT3isfUC0KZtk6nl2NJZ7zzKny6WWSuhQ==, tarball: file:projects/chat.tgz}
     name: '@rush-temp/chat'
     version: 0.0.0
     dependencies:
@@ -18454,7 +18464,7 @@ packages:
       '@types/react-linkify': 1.0.4
       '@typescript-eslint/eslint-plugin': 8.43.0(@typescript-eslint/parser@8.43.0)(eslint@9.35.0)(typescript@5.4.5)
       '@typescript-eslint/parser': 8.43.0(eslint@9.35.0)(typescript@5.4.5)
-      axios: 1.11.0
+      axios: 1.12.2
       babel-loader: 8.1.0(@babel/core@7.28.4)(webpack@5.99.9)
       concurrently: 5.3.0
       copyfiles: 2.4.1

--- a/common/config/rush/variants/stable/pnpm-lock.yaml
+++ b/common/config/rush/variants/stable/pnpm-lock.yaml
@@ -7485,6 +7485,16 @@ packages:
       - debug
     dev: false
 
+  /axios@1.12.2:
+    resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -18412,7 +18422,7 @@ packages:
     dev: false
 
   file:projects/chat.tgz:
-    resolution: {integrity: sha512-IVQ8swVCikC7ytUZN0ad7oHBVVEbp0MjpTNkdOks2Nt4MTFscfJAJD57JLZXnNXArlUuNeRBVKCuQoBcVXZiXw==, tarball: file:projects/chat.tgz}
+    resolution: {integrity: sha512-GlACbScCgbbi90lUvT1qG0p6YpgPZ7JVgYaP4dBew/1vkewUMDLJyfT3isfUC0KZtk6nl2NJZ7zzKny6WWSuhQ==, tarball: file:projects/chat.tgz}
     name: '@rush-temp/chat'
     version: 0.0.0
     dependencies:
@@ -18437,7 +18447,7 @@ packages:
       '@types/react-linkify': 1.0.4
       '@typescript-eslint/eslint-plugin': 8.43.0(@typescript-eslint/parser@8.43.0)(eslint@9.35.0)(typescript@5.4.5)
       '@typescript-eslint/parser': 8.43.0(eslint@9.35.0)(typescript@5.4.5)
-      axios: 1.11.0
+      axios: 1.12.2
       babel-loader: 8.1.0(@babel/core@7.28.4)(webpack@5.99.9)
       concurrently: 5.3.0
       copyfiles: 2.4.1

--- a/samples/Chat/package.json
+++ b/samples/Chat/package.json
@@ -53,7 +53,7 @@
     "react-linkify": "^1.0.0-alpha",
     "reselect": "^4.0.0",
     "shake.js": "1.2.2",
-    "axios": "^1.11.0",
+    "axios": "^1.12.2",
     "form-data": "^4.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
# What
Update Chat sample usage of axios to 1.12.2

# Why
Dependabot alert

- https://github.com/Azure/communication-ui-library/security/dependabot/377
- https://github.com/Azure/communication-ui-library/security/dependabot/378

Storybook playwright test runner also uses an older axios package but we do not make use of that