### PR TITLE
Added announcements when a remote participant starts or stops sharing their screen

### DIFF
--- a/change-beta/@azure-communication-react-screenshare-announcer-a1b2c3d4.json
+++ b/change-beta/@azure-communication-react-screenshare-announcer-a1b2c3d4.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Accessibility",
+  "comment": "Add screen reader announcements when a remote participant starts or stops sharing their screen",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@azure-communication-react-screenshare-announcer-a1b2c3d4.json
+++ b/change/@azure-communication-react-screenshare-announcer-a1b2c3d4.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "area": "fix",
+  "workstream": "Accessibility",
+  "comment": "Add screen reader announcements when a remote participant starts or stops sharing their screen",
+  "packageName": "@azure/communication-react",
+  "email": "miguelgamis@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/communication-react/review/beta/communication-react.api.md
+++ b/packages/communication-react/review/beta/communication-react.api.md
@@ -5758,6 +5758,8 @@ export interface VideoGalleryStrings {
     pinParticipantMenuItemAriaLabel: string;
     screenIsBeingSharedMessage: string;
     screenShareLoadingMessage: string;
+    screenShareStartedAnnouncementAriaLabel: string;
+    screenShareStoppedAnnouncementAriaLabel: string;
     spotlightLimitReachedMenuTitle: string;
     startSpotlightVideoTileMenuLabel: string;
     stopSpotlightOnSelfVideoTileMenuLabel: string;

--- a/packages/communication-react/review/stable/communication-react.api.md
+++ b/packages/communication-react/review/stable/communication-react.api.md
@@ -5161,6 +5161,8 @@ export interface VideoGalleryStrings {
     pinParticipantMenuItemAriaLabel: string;
     screenIsBeingSharedMessage: string;
     screenShareLoadingMessage: string;
+    screenShareStartedAnnouncementAriaLabel: string;
+    screenShareStoppedAnnouncementAriaLabel: string;
     spotlightLimitReachedMenuTitle: string;
     startSpotlightVideoTileMenuLabel: string;
     stopSpotlightOnSelfVideoTileMenuLabel: string;

--- a/packages/react-components/src/components/Announcer.tsx
+++ b/packages/react-components/src/components/Announcer.tsx
@@ -26,6 +26,7 @@ export const Announcer = (props: AnnouncerProps): JSX.Element => {
 
   return (
     <Stack
+      data-testid="announcer"
       aria-live={ariaLive}
       role={role}
       aria-atomic={true}

--- a/packages/react-components/src/components/Announcer.tsx
+++ b/packages/react-components/src/components/Announcer.tsx
@@ -20,14 +20,19 @@ export type AnnouncerProps = {
 export const Announcer = (props: AnnouncerProps): JSX.Element => {
   const { announcementString, ariaLive } = props;
 
+  // Use role="alert" for assertive announcements as it's more reliably announced by screen readers
+  // even when focus is on interactive elements
+  const role = ariaLive === 'assertive' ? 'alert' : 'status';
+
   return (
     <Stack
-      aria-label={announcementString}
       aria-live={ariaLive}
-      role="status"
+      role={role}
       aria-atomic={true}
       styles={announcerStyles}
-    ></Stack>
+    >
+      {announcementString}
+    </Stack>
   );
 };
 

--- a/packages/react-components/src/components/InputBoxComponent.test.tsx
+++ b/packages/react-components/src/components/InputBoxComponent.test.tsx
@@ -75,9 +75,9 @@ describe('InputBoxComponent should show mention popover', () => {
 
   const checkExpectedSuggestions = async (): Promise<void> => {
     for (const suggestion of suggestions) {
-      // Check that all suggestions are presented
-      const contextMenuItem = await screen.findByText(suggestion.displayText);
-      expect(contextMenuItem.classList.contains('ms-Persona-primaryText')).toBe(true);
+      // Check that all suggestions are presented (use selector to exclude announcer elements)
+      const contextMenuItem = await screen.findByText(suggestion.displayText, { selector: '.ms-Persona-primaryText' });
+      expect(contextMenuItem).toBeTruthy();
     }
   };
 
@@ -154,8 +154,9 @@ describe('InputBoxComponent should show mention popover for a custom trigger', (
 
   const checkExpectedSuggestions = async (): Promise<void> => {
     for (const suggestion of suggestions) {
-      const contextMenuItem = await screen.findByText(suggestion?.displayText);
-      expect(contextMenuItem.classList.contains('ms-Persona-primaryText')).toBe(true);
+      // Use selector to exclude announcer elements
+      const contextMenuItem = await screen.findByText(suggestion?.displayText, { selector: '.ms-Persona-primaryText' });
+      expect(contextMenuItem).toBeTruthy();
     }
   };
 
@@ -266,7 +267,8 @@ describe('InputBoxComponent should hide mention popover', () => {
 
   const checkSuggestionsNotShown = (): void => {
     for (const suggestion of suggestions) {
-      const contextMenuItem = screen.queryByText(suggestion?.displayText);
+      // Use selector to exclude announcer elements
+      const contextMenuItem = screen.queryByText(suggestion?.displayText, { selector: '.ms-Persona-primaryText' });
       expect(contextMenuItem).toBeNull();
     }
   };
@@ -276,8 +278,8 @@ describe('InputBoxComponent should hide mention popover', () => {
     if (!firstSuggestionText) {
       throw new Error('Suggestion text is not defined');
     }
-    const firstSuggestionMenuItem = await screen.findByText(firstSuggestionText);
-    expect(firstSuggestionMenuItem.classList.contains('ms-Persona-primaryText')).toBe(true);
+    // Use selector to exclude announcer elements
+    const firstSuggestionMenuItem = await screen.findByText(firstSuggestionText, { selector: '.ms-Persona-primaryText' });
     return firstSuggestionMenuItem;
   };
 

--- a/packages/react-components/src/components/MessageThread.test.tsx
+++ b/packages/react-components/src/components/MessageThread.test.tsx
@@ -396,13 +396,13 @@ describe('Message should display Mention correctly', () => {
       await userEvent.keyboard(' @');
     });
 
-    // Check that Everyone is an option
-    const everyoneMentionContextMenuItem = await screen.findByText('Everyone');
-    expect(everyoneMentionContextMenuItem.classList.contains('ms-Persona-primaryText')).toBe(true);
+    // Check that Everyone is an option (use selector to exclude announcer elements)
+    const everyoneMentionContextMenuItem = await screen.findByText('Everyone', { selector: '.ms-Persona-primaryText' });
+    expect(everyoneMentionContextMenuItem).toBeTruthy();
 
-    // Check that user1Name is an option
-    const user1MentionContextMenuItem = await screen.findByText(user1Name);
-    expect(user1MentionContextMenuItem.classList.contains('ms-Persona-primaryText')).toBe(true);
+    // Check that user1Name is an option (use selector to exclude announcer elements)
+    const user1MentionContextMenuItem = await screen.findByText(user1Name, { selector: '.ms-Persona-primaryText' });
+    expect(user1MentionContextMenuItem).toBeTruthy();
 
     // Select mention from popover for user1Name, verify plain text not contain mention html tag
     fireEvent.click(user1MentionContextMenuItem);

--- a/packages/react-components/src/components/SendBox.test.tsx
+++ b/packages/react-components/src/components/SendBox.test.tsx
@@ -66,8 +66,8 @@ describe('SendBox should return correct value with a selected mention', () => {
     if (!suggestions[0]) {
       throw new Error('No suggestions found');
     }
-    const contextMenuItem = await screen.findByText(suggestions[0].displayText);
-    expect(contextMenuItem.classList.contains('ms-Persona-primaryText')).toBe(true);
+    // Use selector to exclude announcer elements
+    const contextMenuItem = await screen.findByText(suggestions[0].displayText, { selector: '.ms-Persona-primaryText' });
     contextMenuItem && fireEvent.click(contextMenuItem);
   };
 
@@ -161,8 +161,8 @@ describe('Clicks/Touch should select mention', () => {
     if (!suggestions[0]) {
       throw new Error('No suggestions found');
     }
-    const contextMenuItem = await screen.findByText(suggestions[0].displayText);
-    expect(contextMenuItem.classList.contains('ms-Persona-primaryText')).toBe(true);
+    // Use selector to exclude announcer elements
+    const contextMenuItem = await screen.findByText(suggestions[0].displayText, { selector: '.ms-Persona-primaryText' });
     fireEvent.click(contextMenuItem);
   };
 
@@ -421,8 +421,8 @@ describe('Keyboard events should be handled for mentions', () => {
     if (!suggestion) {
       throw new Error('Suggestion not found');
     }
-    const contextMenuItem = await screen.findByText(suggestion.displayText);
-    expect(contextMenuItem.classList.contains('ms-Persona-primaryText')).toBe(true);
+    // Use selector to exclude announcer elements
+    const contextMenuItem = await screen.findByText(suggestion.displayText, { selector: '.ms-Persona-primaryText' });
     fireEvent.click(contextMenuItem);
   };
 

--- a/packages/react-components/src/localization/locales/en-US/strings.json
+++ b/packages/react-components/src/localization/locales/en-US/strings.json
@@ -666,6 +666,8 @@
   },
   "videoGallery": {
     "screenIsBeingSharedMessage": "You are sharing your screen",
+    "screenShareStartedAnnouncementAriaLabel": "{participant} is sharing their screen",
+    "screenShareStoppedAnnouncementAriaLabel": "{participant} stopped sharing their screen",
     "screenShareLoadingMessage": "Loading {participant}'s screen",
     "localScreenShareLoadingMessage": "Loading your screen",
     "localVideoLabel": "You",


### PR DESCRIPTION
# What
Added screen reader announcements when a remote participant starts or stops sharing their screen.

# Why
GroupMe bug https://dev.azure.com/skype/SPOOL/_workitems/edit/4455127

# How Tested
Tested locally

# Process & policy checklist
<!--- Review the list and check the boxes that apply. -->

- [ ] I have updated the project documentation to reflect my changes if necessary.
- [x] I have read the [CONTRIBUTING](https://github.com/Azure/communication-ui-library/blob/main/CONTRIBUTING.md) documentation.

**Is this a breaking change?**

- [ ] This change causes current functionality to break.
<!--- If yes, describe the impact. -->