### PR TITLE
Allow calling teams to review chat paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 /samples/Calling/                                           @Azure/acs-ui-web-calling-reviewer-1 @Azure/acs-ui-web-calling-reviewer-2
 
 # Chat
-/packages/chat-component-bindings/                          @Azure/acs-ui-web-chat-reviewer-1 @Azure/acs-ui-web-chat-reviewer-2
-/packages/chat-stateful-client/                             @Azure/acs-ui-web-chat-reviewer-1 @Azure/acs-ui-web-chat-reviewer-2
-/packages/storybook8/stories/ChatComposite/                  @Azure/acs-ui-web-chat-reviewer-1 @Azure/acs-ui-web-chat-reviewer-2
-/samples/Chat/                                              @Azure/acs-ui-web-chat-reviewer-1 @Azure/acs-ui-web-chat-reviewer-2
+/packages/chat-component-bindings/                          @Azure/acs-ui-web-calling-reviewer-1 @Azure/acs-ui-web-calling-reviewer-2 @Azure/acs-ui-web-chat-reviewer-1 @Azure/acs-ui-web-chat-reviewer-2
+/packages/chat-stateful-client/                             @Azure/acs-ui-web-calling-reviewer-1 @Azure/acs-ui-web-calling-reviewer-2 @Azure/acs-ui-web-chat-reviewer-1 @Azure/acs-ui-web-chat-reviewer-2
+/packages/storybook8/stories/ChatComposite/                  @Azure/acs-ui-web-calling-reviewer-1 @Azure/acs-ui-web-calling-reviewer-2 @Azure/acs-ui-web-chat-reviewer-1 @Azure/acs-ui-web-chat-reviewer-2
+/samples/Chat/                                              @Azure/acs-ui-web-calling-reviewer-1 @Azure/acs-ui-web-calling-reviewer-2 @Azure/acs-ui-web-chat-reviewer-1 @Azure/acs-ui-web-chat-reviewer-2


### PR DESCRIPTION
# What
Allow calling teams to review chat paths

# Why
Reduce reliance for @Azure/acs-ui-web-chat-reviewer-1 @Azure/acs-ui-web-chat-reviewer-2 for chat changes